### PR TITLE
Add JSON benchmarks for zio-schema

### DIFF
--- a/benchmarks/src/main/scala/zio/blocks/schema/json/JsonListOfRecordsBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/blocks/schema/json/JsonListOfRecordsBenchmark.scala
@@ -6,6 +6,7 @@ import org.openjdk.jmh.annotations._
 import zio.blocks.BaseBenchmark
 import zio.blocks.schema.Schema
 import zio.schema.{DeriveSchema, Schema as ZIOSchema}
+import java.nio.charset.StandardCharsets.UTF_8
 
 class JsonListOfRecordsBenchmark extends BaseBenchmark {
   import JsonListOfRecordsDomain._
@@ -33,9 +34,17 @@ class JsonListOfRecordsBenchmark extends BaseBenchmark {
   @Benchmark
   def readingZioJson: List[Person] = {
     import zio.json.DecoderOps
-    import java.nio.charset.StandardCharsets.UTF_8
 
-    new String(encodedListOfRecords, UTF_8).fromJson[List[Person]].fold(sys.error, identity)
+    new String(encodedListOfRecords, UTF_8).fromJson[List[Person]] match {
+      case Right(value) => value
+      case Left(error)  => sys.error(error)
+    }
+  }
+
+  @Benchmark
+  def readingZioSchema: List[Person] = zioSchemaCodec.decodeJson(new String(encodedListOfRecords, UTF_8)) match {
+    case Right(value) => value
+    case Left(error)  => sys.error(error)
   }
 
   @Benchmark
@@ -47,20 +56,23 @@ class JsonListOfRecordsBenchmark extends BaseBenchmark {
   @Benchmark
   def writingZioJson: Array[Byte] = {
     import zio.json.EncoderOps
-    import java.nio.charset.StandardCharsets.UTF_8
 
     listOfRecords.toJson.getBytes(UTF_8)
   }
+
+  @Benchmark
+  def writingZioSchema: Array[Byte] = zioSchemaCodec.encodeJson(listOfRecords, None).toString.getBytes(UTF_8)
 }
 
 object JsonListOfRecordsDomain {
   case class Person(id: Long, name: String, age: Int, address: String, childrenAges: List[Int])
 
-  implicit val zioSchema: ZIOSchema[Person] = DeriveSchema.gen[Person]
-
   implicit val jsoniterScalaCodec: JsonValueCodec[List[Person]] = JsonCodecMaker.make
+
+  val zioBlocksCodec: JsonBinaryCodec[List[Person]] = Schema.derived.derive(JsonFormat.deriver)
 
   implicit val zioJsonCodec: zio.json.JsonCodec[Person] = zio.json.DeriveJsonCodec.gen
 
-  val zioBlocksCodec: JsonBinaryCodec[List[Person]] = Schema.derived.deriving(JsonFormat.deriver).derive
+  val zioSchemaCodec: zio.json.JsonCodec[List[Person]] =
+    zio.schema.codec.JsonCodec.jsonCodec(DeriveSchema.gen[List[Person]])
 }

--- a/benchmarks/src/test/scala/zio/blocks/json/JsonListOfRecordsBenchmarkSpec.scala
+++ b/benchmarks/src/test/scala/zio/blocks/json/JsonListOfRecordsBenchmarkSpec.scala
@@ -11,8 +11,10 @@ object JsonListOfRecordsBenchmarkSpec extends ZIOSpecDefault {
       benchmark.setup()
       val jsoniterScalaOutput = benchmark.readingJsoniterScala
       val zioBlocksOutput     = benchmark.readingZioBlocks
-      val zioSchemaOutput     = benchmark.readingZioJson
+      val zioJsonOutput       = benchmark.readingZioJson
+      val zioSchemaOutput     = benchmark.readingZioSchema
       assert(jsoniterScalaOutput)(equalTo(zioBlocksOutput)) &&
+      assert(zioJsonOutput)(equalTo(zioBlocksOutput)) &&
       assert(zioSchemaOutput)(equalTo(zioBlocksOutput))
     },
     test("writing") {
@@ -21,8 +23,10 @@ object JsonListOfRecordsBenchmarkSpec extends ZIOSpecDefault {
       val jsoniterScalaOutput = benchmark.writingJsoniterScala
       val zioBlocksOutput     = benchmark.writingZioBlocks
       val zioJsonOutput       = benchmark.writingZioJson
+      val zioSchemaOutput     = benchmark.writingZioSchema
       assert(new String(jsoniterScalaOutput))(equalTo(new String(zioBlocksOutput))) &&
-      assert(new String(zioJsonOutput))(equalTo(new String(zioBlocksOutput)))
+      assert(new String(zioJsonOutput))(equalTo(new String(zioBlocksOutput))) &&
+      assert(new String(zioSchemaOutput))(equalTo(new String(zioBlocksOutput)))
     }
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -156,6 +156,7 @@ lazy val benchmarks = project
       "com.sksamuel.avro4s"                   %% "avro4s-core"           % "5.0.14",
       "dev.zio"                               %% "zio-json"              % "0.7.45",
       "dev.zio"                               %% "zio-schema-avro"       % "1.7.5",
+      "dev.zio"                               %% "zio-schema-json"       % "1.7.5",
       "io.github.arainko"                     %% "chanterelle"           % "0.1.1",
       "com.softwaremill.quicklens"            %% "quicklens"             % "1.9.12",
       "dev.optics"                            %% "monocle-core"          % "3.3.0",


### PR DESCRIPTION
Result of benchmarks using Scala 3.8.0-RC3 and JDK 25 on Intel® Core™ Ultra 9 285K CPU @ 3.7GHz (max 5.7GHz, 200S Boost), RAM 64Gb DDR5-6400:

```txt
Benchmark                                         (size)   Mode  Cnt       Score      Error  Units
JsonListOfRecordsBenchmark.readingJsoniterScala      100  thrpt    5  166504.631 ± 1457.745  ops/s
JsonListOfRecordsBenchmark.readingZioBlocks          100  thrpt    5  124963.241 ± 2031.175  ops/s
JsonListOfRecordsBenchmark.readingZioJson            100  thrpt    5   57675.735 ±  261.660  ops/s
JsonListOfRecordsBenchmark.readingZioSchema          100  thrpt    5   49878.522 ±  589.650  ops/s
JsonListOfRecordsBenchmark.writingJsoniterScala      100  thrpt    5  291649.540 ±  937.826  ops/s
JsonListOfRecordsBenchmark.writingZioBlocks          100  thrpt    5  162342.106 ± 4374.005  ops/s
JsonListOfRecordsBenchmark.writingZioJson            100  thrpt    5  155980.135 ± 1515.568  ops/s
JsonListOfRecordsBenchmark.writingZioSchema          100  thrpt    5   81099.437 ± 3354.278  ops/s
JsonNestedRecordsBenchmark.readingErrorZioBlocks     100  thrpt    5  147806.550 ± 2668.567  ops/s
JsonNestedRecordsBenchmark.readingZioBlocks          100  thrpt    5  340270.689 ± 8535.611  ops/s
JsonNestedRecordsBenchmark.writingZioBlocks          100  thrpt    5  461982.616 ± 7630.813  ops/s
```