### PR TITLE
reinstate Variant's caseByName method

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -543,6 +543,12 @@ object Reflect {
 
     def binding(implicit F: HasBinding[F]): Binding[BindingType.Variant, A] = F.binding(variantBinding)
 
+    def caseByName(name: String): Option[Term[F, A, ? <: A]] = {
+      val idx = caseIndexByName.getOrDefault(name, -1)
+      if (idx >= 0) new Some(cases(idx))
+      else None
+    }
+
     private[schema] def caseIndexByName(name: String): Int = caseIndexByName.getOrDefault(name, -1)
 
     def discriminator(implicit F: HasBinding[F]): Discriminator[A] = F.discriminator(variantBinding)


### PR DESCRIPTION
this method is useful when decoding Variants eg I have case name persisted by encoder and am using this method in the decoder to select the Variant