### PR TITLE
Prevent transform from failing with a ClassCastException when changing the binding of a recursive type

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -1137,7 +1137,10 @@ object Reflect {
     def transform[G[_, _]](path: DynamicOptic, f: ReflectTransformer[F, G]): Lazy[Reflect[G, A]] =
       Lazy[Lazy[Reflect[G, A]]] {
         val v = visited.get
-        if (v.containsKey(this)) Lazy(value.asInstanceOf[Reflect[G, A]]) // exit from recursion
+        if (v.containsKey(this))
+          if (value.isInstanceOf[Reflect[G, A]])
+            Lazy(value.asInstanceOf[Reflect[G, A]]) // exit from recursion when we can
+          else value.transform(path, f)
         else {
           v.put(this, ())
           value.transform(path, f).ensuring(Lazy(v.remove(this)))


### PR DESCRIPTION
Closes https://github.com/zio/zio-blocks/issues/214

When we are transforming a recursive type without changing its binding (e.g. `ReflectTransformer.OnlyMetadata`), it is fine to perform a cast since `F` = `G`.

However when changing the binding (e.g. in `Deriver`) it prevents the derivation code from doing anything because it fails with a `ClassCastException`. I think in the `Deriver` case it's up to the user-side `Deriver` code to handle the recursive case with a potential cache and deferred mechanism.