### PR TITLE
MH-05 - DynamicOptic improvements, tests and support

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/DynamicOptic.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/DynamicOptic.scala
@@ -1,6 +1,6 @@
 package zio.blocks.schema
 
-case class DynamicOptic(nodes: IndexedSeq[DynamicOptic.Node]) {
+final case class DynamicOptic(nodes: IndexedSeq[DynamicOptic.Node]) {
   import DynamicOptic.Node
 
   def apply(that: DynamicOptic): DynamicOptic = new DynamicOptic(nodes ++ that.nodes)
@@ -8,15 +8,11 @@ case class DynamicOptic(nodes: IndexedSeq[DynamicOptic.Node]) {
   def apply[F[_, _], A](reflect: Reflect[F, A]): Option[Reflect[F, A]] =
     reflect.get(this).asInstanceOf[Option[Reflect[F, A]]]
 
-  def field(name: String): DynamicOptic = new DynamicOptic(nodes :+ Node.Field(name))
-
+  def field(name: String): DynamicOptic  = new DynamicOptic(nodes :+ Node.Field(name))
   def caseOf(name: String): DynamicOptic = new DynamicOptic(nodes :+ Node.Case(name))
-
-  def elements: DynamicOptic = new DynamicOptic(nodes :+ Node.Elements)
-
-  def mapKeys: DynamicOptic = new DynamicOptic(nodes :+ Node.MapKeys)
-
-  def mapValues: DynamicOptic = new DynamicOptic(nodes :+ Node.MapValues)
+  def elements: DynamicOptic             = new DynamicOptic(nodes :+ Node.Elements)
+  def mapKeys: DynamicOptic              = new DynamicOptic(nodes :+ Node.MapKeys)
+  def mapValues: DynamicOptic            = new DynamicOptic(nodes :+ Node.MapValues)
 
   override lazy val toString: String = {
     val sb  = new StringBuilder
@@ -37,29 +33,19 @@ case class DynamicOptic(nodes: IndexedSeq[DynamicOptic.Node]) {
 }
 
 object DynamicOptic {
-  val root: DynamicOptic = new DynamicOptic(Vector.empty)
-
-  val elements: DynamicOptic = new DynamicOptic(Vector(Node.Elements))
-
-  val mapKeys: DynamicOptic = new DynamicOptic(Vector(Node.MapKeys))
-
+  val root: DynamicOptic      = new DynamicOptic(Vector.empty)
+  val elements: DynamicOptic  = new DynamicOptic(Vector(Node.Elements))
+  val mapKeys: DynamicOptic   = new DynamicOptic(Vector(Node.MapKeys))
   val mapValues: DynamicOptic = new DynamicOptic(Vector(Node.MapValues))
 
   sealed trait Node
-
   object Node {
-    case class Field(name: String) extends Node
-
-    case class Case(name: String) extends Node
-
+    final case class Field(name: String) extends Node
+    final case class Case(name: String)  extends Node
+    final case object Elements           extends Node
+    final case object MapKeys            extends Node
+    final case object MapValues          extends Node
     // case class AtIndex(index: Int)    extends Node // TODO: For At support
-
     // case class AtMapKey(key: String)  extends Node // TODO: For At support
-
-    case object Elements extends Node
-
-    case object MapKeys extends Node
-
-    case object MapValues extends Node
   }
 }


### PR DESCRIPTION
This PR extends support for `DynamicOptic` and was developed as part of LambdaConf 2025 Hackathon.

- [ ] MH-05: Write and test the full set of optics methods on `DynamicOptic`, which operate on `DynamicValue`. Note that you will need a new `DynamicOpticCheck` to accumulate all the types of errors that can occur when the wrong optic is applied to a dynamic value (or when the case is wrong, a sequence or map is empty, etc.).

⚠️  This PR is still in development.