### PR TITLE
Add error tracing during Avro decoding

### DIFF
--- a/schema/shared/src/main/scala-2/zio/blocks/schema/CompanionOptics.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/CompanionOptics.scala
@@ -56,7 +56,7 @@ private object CompanionOptics {
 
     def toPathBody(tree: c.Tree): c.Tree = tree match {
       case q"($_) => $pathBody" => pathBody
-      case _                    => fail(s"Expected a lambda expression, got: '$tree'")
+      case _                    => fail(s"Expected a lambda expression, got '$tree'")
     }
 
     def toOptic(tree: c.Tree): c.Tree = tree match {
@@ -234,7 +234,7 @@ private object CompanionOptics {
         q""
       case tree =>
         fail(
-          s"Expected path elements: .<field>, .when[<T>], .at(<index>), .atIndices(<indices>), .atKey(<key>), .atKeys(<keys>), .each, .eachKey, .eachValue, or .wrapped[<T>], got: '$tree'"
+          s"Expected path elements: .<field>, .when[<T>], .at(<index>), .atIndices(<indices>), .atKey(<key>), .atKeys(<keys>), .each, .eachKey, .eachValue, or .wrapped[<T>], got '$tree'"
         )
     }
 

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/CompanionOptics.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/CompanionOptics.scala
@@ -46,7 +46,7 @@ private object CompanionOptics {
     def toPathBody(term: Term): Term = term match {
       case Inlined(_, _, inlinedBlock)                     => toPathBody(inlinedBlock)
       case Block(List(DefDef(_, _, _, Some(pathBody))), _) => pathBody
-      case _                                               => fail(s"Expected a lambda expression, got: '${term.show}'")
+      case _                                               => fail(s"Expected a lambda expression, got '${term.show}'")
     }
 
     def hasName(using q: Quotes)(term: q.reflect.Term, name: String): Boolean = {
@@ -511,7 +511,7 @@ private object CompanionOptics {
             case Apply(TypeApply(Select(p, "apply"), _), List(Literal(IntConstant(i)))) => (p, i)
             case _                                                                      =>
               fail(
-                s"Expected path elements: .<field>, .when[<T>], .at(<index>), .atIndices(<indices>), .atKey(<key>), .atKeys(<keys>), .each, .eachKey, .eachValue, or .wrapped[<T>], got: '${term.show}'"
+                s"Expected path elements: .<field>, .when[<T>], .at(<index>), .atIndices(<indices>), .atKey(<key>), .atKeys(<keys>), .each, .eachKey, .eachValue, or .wrapped[<T>], got '${term.show}'"
               )
           }
           var parentTpe = parent.tpe.widen.dealias

--- a/schema/shared/src/main/scala/zio/blocks/schema/PrimitiveType.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/PrimitiveType.scala
@@ -30,7 +30,7 @@ object PrimitiveType {
     ): Either[SchemaError, scala.Unit] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Unit) => new Right(())
-        case _                                           => new Left(SchemaError.invalidType(trace, "Expected Unit"))
+        case _                                           => new Left(SchemaError.expectationMismatch(trace, "Expected Unit"))
       }
   }
 
@@ -46,7 +46,7 @@ object PrimitiveType {
     ): Either[SchemaError, scala.Boolean] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Boolean(b)) => new Right(b)
-        case _                                                 => new Left(SchemaError.invalidType(trace, "Expected Boolean"))
+        case _                                                 => new Left(SchemaError.expectationMismatch(trace, "Expected Boolean"))
       }
   }
 
@@ -61,7 +61,7 @@ object PrimitiveType {
     ): Either[SchemaError, scala.Byte] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Byte(b)) => new Right(b)
-        case _                                              => new Left(SchemaError.invalidType(trace, "Expected Byte"))
+        case _                                              => new Left(SchemaError.expectationMismatch(trace, "Expected Byte"))
       }
   }
 
@@ -76,7 +76,7 @@ object PrimitiveType {
     ): Either[SchemaError, scala.Short] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Short(s)) => new Right(s)
-        case _                                               => new Left(SchemaError.invalidType(trace, "Expected Short"))
+        case _                                               => new Left(SchemaError.expectationMismatch(trace, "Expected Short"))
       }
   }
 
@@ -91,7 +91,7 @@ object PrimitiveType {
     ): Either[SchemaError, scala.Int] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Int(i)) => new Right(i)
-        case _                                             => new Left(SchemaError.invalidType(trace, "Expected Int"))
+        case _                                             => new Left(SchemaError.expectationMismatch(trace, "Expected Int"))
       }
   }
 
@@ -106,7 +106,7 @@ object PrimitiveType {
     ): Either[SchemaError, scala.Long] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Long(l)) => new Right(l)
-        case _                                              => new Left(SchemaError.invalidType(trace, "Expected Long"))
+        case _                                              => new Left(SchemaError.expectationMismatch(trace, "Expected Long"))
       }
   }
 
@@ -121,7 +121,7 @@ object PrimitiveType {
     ): Either[SchemaError, scala.Float] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Float(f)) => Right(f)
-        case _                                               => Left(SchemaError.invalidType(trace, "Expected Float"))
+        case _                                               => Left(SchemaError.expectationMismatch(trace, "Expected Float"))
       }
   }
 
@@ -136,7 +136,7 @@ object PrimitiveType {
     ): Either[SchemaError, scala.Double] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Double(d)) => new Right(d)
-        case _                                                => new Left(SchemaError.invalidType(trace, "Expected Double"))
+        case _                                                => new Left(SchemaError.expectationMismatch(trace, "Expected Double"))
       }
   }
 
@@ -151,7 +151,7 @@ object PrimitiveType {
     ): Either[SchemaError, scala.Char] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Char(c)) => new Right(c)
-        case _                                              => new Left(SchemaError.invalidType(trace, "Expected Char"))
+        case _                                              => new Left(SchemaError.expectationMismatch(trace, "Expected Char"))
       }
   }
 
@@ -167,7 +167,7 @@ object PrimitiveType {
     ): Either[SchemaError, Predef.String] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.String(s)) => new Right(s)
-        case _                                                => new Left(SchemaError.invalidType(trace, "Expected String"))
+        case _                                                => new Left(SchemaError.expectationMismatch(trace, "Expected String"))
       }
   }
 
@@ -182,7 +182,7 @@ object PrimitiveType {
     ): Either[SchemaError, scala.BigInt] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.BigInt(b)) => new Right(b)
-        case _                                                => new Left(SchemaError.invalidType(trace, "Expected BigInt"))
+        case _                                                => new Left(SchemaError.expectationMismatch(trace, "Expected BigInt"))
       }
   }
 
@@ -198,7 +198,7 @@ object PrimitiveType {
     ): Either[SchemaError, scala.BigDecimal] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.BigDecimal(b)) => new Right(b)
-        case _                                                    => new Left(SchemaError.invalidType(trace, "Expected BigDecimal"))
+        case _                                                    => new Left(SchemaError.expectationMismatch(trace, "Expected BigDecimal"))
       }
   }
 
@@ -213,7 +213,7 @@ object PrimitiveType {
       trace: List[DynamicOptic.Node]
     ): Either[SchemaError, java.time.DayOfWeek] = value match {
       case DynamicValue.Primitive(PrimitiveValue.DayOfWeek(d)) => new Right(d)
-      case _                                                   => new Left(SchemaError.invalidType(trace, "Expected DayOfWeek"))
+      case _                                                   => new Left(SchemaError.expectationMismatch(trace, "Expected DayOfWeek"))
     }
   }
 
@@ -229,7 +229,7 @@ object PrimitiveType {
     ): Either[SchemaError, java.time.Duration] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Duration(d)) => new Right(d)
-        case _                                                  => new Left(SchemaError.invalidType(trace, "Expected Duration"))
+        case _                                                  => new Left(SchemaError.expectationMismatch(trace, "Expected Duration"))
       }
   }
 
@@ -245,7 +245,7 @@ object PrimitiveType {
     ): Either[SchemaError, java.time.Instant] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Instant(i)) => new Right(i)
-        case _                                                 => new Left(SchemaError.invalidType(trace, "Expected Instant"))
+        case _                                                 => new Left(SchemaError.expectationMismatch(trace, "Expected Instant"))
       }
   }
 
@@ -260,7 +260,7 @@ object PrimitiveType {
       trace: List[DynamicOptic.Node]
     ): Either[SchemaError, java.time.LocalDate] = value match {
       case DynamicValue.Primitive(PrimitiveValue.LocalDate(d)) => new Right(d)
-      case _                                                   => new Left(SchemaError.invalidType(trace, "Expected LocalDate"))
+      case _                                                   => new Left(SchemaError.expectationMismatch(trace, "Expected LocalDate"))
     }
   }
 
@@ -277,7 +277,7 @@ object PrimitiveType {
     ): Either[SchemaError, java.time.LocalDateTime] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.LocalDateTime(d)) => new Right(d)
-        case _                                                       => new Left(SchemaError.invalidType(trace, "Expected LocalDateTime"))
+        case _                                                       => new Left(SchemaError.expectationMismatch(trace, "Expected LocalDateTime"))
       }
   }
 
@@ -292,7 +292,7 @@ object PrimitiveType {
       trace: List[DynamicOptic.Node]
     ): Either[SchemaError, java.time.LocalTime] = value match {
       case DynamicValue.Primitive(PrimitiveValue.LocalTime(t)) => new Right(t)
-      case _                                                   => new Left(SchemaError.invalidType(trace, "Expected LocalTime"))
+      case _                                                   => new Left(SchemaError.expectationMismatch(trace, "Expected LocalTime"))
     }
   }
 
@@ -308,7 +308,7 @@ object PrimitiveType {
     ): Either[SchemaError, java.time.Month] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Month(m)) => new Right(m)
-        case _                                               => new Left(SchemaError.invalidType(trace, "Expected Month"))
+        case _                                               => new Left(SchemaError.expectationMismatch(trace, "Expected Month"))
       }
   }
 
@@ -324,7 +324,7 @@ object PrimitiveType {
     ): Either[SchemaError, java.time.MonthDay] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.MonthDay(m)) => new Right(m)
-        case _                                                  => new Left(SchemaError.invalidType(trace, "Expected MonthDay"))
+        case _                                                  => new Left(SchemaError.expectationMismatch(trace, "Expected MonthDay"))
       }
   }
 
@@ -341,7 +341,7 @@ object PrimitiveType {
     ): Either[SchemaError, java.time.OffsetDateTime] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.OffsetDateTime(d)) => new Right(d)
-        case _                                                        => new Left(SchemaError.invalidType(trace, "Expected OffsetDateTime"))
+        case _                                                        => new Left(SchemaError.expectationMismatch(trace, "Expected OffsetDateTime"))
       }
   }
 
@@ -356,7 +356,7 @@ object PrimitiveType {
       trace: List[DynamicOptic.Node]
     ): Either[SchemaError, java.time.OffsetTime] = value match {
       case DynamicValue.Primitive(PrimitiveValue.OffsetTime(t)) => new Right(t)
-      case _                                                    => new Left(SchemaError.invalidType(trace, "Expected OffsetTime"))
+      case _                                                    => new Left(SchemaError.expectationMismatch(trace, "Expected OffsetTime"))
     }
   }
 
@@ -372,7 +372,7 @@ object PrimitiveType {
     ): Either[SchemaError, java.time.Period] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Period(p)) => new Right(p)
-        case _                                                => new Left(SchemaError.invalidType(trace, "Expected Period"))
+        case _                                                => new Left(SchemaError.expectationMismatch(trace, "Expected Period"))
       }
   }
 
@@ -387,7 +387,7 @@ object PrimitiveType {
     ): Either[SchemaError, java.time.Year] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Year(y)) => new Right(y)
-        case _                                              => new Left(SchemaError.invalidType(trace, "Expected Year"))
+        case _                                              => new Left(SchemaError.expectationMismatch(trace, "Expected Year"))
       }
   }
 
@@ -402,7 +402,7 @@ object PrimitiveType {
       trace: List[DynamicOptic.Node]
     ): Either[SchemaError, java.time.YearMonth] = value match {
       case DynamicValue.Primitive(PrimitiveValue.YearMonth(y)) => new Right(y)
-      case _                                                   => new Left(SchemaError.invalidType(trace, "Expected YearMonth"))
+      case _                                                   => new Left(SchemaError.expectationMismatch(trace, "Expected YearMonth"))
     }
   }
 
@@ -418,7 +418,7 @@ object PrimitiveType {
     ): Either[SchemaError, java.time.ZoneId] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.ZoneId(z)) => new Right(z)
-        case _                                                => new Left(SchemaError.invalidType(trace, "Expected ZoneId"))
+        case _                                                => new Left(SchemaError.expectationMismatch(trace, "Expected ZoneId"))
       }
   }
 
@@ -433,7 +433,7 @@ object PrimitiveType {
       trace: List[DynamicOptic.Node]
     ): Either[SchemaError, java.time.ZoneOffset] = value match {
       case DynamicValue.Primitive(PrimitiveValue.ZoneOffset(z)) => new Right(z)
-      case _                                                    => new Left(SchemaError.invalidType(trace, "Expected ZoneOffset"))
+      case _                                                    => new Left(SchemaError.expectationMismatch(trace, "Expected ZoneOffset"))
     }
   }
 
@@ -450,7 +450,7 @@ object PrimitiveType {
     ): Either[SchemaError, java.time.ZonedDateTime] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.ZonedDateTime(z)) => new Right(z)
-        case _                                                       => new Left(SchemaError.invalidType(trace, "Expected ZonedDateTime"))
+        case _                                                       => new Left(SchemaError.expectationMismatch(trace, "Expected ZonedDateTime"))
       }
   }
 
@@ -466,7 +466,7 @@ object PrimitiveType {
     ): Either[SchemaError, java.util.UUID] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.UUID(u)) => new Right(u)
-        case _                                              => new Left(SchemaError.invalidType(trace, "Expected UUID"))
+        case _                                              => new Left(SchemaError.expectationMismatch(trace, "Expected UUID"))
       }
   }
 
@@ -482,7 +482,7 @@ object PrimitiveType {
     ): Either[SchemaError, java.util.Currency] =
       value match {
         case DynamicValue.Primitive(PrimitiveValue.Currency(c)) => new Right(c)
-        case _                                                  => new Left(SchemaError.invalidType(trace, "Expected Currency"))
+        case _                                                  => new Left(SchemaError.expectationMismatch(trace, "Expected Currency"))
       }
   }
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -358,8 +358,7 @@ object Reflect {
           }
           if (error.isDefined) new Left(error.get)
           else new Right(constructor.construct(registers, RegisterOffset.Zero))
-        case _ =>
-          new Left(SchemaError.invalidType(trace, "Expected a record"))
+        case _ => new Left(SchemaError.expectationMismatch(trace, "Expected a record"))
       }
 
     def lensByName[B](name: String): Option[Lens[A, B]] = lensByIndex(fieldIndexByName.get(name))
@@ -546,7 +545,7 @@ object Reflect {
               .asInstanceOf[Reflect[F, A]]
               .fromDynamicValue(value, new DynamicOptic.Node.Case(case_.name) :: trace)
           } else new Left(SchemaError.unknownCase(trace, discriminator))
-        case _ => new Left(SchemaError.invalidType(trace, "Expected a variant"))
+        case _ => new Left(SchemaError.expectationMismatch(trace, "Expected a variant"))
       }
 
     def matchers(implicit F: HasBinding[F]): Matchers[A] = F.matchers(variantBinding)
@@ -741,8 +740,7 @@ object Reflect {
               if (error.isDefined) new Left(error.get)
               else new Right(constructor.resultObject(builder))
           }
-        case _ =>
-          new Left(SchemaError.invalidType(trace, "Expected a sequence"))
+        case _ => new Left(SchemaError.expectationMismatch(trace, "Expected a sequence"))
       }
     }
 
@@ -849,8 +847,7 @@ object Reflect {
           }
           if (error.isDefined) new Left(error.get)
           else new Right(constructor.resultObject(builder))
-        case _ =>
-          new Left(SchemaError.invalidType(trace, "Expected a map"))
+        case _ => new Left(SchemaError.expectationMismatch(trace, "Expected a map"))
       }
     }
 
@@ -1054,7 +1051,7 @@ object Reflect {
       (wrapped.fromDynamicValue(value) match {
         case Right(unwrapped) =>
           binding.wrap(unwrapped) match {
-            case Left(error) => new Left(SchemaError.invalidType(trace, s"Expected ${typeName.name}: $error"))
+            case Left(error) => new Left(SchemaError.expectationMismatch(trace, s"Expected ${typeName.name}: $error"))
             case right       => right
           }
         case left => left

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaError.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaError.scala
@@ -12,16 +12,16 @@ final case class SchemaError(errors: ::[SchemaError.Single]) extends Exception w
 }
 
 object SchemaError {
-  private[schema] def invalidType(trace: List[DynamicOptic.Node], expectation: String): SchemaError =
-    new SchemaError(new ::(new InvalidType(toDynamicOptic(trace), expectation), Nil))
+  def expectationMismatch(trace: List[DynamicOptic.Node], expectation: String): SchemaError =
+    new SchemaError(new ::(new ExpectationMismatch(toDynamicOptic(trace), expectation), Nil))
 
-  private[schema] def missingField(trace: List[DynamicOptic.Node], fieldName: String): SchemaError =
+  def missingField(trace: List[DynamicOptic.Node], fieldName: String): SchemaError =
     new SchemaError(new ::(new MissingField(toDynamicOptic(trace), fieldName), Nil))
 
-  private[schema] def duplicatedField(trace: List[DynamicOptic.Node], fieldName: String): SchemaError =
+  def duplicatedField(trace: List[DynamicOptic.Node], fieldName: String): SchemaError =
     new SchemaError(new ::(new DuplicatedField(toDynamicOptic(trace), fieldName), Nil))
 
-  private[schema] def unknownCase(trace: List[DynamicOptic.Node], caseName: String): SchemaError =
+  def unknownCase(trace: List[DynamicOptic.Node], caseName: String): SchemaError =
     new SchemaError(new ::(new UnknownCase(toDynamicOptic(trace), caseName), Nil))
 
   private[this] def toDynamicOptic(trace: List[DynamicOptic.Node]): DynamicOptic = {
@@ -54,7 +54,7 @@ object SchemaError {
     override def message: String = s"Duplicated field $fieldName at: $source"
   }
 
-  case class InvalidType(source: DynamicOptic, expectation: String) extends Single {
+  case class ExpectationMismatch(source: DynamicOptic, expectation: String) extends Single {
     override def message: String = s"$expectation at: $source"
   }
 

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
@@ -301,7 +301,7 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
             equalTo(
               SchemaError(errors =
                 ::(
-                  SchemaError.InvalidType(
+                  SchemaError.ExpectationMismatch(
                     source = DynamicOptic(nodes = Vector(DynamicOptic.Node.Field(name = "id"))),
                     expectation = "Expected Id: Expected a string with letter or digit characters"
                   ),
@@ -350,7 +350,7 @@ object SchemaVersionSpecificSpec extends ZIOSpecDefault {
             equalTo(
               SchemaError(errors =
                 ::(
-                  SchemaError.InvalidType(
+                  SchemaError.ExpectationMismatch(
                     source = DynamicOptic(nodes = Vector(DynamicOptic.Node.Field(name = "id"))),
                     expectation = "Expected InnerId: Expected a string with letter or digit characters"
                   ),

--- a/schema/shared/src/test/scala/zio/blocks/schema/OpticSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/OpticSpec.scala
@@ -129,7 +129,7 @@ object OpticSpec extends ZIOSpecDefault {
           assert(_)(
             isLeft(
               startsWithString(
-                "Expected path elements: .<field>, .when[<T>], .at(<index>), .atIndices(<indices>), .atKey(<key>), .atKeys(<keys>), .each, .eachKey, .eachValue, or .wrapped[<T>], got: '"
+                "Expected path elements: .<field>, .when[<T>], .at(<index>), .atIndices(<indices>), .atKey(<key>), .atKeys(<keys>), .each, .eachKey, .eachValue, or .wrapped[<T>], got '"
               ) &&
                 endsWithString(".equals(null)'")
             )
@@ -304,7 +304,7 @@ object OpticSpec extends ZIOSpecDefault {
                implicit val schema: Schema[Test] = Schema.derived
                val prism                         = optic(null.asInstanceOf[Test => Double])
              }"""
-        }.map(assert(_)(isLeft(startsWithString("Expected a lambda expression, got: 'null.asInstanceOf["))))
+        }.map(assert(_)(isLeft(startsWithString("Expected a lambda expression, got 'null.asInstanceOf["))))
       },
       test("has consistent equals and hashCode") {
         assert(Variant1.c1)(equalTo(Variant1.c1)) &&

--- a/schema/shared/src/test/scala/zio/blocks/schema/PrimitiveTypeSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/PrimitiveTypeSpec.scala
@@ -13,7 +13,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
         assertTrue(tpe.toDynamicValue(()) == DynamicValue.Primitive(PrimitiveValue.Unit)) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Unit)))(isRight(equalTo(()))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(1))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Unit")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Unit")))
         )
       },
       test("Validation is set to None") {
@@ -28,7 +28,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(1: Byte))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(1))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Byte")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Byte")))
         )
       }
     ),
@@ -38,7 +38,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
         assertTrue(tpe.toDynamicValue(true) == DynamicValue.Primitive(PrimitiveValue.Boolean(true))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Boolean(true))))(isRight(equalTo(true))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(1))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Boolean")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Boolean")))
         )
       }
     ),
@@ -50,7 +50,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(1: Short))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(1))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Short")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Short")))
         )
       }
     ),
@@ -60,7 +60,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
         assertTrue(tpe.toDynamicValue('1') == DynamicValue.Primitive(PrimitiveValue.Char('1'))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Char('1'))))(isRight(equalTo('1'))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(1))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Char")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Char")))
         )
       }
     ),
@@ -70,7 +70,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
         assertTrue(tpe.toDynamicValue(1) == DynamicValue.Primitive(PrimitiveValue.Int(1))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(1))))(isRight(equalTo(1))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Int")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Int")))
         )
       }
     ),
@@ -80,7 +80,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
         assertTrue(tpe.toDynamicValue(1) == DynamicValue.Primitive(PrimitiveValue.Float(1.0f))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Float(1.0f))))(isRight(equalTo(1.0f))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Float")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Float")))
         )
       }
     ),
@@ -90,7 +90,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
         assertTrue(tpe.toDynamicValue(1) == DynamicValue.Primitive(PrimitiveValue.Long(1L))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(isRight(equalTo(1L))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(1))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Long")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Long")))
         )
       }
     ),
@@ -100,7 +100,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
         assertTrue(tpe.toDynamicValue(1) == DynamicValue.Primitive(PrimitiveValue.Double(1.0))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Double(1.0))))(isRight(equalTo(1.0))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Double")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Double")))
         )
       }
     ),
@@ -110,7 +110,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
         assertTrue(tpe.toDynamicValue("WWW") == DynamicValue.Primitive(PrimitiveValue.String("WWW"))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.String("WWW"))))(isRight(equalTo("WWW"))) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected String")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected String")))
         )
       }
     ),
@@ -122,7 +122,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(BigInt(1)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected BigInt")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected BigInt")))
         )
       }
     ),
@@ -136,7 +136,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(BigDecimal(1.0)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected BigDecimal")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected BigDecimal")))
         )
       }
     ),
@@ -161,9 +161,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
         ) &&
         assert(
           tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.String("123e4567-e89b-12d3-a456-426614174000")))
-        )(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected UUID")))
-        )
+        )(isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected UUID"))))
       }
     ),
     suite("PrimitiveType.DayOfWeek")(
@@ -176,7 +174,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(DayOfWeek.MONDAY))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected DayOfWeek")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected DayOfWeek")))
         )
       }
     ),
@@ -190,7 +188,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.Duration.ofSeconds(1)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Duration")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Duration")))
         )
       }
     ),
@@ -204,7 +202,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.Instant.ofEpochMilli(1)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Instant")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Instant")))
         )
       }
     ),
@@ -220,7 +218,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.LocalDate.of(2023, 1, 1)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected LocalDate")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected LocalDate")))
         )
       }
     ),
@@ -238,7 +236,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.LocalDateTime.of(2023, 1, 1, 1, 1)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected LocalDateTime")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected LocalDateTime")))
         )
       }
     ),
@@ -252,7 +250,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.LocalTime.of(1, 1)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected LocalTime")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected LocalTime")))
         )
       }
     ),
@@ -266,7 +264,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.Month.JANUARY))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Month")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Month")))
         )
       }
     ),
@@ -284,7 +282,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.MonthDay.of(java.time.Month.JANUARY, 1)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected MonthDay")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected MonthDay")))
         )
       }
     ),
@@ -312,7 +310,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.OffsetDateTime.of(2023, 1, 1, 1, 1, 0, 0, java.time.ZoneOffset.UTC)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected OffsetDateTime")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected OffsetDateTime")))
         )
       }
     ),
@@ -336,7 +334,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.OffsetTime.of(1, 1, 0, 0, java.time.ZoneOffset.UTC)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected OffsetTime")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected OffsetTime")))
         )
       }
     ),
@@ -350,7 +348,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.Period.ofDays(1)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Period")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Period")))
         )
       }
     ),
@@ -364,7 +362,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.Year.of(2023)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Year")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Year")))
         )
       }
     ),
@@ -378,7 +376,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.YearMonth.of(2023, 1)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected YearMonth")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected YearMonth")))
         )
       }
     ),
@@ -392,7 +390,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.ZoneId.of("UTC")))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected ZoneId")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected ZoneId")))
         )
       }
     ),
@@ -406,7 +404,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.ZoneOffset.UTC))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected ZoneOffset")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected ZoneOffset")))
         )
       }
     ),
@@ -430,7 +428,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.time.ZonedDateTime.of(2023, 1, 1, 1, 1, 0, 0, java.time.ZoneOffset.UTC)))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected ZonedDateTime")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected ZonedDateTime")))
         )
       }
     ),
@@ -454,7 +452,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(java.util.UUID.fromString("DAD945B7-64F4-4265-BB56-4557325F701C")))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected UUID")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected UUID")))
         )
       }
     ),
@@ -469,7 +467,7 @@ object PrimitiveTypeSpec extends ZIOSpecDefault {
           isRight(equalTo(testCurrency))
         ) &&
         assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(1L))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Currency")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Currency")))
         )
       }
     )

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
@@ -3,7 +3,7 @@ package zio.blocks.schema
 import zio.Chunk
 import zio.blocks.schema.DynamicOptic.Node.{Elements, MapValues}
 import zio.blocks.schema.Reflect.Primitive
-import zio.blocks.schema.SchemaError.{InvalidType, MissingField}
+import zio.blocks.schema.SchemaError.{ExpectationMismatch, MissingField}
 import zio.blocks.schema.binding._
 import zio.blocks.schema.codec.{TextCodec, TextFormat}
 import zio.blocks.schema.derive.Deriver
@@ -50,7 +50,7 @@ object SchemaSpec extends ZIOSpecDefault {
       test("has consistent toDynamicValue and fromDynamicValue") {
         assert(Schema[Byte].fromDynamicValue(Schema[Byte].toDynamicValue(1)))(isRight(equalTo(1: Byte))) &&
         assert(Schema[Byte].fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(1))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected Byte")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected Byte")))
         )
       },
       test("encodes values using provided formats and outputs") {
@@ -109,7 +109,7 @@ object SchemaSpec extends ZIOSpecDefault {
           isRight(equalTo(Record(1: Byte, 1000)))
         ) &&
         assert(Record.schema.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(1))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected a record")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected a record")))
         ) &&
         assert(
           Record.schema.fromDynamicValue(
@@ -807,7 +807,7 @@ object SchemaSpec extends ZIOSpecDefault {
           isRight(equalTo(Case2("VVV")))
         ) &&
         assert(Variant.schema.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(1))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected a variant")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected a variant")))
         ) &&
         assert(
           Variant.schema.fromDynamicValue(
@@ -822,7 +822,7 @@ object SchemaSpec extends ZIOSpecDefault {
         )(
           isLeft(
             equalTo(
-              SchemaError.invalidType(
+              SchemaError.expectationMismatch(
                 List(DynamicOptic.Node.Field("s"), DynamicOptic.Node.Case("Case2")),
                 "Expected String"
               )
@@ -1235,7 +1235,7 @@ object SchemaSpec extends ZIOSpecDefault {
           isRight(equalTo(List("VVV", "WWW")))
         ) &&
         assert(Schema[List[Int]].fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(1))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected a sequence")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected a sequence")))
         ) &&
         assert(
           Schema[List[Boolean]].fromDynamicValue(
@@ -1259,42 +1259,42 @@ object SchemaSpec extends ZIOSpecDefault {
           Schema[List[Byte]].fromDynamicValue(
             DynamicValue.Sequence(Vector(DynamicValue.Primitive(PrimitiveValue.Int(1))))
           )
-        )(isLeft(equalTo(SchemaError.invalidType(Elements :: Nil, "Expected Byte")))) &&
+        )(isLeft(equalTo(SchemaError.expectationMismatch(Elements :: Nil, "Expected Byte")))) &&
         assert(
           Schema[List[Char]].fromDynamicValue(
             DynamicValue.Sequence(Vector(DynamicValue.Primitive(PrimitiveValue.Int(1))))
           )
-        )(isLeft(equalTo(SchemaError.invalidType(Elements :: Nil, "Expected Char")))) &&
+        )(isLeft(equalTo(SchemaError.expectationMismatch(Elements :: Nil, "Expected Char")))) &&
         assert(
           Schema[List[Short]].fromDynamicValue(
             DynamicValue.Sequence(Vector(DynamicValue.Primitive(PrimitiveValue.Int(1))))
           )
-        )(isLeft(equalTo(SchemaError.invalidType(Elements :: Nil, "Expected Short")))) &&
+        )(isLeft(equalTo(SchemaError.expectationMismatch(Elements :: Nil, "Expected Short")))) &&
         assert(
           Schema[List[Int]].fromDynamicValue(
             DynamicValue.Sequence(Vector(DynamicValue.Primitive(PrimitiveValue.Long(1))))
           )
-        )(isLeft(equalTo(SchemaError.invalidType(Elements :: Nil, "Expected Int")))) &&
+        )(isLeft(equalTo(SchemaError.expectationMismatch(Elements :: Nil, "Expected Int")))) &&
         assert(
           Schema[List[Float]].fromDynamicValue(
             DynamicValue.Sequence(Vector(DynamicValue.Primitive(PrimitiveValue.Int(1))))
           )
-        )(isLeft(equalTo(SchemaError.invalidType(Elements :: Nil, "Expected Float")))) &&
+        )(isLeft(equalTo(SchemaError.expectationMismatch(Elements :: Nil, "Expected Float")))) &&
         assert(
           Schema[List[Long]].fromDynamicValue(
             DynamicValue.Sequence(Vector(DynamicValue.Primitive(PrimitiveValue.Int(1))))
           )
-        )(isLeft(equalTo(SchemaError.invalidType(Elements :: Nil, "Expected Long")))) &&
+        )(isLeft(equalTo(SchemaError.expectationMismatch(Elements :: Nil, "Expected Long")))) &&
         assert(
           Schema[List[Double]].fromDynamicValue(
             DynamicValue.Sequence(Vector(DynamicValue.Primitive(PrimitiveValue.Int(1))))
           )
-        )(isLeft(equalTo(SchemaError.invalidType(Elements :: Nil, "Expected Double")))) &&
+        )(isLeft(equalTo(SchemaError.expectationMismatch(Elements :: Nil, "Expected Double")))) &&
         assert(
           Schema[List[String]].fromDynamicValue(
             DynamicValue.Sequence(Vector(DynamicValue.Primitive(PrimitiveValue.Int(1))))
           )
-        )(isLeft(equalTo(SchemaError.invalidType(Elements :: Nil, "Expected String")))) &&
+        )(isLeft(equalTo(SchemaError.expectationMismatch(Elements :: Nil, "Expected String")))) &&
         assert(
           Schema[List[Record]].fromDynamicValue(DynamicValue.Sequence(Vector(DynamicValue.Record(Vector.empty))))
         )(
@@ -1402,7 +1402,7 @@ object SchemaSpec extends ZIOSpecDefault {
           Schema[Map[Int, Long]].fromDynamicValue(Schema[Map[Int, Long]].toDynamicValue(Map(1 -> 1L, 2 -> 2L, 3 -> 3L)))
         )(isRight(equalTo(Map(1 -> 1L, 2 -> 2L, 3 -> 3L)))) &&
         assert(Schema[Map[Int, Long]].fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(1))))(
-          isLeft(equalTo(SchemaError.invalidType(Nil, "Expected a map")))
+          isLeft(equalTo(SchemaError.expectationMismatch(Nil, "Expected a map")))
         ) &&
         assert(
           Schema[Map[Int, Long]].fromDynamicValue(
@@ -1412,7 +1412,7 @@ object SchemaSpec extends ZIOSpecDefault {
               )
             )
           )
-        )(isLeft(equalTo(SchemaError.invalidType(DynamicOptic.Node.MapKeys :: Nil, "Expected Int")))) &&
+        )(isLeft(equalTo(SchemaError.expectationMismatch(DynamicOptic.Node.MapKeys :: Nil, "Expected Int")))) &&
         assert(
           Schema[Map[Int, Long]].fromDynamicValue(
             DynamicValue.Map(
@@ -1427,12 +1427,12 @@ object SchemaSpec extends ZIOSpecDefault {
             equalTo(
               SchemaError(
                 errors = ::(
-                  InvalidType(
+                  ExpectationMismatch(
                     source = DynamicOptic(nodes = Vector(MapValues)),
                     expectation = "Expected Long"
                   ),
                   ::(
-                    InvalidType(
+                    ExpectationMismatch(
                       source = DynamicOptic(nodes = Vector(MapValues)),
                       expectation = "Expected Long"
                     ),
@@ -1705,7 +1705,7 @@ object SchemaSpec extends ZIOSpecDefault {
             equalTo(
               SchemaError(
                 errors = ::(
-                  InvalidType(
+                  ExpectationMismatch(
                     source = DynamicOptic(nodes = Vector()),
                     expectation = "Expected PosInt: Expected positive value"
                   ),
@@ -1720,7 +1720,7 @@ object SchemaSpec extends ZIOSpecDefault {
             equalTo(
               SchemaError(
                 errors = ::(
-                  InvalidType(
+                  ExpectationMismatch(
                     source = DynamicOptic(nodes = Vector()),
                     expectation = "Expected Int"
                   ),


### PR DESCRIPTION
Results with Scala 3 using JDK 21:

```txt
Benchmark                                (size)   Mode  Cnt      Score     Error  Units
ListOfRecordsBenchmark.readingAvro4s       1000  thrpt    5   4207.244 ± 796.258  ops/s
ListOfRecordsBenchmark.readingZioBlocks    1000  thrpt    5   9574.146 ± 355.895  ops/s
ListOfRecordsBenchmark.readingZioSchema    1000  thrpt    5    148.688 ±   4.345  ops/s
ListOfRecordsBenchmark.writingAvro4s       1000  thrpt    5   5154.707 ±  51.467  ops/s
ListOfRecordsBenchmark.writingZioBlocks    1000  thrpt    5  12021.036 ± 322.688  ops/s
ListOfRecordsBenchmark.writingZioSchema    1000  thrpt    5    121.528 ±   2.966  ops/s
```