### PR TITLE
More efficient conversions from/to dynamic value

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -509,7 +509,7 @@ object Reflect {
     ): Either[SchemaError, A] =
       value match {
         case DynamicValue.Variant(discriminator, value) =>
-          val idx = caseIndexByName(discriminator)
+          val idx = caseIndexByName.get(discriminator)
           if (idx >= 0) {
             val case_ = cases(idx)
             case_.value
@@ -546,10 +546,7 @@ object Reflect {
 
     def toDynamicValue(value: A)(implicit F: HasBinding[F]): DynamicValue = {
       val case_ = cases(discriminator.discriminate(value))
-      new DynamicValue.Variant(
-        case_.name,
-        case_.value.asInstanceOf[Reflect[F, case_.Focus]].toDynamicValue(value.asInstanceOf[case_.Focus])
-      )
+      new DynamicValue.Variant(case_.name, case_.value.asInstanceOf[Reflect[F, A]].toDynamicValue(value))
     }
 
     def transform[G[_, _]](path: DynamicOptic, f: ReflectTransformer[F, G]): Lazy[Variant[G, A]] =


### PR DESCRIPTION
Tested Intel(R) Core(TM) i7-11800H @ 2.30GHz with JDK-21

### Before
```txt
[info] Benchmark                                Mode  Cnt        Score       Error  Units
[info] DynamicValueBenchmark.fromDynamicValue  thrpt    5  3420255.610 ± 15551.453  ops/s
[info] DynamicValueBenchmark.toDynamicValue    thrpt    5  3963595.193 ± 45916.986  ops/s
```

### After
```txt
[info] Benchmark                                Mode  Cnt        Score       Error  Units
[info] DynamicValueBenchmark.fromDynamicValue  thrpt    5  4277512.142 ± 36442.450  ops/s
[info] DynamicValueBenchmark.toDynamicValue    thrpt    5  5652314.755 ± 27196.376  ops/s
```