### PR TITLE
Update scalafmt to 3.9.9 and switch to Scala 3 formatting + add more benchmarks for named tuples

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.8.2"
+version = "3.9.9"
 maxColumn = 120
 align.preset = most
 align.multiline = false
@@ -11,7 +11,7 @@ includeCurlyBraceInSelectChains = false
 danglingParentheses.preset = true
 optIn.annotationNewlines = true
 newlines.alwaysBeforeMultilineDef = false
-runner.dialect = scala213
+runner.dialect = scala3
 rewrite.rules = [RedundantBraces]
 
 project.excludePaths = ["glob:**/scalafix/input/**", "glob:**/scalafix/output/**"]

--- a/benchmarks/src/main/scala/zio/blocks/schema/LensBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/blocks/schema/LensBenchmark.scala
@@ -42,21 +42,20 @@ class LensReplaceBenchmark extends BaseBenchmark {
   def zioBlocks: A = A.b_c_d_e_s.replace(a, "test2")
 }
 
-/* FIXME: sbt fmt fails to format it
-class NamedTupleLensBenchmark extends BaseBenchmark {
+class NamedTupleLensGetBenchmark extends BaseBenchmark {
   import zio.blocks.schema.LensDomain._
 
   var namedTuple: NamedTuple25 = (
-    s01 = "",
-    s02 = "",
-    s03 = "",
-    s04 = "",
-    s05 = "",
-    s06 = "",
-    s07 = "",
-    s08 = "",
-    s09 = "",
-    s10 = "",
+    i01 = 1,
+    i02 = 2,
+    i03 = 3,
+    i04 = 4,
+    i05 = 5,
+    i06 = 6,
+    i07 = 7,
+    i08 = 8,
+    i09 = 9,
+    i10 = 10,
     s11 = "",
     s12 = "",
     s13 = "",
@@ -75,12 +74,51 @@ class NamedTupleLensBenchmark extends BaseBenchmark {
   )
 
   @Benchmark
-  def get: String = NamedTuple25.s25.get(namedTuple)
+  def direct: String = namedTuple.s25
 
   @Benchmark
-  def replace: NamedTuple25 = NamedTuple25.s25.replace(namedTuple, "test")
+  def zioBlocks: String = NamedTuple25.s25.get(namedTuple)
 }
- */
+
+import chanterelle._
+
+class NamedTupleLensReplaceBenchmark extends BaseBenchmark {
+  import zio.blocks.schema.LensDomain._
+
+  var namedTuple: NamedTuple25 = (
+    i01 = 1,
+    i02 = 2,
+    i03 = 3,
+    i04 = 4,
+    i05 = 5,
+    i06 = 6,
+    i07 = 7,
+    i08 = 8,
+    i09 = 9,
+    i10 = 10,
+    s11 = "",
+    s12 = "",
+    s13 = "",
+    s14 = "",
+    s15 = "",
+    s16 = "",
+    s17 = "",
+    s18 = "",
+    s19 = "",
+    s20 = "",
+    s21 = "",
+    s22 = "",
+    s23 = "",
+    s24 = "",
+    s25 = ""
+  )
+
+  @Benchmark
+  def chanterelle: NamedTuple25 = namedTuple.transform(_.update(_.s25)(_ => "test"))
+
+  @Benchmark
+  def zioBlocks: NamedTuple25 = NamedTuple25.s25.replace(namedTuple, "test")
+}
 
 object LensDomain {
   case class E(s: String)
@@ -110,18 +148,18 @@ object LensDomain {
     val b_c_d_e_s_monocle: PLens[A, A, String, String] =
       Focus[A](_.b).andThen(Focus[B](_.c)).andThen(Focus[C](_.d)).andThen(Focus[D](_.e)).andThen(Focus[E](_.s))
   }
-  /* FIXME: sbt fmt fails to format it
+
   type NamedTuple25 = (
-    s01: String,
-    s02: String,
-    s03: String,
-    s04: String,
-    s05: String,
-    s06: String,
-    s07: String,
-    s08: String,
-    s09: String,
-    s10: String,
+    i01: Int,
+    i02: Int,
+    i03: Int,
+    i04: Int,
+    i05: Int,
+    i06: Int,
+    i07: Int,
+    i08: Int,
+    i09: Int,
+    i10: Int,
     s11: String,
     s12: String,
     s13: String,
@@ -143,5 +181,4 @@ object LensDomain {
     implicit val schema: Schema[NamedTuple25] = Schema.derived
     val s25: Lens[NamedTuple25, String]       = $(_.s25)
   }
-   */
 }

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ inThisBuild(
   List(
     organization := "dev.zio",
     homepage     := Some(url("https://zio.dev")),
-    licenses := List(
+    licenses     := List(
       "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")
     ),
     developers := List(
@@ -140,19 +140,21 @@ lazy val benchmarks = project
   .settings(
     crossScalaVersions       := Seq("3.7.2"),
     ThisBuild / scalaVersion := "3.7.2",
-    publish / skip           := true,
     libraryDependencies ++= Seq(
+      "io.github.arainko"          %% "chanterelle"   % "0.1.0",
       "com.softwaremill.quicklens" %% "quicklens"     % "1.9.12",
       "dev.optics"                 %% "monocle-core"  % "3.3.0",
       "dev.optics"                 %% "monocle-macro" % "3.3.0",
       "dev.zio"                    %% "zio-test"      % "2.1.20" % Test,
       "dev.zio"                    %% "zio-test-sbt"  % "2.1.20" % Test
     ),
-    assembly / assemblyJarName := "benchmarks.jar",
+    assembly / assemblyJarName       := "benchmarks.jar",
     assembly / assemblyMergeStrategy := {
       case PathList("module-info.class") => MergeStrategy.discard
       case path                          => MergeStrategy.defaultMergeStrategy(path)
     },
     assembly / fullClasspath := (Jmh / fullClasspath).value,
-    assembly / mainClass     := Some("org.openjdk.jmh.Main")
+    assembly / mainClass     := Some("org.openjdk.jmh.Main"),
+    publish / skip           := true,
+    mimaPreviousArtifacts    := Set()
   )

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -48,7 +48,7 @@ object BuildHelper {
       case Some((3, _))  => Seq("2.13+")
       case _             => Seq()
     }
-    platformSpecificSources(platform, conf, baseDir)(versions *)
+    platformSpecificSources(platform, conf, baseDir)(versions*)
   }
 
   def crossProjectSettings: Seq[Def.Setting[?]] = Seq(
@@ -74,7 +74,7 @@ object BuildHelper {
     name                     := prjName,
     crossScalaVersions       := Seq(Scala213, Scala3),
     ThisBuild / scalaVersion := Scala213,
-    ThisBuild / publishTo := {
+    ThisBuild / publishTo    := {
       val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
       if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
       else localStaging.value

--- a/scalaNextTests/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
+++ b/scalaNextTests/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
@@ -57,9 +57,9 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
       test("derives schema for complex named tuples") {
         case class Product(i: Int, s: String)
 
-        val value1 = (i = 1, s = "VVV")
-        val value2 = (i = (1, 2L), s = ("VVV", "WWW"))
-        val value3 = (i = Some(1), s = Some("VVV"))
+        val value1         = (i = 1, s = "VVV")
+        val value2         = (i = (1, 2L), s = ("VVV", "WWW"))
+        val value3         = (i = Some(1), s = Some("VVV"))
         val expectedFields =
           Vector(Schema[Int].reflect.asTerm("i"), Schema[String].reflect.asTerm("s"))
         val schema1: Schema[NamedTuple.NamedTuple[("i", "s"), Int *: String *: EmptyTuple]] = Schema.derived
@@ -226,7 +226,7 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
         }
 
         val record = NamedTuple24.schema.reflect.asRecord
-        val value = (
+        val value  = (
           i1 = 1,
           i2 = 2,
           i3 = 3,

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaVersionSpecific.scala
@@ -13,7 +13,7 @@ trait SchemaVersionSpecific {
 }
 
 private object SchemaVersionSpecific {
-  private[this] val isNonRecursiveCache = TrieMap.empty[Any, Boolean]
+  private[this] val isNonRecursiveCache                                = TrieMap.empty[Any, Boolean]
   private[this] implicit val fullNameOrdering: Ordering[Array[String]] = new Ordering[Array[String]] {
     override def compare(x: Array[String], y: Array[String]): Int = {
       val minLen = Math.min(x.length, y.length)
@@ -61,7 +61,7 @@ private object SchemaVersionSpecific {
       if (comp.isModule) comp
       else {
         val ownerChainOf = (s: Symbol) => Iterator.iterate(s)(_.owner).takeWhile(_ != NoSymbol).toArray.reverseIterator
-        val path = ownerChainOf(tpe.typeSymbol)
+        val path         = ownerChainOf(tpe.typeSymbol)
           .zipAll(ownerChainOf(enclosingOwner), NoSymbol, NoSymbol)
           .dropWhile(x => x._1 == x._2)
           .takeWhile(x => x._1 != NoSymbol)
@@ -154,7 +154,7 @@ private object SchemaVersionSpecific {
       val tpeSymbol = tpe.typeSymbol
       var name      = NameTransformer.decode(tpeSymbol.name.toString)
       val comp      = companion(tpe)
-      var owner =
+      var owner     =
         if (comp == null) tpeSymbol
         else if (comp == NoSymbol) {
           name += ".type"
@@ -252,7 +252,7 @@ private object SchemaVersionSpecific {
               getters.getOrElse(name, fail(s"Cannot find '$name' parameter of '$tpe' in the primary constructor."))
             val anns        = annotations.getOrElse(name, Nil)
             val isTransient = anns.exists(_.tree.tpe =:= typeOf[Modifier.transient])
-            val config = anns
+            val config      = anns
               .filter(_.tree.tpe =:= typeOf[Modifier.config])
               .collect(_.tree.children match {
                 case List(_, Literal(Constant(k: String)), Literal(Constant(v: String))) => (k, v)
@@ -297,7 +297,7 @@ private object SchemaVersionSpecific {
           val fTpe         = fieldInfo.tpe
           lazy val bytes   = RegisterOffset.getBytes(fieldInfo.usedRegisters)
           lazy val objects = RegisterOffset.getObjects(fieldInfo.usedRegisters)
-          val constructor =
+          val constructor  =
             if (fTpe =:= definitions.IntTpe) q"in.getInt(baseOffset, $bytes)"
             else if (fTpe =:= definitions.FloatTpe) q"in.getFloat(baseOffset, $bytes)"
             else if (fTpe =:= definitions.LongTpe) q"in.getLong(baseOffset, $bytes)"
@@ -414,7 +414,7 @@ private object SchemaVersionSpecific {
         if (subTypes.isEmpty) fail(s"Cannot find sub-types for ADT base '$tpe'.")
         var minFullName: Array[String] = null
         var maxFullName: Array[String] = null
-        val fullNames = subTypes.map { sTpe =>
+        val fullNames                  = subTypes.map { sTpe =>
           val (packages, values, name) = typeName(sTpe)
           val fullName                 = toFullName(packages, values, name)
           if (minFullName eq null) {
@@ -495,7 +495,7 @@ private object SchemaVersionSpecific {
       } else fail(s"Cannot derive schema for '$tpe'.")
     }
 
-    val schema = deriveSchema(weakTypeOf[A].dealias)
+    val schema      = deriveSchema(weakTypeOf[A].dealias)
     val schemaBlock =
       q"""{
             import _root_.zio.blocks.schema._

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/CompanionOptics.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/CompanionOptics.scala
@@ -510,7 +510,7 @@ private object CompanionOptics {
         val (parent, idx) = term match {
           case Apply(Apply(_, List(p)), List(Literal(IntConstant(i))))                => (p, i)
           case Apply(TypeApply(Select(p, "apply"), _), List(Literal(IntConstant(i)))) => (p, i)
-          case _ =>
+          case _                                                                      =>
             fail(
               s"Expected path elements: .<field>, .when[<T>], .at(<index>), .atIndices(<indices>), .atKey(<key>), .atKeys(<keys>), .each, .eachKey, .eachValue, or .wrapped[<T>], got: '${term.show}'"
             )

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaVersionSpecific.scala
@@ -11,7 +11,7 @@ trait SchemaVersionSpecific {
 }
 
 private object SchemaVersionSpecific {
-  private val isNonRecursiveCache = TrieMap.empty[Any, Boolean]
+  private val isNonRecursiveCache                                = TrieMap.empty[Any, Boolean]
   private implicit val fullNameOrdering: Ordering[Array[String]] = new Ordering[Array[String]] {
     override def compare(x: Array[String], y: Array[String]): Int = {
       val minLen = Math.min(x.length, y.length)
@@ -139,7 +139,7 @@ private object SchemaVersionSpecific {
         if (symbol.isType) {
           val nudeSubtype = TypeIdent(symbol).tpe
           nudeSubtype.memberType(symbol.primaryConstructor) match {
-            case MethodType(_, _, _) => nudeSubtype
+            case MethodType(_, _, _)                => nudeSubtype
             case PolyType(names, bounds, resPolyTp) =>
               val binding = typeArgs(nudeSubtype.baseType(tpe.typeSymbol))
                 .zip(typeArgs(tpe))
@@ -274,7 +274,7 @@ private object SchemaVersionSpecific {
         derivedSchemaRefs
           .getOrElse(
             tpe, {
-              val name = "s" + derivedSchemaRefs.size
+              val name  = "s" + derivedSchemaRefs.size
               val flags =
                 if (isNonRecursive(tpe)) Flags.Implicit
                 else Flags.Implicit | Flags.Lazy
@@ -391,7 +391,7 @@ private object SchemaVersionSpecific {
               getter = getters.head
             }
             val isTransient = getter.annotations.exists(_.tpe =:= TypeRepr.of[Modifier.transient])
-            val config = getter.annotations
+            val config      = getter.annotations
               .filter(_.tpe =:= TypeRepr.of[Modifier.config])
               .collect { case Apply(_, List(Literal(StringConstant(k)), Literal(StringConstant(v)))) => (k, v) }
               .reverse
@@ -438,7 +438,7 @@ private object SchemaVersionSpecific {
               var name = fieldInfo.name
               if (idx < names.length) name = names(idx)
               var fieldTermExpr = '{ $reflectExpr.asTerm[S](${ Expr(name) }) }
-              var modifiers = fieldInfo.config.map { case (k, v) =>
+              var modifiers     = fieldInfo.config.map { case (k, v) =>
                 '{ Modifier.config(${ Expr(k) }, ${ Expr(v) }) }.asExprOf[Modifier.Term]
               }
               if (fieldInfo.isTransient) modifiers = modifiers :+ '{ Modifier.transient() }.asExprOf[Modifier.Term]
@@ -450,7 +450,7 @@ private object SchemaVersionSpecific {
 
       def constructor(in: Expr[Registers], baseOffset: Expr[RegisterOffset])(using Quotes): Expr[T] = {
         val constructorNoTypes = Select(New(Inferred(tpe)), primaryConstructor)
-        val constructor = typeArgs(tpe) match {
+        val constructor        = typeArgs(tpe) match {
           case Nil      => constructorNoTypes
           case typeArgs => TypeApply(constructorNoTypes, typeArgs.map(Inferred(_)))
         }
@@ -528,10 +528,10 @@ private object SchemaVersionSpecific {
       def constructor(in: Expr[Registers], baseOffset: Expr[RegisterOffset])(using Quotes): Expr[T] =
         (if (fieldInfos.isEmpty) Expr(EmptyTuple)
          else {
-           val args   = fieldInfos.map(fieldInfo => fieldConstructor(in, baseOffset, fieldInfo))
-           val sym    = Symbol.newVal(Symbol.spliceOwner, "as", TypeRepr.of[Array[Any]], Flags.EmptyFlags, Symbol.noSymbol)
-           val ref    = Ref(sym).asExprOf[Array[Any]]
-           val valDef = ValDef(sym, Some('{ new Array[Any](${ Expr(fieldInfos.size) }) }.asTerm))
+           val args        = fieldInfos.map(fieldInfo => fieldConstructor(in, baseOffset, fieldInfo))
+           val sym         = Symbol.newVal(Symbol.spliceOwner, "as", TypeRepr.of[Array[Any]], Flags.EmptyFlags, Symbol.noSymbol)
+           val ref         = Ref(sym).asExprOf[Array[Any]]
+           val valDef      = ValDef(sym, Some('{ new Array[Any](${ Expr(fieldInfos.size) }) }.asTerm))
            val assignments = args.map {
              var i = -1
              term =>
@@ -683,7 +683,7 @@ private object SchemaVersionSpecific {
         }
 
         val isUnionType = isUnion(tpe)
-        val subTypes =
+        val subTypes    =
           if (isUnionType) allUnionTypes(tpe).distinct
           else directSubTypes(tpe)
         if (subTypes.isEmpty) fail(s"Cannot find sub-types for ADT base '${tpe.show}'.")
@@ -692,7 +692,7 @@ private object SchemaVersionSpecific {
           toFullName(packages, values, name)
         }
         val (packages, values, name) = typeName(tpe)
-        val maxCommonPrefixLength = {
+        val maxCommonPrefixLength    = {
           var minFullName = fullNames.min
           var maxFullName = fullNames.max
           if (!isUnionType) {
@@ -757,7 +757,7 @@ private object SchemaVersionSpecific {
       } else if (isNamedTuple(tpe)) {
         tpe match {
           case AppliedType(_, List(tpe1, tpe2)) =>
-            val nTpe = tpe1.dealias
+            val nTpe          = tpe1.dealias
             val nameOverrides = {
               if (isGenericTuple(nTpe)) genericTupleTypeArgs(nTpe.asType)
               else typeArgs(nTpe)

--- a/schema/shared/src/main/scala/zio/blocks/schema/Lazy.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Lazy.scala
@@ -62,7 +62,8 @@ sealed trait Lazy[+A] {
            error = e
            throw e
        }
-     } else value).asInstanceOf[A]
+     } else value)
+    .asInstanceOf[A]
   }
 
   final def isEvaluated: Boolean = value != null || (error ne null)

--- a/schema/shared/src/main/scala/zio/blocks/schema/Namespace.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Namespace.scala
@@ -5,9 +5,9 @@ final case class Namespace(packages: Seq[String], values: Seq[String]) {
 }
 
 object Namespace {
-  private[schema] val javaTime: Namespace = new Namespace("java" :: "time" :: Nil, Nil)
-  private[schema] val javaUtil: Namespace = new Namespace("java" :: "util" :: Nil, Nil)
-  private[schema] val scala: Namespace    = new Namespace("scala" :: Nil, Nil)
+  private[schema] val javaTime: Namespace                 = new Namespace("java" :: "time" :: Nil, Nil)
+  private[schema] val javaUtil: Namespace                 = new Namespace("java" :: "util" :: Nil, Nil)
+  private[schema] val scala: Namespace                    = new Namespace("scala" :: Nil, Nil)
   private[schema] val scalaCollectionImmutable: Namespace =
     new Namespace("scala" :: "collection" :: "immutable" :: Nil, Nil)
   private[schema] val zioSchema: Namespace = new Namespace("zio" :: "blocks" :: "schema" :: Nil, Nil)

--- a/schema/shared/src/main/scala/zio/blocks/schema/Optic.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Optic.scala
@@ -711,9 +711,9 @@ object Optional {
             val lastX = x
             x = prismBinding.matcher.downcastOrNull(x)
             if (x == null) {
-              val actualCaseIdx = prismBinding.discriminator.discriminate(lastX)
-              val actualCase    = sources(idx).asInstanceOf[Reflect.Variant.Bound[Any]].cases(actualCaseIdx).name
-              val focusTermName = focusTerms(idx).name
+              val actualCaseIdx  = prismBinding.discriminator.discriminate(lastX)
+              val actualCase     = sources(idx).asInstanceOf[Reflect.Variant.Bound[Any]].cases(actualCaseIdx).name
+              val focusTermName  = focusTerms(idx).name
               val unexpectedCase =
                 new OpticCheck.UnexpectedCase(focusTermName, actualCase, toDynamic, toDynamic(idx), lastX)
               return new Some(new OpticCheck(new ::(unexpectedCase, Nil)))
@@ -846,7 +846,7 @@ object Optional {
       if (bindings eq null) init()
       try {
         var success = false
-        val x = modifyRecursive(
+        val x       = modifyRecursive(
           Registers(usedRegisters),
           0,
           s,
@@ -866,7 +866,7 @@ object Optional {
       if (bindings eq null) init()
       try {
         var success = false
-        val x = modifyRecursive(
+        val x       = modifyRecursive(
           Registers(usedRegisters),
           0,
           s,
@@ -1117,7 +1117,7 @@ object Optional {
       if (bindings eq null) init()
       try {
         var success = false
-        val x = modifyRecursive(
+        val x       = modifyRecursive(
           Registers(usedRegisters),
           0,
           s,
@@ -1137,7 +1137,7 @@ object Optional {
       if (bindings eq null) init()
       try {
         var success = false
-        val x = modifyRecursive(
+        val x       = modifyRecursive(
           Registers(usedRegisters),
           0,
           s,
@@ -1201,7 +1201,7 @@ sealed trait Traversal[S, A] extends Optic[S, A] { self =>
   def fold[Z](s: S)(zero: Z, f: (Z, A) => Z): Z
 
   def reduceOrFail(s: S)(f: (A, A) => A): Either[OpticCheck, A] = {
-    var one = false
+    var one     = false
     val reduced = fold[A](s)(
       null.asInstanceOf[A],
       (acc, a) => {
@@ -2766,7 +2766,7 @@ object Traversal {
       if (bindings eq null) init()
       try {
         var modified = false
-        val x = modifyRecursive(
+        val x        = modifyRecursive(
           Registers(usedRegisters),
           0,
           s,
@@ -2786,7 +2786,7 @@ object Traversal {
       if (bindings eq null) init()
       try {
         var modified = false
-        val x = modifyRecursive(
+        val x        = modifyRecursive(
           Registers(usedRegisters),
           0,
           s,

--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -284,7 +284,7 @@ object Reflect {
     doc: Doc = Doc.Empty,
     modifiers: Seq[Modifier.Record] = Nil
   ) extends Reflect[F, A] { self =>
-    private[this] val fieldValues = fields.map(_.value).toArray
+    private[this] val fieldValues      = fields.map(_.value).toArray
     private[this] val fieldIndexByName = new StringToIntMap(fields.length) {
       fields.foreach {
         var idx = 0

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
@@ -131,9 +131,9 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
         )
       },
       test("derives schema for complex generic tuples") {
-        val value1 = (1, "VVV")
-        val value2 = ((1, 2L), ("VVV", "WWW"))
-        val value3 = (Some(1), Some("VVV"))
+        val value1         = (1, "VVV")
+        val value2         = ((1, 2L), ("VVV", "WWW"))
+        val value3         = (Some(1), Some("VVV"))
         val expectedFields =
           Vector(Schema[Int].reflect.asTerm("_1"), Schema[String].reflect.asTerm("_2"))
         val schema1: Schema[Tuple.Tail[(Long, Int, String)]]                         = Schema.derived
@@ -212,7 +212,7 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
         }
 
         val record = Tuple24.schema.reflect.asRecord
-        val value =
+        val value  =
           (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, Box1(21L), Box2("22"), 23, "24")
         assert(record.map(_.constructor.usedRegisters))(isSome(equalTo(RegisterOffset(ints = 21, objects = 3)))) &&
         assert(record.map(_.deconstructor.usedRegisters))(isSome(equalTo(RegisterOffset(ints = 21, objects = 3)))) &&

--- a/schema/shared/src/test/scala/zio/blocks/schema/DynamicValueGen.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/DynamicValueGen.scala
@@ -14,7 +14,7 @@ object DynamicValueGen {
       Gen.long(Long.MinValue / 60, Long.MaxValue / 60).map(Duration.ofMinutes),
       Gen.long(Long.MinValue, Long.MaxValue).map(Duration.ofSeconds)
     )
-    val genYear = Gen.oneOf(Gen.int(-9999, 9999), Gen.int(-999999999, 999999999)).map(Year.of)
+    val genYear    = Gen.oneOf(Gen.int(-9999, 9999), Gen.int(-999999999, 999999999)).map(Year.of)
     val genInstant = for {
       epochSecond    <- Gen.long(Instant.MIN.getEpochSecond, Instant.MAX.getEpochSecond)
       nanoAdjustment <- Gen.long(Long.MinValue, Long.MaxValue)

--- a/schema/shared/src/test/scala/zio/blocks/schema/LazySpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/LazySpec.scala
@@ -16,11 +16,11 @@ object LazySpec extends ZIOSpecDefault {
     },
     test("toString") {
       assert(Lazy(42).toString)(equalTo("Lazy(<not evaluated>)")) &&
-      assert({
+      assert {
         val lazyValue = Lazy(42)
         lazyValue.force
         lazyValue.toString
-      })(equalTo("Lazy(42)"))
+      }(equalTo("Lazy(42)"))
     },
     test("isEvaluated") {
       val lazyValue = Lazy(42)
@@ -29,11 +29,11 @@ object LazySpec extends ZIOSpecDefault {
       assert(lazyValue.isEvaluated)(isTrue)
     },
     test("force (success result)") {
-      var world = List.empty[Int]
-      val lazyValue = Lazy({
+      var world     = List.empty[Int]
+      val lazyValue = Lazy {
         world = world :+ 42
         world
-      })
+      }
       assert(world)(equalTo(List.empty[Int])) &&
       assert(lazyValue.force)(equalTo(List(42))) &&
       assert(world)(equalTo(List(42))) &&
@@ -49,15 +49,15 @@ object LazySpec extends ZIOSpecDefault {
       }
     },
     test("ensuring (success result)") {
-      var world = List.empty[Int]
-      val finalizer = Lazy({
+      var world     = List.empty[Int]
+      val finalizer = Lazy {
         world = world :+ 43
         world
-      })
-      val lazyValue = Lazy({
+      }
+      val lazyValue = Lazy {
         world = world :+ 42
         world
-      }).ensuring(finalizer)
+      }.ensuring(finalizer)
       assert(world)(equalTo(List.empty[Int])) &&
       assert(lazyValue.force)(equalTo(List(42))) &&
       assert(world)(equalTo(List(42, 43))) &&
@@ -65,11 +65,11 @@ object LazySpec extends ZIOSpecDefault {
       assert(finalizer.force)(equalTo(List(42, 43)))
     },
     test("ensuring (error result)") {
-      var world = List.empty[Int]
-      val finalizer = Lazy({
+      var world     = List.empty[Int]
+      val finalizer = Lazy {
         world = world :+ 43
         world
-      })
+      }
       ZIO.attempt(Lazy[Int](sys.error("test")).ensuring(finalizer).force).flip.map { e =>
         assertTrue(e.isInstanceOf[Throwable]) &&
         assert(world)(equalTo(List(43))) &&

--- a/schema/shared/src/test/scala/zio/blocks/schema/OpticSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/OpticSpec.scala
@@ -99,24 +99,22 @@ object OpticSpec extends ZIOSpecDefault {
         ZIO.attempt(Lens(null, Case4.reflect.fields(0))).flip.map(e => assertTrue(e.isInstanceOf[Throwable]))
       } @@ jvmOnly,
       test("optic macro requires record for creation") {
-        ZIO
-          .attempt({
-            sealed trait Variant {
-              def b: String
-            }
+        ZIO.attempt {
+          sealed trait Variant {
+            def b: String
+          }
 
-            case class Case(b: String) extends Variant
+          case class Case(b: String) extends Variant
 
-            case class Test(a: Variant)
+          case class Test(a: Variant)
 
-            object Test extends CompanionOptics[Test] {
-              implicit val schema: Schema[Test] = Schema.derived
-              val lens                          = optic(_.a.b)
-            }
+          object Test extends CompanionOptics[Test] {
+            implicit val schema: Schema[Test] = Schema.derived
+            val lens                          = optic(_.a.b)
+          }
 
-            Test.lens
-          })
-          .flip
+          Test.lens
+        }.flip
           .map(e => assert(e.getMessage)(equalTo("Expected a record")))
       },
       test("fail to generate lens") {
@@ -286,18 +284,16 @@ object OpticSpec extends ZIOSpecDefault {
           .map(e => assertTrue(e.isInstanceOf[Throwable]))
       } @@ jvmOnly,
       test("optic macro requires variant for creation") {
-        ZIO
-          .attempt({
-            case class Test(a: Double)
+        ZIO.attempt {
+          case class Test(a: Double)
 
-            object Test extends CompanionOptics[Test] {
-              implicit val schema: Schema[Test] = Schema.derived
-              val prism                         = optic(_.when[Test])
-            }
+          object Test extends CompanionOptics[Test] {
+            implicit val schema: Schema[Test] = Schema.derived
+            val prism                         = optic(_.when[Test])
+          }
 
-            Test.prism
-          })
-          .flip
+          Test.prism
+        }.flip
           .map(e => assert(e.getMessage)(equalTo("Expected a variant")))
       },
       test("has consistent equals and hashCode") {
@@ -2605,44 +2601,38 @@ object OpticSpec extends ZIOSpecDefault {
         assert(Test5.traversal.fold[Long](Map(1 -> 1L, 2 -> 2L, 3 -> 3L))(0, _ + _))(equalTo(3L))
       },
       test("optic macro requires sequence or map for creation") {
-        ZIO
-          .attempt({
-            case class Test(a: Array[Map[Int, String]])
+        ZIO.attempt {
+          case class Test(a: Array[Map[Int, String]])
 
-            object Test extends CompanionOptics[Test] {
-              implicit val schema: Schema[Test] = Schema.derived
-              val traversal                     = optic(_.a.each.each)
-            }
+          object Test extends CompanionOptics[Test] {
+            implicit val schema: Schema[Test] = Schema.derived
+            val traversal                     = optic(_.a.each.each)
+          }
 
-            Test.traversal
-          })
-          .flip
+          Test.traversal
+        }.flip
           .map(e => assert(e.getMessage)(equalTo("Expected a sequence"))) &&
-        ZIO
-          .attempt({
-            case class Test(a: Map[Set[Int], String])
+        ZIO.attempt {
+          case class Test(a: Map[Set[Int], String])
 
-            object Test extends CompanionOptics[Test] {
-              implicit val schema: Schema[Test] = Schema.derived
-              val traversal                     = optic(_.a.eachKey.eachKey)
-            }
+          object Test extends CompanionOptics[Test] {
+            implicit val schema: Schema[Test] = Schema.derived
+            val traversal                     = optic(_.a.eachKey.eachKey)
+          }
 
-            Test.traversal
-          })
-          .flip
+          Test.traversal
+        }.flip
           .map(e => assert(e.getMessage)(equalTo("Expected a map"))) &&
-        ZIO
-          .attempt({
-            case class Test(a: Map[Int, Set[String]])
+        ZIO.attempt {
+          case class Test(a: Map[Int, Set[String]])
 
-            object Test extends CompanionOptics[Test] {
-              implicit val schema: Schema[Test] = Schema.derived
-              val traversal                     = optic(_.a.eachValue.eachValue)
-            }
+          object Test extends CompanionOptics[Test] {
+            implicit val schema: Schema[Test] = Schema.derived
+            val traversal                     = optic(_.a.eachValue.eachValue)
+          }
 
-            Test.traversal
-          })
-          .flip
+          Test.traversal
+        }.flip
           .map(e => assert(e.getMessage)(equalTo("Expected a map")))
       },
       test("has consistent equals and hashCode") {
@@ -3577,9 +3567,9 @@ object OpticSpecTypes {
   }
 
   object Collections {
-    val alb: Optional[List[Byte], Byte]       = Optional.at(Reflect.list(Reflect.byte), 1)
-    val ailb: Traversal[List[Byte], Byte]     = Traversal.atIndices(Reflect.list(Reflect.byte), Seq(1, 2))
-    val alc1_d: Optional[List[Case1], Double] = Optional.at(Reflect.list(Case1.reflect), 1)(Case1.d)
+    val alb: Optional[List[Byte], Byte]         = Optional.at(Reflect.list(Reflect.byte), 1)
+    val ailb: Traversal[List[Byte], Byte]       = Traversal.atIndices(Reflect.list(Reflect.byte), Seq(1, 2))
+    val alc1_d: Optional[List[Case1], Double]   = Optional.at(Reflect.list(Case1.reflect), 1)(Case1.d)
     val aabl: Optional[Array[Boolean], Boolean] =
       Optional.at(
         Schema
@@ -3679,8 +3669,8 @@ object OpticSpecTypes {
           .asInstanceOf[Reflect.Sequence[Binding, String, Array]],
         1
       )
-    val lb: Traversal[List[Byte], Byte]     = Traversal.listValues(Reflect.byte)
-    val vs: Traversal[Vector[Short], Short] = Traversal.vectorValues(Reflect.short)
+    val lb: Traversal[List[Byte], Byte]         = Traversal.listValues(Reflect.byte)
+    val vs: Traversal[Vector[Short], Short]     = Traversal.vectorValues(Reflect.short)
     val abl: Traversal[Array[Boolean], Boolean] =
       Traversal.seqValues(
         Schema
@@ -3805,7 +3795,7 @@ object OpticSpecTypes {
     val lc4_lr3: Traversal[List[Case4], Record3]    = Traversal.listValues(Case4.reflect)(Case4.lr3)
     val lc1: Traversal[List[Variant1], Case1]       = Traversal.listValues(Variant1.reflect)(Variant1.c1)
     val lc1_d: Traversal[List[Variant1], Double]    = Traversal.listValues(Variant1.reflect)(Variant1.c1_d)
-    val mkc: Traversal[Map[Char, String], Char] =
+    val mkc: Traversal[Map[Char, String], Char]     =
       Traversal.mapKeys(Reflect.map(Reflect.char, Reflect.string))
     val mvs: Traversal[Map[Char, String], String] =
       Traversal.mapValues(Reflect.map(Reflect.char, Reflect.string))

--- a/schema/shared/src/test/scala/zio/blocks/schema/PatchSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/PatchSpec.scala
@@ -40,7 +40,7 @@ object PatchSpec extends ZIOSpecDefault {
           CreditCard(1234567812345678L, YearMonth.parse("2030-12"), 123, "John")
         )
       )
-      val patch = Patch.replace(Person.payPalPaymentMethods, PayPal("y@gmail.com"))
+      val patch   = Patch.replace(Person.payPalPaymentMethods, PayPal("y@gmail.com"))
       val person2 = person1.copy(paymentMethods =
         List(
           PayPal("y@gmail.com"),

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaAspectSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaAspectSpec.scala
@@ -11,7 +11,7 @@ object SchemaAspectSpec extends ZIOSpecDefault {
     implicit val schema: Schema[Person] = Schema.derived
     val name: Lens[Person, String]      = optic(_.name)
     val age: Lens[Person, Int]          = optic(_.age)
-    val x: Lens[Person, Boolean] = // invalid lens
+    val x: Lens[Person, Boolean]        = // invalid lens
       Lens(schema.reflect.asRecord.get, Reflect.boolean[Binding].asTerm("x").asInstanceOf[Term.Bound[Person, Boolean]])
   }
 

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
@@ -1573,7 +1573,7 @@ object SchemaSpec extends ZIOSpecDefault {
     implicit val schema: Schema[Record] = Schema.derived
     val b: Lens[Record, Byte]           = $(_.b)
     val i: Lens[Record, Int]            = $(_.i)
-    val x: Lens[Record, Boolean] = // invalid lens
+    val x: Lens[Record, Boolean]        = // invalid lens
       Lens(schema.reflect.asRecord.get, Reflect.boolean[Binding].asTerm("x").asInstanceOf[Term.Bound[Record, Boolean]])
   }
 


### PR DESCRIPTION
Results of named tuple benchmarks using Open JDK 21 on Intel(R) Core(TM) i7-11800H:
```
[info] Benchmark                                     Mode  Cnt           Score         Error  Units
[info] NamedTupleLensGetBenchmark.direct            thrpt   10  1136927222.047 ± 2352720.872  ops/s
[info] NamedTupleLensGetBenchmark.zioBlocks         thrpt   10    27492700.986 ±  985300.852  ops/s
[info] NamedTupleLensReplaceBenchmark.chanterelle   thrpt   10    23090221.755 ±  766226.340  ops/s
[info] NamedTupleLensReplaceBenchmark.zioBlocks     thrpt   10    10131506.621 ±   57428.526  ops/s
```