### PR TITLE
Add the ability to override instances and modifiers at the Deriver level

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
@@ -42,11 +42,14 @@ final case class DerivationBuilder[TC[_], A](
   }
 
   lazy val derive: TC[A] = {
+    val allInstanceOverrides = instanceOverrides ++ deriver.instanceOverrides
+    val allModifierOverrides = modifierOverrides ++ deriver.modifierOverrides
+
     val instanceByOpticMap =
-      instanceOverrides.collect { case InstanceOverride(By.Optic(optic), instance) => optic -> instance }.toMap
+      allInstanceOverrides.collect { case InstanceOverride(By.Optic(optic), instance) => optic -> instance }.toMap
     val instanceByTypeMap =
-      instanceOverrides.collect { case InstanceOverride(By.Type(name), instance) => name -> instance }.toMap
-    val modifierMap = modifierOverrides.foldLeft[Map[DynamicOptic, Vector[Modifier]]](Map.empty) {
+      allInstanceOverrides.collect { case InstanceOverride(By.Type(name), instance) => name -> instance }.toMap
+    val modifierMap = allModifierOverrides.foldLeft[Map[DynamicOptic, Vector[Modifier]]](Map.empty) {
       case (acc, override_) =>
         acc + (override_.optic -> acc.getOrElse(override_.optic, Vector.empty).appended(override_.modifier))
     }

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/Deriver.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/Deriver.scala
@@ -64,4 +64,8 @@ trait Deriver[TC[_]] { self =>
     doc: Doc,
     modifiers: Seq[Modifier.Wrapper]
   )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TC[A]]
+
+  def instanceOverrides: IndexedSeq[InstanceOverride[TC, ?]] = IndexedSeq.empty
+
+  def modifierOverrides: IndexedSeq[ModifierOverride] = IndexedSeq.empty
 }


### PR DESCRIPTION
Let's say I have a group of instances for specific types and I always want those instances to be used.
Currently, everywhere I derive a codec, I need to call `.instance(typeName, instance)` for each of those instances.
Instead, I would like to define them once and use them everywhere. So this PR allows defining them at the `Deriver` level.

If you have a better way to handle this, let me know 😄 