### PR TITLE
Add traversal modify benchmark for quicklens

### DIFF
--- a/benchmarks/src/main/scala/zio/blocks/schema/OpticBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/blocks/schema/OpticBenchmark.scala
@@ -173,6 +173,9 @@ class TraversalModifyBenchmark extends BaseBenchmark {
   }
 
   @Benchmark
+  def quicklens: Array[Int] = a_i_quicklens.apply(ai).using(_ + 1)
+
+  @Benchmark
   def zioBlocks: Array[Int] = a_i.modify(ai, _ + 1)
 }
 
@@ -334,5 +337,6 @@ object OptionalDomain {
 }
 
 object TraversalDomain {
-  val a_i: Traversal[Array[Int], Int] = Traversal.arrayValues(Reflect.int[Binding])
+  val a_i: Traversal[Array[Int], Int]                          = Traversal.arrayValues(Reflect.int[Binding])
+  val a_i_quicklens: Array[Int] => PathModify[Array[Int], Int] = modify(_: Array[Int])(_.each)
 }

--- a/benchmarks/src/test/scala/zio/blocks/schema/OpticBenchmarkSpec.scala
+++ b/benchmarks/src/test/scala/zio/blocks/schema/OpticBenchmarkSpec.scala
@@ -49,6 +49,7 @@ object OpticBenchmarkSpec extends ZIOSpecDefault {
     suite("TraversalModifyBenchmark")(
       test("has consistent output") {
         assert((new TraversalModifyBenchmark).direct.toList)(equalTo((2 to 11).toList)) &&
+        assert((new TraversalModifyBenchmark).quicklens.toList)(equalTo((2 to 11).toList)) &&
         assert((new TraversalModifyBenchmark).zioBlocks.toList)(equalTo((2 to 11).toList))
       }
     )

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
@@ -43,7 +43,7 @@ final case class DerivationBuilder[TC[_], A](
         acc + (override_.optic -> acc.getOrElse(override_.optic, Vector.empty).appended(override_.modifier))
     }
 
-    def extraModifiers[A](reflect: Reflect.Type, optic: DynamicOptic): Vector[reflect.ModifierType] = {
+    def extraModifiers(reflect: Reflect.Type, optic: DynamicOptic): Vector[reflect.ModifierType] = {
       val extra = modifierMap.getOrElse(optic, Vector.empty)
 
       (reflect match {
@@ -66,11 +66,8 @@ final case class DerivationBuilder[TC[_], A](
       }).asInstanceOf[Vector[reflect.ModifierType]]
     }
 
-    def getCustomInstance[A](path: DynamicOptic): Option[Lazy[TC[A]]] = {
-      def coerceTC[B](lazy_tc: Lazy[TC[B]]): Lazy[TC[A]] = lazy_tc.asInstanceOf[Lazy[TC[A]]]
-
-      instanceMap.get(path).map(coerceTC(_))
-    }
+    def getCustomInstance[A](path: DynamicOptic): Option[Lazy[TC[A]]] =
+      instanceMap.get(path).map(_.asInstanceOf[Lazy[TC[A]]])
 
     type F[T, A] = Binding[T, A]
     type G[T, A] = BindingInstance[TC, T, A]


### PR DESCRIPTION
Below are results with Scala 2.13 and JDK 21 on Intel® Core™ i7-11800H.

```
[info] Benchmark                             (size)   Mode  Cnt          Score          Error  Units
[info] LensGetBenchmark.direct                  N/A  thrpt    5  953457833.021 ±  1572742.252  ops/s
[info] LensGetBenchmark.monocle                 N/A  thrpt    5   76846100.018 ±  2938889.268  ops/s
[info] LensGetBenchmark.zioBlocks               N/A  thrpt    5   31804089.260 ±   738956.469  ops/s
[info] LensReplaceBenchmark.direct              N/A  thrpt    5  150325508.623 ±  1573909.722  ops/s
[info] LensReplaceBenchmark.monocle             N/A  thrpt    5   51345530.555 ±  1239774.211  ops/s
[info] LensReplaceBenchmark.quicklens           N/A  thrpt    5   20238022.721 ±   416241.142  ops/s
[info] LensReplaceBenchmark.zioBlocks           N/A  thrpt    5   17846751.527 ±   605350.244  ops/s
[info] OptionalGetOptionBenchmark.direct        N/A  thrpt    5  422855275.042 ±  6046604.486  ops/s
[info] OptionalGetOptionBenchmark.monocle       N/A  thrpt    5   25772697.581 ±   656592.465  ops/s
[info] OptionalGetOptionBenchmark.zioBlocks     N/A  thrpt    5   23592927.145 ±   349007.398  ops/s
[info] OptionalReplaceBenchmark.direct          N/A  thrpt    5  145476667.109 ± 14534715.188  ops/s
[info] OptionalReplaceBenchmark.monocle         N/A  thrpt    5   16593023.995 ±   365595.189  ops/s
[info] OptionalReplaceBenchmark.quicklens       N/A  thrpt    5   19767784.021 ±   510949.582  ops/s
[info] OptionalReplaceBenchmark.zioBlocks       N/A  thrpt    5   13703772.260 ±   200120.674  ops/s
[info] TraversalFoldBenchmark.direct              1  thrpt    5  763520919.741 ±   859019.668  ops/s
[info] TraversalFoldBenchmark.direct             10  thrpt    5  387225865.976 ±   333473.586  ops/s
[info] TraversalFoldBenchmark.direct            100  thrpt    5   62457635.340 ±    41676.815  ops/s
[info] TraversalFoldBenchmark.direct           1000  thrpt    5    4705136.403 ±     3044.203  ops/s
[info] TraversalFoldBenchmark.direct          10000  thrpt    5     459555.197 ±      275.845  ops/s
[info] TraversalFoldBenchmark.zioBlocks           1  thrpt    5  232413557.829 ±  1644844.610  ops/s
[info] TraversalFoldBenchmark.zioBlocks          10  thrpt    5  191804951.595 ±   928089.102  ops/s
[info] TraversalFoldBenchmark.zioBlocks         100  thrpt    5   42445375.150 ±  2799370.341  ops/s
[info] TraversalFoldBenchmark.zioBlocks        1000  thrpt    5    4461093.242 ±    35555.657  ops/s
[info] TraversalFoldBenchmark.zioBlocks       10000  thrpt    5     455422.968 ±     1029.682  ops/s
[info] TraversalModifyBenchmark.direct            1  thrpt    5  333744657.410 ±  2210419.028  ops/s
[info] TraversalModifyBenchmark.direct           10  thrpt    5  153554139.482 ± 18593369.625  ops/s
[info] TraversalModifyBenchmark.direct          100  thrpt    5   36070981.887 ±   479365.675  ops/s
[info] TraversalModifyBenchmark.direct         1000  thrpt    5    3474483.366 ±    47372.408  ops/s
[info] TraversalModifyBenchmark.direct        10000  thrpt    5     297019.803 ±     2967.977  ops/s
[info] TraversalModifyBenchmark.quicklens         1  thrpt    5   56980305.714 ±  9574843.047  ops/s
[info] TraversalModifyBenchmark.quicklens        10  thrpt    5   21920584.173 ±   242454.713  ops/s
[info] TraversalModifyBenchmark.quicklens       100  thrpt    5    2854026.610 ±    27177.771  ops/s
[info] TraversalModifyBenchmark.quicklens      1000  thrpt    5     192744.680 ±     2972.790  ops/s
[info] TraversalModifyBenchmark.quicklens     10000  thrpt    5      22404.016 ±     1249.763  ops/s
[info] TraversalModifyBenchmark.zioBlocks         1  thrpt    5   93519605.268 ±  2975846.849  ops/s
[info] TraversalModifyBenchmark.zioBlocks        10  thrpt    5  103456585.097 ±  2536807.640  ops/s
[info] TraversalModifyBenchmark.zioBlocks       100  thrpt    5   19853838.525 ±   241153.435  ops/s
[info] TraversalModifyBenchmark.zioBlocks      1000  thrpt    5    1505825.982 ±     1609.998  ops/s
[info] TraversalModifyBenchmark.zioBlocks     10000  thrpt    5     133071.349 ±     1445.331  ops/s
```