### PR TITLE
ME-04 develop SchemaAspect[-Min, +Max]

### DIFF
--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -3,6 +3,6 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.9")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.10")
 
 // format: on

--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -3,6 +3,6 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.9")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.10")
 
 // format: on

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -3,6 +3,6 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.9")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.10")
 
 // format: on

--- a/project/project/project/project/metals.sbt
+++ b/project/project/project/project/metals.sbt
@@ -3,6 +3,6 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.9")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.10")
 
 // format: on

--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -277,6 +277,12 @@ sealed trait Reflect[F[_, _], A] extends Reflectable[A] { self =>
   }
 
   def aspect[Min, Max](aspect: SchemaAspect[Min, Max]): Reflect.Bound[A] = aspect(self.asInstanceOf[Reflect.Bound[A]])
+
+  def aspect[B](part: Optic[A, B], aspect: SchemaAspect[B, B]): Reflect.Bound[A] =
+    self
+      .updated[B](part)(innerReflect => aspect(innerReflect.asInstanceOf[Reflect.Bound[B]]).asInstanceOf[Reflect[F, B]])
+      .get
+      .asInstanceOf[Reflect.Bound[A]]
 }
 
 object Reflect {

--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -275,6 +275,8 @@ sealed trait Reflect[F[_, _], A] extends Reflectable[A] { self =>
 
     loop(this, 0).asInstanceOf[Option[Reflect[F, A]]]
   }
+
+  def aspect(aspect: SchemaAspect): Reflect.Bound[A] = aspect(self.asInstanceOf[Reflect.Bound[A]])
 }
 
 object Reflect {

--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -276,7 +276,7 @@ sealed trait Reflect[F[_, _], A] extends Reflectable[A] { self =>
     loop(this, 0).asInstanceOf[Option[Reflect[F, A]]]
   }
 
-  def aspect(aspect: SchemaAspect): Reflect.Bound[A] = aspect(self.asInstanceOf[Reflect.Bound[A]])
+  def aspect[Min, Max](aspect: SchemaAspect[Min, Max]): Reflect.Bound[A] = aspect(self.asInstanceOf[Reflect.Bound[A]])
 }
 
 object Reflect {

--- a/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
@@ -67,6 +67,10 @@ final case class Schema[A](reflect: Reflect.Bound[A]) {
 
   def updated[B](optic: Optic[A, B])(f: Reflect.Bound[B] => Reflect.Bound[B]): Option[Schema[A]] =
     reflect.updated(optic)(f).map(Schema(_))
+
+  def @@(aspect: SchemaAspect): Schema[A] = new Schema(reflect.aspect(aspect))
+
+  // def @@ (part: Optic[A, B], aspect: SchemaAspect[B, B]) = ???
 }
 
 object Schema extends SchemaVersionSpecific {

--- a/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
@@ -71,7 +71,7 @@ final case class Schema[A](reflect: Reflect.Bound[A]) {
   def @@[Min, Max](aspect: SchemaAspect[Min, Max])(implicit ev1: Max <:< A, ev2: A <:< Min): Schema[A] =
     new Schema(reflect.aspect(aspect))
 
-  // def @@ (part: Optic[A, B], aspect: SchemaAspect[B, B]) = ???
+  def @@[B](part: Optic[A, B], aspect: SchemaAspect[B, B]) = new Schema(reflect.aspect(part, aspect))
 }
 
 object Schema extends SchemaVersionSpecific {

--- a/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
@@ -68,7 +68,8 @@ final case class Schema[A](reflect: Reflect.Bound[A]) {
   def updated[B](optic: Optic[A, B])(f: Reflect.Bound[B] => Reflect.Bound[B]): Option[Schema[A]] =
     reflect.updated(optic)(f).map(Schema(_))
 
-  def @@(aspect: SchemaAspect): Schema[A] = new Schema(reflect.aspect(aspect))
+  def @@[Min, Max](aspect: SchemaAspect[Min, Max])(implicit ev1: Max <:< A, ev2: A <:< Min): Schema[A] =
+    new Schema(reflect.aspect(aspect))
 
   // def @@ (part: Optic[A, B], aspect: SchemaAspect[B, B]) = ???
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaAspect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaAspect.scala
@@ -1,24 +1,24 @@
 package zio.blocks.schema
 
-trait SchemaAspect { // [-Min, +Max] {
+trait SchemaAspect[-Min, +Max] {
 
   def apply[A](reflect: Reflect.Bound[A]): Reflect.Bound[A]
 }
 
 object SchemaAspect {
 
-  val identity: SchemaAspect = new SchemaAspect {
+  val identity: SchemaAspect[Any, Nothing] = new SchemaAspect[Any, Nothing] {
     def apply[A](reflect: Reflect.Bound[A]): Reflect.Bound[A] = reflect
   }
 
-  def doc(doc: String): SchemaAspect = new SchemaAspect {
+  def doc(doc: String): SchemaAspect[Any, Nothing] = new SchemaAspect[Any, Nothing] {
     def apply[A](reflect: Reflect.Bound[A]): Reflect.Bound[A] = reflect.doc(doc)
   }
 
-//   def examples[A](value: A, values: A): SchemaAspect = new SchemaAspect {
+  def examples[A](value: A, values: A*): SchemaAspect[A, A] = new SchemaAspect[A, A] {
 
-//     def apply[A](reflect: Reflect.Bound[A]): Reflect.Bound[A] =
-//       reflect.examples(value.asInstanceOf[A], values.asInstanceOf[Seq[A]]: _*)
-//   }
+    def apply[A](reflect: Reflect.Bound[A]): Reflect.Bound[A] =
+      reflect.examples(value.asInstanceOf[A], values.asInstanceOf[Seq[A]]: _*)
+  }
 
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaAspect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaAspect.scala
@@ -1,0 +1,24 @@
+package zio.blocks.schema
+
+trait SchemaAspect { // [-Min, +Max] {
+
+  def apply[A](reflect: Reflect.Bound[A]): Reflect.Bound[A]
+}
+
+object SchemaAspect {
+
+  val identity: SchemaAspect = new SchemaAspect {
+    def apply[A](reflect: Reflect.Bound[A]): Reflect.Bound[A] = reflect
+  }
+
+  def doc(doc: String): SchemaAspect = new SchemaAspect {
+    def apply[A](reflect: Reflect.Bound[A]): Reflect.Bound[A] = reflect.doc(doc)
+  }
+
+//   def examples[A](value: A, values: A): SchemaAspect = new SchemaAspect {
+
+//     def apply[A](reflect: Reflect.Bound[A]): Reflect.Bound[A] =
+//       reflect.examples(value.asInstanceOf[A], values.asInstanceOf[Seq[A]]: _*)
+//   }
+
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaAspectSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaAspectSpec.scala
@@ -20,7 +20,7 @@ object SchemaAspectSpec extends ZIOSpecDefault {
         final case class Person(name: String, age: Int)
         implicit val schema: Schema[Person] = Schema.derived
 
-        val doc = "Person data`type"
+        val doc = "Person data type"
 
         val updatedSchema = schema @@ SchemaAspect.doc(doc)
 
@@ -35,6 +35,25 @@ object SchemaAspectSpec extends ZIOSpecDefault {
         val updatedSchema = schema @@ SchemaAspect.examples(p)
 
         assert(updatedSchema.examples)(equalTo(Seq(p)))
+      },
+      test("update doc of a field") {
+        final case class Person(name: String, age: Int)
+
+        object Person extends CompanionOptics[Person] {
+          implicit val schema: Schema[Person] = Schema.derived
+
+          val nameLens: Lens[Person, String] = field(_.name)
+          val ageLens: Lens[Person, Int]     = field(_.age)
+        }
+        import Person._
+
+        val p = Person("Jaro", 34)
+
+        val doc = "name of the person"
+
+        val updatedSchema = schema @@ (Person.nameLens, SchemaAspect.doc(doc))
+
+        assert(updatedSchema.get(Person.nameLens).get.doc)(equalTo(Doc.Text(doc)))
       }
     )
 }

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaAspectSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaAspectSpec.scala
@@ -6,20 +6,24 @@ import zio.test._
 
 object SchemaAspectSpec extends ZIOSpecDefault {
 
+  final case class Person(name: String, age: Int)
+
+  object Person extends CompanionOptics[Person] {
+    implicit val schema: Schema[Person] = Schema.derived
+
+    val nameLens: Lens[Person, String] = field(_.name)
+    val ageLens: Lens[Person, Int]     = field(_.age)
+  }
+  import Person._
+
   def spec: Spec[TestEnvironment with Scope, Any] =
     suite("SchemaAspectSpec")(
       test("identity aspect") {
-        final case class Person(name: String, age: Int)
-        implicit val schema: Schema[Person] = Schema.derived
-
         val updatedSchema = schema @@ SchemaAspect.identity
 
         assert(updatedSchema)(equalTo(schema))
       },
       test("doc aspect") {
-        final case class Person(name: String, age: Int)
-        implicit val schema: Schema[Person] = Schema.derived
-
         val doc = "Person data type"
 
         val updatedSchema = schema @@ SchemaAspect.doc(doc)
@@ -27,9 +31,6 @@ object SchemaAspectSpec extends ZIOSpecDefault {
         assert(updatedSchema.doc)(equalTo(Doc.Text(doc)))
       },
       test("example aspect") {
-        final case class Person(name: String, age: Int)
-        implicit val schema: Schema[Person] = Schema.derived
-
         val p = Person("Jaro", 34)
 
         val updatedSchema = schema @@ SchemaAspect.examples(p)
@@ -37,18 +38,6 @@ object SchemaAspectSpec extends ZIOSpecDefault {
         assert(updatedSchema.examples)(equalTo(Seq(p)))
       },
       test("update doc of a field") {
-        final case class Person(name: String, age: Int)
-
-        object Person extends CompanionOptics[Person] {
-          implicit val schema: Schema[Person] = Schema.derived
-
-          val nameLens: Lens[Person, String] = field(_.name)
-          val ageLens: Lens[Person, Int]     = field(_.age)
-        }
-        import Person._
-
-        val p = Person("Jaro", 34)
-
         val doc = "name of the person"
 
         val updatedSchema = schema @@ (Person.nameLens, SchemaAspect.doc(doc))

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaAspectSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaAspectSpec.scala
@@ -25,20 +25,16 @@ object SchemaAspectSpec extends ZIOSpecDefault {
         val updatedSchema = schema @@ SchemaAspect.doc(doc)
 
         assert(updatedSchema.doc)(equalTo(Doc.Text(doc)))
+      },
+      test("example aspect") {
+        final case class Person(name: String, age: Int)
+        implicit val schema: Schema[Person] = Schema.derived
+
+        val p = Person("Jaro", 34)
+
+        val updatedSchema = schema @@ SchemaAspect.examples(p)
+
+        assert(updatedSchema.examples)(equalTo(Seq(p)))
       }
-    //   test("example aspect") {
-    //     final case class Person(name: String, age: Int)
-    //     implicit val schema: Schema[Person] = Schema.derived
-
-    //     val p = Person("Jaro", 34)
-
-    //     case class Hey(name: String)
-
-    //     val h = Hey("aaa")
-
-    //     val updatedSchema = schema @@ SchemaAspect.examples(h)
-
-    //     assert(updatedSchema.examples)(equalTo(Seq(p)))
-    //   }
     )
 }

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaAspectSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaAspectSpec.scala
@@ -1,0 +1,44 @@
+package zio.blocks.schema
+
+import zio.Scope
+import zio.test.Assertion._
+import zio.test._
+
+object SchemaAspectSpec extends ZIOSpecDefault {
+
+  def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("SchemaAspectSpec")(
+      test("identity aspect") {
+        final case class Person(name: String, age: Int)
+        implicit val schema: Schema[Person] = Schema.derived
+
+        val updatedSchema = schema @@ SchemaAspect.identity
+
+        assert(updatedSchema)(equalTo(schema))
+      },
+      test("doc aspect") {
+        final case class Person(name: String, age: Int)
+        implicit val schema: Schema[Person] = Schema.derived
+
+        val doc = "Person data`type"
+
+        val updatedSchema = schema @@ SchemaAspect.doc(doc)
+
+        assert(updatedSchema.doc)(equalTo(Doc.Text(doc)))
+      }
+    //   test("example aspect") {
+    //     final case class Person(name: String, age: Int)
+    //     implicit val schema: Schema[Person] = Schema.derived
+
+    //     val p = Person("Jaro", 34)
+
+    //     case class Hey(name: String)
+
+    //     val h = Hey("aaa")
+
+    //     val updatedSchema = schema @@ SchemaAspect.examples(h)
+
+    //     assert(updatedSchema.examples)(equalTo(Seq(p)))
+    //   }
+    )
+}


### PR DESCRIPTION
This PR adds support SchemaAspect[-Min, +Max]

Requirements:
ME-04: Develop, implement, and test a suite of SchemaAspect[-Min, +Max], which are transformers on Reflect.Bound[A] => Reflect.Bound[A] for any A between Min and Max. Then add and test a method to Schema called @@ to apply a schema aspect to either the schema as a whole (def @@ (aspect: SchemaAspect[A, A])), or to a specified subtree of the schema (def @@ (part: Optic[A, B], aspect: SchemaAspect[B, B])). Note that any schema aspect with Min = Any and Max = Nothing can be applied not just to a single node, but recursively to all nodes. Rather than have to deal with this choice of “flat” versus “recursive”, we can just have two aspects, one for point-wise application, and another for recursive application. Some example aspects:
SchemaAspect.identity: Does nothing
SchemaAspect.examples(a, b, c): Attaches examples
SchemaAspect.doc(doc: String/Doc): Attaches docs
Etc.


This PR is still in development.