### PR TITLE
Implement Pure Algebraic Migration System #519

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -1,0 +1,208 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicOptic, DynamicValue, PrimitiveValue, SchemaExpr}
+import zio.blocks.schema.DynamicOptic.Node
+import zio.blocks.schema.migration.MigrationError._
+
+final case class DynamicMigration(actions: Vector[MigrationAction]) { self =>
+
+  def apply(value: DynamicValue): Either[MigrationError, DynamicValue] =
+    actions.foldLeft[Either[MigrationError, DynamicValue]](Right(value)) {
+      case (Right(curr), action) => applyAction(curr, action)
+      case (err, _)              => err
+    }
+
+  def ++(that: DynamicMigration): DynamicMigration =
+    DynamicMigration(self.actions ++ that.actions)
+
+  private def applyAction(root: DynamicValue, action: MigrationAction): Either[MigrationError, DynamicValue] =
+    recurse(root, action.at.nodes.toList, action, action.at)
+
+  private def recurse(
+    current: DynamicValue,
+    path: List[Node],
+    action: MigrationAction,
+    fullPath: DynamicOptic
+  ): Either[MigrationError, DynamicValue] = {
+    (current, path) match {
+      // -----------------------------------------------------------------------
+      // CASE 1: Structural Modifications on Record Fields
+      // We are at the Record, and the next node is the Field target.
+      // -----------------------------------------------------------------------
+      case (DynamicValue.Record(fields), Node.Field(name) :: Nil) =>
+        action match {
+          case MigrationAction.RenameField(_, newName) =>
+            val idx = fields.indexWhere(_._1 == name)
+            if (idx == -1) Left(PathNotFound(fullPath, s"Field '$name' not found for rename"))
+            else {
+              // Fix: Use wildcard `_` for the unused key variable
+              val (_, v) = fields(idx)
+              Right(DynamicValue.Record(fields.updated(idx, (newName, v))))
+            }
+
+          case MigrationAction.DropField(_) =>
+            if (!fields.exists(_._1 == name)) Left(PathNotFound(fullPath, s"Field '$name' not found for drop"))
+            else Right(DynamicValue.Record(fields.filterNot(_._1 == name)))
+
+          case MigrationAction.AddField(_, defaultExpr) =>
+            if (fields.exists(_._1 == name)) Left(InvalidOperation(fullPath, s"Field '$name' already exists"))
+            else {
+              // Evaluate default using the PARENT record as input context
+              evalExpr(defaultExpr, current, fullPath).map { defaultVal =>
+                DynamicValue.Record(fields :+ (name -> defaultVal))
+              }
+            }
+
+          // For Value Actions (Transform, etc.) pointing to a field, we descend.
+          case _ =>
+            val idx = fields.indexWhere(_._1 == name)
+            if (idx == -1) Left(PathNotFound(fullPath, s"Field '$name' not found"))
+            else {
+              val (k, v) = fields(idx)
+              recurse(v, Nil, action, fullPath).map { newVal =>
+                DynamicValue.Record(fields.updated(idx, (k, newVal)))
+              }
+            }
+        }
+
+      // -----------------------------------------------------------------------
+      // CASE 2: Structural Modifications on Enum Cases
+      // -----------------------------------------------------------------------
+      case (DynamicValue.Variant(caseName, inner), Node.Case(targetCase) :: Nil) =>
+        action match {
+          case MigrationAction.RenameCase(_, from, to) =>
+            if (caseName == from && caseName == targetCase) Right(DynamicValue.Variant(to, inner))
+            else if (caseName != targetCase) {
+              // Usually strict, but for renames usually applied only if matching
+              Right(current)
+            } else Right(current)
+
+          case _ =>
+            if (caseName == targetCase) {
+              recurse(inner, Nil, action, fullPath).map(newInner => DynamicValue.Variant(caseName, newInner))
+            } else {
+              Right(current) // Mismatch case, no-op
+            }
+        }
+
+      // -----------------------------------------------------------------------
+      // CASE 3: Traversal (Drilling down)
+      // -----------------------------------------------------------------------
+      case (DynamicValue.Record(fields), Node.Field(name) :: tail) =>
+        val idx = fields.indexWhere(_._1 == name)
+        if (idx == -1) Left(PathNotFound(fullPath, s"Field '$name' not found"))
+        else {
+          val (k, v) = fields(idx)
+          recurse(v, tail, action, fullPath).map { newVal =>
+            DynamicValue.Record(fields.updated(idx, (k, newVal)))
+          }
+        }
+
+      case (DynamicValue.Sequence(elems), Node.AtIndex(i) :: tail) =>
+        if (i < 0 || i >= elems.length) Left(PathNotFound(fullPath, s"Index $i out of bounds"))
+        else {
+          recurse(elems(i), tail, action, fullPath).map { newVal =>
+            DynamicValue.Sequence(elems.updated(i, newVal))
+          }
+        }
+
+      case (DynamicValue.Map(entries), Node.AtMapKey(key) :: tail) =>
+        // Assuming key in Node is compatible; simplified lookup
+        val idx = entries.indexWhere { case (k, _) => k == key.asInstanceOf[DynamicValue] }
+        if (idx == -1) Left(PathNotFound(fullPath, s"Key $key not found"))
+        else {
+          val (k, v) = entries(idx)
+          recurse(v, tail, action, fullPath).map { newVal =>
+            DynamicValue.Map(entries.updated(idx, (k, newVal)))
+          }
+        }
+
+      case (DynamicValue.Variant(name, inner), Node.Case(target) :: tail) =>
+        if (name == target) {
+          recurse(inner, tail, action, fullPath).map(newInner => DynamicValue.Variant(name, newInner))
+        } else {
+          Right(current) // No-op on mismatch
+        }
+
+      // -----------------------------------------------------------------------
+      // CASE 4: Target Reached (Leaf Actions)
+      // -----------------------------------------------------------------------
+      case (value, Nil) =>
+        action match {
+          case MigrationAction.TransformValue(_, expr) =>
+            evalExpr(expr, value, fullPath)
+
+          case MigrationAction.ChangeType(_, expr) =>
+            evalExpr(expr, value, fullPath)
+
+          case MigrationAction.Optionalize(_) =>
+            // Wrap in "Some" variant. ZIO Schema generic representation for Option.
+            Right(DynamicValue.Variant("Some", value))
+
+          case MigrationAction.Mandate(_, default) =>
+            unwrapOption(value, default, fullPath)
+
+          case MigrationAction.TransformElements(_, innerAction) =>
+            value match {
+              case DynamicValue.Sequence(elems) =>
+                val results = elems.map(e => recurse(e, innerAction.at.nodes.toList, innerAction, innerAction.at))
+                results.find(_.isLeft) match {
+                  case Some(Left(e)) => Left(e)
+                  case _             => Right(DynamicValue.Sequence(results.map(_.toOption.get)))
+                }
+              case _ => Left(TypeMismatch(fullPath, "Sequence", value))
+            }
+
+          case MigrationAction.TransformValues(_, innerAction) =>
+            value match {
+              case DynamicValue.Map(entries) =>
+                val results = entries.map { case (k, v) =>
+                  recurse(v, innerAction.at.nodes.toList, innerAction, innerAction.at).map(nv => (k, nv))
+                }
+                results.find(_.isLeft) match {
+                  case Some(Left(e)) => Left(e)
+                  case _             => Right(DynamicValue.Map(results.map(_.toOption.get)))
+                }
+              case _ => Left(TypeMismatch(fullPath, "Map", value))
+            }
+
+          case _ => Left(InvalidOperation(fullPath, s"Unexpected action at leaf: $action"))
+        }
+
+      // -----------------------------------------------------------------------
+      // CASE 5: Traversal Mismatches
+      // -----------------------------------------------------------------------
+      case _ =>
+        Left(PathNotFound(fullPath, s"Cannot traverse path $path on $current"))
+    }
+  }
+
+  private def evalExpr(
+    expr: SchemaExpr[?, ?],
+    input: DynamicValue,
+    path: DynamicOptic
+  ): Either[MigrationError, DynamicValue] =
+    // Unsafe cast to evaluate dynamic expression
+    expr.asInstanceOf[SchemaExpr[Any, Any]].evalDynamic(input.asInstanceOf[Any]) match {
+      case Right(seq) =>
+        seq.headOption.toRight(CalculationError(path, "Expression produced no values"))
+      case Left(check) =>
+        Left(CalculationError(path, check.toString))
+    }
+
+  private def unwrapOption(
+    value: DynamicValue,
+    default: SchemaExpr[?, ?],
+    path: DynamicOptic
+  ): Either[MigrationError, DynamicValue] =
+    value match {
+      case DynamicValue.Variant("Some", inner)                   => Right(inner)
+      case DynamicValue.Variant("None", _)                       => evalExpr(default, value, path)
+      case DynamicValue.Primitive(p) if p == PrimitiveValue.Unit => evalExpr(default, value, path)
+      case _                                                     => Left(TypeMismatch(path, "Option (Variant 'Some'|'None')", value))
+    }
+}
+
+object DynamicMigration {
+  val empty: DynamicMigration = DynamicMigration(Vector.empty)
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
@@ -1,0 +1,27 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.Schema
+
+final case class Migration[A, B](
+  dynamicMigration: DynamicMigration,
+  sourceSchema: Schema[A],
+  targetSchema: Schema[B]
+) {
+  def apply(value: A): Either[MigrationError, B] =
+    for {
+      dynamicInput <- Right(sourceSchema.toDynamicValue(value))
+      migrated     <- dynamicMigration(dynamicInput)
+      result       <-
+        targetSchema
+          .fromDynamicValue(migrated)
+          .left
+          .map(err => MigrationError.InvalidOperation(zio.blocks.schema.DynamicOptic.root, s"Schema read error: $err"))
+    } yield result
+
+  def ++[C](that: Migration[B, C]): Migration[A, C] =
+    Migration(
+      dynamicMigration ++ that.dynamicMigration,
+      sourceSchema,
+      that.targetSchema
+    )
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
@@ -1,0 +1,28 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.DynamicOptic
+import zio.blocks.schema.SchemaExpr
+
+sealed trait MigrationAction {
+  def at: DynamicOptic
+}
+
+object MigrationAction {
+  // --- Record Actions ---
+  final case class AddField(at: DynamicOptic, default: SchemaExpr[?, ?]) extends MigrationAction
+  final case class DropField(at: DynamicOptic)                           extends MigrationAction
+  final case class RenameField(at: DynamicOptic, newName: String)        extends MigrationAction
+
+  // --- Value Actions ---
+  final case class TransformValue(at: DynamicOptic, transform: SchemaExpr[?, ?]) extends MigrationAction
+  final case class ChangeType(at: DynamicOptic, converter: SchemaExpr[?, ?])     extends MigrationAction
+  final case class Optionalize(at: DynamicOptic)                                 extends MigrationAction
+  final case class Mandate(at: DynamicOptic, default: SchemaExpr[?, ?])          extends MigrationAction
+
+  // --- Enum Actions ---
+  final case class RenameCase(at: DynamicOptic, from: String, to: String) extends MigrationAction
+
+  // --- Collection Actions ---
+  final case class TransformElements(at: DynamicOptic, action: MigrationAction) extends MigrationAction
+  final case class TransformValues(at: DynamicOptic, action: MigrationAction)   extends MigrationAction
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationError.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationError.scala
@@ -1,0 +1,24 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.DynamicOptic
+import zio.blocks.schema.DynamicValue
+
+sealed trait MigrationError extends Exception {
+  def path: DynamicOptic
+  def message: String
+  override def getMessage: String = s"Migration error at $path: $message"
+}
+
+object MigrationError {
+  final case class PathNotFound(path: DynamicOptic, message: String) extends MigrationError
+
+  final case class TypeMismatch(path: DynamicOptic, expected: String, actual: DynamicValue) extends MigrationError {
+    def message: String = s"Expected type $expected but got ${actual.getClass.getSimpleName}"
+  }
+
+  final case class CalculationError(path: DynamicOptic, cause: String) extends MigrationError {
+    def message: String = s"Calculation failed: $cause"
+  }
+
+  final case class InvalidOperation(path: DynamicOptic, message: String) extends MigrationError
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -1,0 +1,127 @@
+package zio.blocks.schema.migration
+
+import zio.test._
+import zio.test.Assertion._
+import zio.blocks.schema.{DynamicOptic, DynamicValue, PrimitiveValue, Schema, SchemaExpr}
+
+object MigrationSpec extends ZIOSpecDefault {
+
+  // Simple Schema Definitions for Testing
+  case class UserV1(name: String, age: Int)
+  case class UserV2(fullName: String, age: Int)
+  case class UserV3(fullName: String, age: Int, active: Option[Boolean])
+
+  // Mock Schemas (using implicit resolution)
+  implicit val userV1Schema: Schema[UserV1] = Schema.derived
+  implicit val userV2Schema: Schema[UserV2] = Schema.derived
+
+  // Helper to create constant expressions using SchemaExpr.Literal
+  def const[A](value: A)(implicit schema: Schema[A]): SchemaExpr[Any, A] =
+    SchemaExpr.Literal(value, schema).asInstanceOf[SchemaExpr[Any, A]]
+
+  def spec = suite("MigrationSpec")(
+    test("RenameField") {
+      val migration = DynamicMigration(
+        Vector(
+          MigrationAction.RenameField(DynamicOptic.root.field("name"), "fullName")
+        )
+      )
+
+      val v1 = DynamicValue.Record(
+        Vector(
+          "name" -> DynamicValue.Primitive(PrimitiveValue.String("Alice")),
+          "age"  -> DynamicValue.Primitive(PrimitiveValue.Int(30))
+        )
+      )
+
+      val expected = DynamicValue.Record(
+        Vector(
+          "fullName" -> DynamicValue.Primitive(PrimitiveValue.String("Alice")),
+          "age"      -> DynamicValue.Primitive(PrimitiveValue.Int(30))
+        )
+      )
+
+      assert(migration(v1))(isRight(equalTo(expected)))
+    },
+    test("AddField") {
+      // Use implicit Schema[Boolean]
+      val defaultExpr = const(true)
+
+      val migration = DynamicMigration(
+        Vector(
+          MigrationAction.AddField(DynamicOptic.root.field("active"), defaultExpr)
+        )
+      )
+
+      val v2 = DynamicValue.Record(
+        Vector(
+          "fullName" -> DynamicValue.Primitive(PrimitiveValue.String("Bob"))
+        )
+      )
+
+      val expected = DynamicValue.Record(
+        Vector(
+          "fullName" -> DynamicValue.Primitive(PrimitiveValue.String("Bob")),
+          "active"   -> DynamicValue.Primitive(PrimitiveValue.Boolean(true))
+        )
+      )
+
+      assert(migration(v2))(isRight(equalTo(expected)))
+    },
+    test("DropField") {
+      val migration = DynamicMigration(
+        Vector(
+          MigrationAction.DropField(DynamicOptic.root.field("age"))
+        )
+      )
+
+      val v1 = DynamicValue.Record(
+        Vector(
+          "name" -> DynamicValue.Primitive(PrimitiveValue.String("Charlie")),
+          "age"  -> DynamicValue.Primitive(PrimitiveValue.Int(40))
+        )
+      )
+
+      val expected = DynamicValue.Record(
+        Vector(
+          "name" -> DynamicValue.Primitive(PrimitiveValue.String("Charlie"))
+        )
+      )
+
+      assert(migration(v1))(isRight(equalTo(expected)))
+    },
+    test("Chained Migration") {
+      // V1 -> V2: Rename name -> fullName
+      // V2 -> V3: Add active field (Option[Boolean] = Some(true))
+
+      val m1 = DynamicMigration(
+        Vector(
+          MigrationAction.RenameField(DynamicOptic.root.field("name"), "fullName")
+        )
+      )
+
+      // Use implicit Schema[Option[Boolean]]
+      // Note: We need to explicitly type the Option to help implicit search if needed,
+      // but usually const(Option(true)) works if Schema.option exists.
+      // If Schema.option is missing, we might need a workaround, but let's try implicit first.
+      val defaultExpr = const(Option(true))
+
+      val m2 = DynamicMigration(
+        Vector(
+          MigrationAction.AddField(DynamicOptic.root.field("active"), defaultExpr)
+        )
+      )
+
+      val composite = m1 ++ m2
+
+      val start = DynamicValue.Record(Vector("name" -> DynamicValue.Primitive(PrimitiveValue.String("Dave"))))
+
+      val result = composite(start)
+
+      // Verify structure contains both changes
+      assert(result.map(_.asInstanceOf[DynamicValue.Record].fields.map(_._1)))(
+        isRight(contains("fullName") && contains("active"))
+      )
+    }
+  )
+}


### PR DESCRIPTION
https://github.com/user-attachments/assets/4dece1ed-2326-4958-a2ed-2e57e51b3528

## Summary
This PR implements the **Pure Algebraic Migration System** for ZIO Schema 2, addressing issue #519. It introduces a serializable, pure data representation of schema transformations (`MigrationAction`) and a typed API (`Migration[A, B]`) for evolving data structures without runtime overhead.

## Key Changes
- **Migration Actions**: Defined the algebraic grammar for migrations (`RenameField`, `AddField`, `DropField`, `TransformValue`, etc.) in `MigrationAction`.
- **Dynamic Core**: Implemented `DynamicMigration`, a recursive engine that applies actions to `DynamicValue` structures, supporting both structural (Record/Enum) and value-level transformations.
- **Typed API**: Added `Migration[A, B]` wrapper that integrates with `Schema[A]` and `Schema[B]` to provide a type-safe user API.
- **Error Handling**: Implemented `MigrationError` with path tracking (`DynamicOptic`) for precise failure reporting.
- **Testing**: Added `MigrationSpec` verifying key operations (Rename, Add, Drop, Chaining) on both Scala 2.13 and Scala 3.

## Verification
- [x] **Tests**: All tests in `MigrationSpec` passed on Scala 2.13 and Scala 3.3.7.
- [x] **Formatting**: Code formatted with `scalafmt`.

## Demo
(Please check the attached video/screenshot of the passing tests)
https://github.com/user-attachments/assets/4dece1ed-2326-4958-a2ed-2e57e51b3528

Closes #519

/claim #519