### PR TITLE
MH-02 Schema.diff 

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/Diff.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Diff.scala
@@ -1,0 +1,18 @@
+package zio.blocks.schema
+
+object Diff {
+
+  def diff[A](source: A, target: A)(implicit schema: Schema[A]): Patch[A] = schema.reflect match {
+    case x @ Reflect.Record(fields, _, _, _, _) =>
+      fields.foldLeft(Patch(Vector.empty, schema)) { (acc, field) =>
+        val lens        = Lens.apply(x, field.asInstanceOf[Term.Bound[A, Any]])
+        val targetValue = lens.get(target)
+        if (lens.get(source) != targetValue) {
+          acc ++ Patch.replace(lens, targetValue)
+        } else acc
+      }
+    // resolve other cases
+    case _ => Patch(Vector.empty, schema)
+  }
+
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
@@ -34,6 +34,8 @@ final case class Schema[A](reflect: Reflect.Bound[A]) {
   def decode[F <: codec.Format](format: F)(decodeInput: format.DecodeInput): Either[SchemaError, A] =
     getInstance(format).decode(decodeInput)
 
+  def diff(source: A, target: A): Patch[A] = Diff.diff(source, target)(this)
+
   def doc: Doc = reflect.doc
 
   def doc(value: String): Schema[A] = new Schema(reflect.doc(value))

--- a/schema/shared/src/test/scala/zio/blocks/schema/DiffSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/DiffSpec.scala
@@ -1,0 +1,66 @@
+package zio.blocks.schema
+
+import zio.Scope
+import zio.test._
+import zio.test.Assertion._
+
+object DiffSpec extends ZIOSpecDefault {
+
+  def spec: Spec[TestEnvironment with Scope, Any] = suite("DiffSpec")(
+    suite("Record")(
+      test("recover original from patch") {
+        case class Person(name: String, age: Int)
+
+        object Person extends CompanionOptics[Person] {
+          implicit val schema: Schema[Person] = Schema.derived
+          val name: Lens[Person, String]      = field(_.name)
+          val age: Lens[Person, Int]          = field(_.age)
+        }
+
+        val person  = Person("Alice", 30)
+        val person2 = Person.name.replace(person, "Not-Alice")
+        val person3 = Person.age.replace(person2, 99)
+        val patch   = Person.schema.diff(person, person3)
+
+        assert(patch.apply(person))(isSome(equalTo(person3)))
+      },
+      test("diff to self is no-op") {
+        case class Person(name: String, age: Int)
+
+        val schema: Schema[Person] = Schema.derived
+        val person                 = Person("Bob", 25)
+        val patch                  = schema.diff(person, person)
+
+        assert(patch.apply(person))(isSome(equalTo(person)))
+      }
+    ),
+    suite("Variant")(
+      test("recover") {
+        sealed trait A
+        case class B(b: Int) extends A
+        case class C(c: Int) extends A
+
+        object B extends CompanionOptics[B] {
+          implicit val schema: Schema[B] = Schema.derived
+        }
+
+        object C extends CompanionOptics[C] {
+          implicit val schema: Schema[C] = Schema.derived
+        }
+
+        object A extends CompanionOptics[A] {
+          implicit val schema: Schema[A] = Schema.derived
+          val b: Prism[A, B]             = caseOf
+          val c: Prism[A, C]             = caseOf
+        }
+
+        val b         = B(2)
+        val c         = C(3)
+        val diff      = A.schema.diff(b, C(3))
+        val recovered = diff.apply(b)
+
+        assert(recovered)(isSome(equalTo(c)))
+      }
+    ) @@ TestAspect.ignore
+  )
+}


### PR DESCRIPTION
LambdaConf 2025 : MH-02 : Schema.diff

Adds Schema.diff to produce a patch for transforming one value to another.
Partial implementation handles the case of Reflect.Record, along with test class.