### PR TITLE
Providing Binding in Deriver

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
@@ -74,7 +74,8 @@ final case class DerivationBuilder[TC[_], A](
             modifiers: Seq[Modifier.Record]
           ): Lazy[Reflect.Record[G, A]] = {
             val instance = getCustomInstance[A](path).getOrElse(
-              deriver.deriveRecord(fields, typeName, doc, modifiers ++ extraModifiers(Reflect.Type.Record, path))
+              deriver
+                .deriveRecord(fields, typeName, metadata, doc, modifiers ++ extraModifiers(Reflect.Type.Record, path))
             )
             Lazy(Reflect.Record(fields, typeName, BindingInstance(metadata, instance), doc, modifiers))
           }
@@ -88,7 +89,8 @@ final case class DerivationBuilder[TC[_], A](
             modifiers: Seq[Modifier.Variant]
           ): Lazy[Reflect.Variant[G, A]] = {
             val instance = getCustomInstance[A](path).getOrElse(
-              deriver.deriveVariant(cases, typeName, doc, modifiers ++ extraModifiers(Reflect.Type.Variant, path))
+              deriver
+                .deriveVariant(cases, typeName, metadata, doc, modifiers ++ extraModifiers(Reflect.Type.Variant, path))
             )
             Lazy(Reflect.Variant(cases, typeName, BindingInstance(metadata, instance), doc, modifiers))
           }
@@ -102,7 +104,13 @@ final case class DerivationBuilder[TC[_], A](
             modifiers: Seq[Modifier.Seq]
           ): Lazy[Reflect.Sequence[G, A, C]] = {
             val instance = getCustomInstance[C[A]](path).getOrElse(
-              deriver.deriveSequence(element, typeName, doc, modifiers ++ extraModifiers(Reflect.Type.Sequence(), path))
+              deriver.deriveSequence(
+                element,
+                typeName,
+                metadata,
+                doc,
+                modifiers ++ extraModifiers(Reflect.Type.Sequence(), path)
+              )
             )
             Lazy(Reflect.Sequence(element, typeName, BindingInstance(metadata, instance), doc, modifiers))
           }
@@ -117,7 +125,8 @@ final case class DerivationBuilder[TC[_], A](
             modifiers: Seq[Modifier.Map]
           ): Lazy[Reflect.Map[G, Key, Value, M]] = {
             val instance = getCustomInstance[M[Key, Value]](path).getOrElse(
-              deriver.deriveMap(key, value, typeName, doc, modifiers ++ extraModifiers(Reflect.Type.Map(), path))
+              deriver
+                .deriveMap(key, value, typeName, metadata, doc, modifiers ++ extraModifiers(Reflect.Type.Map(), path))
             )
             Lazy(Reflect.Map(key, value, typeName, BindingInstance(metadata, instance), doc, modifiers))
           }
@@ -129,7 +138,9 @@ final case class DerivationBuilder[TC[_], A](
             modifiers: Seq[Modifier.Dynamic]
           ): Lazy[Reflect.Dynamic[G]] = {
             val instance = getCustomInstance[DynamicValue](path)
-              .getOrElse(deriver.deriveDynamic[G](doc, modifiers ++ extraModifiers(Reflect.Type.Dynamic, path)))
+              .getOrElse(
+                deriver.deriveDynamic[G](metadata, doc, modifiers ++ extraModifiers(Reflect.Type.Dynamic, path))
+              )
             Lazy(Reflect.Dynamic(BindingInstance(metadata, instance), doc, modifiers))
           }
 
@@ -145,6 +156,7 @@ final case class DerivationBuilder[TC[_], A](
               deriver.derivePrimitive(
                 primitiveType,
                 typeName,
+                metadata,
                 doc,
                 modifiers ++ extraModifiers(Reflect.Type.Primitive, path)
               )

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/Deriver.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/Deriver.scala
@@ -1,7 +1,7 @@
 package zio.blocks.schema.derive
 
 import zio.blocks.schema._
-import zio.blocks.schema.binding.{Binding, HasBinding}
+import zio.blocks.schema.binding._
 
 trait Deriver[TC[_]] { self =>
   type HasInstance[F[_, _]] = zio.blocks.schema.derive.HasInstance[F, TC]
@@ -13,6 +13,7 @@ trait Deriver[TC[_]] { self =>
   def derivePrimitive[F[_, _], A](
     primitiveType: PrimitiveType[A],
     typeName: TypeName[A],
+    binding: Binding[BindingType.Primitive, A],
     doc: Doc,
     modifiers: Seq[Modifier.Primitive]
   ): Lazy[TC[A]]
@@ -20,6 +21,7 @@ trait Deriver[TC[_]] { self =>
   def deriveRecord[F[_, _], A](
     fields: IndexedSeq[Term[F, A, ?]],
     typeName: TypeName[A],
+    binding: Binding[BindingType.Record, A],
     doc: Doc,
     modifiers: Seq[Modifier.Record]
   )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TC[A]]
@@ -27,6 +29,7 @@ trait Deriver[TC[_]] { self =>
   def deriveVariant[F[_, _], A](
     cases: IndexedSeq[Term[F, A, ?]],
     typeName: TypeName[A],
+    binding: Binding[BindingType.Variant, A],
     doc: Doc,
     modifiers: Seq[Modifier.Variant]
   )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TC[A]]
@@ -34,6 +37,7 @@ trait Deriver[TC[_]] { self =>
   def deriveSequence[F[_, _], C[_], A](
     element: Reflect[F, A],
     typeName: TypeName[C[A]],
+    binding: Binding[BindingType.Seq[C], C[A]],
     doc: Doc,
     modifiers: Seq[Modifier.Seq]
   )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TC[C[A]]]
@@ -42,11 +46,13 @@ trait Deriver[TC[_]] { self =>
     key: Reflect[F, K],
     value: Reflect[F, V],
     typeName: TypeName[M[K, V]],
+    binding: Binding[BindingType.Map[M], M[K, V]],
     doc: Doc,
     modifiers: Seq[Modifier.Map]
   )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TC[M[K, V]]]
 
   def deriveDynamic[F[_, _]](
+    binding: Binding[BindingType.Dynamic, DynamicValue],
     doc: Doc,
     modifiers: Seq[Modifier.Dynamic]
   )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TC[DynamicValue]]

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
@@ -1285,6 +1285,7 @@ object SchemaSpec extends ZIOSpecDefault {
           override def derivePrimitive[F[_, _], A](
             primitiveType: PrimitiveType[A],
             typeName: TypeName[A],
+            binding: Binding[BindingType.Primitive, A],
             doc: Doc,
             modifiers: Seq[Modifier.Primitive]
           ): Lazy[TextCodec[A]] =
@@ -1297,6 +1298,7 @@ object SchemaSpec extends ZIOSpecDefault {
           override def deriveRecord[F[_, _], A](
             fields: IndexedSeq[Term[F, A, _]],
             typeName: TypeName[A],
+            binding: Binding[BindingType.Record, A],
             doc: Doc,
             modifiers: Seq[Modifier.Record]
           )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TextCodec[A]] =
@@ -1309,6 +1311,7 @@ object SchemaSpec extends ZIOSpecDefault {
           override def deriveVariant[F[_, _], A](
             cases: IndexedSeq[Term[F, A, _]],
             typeName: TypeName[A],
+            binding: Binding[BindingType.Variant, A],
             doc: Doc,
             modifiers: Seq[Modifier.Variant]
           )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TextCodec[A]] =
@@ -1321,6 +1324,7 @@ object SchemaSpec extends ZIOSpecDefault {
           override def deriveSequence[F[_, _], C[_], A](
             element: Reflect[F, A],
             typeName: TypeName[C[A]],
+            binding: Binding[BindingType.Seq[C], C[A]],
             doc: Doc,
             modifiers: Seq[Modifier.Seq]
           )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TextCodec[C[A]]] =
@@ -1334,6 +1338,7 @@ object SchemaSpec extends ZIOSpecDefault {
             key: Reflect[F, K],
             value: Reflect[F, V],
             typeName: TypeName[M[K, V]],
+            binding: Binding[BindingType.Map[M], M[K, V]],
             doc: Doc,
             modifiers: Seq[Modifier.Map]
           )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TextCodec[M[K, V]]] =
@@ -1343,7 +1348,11 @@ object SchemaSpec extends ZIOSpecDefault {
               override def decode(input: CharBuffer): Either[SchemaError, M[K, V]] = ???
             })
 
-          override def deriveDynamic[F[_, _]](doc: Doc, modifiers: Seq[Modifier.Dynamic])(implicit
+          override def deriveDynamic[F[_, _]](
+            binding: Binding[BindingType.Dynamic, DynamicValue],
+            doc: Doc,
+            modifiers: Seq[Modifier.Dynamic]
+          )(implicit
             F: HasBinding[F],
             D: HasInstance[F]
           ): Lazy[TextCodec[DynamicValue]] =


### PR DESCRIPTION
When using `Deriver` to derive some codec, we need access to `Binding` in order to be able to use `constructor` and `deconstructor`.