### PR TITLE
Add benchmarks for decoding and encoding of deeply nested data structures with Avro codecs + more efficient error returning in case of decoding error

### DIFF
--- a/avro/src/main/scala/zio/blocks/avro/AvroFormat.scala
+++ b/avro/src/main/scala/zio/blocks/avro/AvroFormat.scala
@@ -535,7 +535,7 @@ object AvroFormat
                       caseCodecs(idx).asInstanceOf[AvroBinaryCodec[A]].decode(decoder)
                     } catch {
                       case error if NonFatal(error) =>
-                        decodeError(new DynamicOptic.Node.Case(cases(idx).name) :: Nil, error)
+                        decodeError(new DynamicOptic.Node.Case(cases(idx).name), error)
                     }
                   } else decodeError(s"Expected enum index from 0 to ${caseCodecs.length - 1}, got $idx")
                 }
@@ -576,7 +576,7 @@ object AvroFormat
                           elementCodec.decode(decoder)
                         } catch {
                           case error if NonFatal(error) =>
-                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt) :: Nil, error)
+                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt), error)
                         }
                       constructor.addObject(builder, v)
                       count += 1
@@ -629,14 +629,14 @@ object AvroFormat
                           keyCodec.decode(decoder)
                         } catch {
                           case error if NonFatal(error) =>
-                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt) :: Nil, error)
+                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt), error)
                         }
                       val v =
                         try {
                           valueCodec.decode(decoder)
                         } catch {
                           case error if NonFatal(error) =>
-                            decodeError(new DynamicOptic.Node.AtMapKey(k) :: Nil, error)
+                            decodeError(new DynamicOptic.Node.AtMapKey(k), error)
                         }
                       constructor.addObject(builder, k, v)
                       count += 1
@@ -721,7 +721,7 @@ object AvroFormat
                     }
                   } catch {
                     case error if NonFatal(error) =>
-                      decodeError(new DynamicOptic.Node.Field(fields(idx).name) :: Nil, error)
+                      decodeError(new DynamicOptic.Node.Field(fields(idx).name), error)
                   }
                   constructor.construct(registers, RegisterOffset.Zero)
                 }
@@ -776,7 +776,7 @@ object AvroFormat
                     try {
                       codec.decode(decoder)
                     } catch {
-                      case error if NonFatal(error) => decodeError(DynamicOptic.Node.Wrapped :: Nil, error)
+                      case error if NonFatal(error) => decodeError(DynamicOptic.Node.Wrapped, error)
                     }
                   wrap(wrapped) match {
                     case Right(x)  => x
@@ -816,7 +816,7 @@ object AvroFormat
                 try {
                   primitiveDynamicValueCodec.decode(decoder)
                 } catch {
-                  case error if NonFatal(error) => decodeError(spanPrimitive :: Nil, error)
+                  case error if NonFatal(error) => decodeError(spanPrimitive, error)
                 }
               case 1 =>
                 try {
@@ -838,14 +838,14 @@ object AvroFormat
                           decoder.readString()
                         } catch {
                           case error if NonFatal(error) =>
-                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt) :: span_1 :: Nil, error)
+                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt), span_1, error)
                         }
                       val v =
                         try {
                           decode(decoder)
                         } catch {
                           case error if NonFatal(error) =>
-                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt) :: span_2 :: Nil, error)
+                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt), span_2, error)
                         }
                       builder.addOne((k, v))
                       count += 1
@@ -855,7 +855,7 @@ object AvroFormat
                   if (size < 0) decodeError(s"Expected positive collection part size, got $size")
                   new DynamicValue.Record(builder.result())
                 } catch {
-                  case error if NonFatal(error) => decodeError(spanRecord :: spanFields :: Nil, error)
+                  case error if NonFatal(error) => decodeError(spanRecord, spanFields, error)
                 }
               case 2 =>
                 try {
@@ -863,17 +863,17 @@ object AvroFormat
                     try {
                       decoder.readString()
                     } catch {
-                      case error if NonFatal(error) => decodeError(spanCaseName :: Nil, error)
+                      case error if NonFatal(error) => decodeError(spanCaseName, error)
                     }
                   val value =
                     try {
                       decode(decoder)
                     } catch {
-                      case error if NonFatal(error) => decodeError(spanValue :: Nil, error)
+                      case error if NonFatal(error) => decodeError(spanValue, error)
                     }
                   new DynamicValue.Variant(caseName, value)
                 } catch {
-                  case error if NonFatal(error) => decodeError(spanVariant :: Nil, error)
+                  case error if NonFatal(error) => decodeError(spanVariant, error)
                 }
               case 3 =>
                 try {
@@ -895,7 +895,7 @@ object AvroFormat
                           decode(decoder)
                         } catch {
                           case error if NonFatal(error) =>
-                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt) :: Nil, error)
+                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt), error)
                         }
                       builder.addOne(v)
                       count += 1
@@ -905,7 +905,7 @@ object AvroFormat
                   if (size < 0) decodeError(s"Expected positive collection part size, got $size")
                   new DynamicValue.Sequence(builder.result())
                 } catch {
-                  case error if NonFatal(error) => decodeError(spanSequence :: spanElements :: Nil, error)
+                  case error if NonFatal(error) => decodeError(spanSequence, spanElements, error)
                 }
               case 4 =>
                 try {
@@ -927,14 +927,14 @@ object AvroFormat
                           decode(decoder)
                         } catch {
                           case error if NonFatal(error) =>
-                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt) :: span_1 :: Nil, error)
+                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt), span_1, error)
                         }
                       val v =
                         try {
                           decode(decoder)
                         } catch {
                           case error if NonFatal(error) =>
-                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt) :: span_2 :: Nil, error)
+                            decodeError(new DynamicOptic.Node.AtIndex(count.toInt), span_2, error)
                         }
                       builder.addOne((k, v))
                       count += 1
@@ -944,7 +944,7 @@ object AvroFormat
                   if (size < 0) decodeError(s"Expected positive collection part size, got $size")
                   new DynamicValue.Map(builder.result())
                 } catch {
-                  case error if NonFatal(error) => decodeError(spanMap :: spanEntries :: Nil, error)
+                  case error if NonFatal(error) => decodeError(spanMap, spanEntries, error)
                 }
               case idx => decodeError(s"Expected enum index from 0 to 4, got $idx")
             }

--- a/avro/src/test/scala/zio/blocks/avro/AvroFormatSpec.scala
+++ b/avro/src/test/scala/zio/blocks/avro/AvroFormatSpec.scala
@@ -392,7 +392,7 @@ object AvroFormatSpec extends ZIOSpecDefault {
                     try {
                       codec.decode(decoder)
                     } catch {
-                      case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(idx) :: Nil, error)
+                      case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(idx), error)
                     }
                   builder.addOne(v)
                   idx += 1

--- a/benchmarks/src/main/scala/zio/blocks/avro/ListOfRecordsBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/blocks/avro/ListOfRecordsBenchmark.scala
@@ -21,7 +21,7 @@ class ListOfRecordsBenchmark extends BaseBenchmark {
   @Setup
   def setup(): Unit = {
     listOfRecords = (1 to size).map(_ => Person(12345678901L, "John", 30, "123 Main St", List(5, 7, 9))).toList
-    encodedListOfRecords = zioSchemaCodec.encode(listOfRecords).toArray
+    encodedListOfRecords = zioBlocksCodec.encode(listOfRecords)
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/blocks/avro/NestedRecordsBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/blocks/avro/NestedRecordsBenchmark.scala
@@ -1,0 +1,44 @@
+package zio.blocks.avro
+
+import org.openjdk.jmh.annotations._
+import zio.blocks.BaseBenchmark
+import zio.blocks.schema.{Schema, SchemaError}
+import zio.blocks.avro.AvroFormat
+
+class NestedRecordsBenchmark extends BaseBenchmark {
+  import NestedRecordsBenchmark._
+
+  @Param(Array("1", "10", "100"))
+  var size: Int                         = 100
+  var nestedRecords: Nested             = _
+  var encodedNestedRecords: Array[Byte] = _
+  var brokenNestedRecords: Array[Byte]  = _
+
+  @Setup
+  def setup(): Unit = {
+    nestedRecords = (1 to size).foldLeft(Nested(0, None))((n, i) => Nested(i, Some(n)))
+    encodedNestedRecords = zioBlocksCodec.encode(nestedRecords)
+    brokenNestedRecords = zioBlocksCodec.encode(nestedRecords)
+    brokenNestedRecords(brokenNestedRecords.length - 1) = 1.toByte
+  }
+
+  @Benchmark
+  def readingZioBlocks: Nested =
+    zioBlocksCodec.decode(encodedNestedRecords) match {
+      case Right(value) => value
+      case Left(error)  => sys.error(error.getMessage)
+    }
+
+  @Benchmark
+  def readingErrorZioBlocks: Either[SchemaError, Nested] =
+    zioBlocksCodec.decode(brokenNestedRecords)
+
+  @Benchmark
+  def writingZioBlocks: Array[Byte] = zioBlocksCodec.encode(nestedRecords)
+}
+
+object NestedRecordsBenchmark {
+  case class Nested(value: Int, next: Option[Nested])
+
+  val zioBlocksCodec: AvroBinaryCodec[Nested] = Schema.derived.deriving(AvroFormat.deriver).derive
+}

--- a/benchmarks/src/test/scala/zio/blocks/avro/NestedRecordsBenchmarkSpec.scala
+++ b/benchmarks/src/test/scala/zio/blocks/avro/NestedRecordsBenchmarkSpec.scala
@@ -1,0 +1,37 @@
+package zio.blocks.avro
+
+import zio.blocks.schema.{DynamicOptic, SchemaError}
+import zio.test._
+import zio.test.Assertion._
+
+object NestedRecordsBenchmarkSpec extends ZIOSpecDefault {
+  def spec: Spec[TestEnvironment, Any] = suite("NestedRecordsBenchmarkSpec")(
+    test("reading") {
+      val benchmark = new NestedRecordsBenchmark
+      benchmark.setup()
+      val zioBlocksOutput = benchmark.readingZioBlocks
+      assert(zioBlocksOutput)(equalTo(zioBlocksOutput))
+    },
+    test("reading error") {
+      val benchmark = new NestedRecordsBenchmark
+      benchmark.setup()
+      val trace =
+        (1 to benchmark.size)
+          .foldLeft[List[DynamicOptic.Node]](DynamicOptic.Node.Field("next") :: Nil) { (trace, _) =>
+            DynamicOptic.Node
+              .Field("next") :: DynamicOptic.Node.Case("Some") :: DynamicOptic.Node.Field("value") :: trace
+          }
+          .toIndexedSeq
+      val message       = "Expected enum index from 0 to 1, got -1"
+      val expectedError =
+        new SchemaError(new ::(new SchemaError.ExpectationMismatch(new DynamicOptic(trace), message), Nil))
+      assert(benchmark.readingErrorZioBlocks)(isLeft(equalTo(expectedError)))
+    },
+    test("writing") {
+      val benchmark = new NestedRecordsBenchmark
+      benchmark.setup()
+      val zioBlocksOutput = benchmark.writingZioBlocks
+      assert(java.util.Arrays.compare(zioBlocksOutput, zioBlocksOutput))(equalTo(0))
+    }
+  )
+}


### PR DESCRIPTION
Benchmark results with Scala 3.

JDK 25:
```txt
Benchmark                                     (size)   Mode  Cnt         Score        Error  Units
NestedRecordsBenchmark.readingErrorZioBlocks       1  thrpt    5   3296332.626 ±  92173.618  ops/s
NestedRecordsBenchmark.readingErrorZioBlocks      10  thrpt    5    671654.527 ±   3605.444  ops/s
NestedRecordsBenchmark.readingErrorZioBlocks     100  thrpt    5     69691.812 ±   2982.806  ops/s
NestedRecordsBenchmark.readingZioBlocks            1  thrpt    5  11891220.816 ± 417189.292  ops/s
NestedRecordsBenchmark.readingZioBlocks           10  thrpt    5   2428394.494 ±  34864.199  ops/s
NestedRecordsBenchmark.readingZioBlocks          100  thrpt    5    224885.601 ±   3529.817  ops/s
NestedRecordsBenchmark.writingZioBlocks            1  thrpt    5  13845537.638 ± 290895.022  ops/s
NestedRecordsBenchmark.writingZioBlocks           10  thrpt    5   2494702.462 ±  23445.723  ops/s
NestedRecordsBenchmark.writingZioBlocks          100  thrpt    5    228653.007 ±   4166.941  ops/s
```

GraalVM JDK 25
```txt
Benchmark                                     (size)   Mode  Cnt         Score        Error  Units
NestedRecordsBenchmark.readingErrorZioBlocks       1  thrpt    5   3658938.062 ±  38182.176  ops/s
NestedRecordsBenchmark.readingErrorZioBlocks      10  thrpt    5    591412.208 ±   6726.411  ops/s
NestedRecordsBenchmark.readingErrorZioBlocks     100  thrpt    5     33964.031 ±    269.569  ops/s
NestedRecordsBenchmark.readingZioBlocks            1  thrpt    5  14962302.117 ± 293234.258  ops/s
NestedRecordsBenchmark.readingZioBlocks           10  thrpt    5   3181438.277 ±  38313.592  ops/s
NestedRecordsBenchmark.readingZioBlocks          100  thrpt    5    311870.859 ±   4018.273  ops/s
NestedRecordsBenchmark.writingZioBlocks            1  thrpt    5  19031169.809 ± 248333.297  ops/s
NestedRecordsBenchmark.writingZioBlocks           10  thrpt    5   3393110.627 ±  40242.608  ops/s
NestedRecordsBenchmark.writingZioBlocks          100  thrpt    5    300033.490 ±   3952.849  ops/s
```