### PR TITLE
Make RegisterOffet's Operations Public for Scala 3

### DIFF
--- a/schema/shared/src/main/scala-3/zio/blocks/schema/binding/RegisterOffset.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/binding/RegisterOffset.scala
@@ -30,17 +30,17 @@ object RegisterOffset {
     left + right
   }
 
-  inline private[schema] def getObjects(offset: RegisterOffset): Int = offset & 0xffff
+  inline def getObjects(offset: RegisterOffset): Int = offset & 0xffff
 
-  inline private[schema] def getBytes(offset: RegisterOffset): Int = offset >>> 16
+  inline def getBytes(offset: RegisterOffset): Int = offset >>> 16
 
-  inline private[schema] def incrementObjects(offset: RegisterOffset): RegisterOffset = offset + 1
+  inline def incrementObjects(offset: RegisterOffset): RegisterOffset = offset + 1
 
-  inline private[schema] def incrementBooleansAndBytes(offset: RegisterOffset): RegisterOffset = offset + 0x10000
+  inline def incrementBooleansAndBytes(offset: RegisterOffset): RegisterOffset = offset + 0x10000
 
-  inline private[schema] def incrementCharsAndShorts(offset: RegisterOffset): RegisterOffset = offset + 0x20000
+  inline def incrementCharsAndShorts(offset: RegisterOffset): RegisterOffset = offset + 0x20000
 
-  inline private[schema] def incrementFloatsAndInts(offset: RegisterOffset): RegisterOffset = offset + 0x40000
+  inline def incrementFloatsAndInts(offset: RegisterOffset): RegisterOffset = offset + 0x40000
 
-  inline private[schema] def incrementDoublesAndLongs(offset: RegisterOffset): RegisterOffset = offset + 0x80000
+  inline def incrementDoublesAndLongs(offset: RegisterOffset): RegisterOffset = offset + 0x80000
 }


### PR DESCRIPTION
Made it consistent with Scala 2 version.