### PR TITLE
More efficient Avro encoding to byte arrays

### DIFF
--- a/benchmarks/src/main/scala/zio/blocks/avro/ListOfRecordsBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/blocks/avro/ListOfRecordsBenchmark.scala
@@ -7,7 +7,6 @@ import zio.blocks.schema.Schema
 import zio.blocks.avro.AvroFormat
 import zio.schema.codec.AvroCodec
 import zio.schema.{DeriveSchema, Schema => ZIOSchema}
-import java.nio.ByteBuffer
 import java.io.ByteArrayOutputStream
 import com.sksamuel.avro4s.{AvroSchema, AvroInputStream, AvroOutputStream}
 
@@ -53,11 +52,7 @@ class ListOfRecordsBenchmark extends BaseBenchmark {
   }
 
   @Benchmark
-  def writingZioBlocks: Array[Byte] = {
-    val byteBuffer = ByteBuffer.allocate(30 * size)
-    zioBlocksCodec.encode(listOfRecords, byteBuffer)
-    java.util.Arrays.copyOf(byteBuffer.array, byteBuffer.position)
-  }
+  def writingZioBlocks: Array[Byte] = zioBlocksCodec.encode(listOfRecords)
 
   @Benchmark
   def writingZioSchema: Array[Byte] = zioSchemaCodec.encode(listOfRecords).toArray


### PR DESCRIPTION
Results with Scala 3 using JDK 21:

```txt
Benchmark                                (size)   Mode  Cnt      Score     Error  Units
ListOfRecordsBenchmark.readingAvro4s       1000  thrpt    5   4233.245 ± 826.558  ops/s
ListOfRecordsBenchmark.readingZioBlocks    1000  thrpt    5  12237.920 ±  56.294  ops/s
ListOfRecordsBenchmark.readingZioSchema    1000  thrpt    5    147.732 ±   5.114  ops/s
ListOfRecordsBenchmark.writingAvro4s       1000  thrpt    5   5122.085 ± 162.473  ops/s
ListOfRecordsBenchmark.writingZioBlocks    1000  thrpt    5  12020.081 ±  77.276  ops/s
ListOfRecordsBenchmark.writingZioSchema    1000  thrpt    5    120.960 ±   2.823  ops/s
```