### PR TITLE
Fix Deferred#transform to maintain laziness

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -1136,12 +1136,13 @@ object Reflect {
 
     def transform[G[_, _]](path: DynamicOptic, f: ReflectTransformer[F, G]): Lazy[Reflect[G, A]] =
       Lazy {
-        val c = cache.get
-        if (c.containsKey(this))
-          c.get(this).asInstanceOf[Reflect[G, A]]
+        val c      = cache.get
+        val key    = (this, f)
+        val cached = c.get(key)
+        if (cached ne null) cached.asInstanceOf[Reflect[G, A]]
         else {
           val result = Deferred(() => value.transform(path, f).force)
-          c.put(this, result)
+          c.put(key, result)
           result
         }
       }
@@ -1346,9 +1347,9 @@ object Reflect {
       }
 
     private[this] val cache =
-      new ThreadLocal[java.util.IdentityHashMap[AnyRef, AnyRef]] {
-        override def initialValue: java.util.IdentityHashMap[AnyRef, AnyRef] =
-          new java.util.IdentityHashMap[AnyRef, AnyRef]
+      new ThreadLocal[java.util.HashMap[AnyRef, AnyRef]] {
+        override def initialValue: java.util.HashMap[AnyRef, AnyRef] =
+          new java.util.HashMap[AnyRef, AnyRef]
       }
 
     def nodeType = value.nodeType

--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -1135,17 +1135,16 @@ object Reflect {
     def toDynamicValue(value: A)(implicit F: HasBinding[F]): DynamicValue = this.value.toDynamicValue(value)
 
     def transform[G[_, _]](path: DynamicOptic, f: ReflectTransformer[F, G]): Lazy[Reflect[G, A]] =
-      Lazy[Lazy[Reflect[G, A]]] {
-        val v = visited.get
-        if (v.containsKey(this))
-          if (value.isInstanceOf[Reflect[G, A]])
-            Lazy(value.asInstanceOf[Reflect[G, A]]) // exit from recursion when we can
-          else value.transform(path, f)
+      Lazy {
+        val c = cache.get
+        if (c.containsKey(this))
+          c.get(this).asInstanceOf[Reflect[G, A]]
         else {
-          v.put(this, ())
-          value.transform(path, f).ensuring(Lazy(v.remove(this)))
+          val result = Deferred(() => value.transform(path, f).force)
+          c.put(this, result)
+          result
         }
-      }.flatten
+      }
 
     override def hashCode: Int = {
       val v = visited.get
@@ -1344,6 +1343,12 @@ object Reflect {
     private[this] val visited =
       new ThreadLocal[java.util.IdentityHashMap[AnyRef, Unit]] {
         override def initialValue: java.util.IdentityHashMap[AnyRef, Unit] = new java.util.IdentityHashMap[AnyRef, Unit]
+      }
+
+    private[this] val cache =
+      new ThreadLocal[java.util.IdentityHashMap[AnyRef, AnyRef]] {
+        override def initialValue: java.util.IdentityHashMap[AnyRef, AnyRef] =
+          new java.util.IdentityHashMap[AnyRef, AnyRef]
       }
 
     def nodeType = value.nodeType


### PR DESCRIPTION
Closes https://github.com/zio/zio-blocks/issues/214

The old implementation was losing the laziness by transforming a `Deferred` into its underlying type. Instead, we create a new `Deferred` with the new binding. However if it's a recursive type we shouldn't create a new `Deferred` at every loop, otherwise the short-circuit logic with `visited` won't work. So I added a cache to reuse the new `Deferred` if the same transformation is invoked again.

Wdyt?