### PR TITLE
Add benchmarks for avro4s

### DIFF
--- a/benchmarks/src/main/scala/zio/blocks/avro/ListOfRecordsBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/blocks/avro/ListOfRecordsBenchmark.scala
@@ -8,9 +8,31 @@ import zio.blocks.avro.AvroFormat
 import zio.schema.codec.AvroCodec
 import zio.schema.{DeriveSchema, Schema => ZIOSchema}
 import java.nio.ByteBuffer
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import com.sksamuel.avro4s.{AvroSchema, AvroInputStream, AvroOutputStream}
 
 class ListOfRecordsBenchmark extends BaseBenchmark {
   import ListOfRecordsDomain._
+
+  @Param(Array("1", "10", "100", "1000", "10000", "100000"))
+  var size: Int                         = 1000
+  var listOfRecords: List[Person]       = _
+  var encodedListOfRecords: Array[Byte] = _
+
+  @Setup
+  def setup(): Unit = {
+    listOfRecords = (1 to size).map(_ => Person(12345678901L, "John", 30, "123 Main St", List(5, 7, 9))).toList
+    encodedListOfRecords = zioSchemaCodec.encode(listOfRecords).toArray
+  }
+
+  @Benchmark
+  def readingAvro4s: List[Person] =
+    AvroInputStream
+      .binary[List[Person]]
+      .from(new ByteArrayInputStream(encodedListOfRecords))
+      .build(AvroSchema[List[Person]])
+      .iterator
+      .next()
 
   @Benchmark
   def readingZioBlocks: List[Person] =
@@ -27,8 +49,17 @@ class ListOfRecordsBenchmark extends BaseBenchmark {
     }
 
   @Benchmark
+  def writingAvro4s: Array[Byte] = {
+    val baos   = new ByteArrayOutputStream()
+    val output = AvroOutputStream.binary[List[Person]].to(baos).build()
+    output.write(listOfRecords)
+    output.close()
+    baos.toByteArray
+  }
+
+  @Benchmark
   def writingZioBlocks: Array[Byte] = {
-    val byteBuffer = ByteBuffer.allocate(1024)
+    val byteBuffer = ByteBuffer.allocate(300 * size)
     zioBlocksSchema.encode(AvroFormat)(byteBuffer)(listOfRecords)
     java.util.Arrays.copyOf(byteBuffer.array, byteBuffer.position)
   }
@@ -45,9 +76,4 @@ object ListOfRecordsDomain {
   implicit val zioBlocksSchema: Schema[List[Person]] = Schema.derived
 
   val zioSchemaCodec: AvroCodec.ExtendedBinaryCodec[List[Person]] = AvroCodec.schemaBasedBinaryCodec[List[Person]]
-
-  val listOfRecords: List[Person] =
-    (1 to 10).map(_ => Person(12345678901L, "John", 30, "123 Main St", List(5, 7, 9))).toList
-
-  val encodedListOfRecords: Array[Byte] = zioSchemaCodec.encode(listOfRecords).toArray
 }

--- a/benchmarks/src/test/scala/zio/blocks/avro/ListOfRecordsBenchmarkSpec.scala
+++ b/benchmarks/src/test/scala/zio/blocks/avro/ListOfRecordsBenchmarkSpec.scala
@@ -6,14 +6,22 @@ import zio.test.Assertion._
 object ListOfRecordsBenchmarkSpec extends ZIOSpecDefault {
   def spec: Spec[TestEnvironment, Any] = suite("ListOfRecordsBenchmarkSpec")(
     test("reading") {
-      val zioBlocksOutput = (new ListOfRecordsBenchmark).readingZioBlocks
-      val zioSchemaOutput = (new ListOfRecordsBenchmark).readingZioSchema
-      assert(zioBlocksOutput)(equalTo(zioSchemaOutput))
+      val benchmark = new ListOfRecordsBenchmark
+      benchmark.setup()
+      val avro4sOutput    = benchmark.readingAvro4s
+      val zioBlocksOutput = benchmark.readingZioBlocks
+      val zioSchemaOutput = benchmark.readingZioSchema
+      assert(avro4sOutput)(equalTo(zioBlocksOutput)) &&
+      assert(zioSchemaOutput)(equalTo(zioBlocksOutput))
     },
     test("writing") {
-      val zioBlocksOutput = (new ListOfRecordsBenchmark).writingZioBlocks
-      val zioSchemaOutput = (new ListOfRecordsBenchmark).writingZioSchema
-      assert(java.util.Arrays.compare(zioBlocksOutput, zioSchemaOutput))(equalTo(0))
+      val benchmark = new ListOfRecordsBenchmark
+      benchmark.setup()
+      val avro4sOutput    = benchmark.writingAvro4s
+      val zioBlocksOutput = benchmark.writingZioBlocks
+      val zioSchemaOutput = benchmark.writingZioSchema
+      assert(java.util.Arrays.compare(avro4sOutput, zioBlocksOutput))(equalTo(0)) &&
+      assert(java.util.Arrays.compare(zioSchemaOutput, zioBlocksOutput))(equalTo(0))
     }
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -154,6 +154,7 @@ lazy val benchmarks = project
     crossScalaVersions       := Seq("3.7.3"),
     ThisBuild / scalaVersion := "3.7.3",
     libraryDependencies ++= Seq(
+      "com.sksamuel.avro4s"        %% "avro4s-core"     % "5.0.14",
       "dev.zio"                    %% "zio-schema-avro" % "1.7.5",
       "io.github.arainko"          %% "chanterelle"     % "0.1.1",
       "com.softwaremill.quicklens" %% "quicklens"       % "1.9.12",


### PR DESCRIPTION
Results with Scala 3 using JDK 21:

```txt
Benchmark                                (size)   Mode  Cnt     Score     Error  Units
ListOfRecordsBenchmark.readingAvro4s       1000  thrpt    5  3022.155 ±   8.765  ops/s
ListOfRecordsBenchmark.readingZioBlocks    1000  thrpt    5  3010.704 ± 141.600  ops/s
ListOfRecordsBenchmark.readingZioSchema    1000  thrpt    5   143.199 ±   3.836  ops/s
ListOfRecordsBenchmark.writingAvro4s       1000  thrpt    5  5084.974 ± 459.957  ops/s
ListOfRecordsBenchmark.writingZioBlocks    1000  thrpt    5  3494.903 ± 118.330  ops/s
ListOfRecordsBenchmark.writingZioSchema    1000  thrpt    5   115.948 ±  12.949  ops/s
```