### PR TITLE
feat(schema): add Migration DSL for schema evolution

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/Migration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Migration.scala
@@ -1,0 +1,944 @@
+package zio.blocks.schema
+
+import scala.util.control.NoStackTrace
+
+/**
+ * MigrationError represents errors that can occur during schema migration.
+ * All errors carry path information via DynamicOptic to identify the exact
+ * location where the error occurred.
+ */
+final case class MigrationError(errors: ::[MigrationError.Single]) extends Exception with NoStackTrace {
+  def ++(other: MigrationError): MigrationError =
+    MigrationError(new ::(errors.head, errors.tail ++ other.errors))
+
+  override def getMessage: String = message
+
+  def message: String = errors
+    .foldLeft(new java.lang.StringBuilder) {
+      var lineFeed = false
+      (sb, e) =>
+        if (lineFeed) sb.append('\n')
+        else lineFeed = true
+        sb.append(e.message)
+    }
+    .toString
+}
+
+object MigrationError {
+  def pathNotFound(path: DynamicOptic): MigrationError =
+    new MigrationError(new ::(new PathNotFound(path), Nil))
+
+  def typeMismatch(path: DynamicOptic, expected: String, actual: String): MigrationError =
+    new MigrationError(new ::(new TypeMismatch(path, expected, actual), Nil))
+
+  def missingDefault(path: DynamicOptic, fieldName: String): MigrationError =
+    new MigrationError(new ::(new MissingDefault(path, fieldName), Nil))
+
+  def invalidTransform(path: DynamicOptic, reason: String): MigrationError =
+    new MigrationError(new ::(new InvalidTransform(path, reason), Nil))
+
+  def unknownCase(path: DynamicOptic, caseName: String): MigrationError =
+    new MigrationError(new ::(new UnknownCase(path, caseName), Nil))
+
+  def mandatoryFieldIsNone(path: DynamicOptic, fieldName: String): MigrationError =
+    new MigrationError(new ::(new MandatoryFieldIsNone(path, fieldName), Nil))
+
+  sealed trait Single {
+    def message: String
+    def path: DynamicOptic
+  }
+
+  case class PathNotFound(path: DynamicOptic) extends Single {
+    override def message: String = s"Path not found: $path"
+  }
+
+  case class TypeMismatch(path: DynamicOptic, expected: String, actual: String) extends Single {
+    override def message: String = s"Type mismatch at $path: expected $expected, got $actual"
+  }
+
+  case class MissingDefault(path: DynamicOptic, fieldName: String) extends Single {
+    override def message: String = s"Missing default value for field '$fieldName' at $path"
+  }
+
+  case class InvalidTransform(path: DynamicOptic, reason: String) extends Single {
+    override def message: String = s"Invalid transform at $path: $reason"
+  }
+
+  case class UnknownCase(path: DynamicOptic, caseName: String) extends Single {
+    override def message: String = s"Unknown case '$caseName' at $path"
+  }
+
+  case class MandatoryFieldIsNone(path: DynamicOptic, fieldName: String) extends Single {
+    override def message: String = s"Mandatory field '$fieldName' is None at $path"
+  }
+}
+
+/**
+ * MigrationAction represents a single, serializable migration operation.
+ * All actions are pure data - no closures or functions - making them
+ * suitable for serialization and introspection.
+ */
+sealed trait MigrationAction {
+  def path: DynamicOptic
+}
+
+object MigrationAction {
+  // ============================================================
+  // Record field operations
+  // ============================================================
+
+  /**
+   * Add a new field to a record with a default value.
+   * The default value is represented as a DynamicValue for serializability.
+   */
+  final case class AddField(
+    path: DynamicOptic,
+    fieldName: String,
+    defaultValue: DynamicValue
+  ) extends MigrationAction
+
+  /**
+   * Drop a field from a record.
+   * Optionally stores a reverse default for bidirectional migrations.
+   */
+  final case class DropField(
+    path: DynamicOptic,
+    fieldName: String,
+    reverseDefault: Option[DynamicValue]
+  ) extends MigrationAction
+
+  /**
+   * Rename a field in a record.
+   */
+  final case class RenameField(
+    path: DynamicOptic,
+    oldName: String,
+    newName: String
+  ) extends MigrationAction
+
+  // ============================================================
+  // Value transformation operations
+  // ============================================================
+
+  /**
+   * Transform a value using a named, registered transform.
+   * The transformId references a pure function that must be registered
+   * in a TransformRegistry for execution.
+   */
+  final case class TransformValue(
+    path: DynamicOptic,
+    transformId: String,
+    reverseTransformId: Option[String]
+  ) extends MigrationAction
+
+  /**
+   * Change the type of a value using a named coercion.
+   * The coercionId references a type coercion function in a registry.
+   */
+  final case class ChangeType(
+    path: DynamicOptic,
+    fromTypeName: String,
+    toTypeName: String,
+    coercionId: String,
+    reverseCoercionId: Option[String]
+  ) extends MigrationAction
+
+  /**
+   * Make a required field optional by wrapping it in Some.
+   */
+  final case class Optionalize(
+    path: DynamicOptic,
+    fieldName: String
+  ) extends MigrationAction
+
+  /**
+   * Make an optional field required, using a default for None values.
+   */
+  final case class Mandate(
+    path: DynamicOptic,
+    fieldName: String,
+    defaultForNone: DynamicValue
+  ) extends MigrationAction
+
+  // ============================================================
+  // Variant/enum operations
+  // ============================================================
+
+  /**
+   * Rename a case in a variant/enum.
+   */
+  final case class RenameCase(
+    path: DynamicOptic,
+    oldCaseName: String,
+    newCaseName: String
+  ) extends MigrationAction
+
+  /**
+   * Transform a case's payload using a named transform.
+   */
+  final case class TransformCase(
+    path: DynamicOptic,
+    caseName: String,
+    transformId: String,
+    reverseTransformId: Option[String]
+  ) extends MigrationAction
+
+  /**
+   * Add a new case to a variant/enum.
+   */
+  final case class AddCase(
+    path: DynamicOptic,
+    caseName: String
+  ) extends MigrationAction
+
+  /**
+   * Drop a case from a variant/enum.
+   * The migrateTo specifies which case existing values should migrate to.
+   */
+  final case class DropCase(
+    path: DynamicOptic,
+    caseName: String,
+    migrateTo: String,
+    payloadTransformId: Option[String]
+  ) extends MigrationAction
+
+  // ============================================================
+  // Collection operations
+  // ============================================================
+
+  /**
+   * Transform all elements in a sequence using a named transform.
+   */
+  final case class TransformElements(
+    path: DynamicOptic,
+    transformId: String,
+    reverseTransformId: Option[String]
+  ) extends MigrationAction
+
+  /**
+   * Transform all keys in a map using a named transform.
+   */
+  final case class TransformKeys(
+    path: DynamicOptic,
+    transformId: String,
+    reverseTransformId: Option[String]
+  ) extends MigrationAction
+
+  /**
+   * Transform all values in a map using a named transform.
+   */
+  final case class TransformValues(
+    path: DynamicOptic,
+    transformId: String,
+    reverseTransformId: Option[String]
+  ) extends MigrationAction
+
+  /**
+   * Filter elements in a sequence based on a named predicate.
+   */
+  final case class FilterElements(
+    path: DynamicOptic,
+    predicateId: String
+  ) extends MigrationAction
+
+  /**
+   * Filter entries in a map based on a named predicate.
+   */
+  final case class FilterEntries(
+    path: DynamicOptic,
+    predicateId: String
+  ) extends MigrationAction
+}
+
+/**
+ * TransformRegistry provides named transforms for use in migrations.
+ * All transforms must be registered by name, allowing migrations to
+ * remain serializable while still supporting custom logic.
+ */
+trait TransformRegistry {
+  def getTransform(id: String): Option[DynamicValue => Either[String, DynamicValue]]
+  def getPredicate(id: String): Option[DynamicValue => Boolean]
+}
+
+object TransformRegistry {
+  val empty: TransformRegistry = new TransformRegistry {
+    def getTransform(id: String): Option[DynamicValue => Either[String, DynamicValue]] = None
+    def getPredicate(id: String): Option[DynamicValue => Boolean] = None
+  }
+
+  def apply(
+    transforms: scala.collection.immutable.Map[String, DynamicValue => Either[String, DynamicValue]],
+    predicates: scala.collection.immutable.Map[String, DynamicValue => Boolean]
+  ): TransformRegistry = new TransformRegistry {
+    def getTransform(id: String): Option[DynamicValue => Either[String, DynamicValue]] = transforms.get(id)
+    def getPredicate(id: String): Option[DynamicValue => Boolean] = predicates.get(id)
+  }
+}
+
+/**
+ * DynamicMigration represents a sequence of migration actions that can be
+ * applied to DynamicValue instances. This is the untyped, serializable
+ * representation of a migration.
+ */
+final case class DynamicMigration(actions: Vector[MigrationAction]) {
+
+  /**
+   * Compose this migration with another, executing actions in sequence.
+   */
+  def andThen(that: DynamicMigration): DynamicMigration =
+    DynamicMigration(this.actions ++ that.actions)
+
+  /**
+   * Alias for andThen.
+   */
+  def >>>(that: DynamicMigration): DynamicMigration = andThen(that)
+
+  /**
+   * Apply this migration to a DynamicValue.
+   */
+  def apply(value: DynamicValue)(implicit registry: TransformRegistry): Either[MigrationError, DynamicValue] =
+    applyActions(value, actions, 0)
+
+  private def applyActions(
+    value: DynamicValue,
+    actions: Vector[MigrationAction],
+    idx: Int
+  )(implicit registry: TransformRegistry): Either[MigrationError, DynamicValue] =
+    if (idx >= actions.length) Right(value)
+    else {
+      applyAction(value, actions(idx)) match {
+        case Right(newValue) => applyActions(newValue, actions, idx + 1)
+        case left            => left
+      }
+    }
+
+  private def applyAction(
+    value: DynamicValue,
+    action: MigrationAction
+  )(implicit registry: TransformRegistry): Either[MigrationError, DynamicValue] =
+    action match {
+      case MigrationAction.AddField(path, fieldName, defaultValue) =>
+        modifyAtPath(value, path) {
+          case DynamicValue.Record(fields) =>
+            Right(DynamicValue.Record(fields :+ (fieldName -> defaultValue)))
+          case _ =>
+            Left(MigrationError.typeMismatch(path, "Record", value.getClass.getSimpleName))
+        }
+
+      case MigrationAction.DropField(path, fieldName, _) =>
+        modifyAtPath(value, path) {
+          case DynamicValue.Record(fields) =>
+            Right(DynamicValue.Record(fields.filterNot(_._1 == fieldName)))
+          case _ =>
+            Left(MigrationError.typeMismatch(path, "Record", value.getClass.getSimpleName))
+        }
+
+      case MigrationAction.RenameField(path, oldName, newName) =>
+        modifyAtPath(value, path) {
+          case DynamicValue.Record(fields) =>
+            Right(DynamicValue.Record(fields.map {
+              case (name, v) if name == oldName => (newName, v)
+              case other                        => other
+            }))
+          case _ =>
+            Left(MigrationError.typeMismatch(path, "Record", value.getClass.getSimpleName))
+        }
+
+      case MigrationAction.TransformValue(path, transformId, _) =>
+        registry.getTransform(transformId) match {
+          case Some(transform) =>
+            modifyAtPath(value, path) { v =>
+              transform(v).left.map(reason => MigrationError.invalidTransform(path, reason))
+            }
+          case None =>
+            Left(MigrationError.invalidTransform(path, s"Transform '$transformId' not found"))
+        }
+
+      case MigrationAction.ChangeType(path, _, _, coercionId, _) =>
+        registry.getTransform(coercionId) match {
+          case Some(coerce) =>
+            modifyAtPath(value, path) { v =>
+              coerce(v).left.map(reason => MigrationError.invalidTransform(path, reason))
+            }
+          case None =>
+            Left(MigrationError.invalidTransform(path, s"Coercion '$coercionId' not found"))
+        }
+
+      case MigrationAction.Optionalize(path, fieldName) =>
+        modifyAtPath(value, path) {
+          case DynamicValue.Record(fields) =>
+            Right(DynamicValue.Record(fields.map {
+              case (name, v) if name == fieldName =>
+                // NOTE: This encoding (Variant("Some", Record(Vector("value" -> v)))) is
+                // ZIO Schema's standard representation for Option[A]. The Option type is
+                // represented as a variant with "Some" containing a record with the value,
+                // or "None" containing an empty record.
+                (name, DynamicValue.Variant("Some", DynamicValue.Record(Vector("value" -> v))))
+              case other => other
+            }))
+          case _ =>
+            Left(MigrationError.typeMismatch(path, "Record", value.getClass.getSimpleName))
+        }
+
+      case MigrationAction.Mandate(path, fieldName, defaultForNone) =>
+        modifyAtPath(value, path) {
+          case DynamicValue.Record(fields) =>
+            val newFields = fields.map {
+              case (name, v) if name == fieldName =>
+                v match {
+                  case DynamicValue.Variant("Some", DynamicValue.Record(innerFields)) =>
+                    innerFields.find(_._1 == "value") match {
+                      case Some((_, innerValue)) => (name, innerValue)
+                      case None                  => (name, defaultForNone)
+                    }
+                  case DynamicValue.Variant("None", _) =>
+                    (name, defaultForNone)
+                  case other =>
+                    (name, other)
+                }
+              case other => other
+            }
+            Right(DynamicValue.Record(newFields))
+          case _ =>
+            Left(MigrationError.typeMismatch(path, "Record", value.getClass.getSimpleName))
+        }
+
+      case MigrationAction.RenameCase(path, oldCaseName, newCaseName) =>
+        modifyAtPath(value, path) {
+          case DynamicValue.Variant(caseName, payload) if caseName == oldCaseName =>
+            Right(DynamicValue.Variant(newCaseName, payload))
+          case v @ DynamicValue.Variant(_, _) =>
+            Right(v)
+          case _ =>
+            Left(MigrationError.typeMismatch(path, "Variant", value.getClass.getSimpleName))
+        }
+
+      case MigrationAction.TransformCase(path, caseName, transformId, _) =>
+        registry.getTransform(transformId) match {
+          case Some(transform) =>
+            modifyAtPath(value, path) {
+              case DynamicValue.Variant(cn, payload) if cn == caseName =>
+                transform(payload).map(DynamicValue.Variant(cn, _)).left.map { reason =>
+                  MigrationError.invalidTransform(path, reason)
+                }
+              case v @ DynamicValue.Variant(_, _) =>
+                Right(v)
+              case _ =>
+                Left(MigrationError.typeMismatch(path, "Variant", value.getClass.getSimpleName))
+            }
+          case None =>
+            Left(MigrationError.invalidTransform(path, s"Transform '$transformId' not found"))
+        }
+
+      case MigrationAction.AddCase(_, _) =>
+        Right(value)
+
+      case MigrationAction.DropCase(path, caseName, migrateTo, payloadTransformId) =>
+        modifyAtPath(value, path) {
+          case DynamicValue.Variant(cn, payload) if cn == caseName =>
+            payloadTransformId match {
+              case Some(tid) =>
+                registry.getTransform(tid) match {
+                  case Some(transform) =>
+                    transform(payload).map(DynamicValue.Variant(migrateTo, _)).left.map { reason =>
+                      MigrationError.invalidTransform(path, reason)
+                    }
+                  case None =>
+                    Left(MigrationError.invalidTransform(path, s"Transform '$tid' not found"))
+                }
+              case None =>
+                Right(DynamicValue.Variant(migrateTo, payload))
+            }
+          case v @ DynamicValue.Variant(_, _) =>
+            Right(v)
+          case _ =>
+            Left(MigrationError.typeMismatch(path, "Variant", value.getClass.getSimpleName))
+        }
+
+      case MigrationAction.TransformElements(path, transformId, _) =>
+        registry.getTransform(transformId) match {
+          case Some(transform) =>
+            modifyAtPath(value, path) {
+              case DynamicValue.Sequence(elements) =>
+                val results = elements.map(transform)
+                val errors  = results.collect { case Left(e) => e }
+                if (errors.nonEmpty) Left(MigrationError.invalidTransform(path, errors.mkString(", ")))
+                else Right(DynamicValue.Sequence(results.collect { case Right(v) => v }))
+              case _ =>
+                Left(MigrationError.typeMismatch(path, "Sequence", value.getClass.getSimpleName))
+            }
+          case None =>
+            Left(MigrationError.invalidTransform(path, s"Transform '$transformId' not found"))
+        }
+
+      case MigrationAction.TransformKeys(path, transformId, _) =>
+        registry.getTransform(transformId) match {
+          case Some(transform) =>
+            modifyAtPath(value, path) {
+              case DynamicValue.Map(entries) =>
+                val results = entries.map { case (k, v) => transform(k).map(_ -> v) }
+                val errors  = results.collect { case Left(e) => e }
+                if (errors.nonEmpty) Left(MigrationError.invalidTransform(path, errors.mkString(", ")))
+                else Right(DynamicValue.Map(results.collect { case Right(kv) => kv }))
+              case _ =>
+                Left(MigrationError.typeMismatch(path, "Map", value.getClass.getSimpleName))
+            }
+          case None =>
+            Left(MigrationError.invalidTransform(path, s"Transform '$transformId' not found"))
+        }
+
+      case MigrationAction.TransformValues(path, transformId, _) =>
+        registry.getTransform(transformId) match {
+          case Some(transform) =>
+            modifyAtPath(value, path) {
+              case DynamicValue.Map(entries) =>
+                val results = entries.map { case (k, v) => transform(v).map(k -> _) }
+                val errors  = results.collect { case Left(e) => e }
+                if (errors.nonEmpty) Left(MigrationError.invalidTransform(path, errors.mkString(", ")))
+                else Right(DynamicValue.Map(results.collect { case Right(kv) => kv }))
+              case _ =>
+                Left(MigrationError.typeMismatch(path, "Map", value.getClass.getSimpleName))
+            }
+          case None =>
+            Left(MigrationError.invalidTransform(path, s"Transform '$transformId' not found"))
+        }
+
+      case MigrationAction.FilterElements(path, predicateId) =>
+        registry.getPredicate(predicateId) match {
+          case Some(predicate) =>
+            modifyAtPath(value, path) {
+              case DynamicValue.Sequence(elements) =>
+                Right(DynamicValue.Sequence(elements.filter(predicate)))
+              case _ =>
+                Left(MigrationError.typeMismatch(path, "Sequence", value.getClass.getSimpleName))
+            }
+          case None =>
+            Left(MigrationError.invalidTransform(path, s"Predicate '$predicateId' not found"))
+        }
+
+      case MigrationAction.FilterEntries(path, predicateId) =>
+        registry.getPredicate(predicateId) match {
+          case Some(predicate) =>
+            modifyAtPath(value, path) {
+              case DynamicValue.Map(entries) =>
+                Right(DynamicValue.Map(entries.filter { case (k, v) =>
+                  predicate(DynamicValue.Record(Vector("key" -> k, "value" -> v)))
+                }))
+              case _ =>
+                Left(MigrationError.typeMismatch(path, "Map", value.getClass.getSimpleName))
+            }
+          case None =>
+            Left(MigrationError.invalidTransform(path, s"Predicate '$predicateId' not found"))
+        }
+    }
+
+  private def modifyAtPath(
+    value: DynamicValue,
+    path: DynamicOptic
+  )(f: DynamicValue => Either[MigrationError, DynamicValue]): Either[MigrationError, DynamicValue] =
+    if (path.nodes.isEmpty) f(value)
+    else modifyAtPathRec(value, path, 0)(f)
+
+  private def modifyAtPathRec(
+    value: DynamicValue,
+    path: DynamicOptic,
+    idx: Int
+  )(f: DynamicValue => Either[MigrationError, DynamicValue]): Either[MigrationError, DynamicValue] =
+    if (idx >= path.nodes.length) f(value)
+    else {
+      path.nodes(idx) match {
+        case DynamicOptic.Node.Field(name) =>
+          value match {
+            case DynamicValue.Record(fields) =>
+              val fieldIdx = fields.indexWhere(_._1 == name)
+              if (fieldIdx < 0) Left(MigrationError.pathNotFound(path))
+              else {
+                modifyAtPathRec(fields(fieldIdx)._2, path, idx + 1)(f).map { newValue =>
+                  DynamicValue.Record(fields.updated(fieldIdx, (name, newValue)))
+                }
+              }
+            case _ =>
+              Left(MigrationError.typeMismatch(path, "Record", value.getClass.getSimpleName))
+          }
+
+        case DynamicOptic.Node.Case(name) =>
+          value match {
+            case DynamicValue.Variant(caseName, payload) if caseName == name =>
+              modifyAtPathRec(payload, path, idx + 1)(f).map(DynamicValue.Variant(caseName, _))
+            case DynamicValue.Variant(_, _) =>
+              Right(value)
+            case _ =>
+              Left(MigrationError.typeMismatch(path, "Variant", value.getClass.getSimpleName))
+          }
+
+        case DynamicOptic.Node.AtIndex(index) =>
+          value match {
+            case DynamicValue.Sequence(elements) =>
+              if (index < 0 || index >= elements.length) Left(MigrationError.pathNotFound(path))
+              else {
+                modifyAtPathRec(elements(index), path, idx + 1)(f).map { newElement =>
+                  DynamicValue.Sequence(elements.updated(index, newElement))
+                }
+              }
+            case _ =>
+              Left(MigrationError.typeMismatch(path, "Sequence", value.getClass.getSimpleName))
+          }
+
+        case DynamicOptic.Node.Elements =>
+          value match {
+            case DynamicValue.Sequence(elements) =>
+              val results = elements.map(modifyAtPathRec(_, path, idx + 1)(f))
+              val errors  = results.collect { case Left(e) => e }
+              if (errors.nonEmpty) Left(errors.reduce(_ ++ _))
+              else Right(DynamicValue.Sequence(results.collect { case Right(v) => v }))
+            case _ =>
+              Left(MigrationError.typeMismatch(path, "Sequence", value.getClass.getSimpleName))
+          }
+
+        case DynamicOptic.Node.MapKeys =>
+          value match {
+            case DynamicValue.Map(entries) =>
+              val results = entries.map { case (k, v) =>
+                modifyAtPathRec(k, path, idx + 1)(f).map(_ -> v)
+              }
+              val errors = results.collect { case Left(e) => e }
+              if (errors.nonEmpty) Left(errors.reduce(_ ++ _))
+              else Right(DynamicValue.Map(results.collect { case Right(kv) => kv }))
+            case _ =>
+              Left(MigrationError.typeMismatch(path, "Map", value.getClass.getSimpleName))
+          }
+
+        case DynamicOptic.Node.MapValues =>
+          value match {
+            case DynamicValue.Map(entries) =>
+              val results = entries.map { case (k, v) =>
+                modifyAtPathRec(v, path, idx + 1)(f).map(k -> _)
+              }
+              val errors = results.collect { case Left(e) => e }
+              if (errors.nonEmpty) Left(errors.reduce(_ ++ _))
+              else Right(DynamicValue.Map(results.collect { case Right(kv) => kv }))
+            case _ =>
+              Left(MigrationError.typeMismatch(path, "Map", value.getClass.getSimpleName))
+          }
+
+        case DynamicOptic.Node.AtMapKey(key) =>
+          value match {
+            case DynamicValue.Map(entries) =>
+              // NOTE: The asInstanceOf is safe here because DynamicOptic.Node.AtMapKey[K]
+              // in the context of DynamicValue operations is always created with K = DynamicValue.
+              // The migration system only operates on DynamicValue, not typed values.
+              val keyDV    = key.asInstanceOf[DynamicValue]
+              val entryIdx = entries.indexWhere(_._1 == keyDV)
+              if (entryIdx < 0) Left(MigrationError.pathNotFound(path))
+              else {
+                modifyAtPathRec(entries(entryIdx)._2, path, idx + 1)(f).map { newValue =>
+                  DynamicValue.Map(entries.updated(entryIdx, (keyDV, newValue)))
+                }
+              }
+            case _ =>
+              Left(MigrationError.typeMismatch(path, "Map", value.getClass.getSimpleName))
+          }
+
+        case _: DynamicOptic.Node.AtIndices =>
+          Left(MigrationError.invalidTransform(path, "AtIndices not supported in migrations"))
+
+        case _: DynamicOptic.Node.AtMapKeys[?] =>
+          Left(MigrationError.invalidTransform(path, "AtMapKeys not supported in migrations"))
+
+        case DynamicOptic.Node.Wrapped =>
+          Left(MigrationError.invalidTransform(path, "Wrapped not yet supported in migrations"))
+      }
+    }
+
+  /**
+   * Attempt to create a reverse migration.
+   * Returns None if any action is not reversible.
+   */
+  def reverse: Option[DynamicMigration] = {
+    val reversed = actions.reverse.map(reverseAction)
+    if (reversed.forall(_.isDefined)) Some(DynamicMigration(reversed.flatten))
+    else None
+  }
+
+  private def reverseAction(action: MigrationAction): Option[MigrationAction] =
+    action match {
+      case MigrationAction.AddField(path, fieldName, defaultValue) =>
+        Some(MigrationAction.DropField(path, fieldName, Some(defaultValue)))
+
+      case MigrationAction.DropField(path, fieldName, Some(reverseDefault)) =>
+        Some(MigrationAction.AddField(path, fieldName, reverseDefault))
+
+      case MigrationAction.DropField(_, _, None) =>
+        None
+
+      case MigrationAction.RenameField(path, oldName, newName) =>
+        Some(MigrationAction.RenameField(path, newName, oldName))
+
+      case MigrationAction.TransformValue(path, transformId, Some(reverseId)) =>
+        Some(MigrationAction.TransformValue(path, reverseId, Some(transformId)))
+
+      case MigrationAction.TransformValue(_, _, None) =>
+        None
+
+      case MigrationAction.ChangeType(path, from, to, coercionId, Some(reverseId)) =>
+        Some(MigrationAction.ChangeType(path, to, from, reverseId, Some(coercionId)))
+
+      case MigrationAction.ChangeType(_, _, _, _, None) =>
+        None
+
+      case MigrationAction.Optionalize(path, fieldName) =>
+        None
+
+      case MigrationAction.Mandate(_, _, _) =>
+        None
+
+      case MigrationAction.RenameCase(path, oldName, newName) =>
+        Some(MigrationAction.RenameCase(path, newName, oldName))
+
+      case MigrationAction.TransformCase(path, caseName, transformId, Some(reverseId)) =>
+        Some(MigrationAction.TransformCase(path, caseName, reverseId, Some(transformId)))
+
+      case MigrationAction.TransformCase(_, _, _, None) =>
+        None
+
+      case MigrationAction.AddCase(path, caseName) =>
+        None
+
+      case MigrationAction.DropCase(_, _, _, _) =>
+        None
+
+      case MigrationAction.TransformElements(path, transformId, Some(reverseId)) =>
+        Some(MigrationAction.TransformElements(path, reverseId, Some(transformId)))
+
+      case MigrationAction.TransformElements(_, _, None) =>
+        None
+
+      case MigrationAction.TransformKeys(path, transformId, Some(reverseId)) =>
+        Some(MigrationAction.TransformKeys(path, reverseId, Some(transformId)))
+
+      case MigrationAction.TransformKeys(_, _, None) =>
+        None
+
+      case MigrationAction.TransformValues(path, transformId, Some(reverseId)) =>
+        Some(MigrationAction.TransformValues(path, reverseId, Some(transformId)))
+
+      case MigrationAction.TransformValues(_, _, None) =>
+        None
+
+      case MigrationAction.FilterElements(_, _) =>
+        None
+
+      case MigrationAction.FilterEntries(_, _) =>
+        None
+    }
+}
+
+object DynamicMigration {
+  val identity: DynamicMigration = DynamicMigration(Vector.empty)
+
+  def addField(fieldName: String, defaultValue: DynamicValue): DynamicMigration =
+    DynamicMigration(Vector(MigrationAction.AddField(DynamicOptic.root, fieldName, defaultValue)))
+
+  def addField(path: DynamicOptic, fieldName: String, defaultValue: DynamicValue): DynamicMigration =
+    DynamicMigration(Vector(MigrationAction.AddField(path, fieldName, defaultValue)))
+
+  def dropField(fieldName: String): DynamicMigration =
+    DynamicMigration(Vector(MigrationAction.DropField(DynamicOptic.root, fieldName, None)))
+
+  def dropField(path: DynamicOptic, fieldName: String): DynamicMigration =
+    DynamicMigration(Vector(MigrationAction.DropField(path, fieldName, None)))
+
+  def dropField(fieldName: String, reverseDefault: DynamicValue): DynamicMigration =
+    DynamicMigration(Vector(MigrationAction.DropField(DynamicOptic.root, fieldName, Some(reverseDefault))))
+
+  def renameField(oldName: String, newName: String): DynamicMigration =
+    DynamicMigration(Vector(MigrationAction.RenameField(DynamicOptic.root, oldName, newName)))
+
+  def renameField(path: DynamicOptic, oldName: String, newName: String): DynamicMigration =
+    DynamicMigration(Vector(MigrationAction.RenameField(path, oldName, newName)))
+
+  def renameCase(oldCaseName: String, newCaseName: String): DynamicMigration =
+    DynamicMigration(Vector(MigrationAction.RenameCase(DynamicOptic.root, oldCaseName, newCaseName)))
+
+  def optionalize(fieldName: String): DynamicMigration =
+    DynamicMigration(Vector(MigrationAction.Optionalize(DynamicOptic.root, fieldName)))
+
+  def mandate(fieldName: String, defaultForNone: DynamicValue): DynamicMigration =
+    DynamicMigration(Vector(MigrationAction.Mandate(DynamicOptic.root, fieldName, defaultForNone)))
+}
+
+/**
+ * Migration[A, B] is a typed wrapper around DynamicMigration that carries
+ * schema information for both source and target types.
+ *
+ * Laws:
+ * - Identity: Migration.identity[A].apply(a) == Right(a)
+ * - Associativity: (m1 >>> m2) >>> m3 == m1 >>> (m2 >>> m3)
+ * - Structural Reverse: m.reverse.flatMap(r => m(a).flatMap(r(_))) == Right(a)
+ *   (when reverse is defined and all transforms are reversible)
+ */
+final case class Migration[A, B](
+  sourceSchema: Schema[A],
+  targetSchema: Schema[B],
+  dynamicMigration: DynamicMigration
+) {
+
+  /**
+   * Apply this migration to a value of type A, producing Either[MigrationError, B].
+   */
+  def apply(value: A)(implicit registry: TransformRegistry): Either[MigrationError, B] = {
+    val dynamicValue = sourceSchema.toDynamicValue(value)
+    dynamicMigration(dynamicValue).flatMap { migratedDynamic =>
+      targetSchema.fromDynamicValue(migratedDynamic).left.map { schemaError =>
+        MigrationError.invalidTransform(
+          DynamicOptic.root,
+          s"Failed to convert migrated value to target type: ${schemaError.message}"
+        )
+      }
+    }
+  }
+
+  /**
+   * Compose this migration with another.
+   */
+  def andThen[C](that: Migration[B, C]): Migration[A, C] =
+    Migration(this.sourceSchema, that.targetSchema, this.dynamicMigration >>> that.dynamicMigration)
+
+  /**
+   * Alias for andThen.
+   */
+  def >>>[C](that: Migration[B, C]): Migration[A, C] = andThen(that)
+
+  /**
+   * Attempt to create a reverse migration.
+   */
+  def reverse: Option[Migration[B, A]] =
+    dynamicMigration.reverse.map(Migration(targetSchema, sourceSchema, _))
+}
+
+object Migration {
+
+  /**
+   * Create an identity migration that performs no changes.
+   */
+  def identity[A](implicit schema: Schema[A]): Migration[A, A] =
+    Migration(schema, schema, DynamicMigration.identity)
+
+  /**
+   * Create a migration from a DynamicMigration.
+   */
+  def fromDynamic[A, B](
+    dynamicMigration: DynamicMigration
+  )(implicit sourceSchema: Schema[A], targetSchema: Schema[B]): Migration[A, B] =
+    Migration(sourceSchema, targetSchema, dynamicMigration)
+
+  /**
+   * Builder for constructing migrations step by step.
+   */
+  final class Builder[A, B] private[Migration] (
+    sourceSchema: Schema[A],
+    targetSchema: Schema[B],
+    actions: Vector[MigrationAction]
+  ) {
+    def addField(fieldName: String, defaultValue: DynamicValue): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.AddField(DynamicOptic.root, fieldName, defaultValue))
+
+    def addField(path: DynamicOptic, fieldName: String, defaultValue: DynamicValue): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.AddField(path, fieldName, defaultValue))
+
+    def dropField(fieldName: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.DropField(DynamicOptic.root, fieldName, None))
+
+    def dropField(path: DynamicOptic, fieldName: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.DropField(path, fieldName, None))
+
+    def renameField(oldName: String, newName: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.RenameField(DynamicOptic.root, oldName, newName))
+
+    def renameField(path: DynamicOptic, oldName: String, newName: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.RenameField(path, oldName, newName))
+
+    def transformValue(path: DynamicOptic, transformId: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.TransformValue(path, transformId, None))
+
+    def transformValue(path: DynamicOptic, transformId: String, reverseId: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.TransformValue(path, transformId, Some(reverseId)))
+
+    def renameCase(oldCaseName: String, newCaseName: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.RenameCase(DynamicOptic.root, oldCaseName, newCaseName))
+
+    def optionalize(fieldName: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.Optionalize(DynamicOptic.root, fieldName))
+
+    def mandate(fieldName: String, defaultForNone: DynamicValue): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.Mandate(DynamicOptic.root, fieldName, defaultForNone))
+
+    def changeType(
+      path: DynamicOptic,
+      fromTypeName: String,
+      toTypeName: String,
+      coercionId: String
+    ): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.ChangeType(path, fromTypeName, toTypeName, coercionId, None))
+
+    def changeType(
+      path: DynamicOptic,
+      fromTypeName: String,
+      toTypeName: String,
+      coercionId: String,
+      reverseCoercionId: String
+    ): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.ChangeType(path, fromTypeName, toTypeName, coercionId, Some(reverseCoercionId)))
+
+    def transformCase(path: DynamicOptic, caseName: String, transformId: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.TransformCase(path, caseName, transformId, None))
+
+    def transformCase(path: DynamicOptic, caseName: String, transformId: String, reverseId: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.TransformCase(path, caseName, transformId, Some(reverseId)))
+
+    def addCase(caseName: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.AddCase(DynamicOptic.root, caseName))
+
+    def addCase(path: DynamicOptic, caseName: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.AddCase(path, caseName))
+
+    def dropCase(caseName: String, migrateTo: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.DropCase(DynamicOptic.root, caseName, migrateTo, None))
+
+    def dropCase(path: DynamicOptic, caseName: String, migrateTo: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.DropCase(path, caseName, migrateTo, None))
+
+    def dropCase(caseName: String, migrateTo: String, payloadTransformId: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.DropCase(DynamicOptic.root, caseName, migrateTo, Some(payloadTransformId)))
+
+    def transformElements(path: DynamicOptic, transformId: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.TransformElements(path, transformId, None))
+
+    def transformElements(path: DynamicOptic, transformId: String, reverseId: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.TransformElements(path, transformId, Some(reverseId)))
+
+    def transformKeys(path: DynamicOptic, transformId: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.TransformKeys(path, transformId, None))
+
+    def transformKeys(path: DynamicOptic, transformId: String, reverseId: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.TransformKeys(path, transformId, Some(reverseId)))
+
+    def transformValues(path: DynamicOptic, transformId: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.TransformValues(path, transformId, None))
+
+    def transformValues(path: DynamicOptic, transformId: String, reverseId: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.TransformValues(path, transformId, Some(reverseId)))
+
+    def filterElements(path: DynamicOptic, predicateId: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.FilterElements(path, predicateId))
+
+    def filterEntries(path: DynamicOptic, predicateId: String): Builder[A, B] =
+      new Builder(sourceSchema, targetSchema, actions :+ MigrationAction.FilterEntries(path, predicateId))
+
+    def build: Migration[A, B] =
+      Migration(sourceSchema, targetSchema, DynamicMigration(actions))
+  }
+
+  def builder[A, B](implicit sourceSchema: Schema[A], targetSchema: Schema[B]): Builder[A, B] =
+    new Builder(sourceSchema, targetSchema, Vector.empty)
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/MigrationSpec.scala
@@ -1,0 +1,795 @@
+package zio.blocks.schema
+
+import zio.test._
+
+object MigrationSpec extends ZIOSpecDefault {
+
+  // Helper to create primitive DynamicValues
+  private def int(i: Int): DynamicValue = DynamicValue.Primitive(PrimitiveValue.Int(i))
+  private def str(s: String): DynamicValue = DynamicValue.Primitive(PrimitiveValue.String(s))
+  private def bool(b: Boolean): DynamicValue = DynamicValue.Primitive(PrimitiveValue.Boolean(b))
+
+  // Helper to create records
+  private def record(fields: (String, DynamicValue)*): DynamicValue.Record =
+    DynamicValue.Record(fields.toVector)
+
+  // Helper to create variants
+  private def variant(caseName: String, payload: DynamicValue): DynamicValue.Variant =
+    DynamicValue.Variant(caseName, payload)
+
+  // Helper to create sequences
+  private def seq(elements: DynamicValue*): DynamicValue.Sequence =
+    DynamicValue.Sequence(elements.toVector)
+
+  // Helper to create maps
+  private def map(entries: (DynamicValue, DynamicValue)*): DynamicValue.Map =
+    DynamicValue.Map(entries.toVector)
+
+  // Standard test registry with common transforms
+  private val testRegistry: TransformRegistry = TransformRegistry(
+    transforms = scala.collection.immutable.Map(
+      "uppercase" -> { (dv: DynamicValue) =>
+        dv match {
+          case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+            Right(DynamicValue.Primitive(PrimitiveValue.String(s.toUpperCase)))
+          case _ => Left("Expected string")
+        }
+      },
+      "lowercase" -> { (dv: DynamicValue) =>
+        dv match {
+          case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+            Right(DynamicValue.Primitive(PrimitiveValue.String(s.toLowerCase)))
+          case _ => Left("Expected string")
+        }
+      },
+      "double" -> { (dv: DynamicValue) =>
+        dv match {
+          case DynamicValue.Primitive(PrimitiveValue.Int(n)) =>
+            Right(DynamicValue.Primitive(PrimitiveValue.Int(n * 2)))
+          case _ => Left("Expected int")
+        }
+      },
+      "halve" -> { (dv: DynamicValue) =>
+        dv match {
+          case DynamicValue.Primitive(PrimitiveValue.Int(n)) =>
+            Right(DynamicValue.Primitive(PrimitiveValue.Int(n / 2)))
+          case _ => Left("Expected int")
+        }
+      },
+      "intToString" -> { (dv: DynamicValue) =>
+        dv match {
+          case DynamicValue.Primitive(PrimitiveValue.Int(n)) =>
+            Right(DynamicValue.Primitive(PrimitiveValue.String(n.toString)))
+          case _ => Left("Expected int")
+        }
+      },
+      "stringToInt" -> { (dv: DynamicValue) =>
+        dv match {
+          case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+            scala.util.Try(s.toInt).toEither.left.map(_ => "Invalid int").map(n => DynamicValue.Primitive(PrimitiveValue.Int(n)))
+          case _ => Left("Expected string")
+        }
+      },
+      "addPrefix" -> { (dv: DynamicValue) =>
+        dv match {
+          case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+            Right(DynamicValue.Primitive(PrimitiveValue.String("prefix_" + s)))
+          case _ => Left("Expected string")
+        }
+      },
+      "identity" -> { (dv: DynamicValue) => Right(dv) }
+    ),
+    predicates = scala.collection.immutable.Map(
+      "isPositive" -> { (dv: DynamicValue) =>
+        dv match {
+          case DynamicValue.Primitive(PrimitiveValue.Int(n)) => n > 0
+          case _ => false
+        }
+      },
+      "nonEmpty" -> { (dv: DynamicValue) =>
+        dv match {
+          case DynamicValue.Primitive(PrimitiveValue.String(s)) => s.nonEmpty
+          case _ => false
+        }
+      },
+      "keyIsName" -> { (dv: DynamicValue) =>
+        dv match {
+          case DynamicValue.Record(fields) =>
+            fields.find(_._1 == "key").exists {
+              case (_, DynamicValue.Primitive(PrimitiveValue.String(s))) => s == "name"
+              case _ => false
+            }
+          case _ => false
+        }
+      }
+    )
+  )
+
+  implicit val registry: TransformRegistry = testRegistry
+
+  def spec: Spec[TestEnvironment, Any] = suite("MigrationSpec")(
+    suite("MigrationError")(
+      test("pathNotFound creates correct error") {
+        val path = DynamicOptic.root.field("missing")
+        val error = MigrationError.pathNotFound(path)
+        assertTrue(
+          error.message.contains("Path not found"),
+          error.errors.length == 1
+        )
+      },
+      test("typeMismatch creates correct error") {
+        val path = DynamicOptic.root.field("name")
+        val error = MigrationError.typeMismatch(path, "Record", "Primitive")
+        assertTrue(
+          error.message.contains("Type mismatch"),
+          error.message.contains("Record"),
+          error.message.contains("Primitive")
+        )
+      },
+      test("errors can be combined with ++") {
+        val error1 = MigrationError.pathNotFound(DynamicOptic.root.field("a"))
+        val error2 = MigrationError.pathNotFound(DynamicOptic.root.field("b"))
+        val combined = error1 ++ error2
+        assertTrue(combined.errors.length == 2)
+      }
+    ),
+
+    suite("DynamicMigration - AddField")(
+      test("adds field with default value to record") {
+        val migration = DynamicMigration.addField("age", int(25))
+        val input = record("name" -> str("John"))
+        val result = migration(input)
+        assertTrue(
+          result == Right(record("name" -> str("John"), "age" -> int(25)))
+        )
+      },
+      test("adds field at nested path") {
+        val path = DynamicOptic.root.field("address")
+        val migration = DynamicMigration.addField(path, "country", str("USA"))
+        val input = record("name" -> str("John"), "address" -> record("city" -> str("NYC")))
+        val result = migration(input)
+        assertTrue(
+          result == Right(record(
+            "name" -> str("John"),
+            "address" -> record("city" -> str("NYC"), "country" -> str("USA"))
+          ))
+        )
+      },
+      test("fails when path target is not a record") {
+        val migration = DynamicMigration.addField("age", int(25))
+        val input = str("not a record")
+        val result = migration(input)
+        assertTrue(result.isLeft)
+      }
+    ),
+
+    suite("DynamicMigration - DropField")(
+      test("drops field from record") {
+        val migration = DynamicMigration.dropField("age")
+        val input = record("name" -> str("John"), "age" -> int(30))
+        val result = migration(input)
+        assertTrue(result == Right(record("name" -> str("John"))))
+      },
+      test("drops field at nested path") {
+        val path = DynamicOptic.root.field("address")
+        val migration = DynamicMigration.dropField(path, "zip")
+        val input = record("address" -> record("city" -> str("NYC"), "zip" -> str("10001")))
+        val result = migration(input)
+        assertTrue(
+          result == Right(record("address" -> record("city" -> str("NYC"))))
+        )
+      },
+      test("silently succeeds when field does not exist") {
+        val migration = DynamicMigration.dropField("nonexistent")
+        val input = record("name" -> str("John"))
+        val result = migration(input)
+        assertTrue(result == Right(record("name" -> str("John"))))
+      }
+    ),
+
+    suite("DynamicMigration - RenameField")(
+      test("renames field in record") {
+        val migration = DynamicMigration.renameField("name", "fullName")
+        val input = record("name" -> str("John"), "age" -> int(30))
+        val result = migration(input)
+        assertTrue(result == Right(record("fullName" -> str("John"), "age" -> int(30))))
+      },
+      test("renames field at nested path") {
+        val path = DynamicOptic.root.field("person")
+        val migration = DynamicMigration.renameField(path, "name", "fullName")
+        val input = record("person" -> record("name" -> str("John")))
+        val result = migration(input)
+        assertTrue(
+          result == Right(record("person" -> record("fullName" -> str("John"))))
+        )
+      },
+      test("preserves field order after rename") {
+        val migration = DynamicMigration.renameField("b", "bb")
+        val input = record("a" -> int(1), "b" -> int(2), "c" -> int(3))
+        val result = migration(input)
+        result match {
+          case Right(DynamicValue.Record(fields)) =>
+            assertTrue(fields.map(_._1) == Vector("a", "bb", "c"))
+          case _ => assertTrue(false)
+        }
+      }
+    ),
+
+    suite("DynamicMigration - TransformValue")(
+      test("transforms value using registered transform") {
+        val path = DynamicOptic.root.field("name")
+        val migration = DynamicMigration(Vector(MigrationAction.TransformValue(path, "uppercase", None)))
+        val input = record("name" -> str("john"))
+        val result = migration(input)
+        assertTrue(result == Right(record("name" -> str("JOHN"))))
+      },
+      test("fails when transform is not registered") {
+        val path = DynamicOptic.root.field("name")
+        val migration = DynamicMigration(Vector(MigrationAction.TransformValue(path, "unknown", None)))
+        val input = record("name" -> str("john"))
+        val result = migration(input)
+        assertTrue(result.isLeft)
+      },
+      test("fails when transform returns error") {
+        val path = DynamicOptic.root.field("count")
+        val migration = DynamicMigration(Vector(MigrationAction.TransformValue(path, "uppercase", None)))
+        val input = record("count" -> int(42))
+        val result = migration(input)
+        assertTrue(result.isLeft)
+      }
+    ),
+
+    suite("DynamicMigration - ChangeType")(
+      test("changes type using registered coercion") {
+        val path = DynamicOptic.root.field("count")
+        val migration = DynamicMigration(Vector(
+          MigrationAction.ChangeType(path, "Int", "String", "intToString", None)
+        ))
+        val input = record("count" -> int(42))
+        val result = migration(input)
+        assertTrue(result == Right(record("count" -> str("42"))))
+      },
+      test("fails when coercion is not registered") {
+        val path = DynamicOptic.root.field("count")
+        val migration = DynamicMigration(Vector(
+          MigrationAction.ChangeType(path, "Int", "String", "unknown", None)
+        ))
+        val input = record("count" -> int(42))
+        val result = migration(input)
+        assertTrue(result.isLeft)
+      }
+    ),
+
+    suite("DynamicMigration - Optionalize")(
+      test("wraps field value in Some variant") {
+        val migration = DynamicMigration.optionalize("name")
+        val input = record("name" -> str("John"))
+        val result = migration(input)
+        // Option is encoded as Variant("Some", Record(Vector("value" -> v)))
+        assertTrue(
+          result == Right(record(
+            "name" -> variant("Some", record("value" -> str("John")))
+          ))
+        )
+      },
+      test("optionalizes nested field") {
+        val path = DynamicOptic.root.field("person")
+        val migration = DynamicMigration(Vector(MigrationAction.Optionalize(path, "age")))
+        val input = record("person" -> record("name" -> str("John"), "age" -> int(30)))
+        val result = migration(input)
+        assertTrue(
+          result == Right(record(
+            "person" -> record(
+              "name" -> str("John"),
+              "age" -> variant("Some", record("value" -> int(30)))
+            )
+          ))
+        )
+      }
+    ),
+
+    suite("DynamicMigration - Mandate")(
+      test("unwraps Some variant to direct value") {
+        val migration = DynamicMigration.mandate("name", str("default"))
+        val input = record("name" -> variant("Some", record("value" -> str("John"))))
+        val result = migration(input)
+        assertTrue(result == Right(record("name" -> str("John"))))
+      },
+      test("uses default for None variant") {
+        val migration = DynamicMigration.mandate("name", str("default"))
+        val input = record("name" -> variant("None", record()))
+        val result = migration(input)
+        assertTrue(result == Right(record("name" -> str("default"))))
+      },
+      test("leaves non-Option values unchanged") {
+        val migration = DynamicMigration.mandate("name", str("default"))
+        val input = record("name" -> str("already-required"))
+        val result = migration(input)
+        assertTrue(result == Right(record("name" -> str("already-required"))))
+      }
+    ),
+
+    suite("DynamicMigration - RenameCase")(
+      test("renames matching case") {
+        val migration = DynamicMigration.renameCase("OldCase", "NewCase")
+        val input = variant("OldCase", record("value" -> int(42)))
+        val result = migration(input)
+        assertTrue(result == Right(variant("NewCase", record("value" -> int(42)))))
+      },
+      test("leaves non-matching case unchanged") {
+        val migration = DynamicMigration.renameCase("OldCase", "NewCase")
+        val input = variant("OtherCase", record("value" -> int(42)))
+        val result = migration(input)
+        assertTrue(result == Right(variant("OtherCase", record("value" -> int(42)))))
+      }
+    ),
+
+    suite("DynamicMigration - TransformCase")(
+      test("transforms matching case payload") {
+        val migration = DynamicMigration(Vector(
+          MigrationAction.TransformCase(DynamicOptic.root, "StringCase", "uppercase", None)
+        ))
+        val input = variant("StringCase", str("hello"))
+        val result = migration(input)
+        assertTrue(result == Right(variant("StringCase", str("HELLO"))))
+      },
+      test("leaves non-matching case unchanged") {
+        val migration = DynamicMigration(Vector(
+          MigrationAction.TransformCase(DynamicOptic.root, "StringCase", "uppercase", None)
+        ))
+        val input = variant("OtherCase", str("hello"))
+        val result = migration(input)
+        assertTrue(result == Right(variant("OtherCase", str("hello"))))
+      }
+    ),
+
+    suite("DynamicMigration - AddCase")(
+      test("addCase is a no-op on existing data") {
+        val migration = DynamicMigration(Vector(
+          MigrationAction.AddCase(DynamicOptic.root, "NewCase")
+        ))
+        val input = variant("ExistingCase", record())
+        val result = migration(input)
+        assertTrue(result == Right(input))
+      }
+    ),
+
+    suite("DynamicMigration - DropCase")(
+      test("migrates dropped case to target case") {
+        val migration = DynamicMigration(Vector(
+          MigrationAction.DropCase(DynamicOptic.root, "OldCase", "NewCase", None)
+        ))
+        val input = variant("OldCase", record("value" -> int(42)))
+        val result = migration(input)
+        assertTrue(result == Right(variant("NewCase", record("value" -> int(42)))))
+      },
+      test("leaves non-matching case unchanged") {
+        val migration = DynamicMigration(Vector(
+          MigrationAction.DropCase(DynamicOptic.root, "OldCase", "NewCase", None)
+        ))
+        val input = variant("OtherCase", record())
+        val result = migration(input)
+        assertTrue(result == Right(variant("OtherCase", record())))
+      },
+      test("applies payload transform when migrating case") {
+        val migration = DynamicMigration(Vector(
+          MigrationAction.DropCase(DynamicOptic.root, "IntCase", "StringCase", Some("intToString"))
+        ))
+        val input = variant("IntCase", int(42))
+        val result = migration(input)
+        assertTrue(result == Right(variant("StringCase", str("42"))))
+      }
+    ),
+
+    suite("DynamicMigration - TransformElements")(
+      test("transforms all sequence elements") {
+        val path = DynamicOptic.root.field("numbers")
+        val migration = DynamicMigration(Vector(
+          MigrationAction.TransformElements(path, "double", None)
+        ))
+        val input = record("numbers" -> seq(int(1), int(2), int(3)))
+        val result = migration(input)
+        assertTrue(result == Right(record("numbers" -> seq(int(2), int(4), int(6)))))
+      },
+      test("fails if any element transform fails") {
+        val path = DynamicOptic.root.field("items")
+        val migration = DynamicMigration(Vector(
+          MigrationAction.TransformElements(path, "uppercase", None)
+        ))
+        val input = record("items" -> seq(str("hello"), int(42)))
+        val result = migration(input)
+        assertTrue(result.isLeft)
+      }
+    ),
+
+    suite("DynamicMigration - TransformKeys")(
+      test("transforms all map keys") {
+        val path = DynamicOptic.root.field("data")
+        val migration = DynamicMigration(Vector(
+          MigrationAction.TransformKeys(path, "uppercase", None)
+        ))
+        val input = record("data" -> map(str("name") -> str("John"), str("city") -> str("NYC")))
+        val result = migration(input)
+        assertTrue(result == Right(record("data" -> map(str("NAME") -> str("John"), str("CITY") -> str("NYC")))))
+      }
+    ),
+
+    suite("DynamicMigration - TransformValues (map)")(
+      test("transforms all map values") {
+        val path = DynamicOptic.root.field("counts")
+        val migration = DynamicMigration(Vector(
+          MigrationAction.TransformValues(path, "double", None)
+        ))
+        val input = record("counts" -> map(str("a") -> int(1), str("b") -> int(2)))
+        val result = migration(input)
+        assertTrue(result == Right(record("counts" -> map(str("a") -> int(2), str("b") -> int(4)))))
+      }
+    ),
+
+    suite("DynamicMigration - FilterElements")(
+      test("filters sequence elements by predicate") {
+        val path = DynamicOptic.root.field("numbers")
+        val migration = DynamicMigration(Vector(
+          MigrationAction.FilterElements(path, "isPositive")
+        ))
+        val input = record("numbers" -> seq(int(-1), int(0), int(1), int(2)))
+        val result = migration(input)
+        assertTrue(result == Right(record("numbers" -> seq(int(1), int(2)))))
+      },
+      test("fails when predicate not found") {
+        val path = DynamicOptic.root.field("numbers")
+        val migration = DynamicMigration(Vector(
+          MigrationAction.FilterElements(path, "unknown")
+        ))
+        val input = record("numbers" -> seq(int(1), int(2)))
+        val result = migration(input)
+        assertTrue(result.isLeft)
+      }
+    ),
+
+    suite("DynamicMigration - FilterEntries")(
+      test("filters map entries by predicate") {
+        val path = DynamicOptic.root.field("data")
+        val migration = DynamicMigration(Vector(
+          MigrationAction.FilterEntries(path, "keyIsName")
+        ))
+        val input = record("data" -> map(str("name") -> str("John"), str("age") -> int(30)))
+        val result = migration(input)
+        assertTrue(result == Right(record("data" -> map(str("name") -> str("John")))))
+      }
+    ),
+
+    suite("DynamicMigration - Path traversal")(
+      test("traverses through nested fields") {
+        val path = DynamicOptic.root.field("person").field("address")
+        val migration = DynamicMigration.addField(path, "zip", str("10001"))
+        val input = record(
+          "person" -> record(
+            "name" -> str("John"),
+            "address" -> record("city" -> str("NYC"))
+          )
+        )
+        val result = migration(input)
+        assertTrue(
+          result == Right(record(
+            "person" -> record(
+              "name" -> str("John"),
+              "address" -> record("city" -> str("NYC"), "zip" -> str("10001"))
+            )
+          ))
+        )
+      },
+      test("traverses through case in variant") {
+        val path = DynamicOptic.root.caseOf("Person")
+        val migration = DynamicMigration.addField(path, "age", int(25))
+        val input = variant("Person", record("name" -> str("John")))
+        val result = migration(input)
+        assertTrue(
+          result == Right(variant("Person", record("name" -> str("John"), "age" -> int(25))))
+        )
+      },
+      test("skips non-matching case") {
+        val path = DynamicOptic.root.caseOf("Person")
+        val migration = DynamicMigration.addField(path, "age", int(25))
+        val input = variant("Company", record("name" -> str("Acme")))
+        val result = migration(input)
+        assertTrue(result == Right(input))
+      },
+      test("traverses sequence elements with Elements node") {
+        val path = DynamicOptic.root.field("items").elements
+        val migration = DynamicMigration.addField(path, "processed", bool(true))
+        val input = record(
+          "items" -> seq(
+            record("id" -> int(1)),
+            record("id" -> int(2))
+          )
+        )
+        val result = migration(input)
+        assertTrue(
+          result == Right(record(
+            "items" -> seq(
+              record("id" -> int(1), "processed" -> bool(true)),
+              record("id" -> int(2), "processed" -> bool(true))
+            )
+          ))
+        )
+      },
+      test("traverses by index with AtIndex") {
+        val path = DynamicOptic.root.field("items").at(0)
+        val migration = DynamicMigration.addField(path, "first", bool(true))
+        val input = record(
+          "items" -> seq(
+            record("id" -> int(1)),
+            record("id" -> int(2))
+          )
+        )
+        val result = migration(input)
+        assertTrue(
+          result == Right(record(
+            "items" -> seq(
+              record("id" -> int(1), "first" -> bool(true)),
+              record("id" -> int(2))
+            )
+          ))
+        )
+      },
+      test("fails with pathNotFound for invalid index") {
+        val path = DynamicOptic.root.field("items").at(10)
+        val migration = DynamicMigration.addField(path, "flag", bool(true))
+        val input = record("items" -> seq(record("id" -> int(1))))
+        val result = migration(input)
+        assertTrue(result.isLeft)
+      }
+    ),
+
+    suite("DynamicMigration - Composition")(
+      test("andThen chains migrations") {
+        val m1 = DynamicMigration.addField("b", int(2))
+        val m2 = DynamicMigration.addField("c", int(3))
+        val combined = m1.andThen(m2)
+        val input = record("a" -> int(1))
+        val result = combined(input)
+        assertTrue(result == Right(record("a" -> int(1), "b" -> int(2), "c" -> int(3))))
+      },
+      test(">>> is alias for andThen") {
+        val m1 = DynamicMigration.addField("b", int(2))
+        val m2 = DynamicMigration.addField("c", int(3))
+        val combined = m1 >>> m2
+        val input = record("a" -> int(1))
+        val result = combined(input)
+        assertTrue(result == Right(record("a" -> int(1), "b" -> int(2), "c" -> int(3))))
+      },
+      test("identity migration does nothing") {
+        val migration = DynamicMigration.identity
+        val input = record("a" -> int(1))
+        val result = migration(input)
+        assertTrue(result == Right(input))
+      },
+      test("composing with identity yields same result") {
+        val m = DynamicMigration.addField("b", int(2))
+        val input = record("a" -> int(1))
+        val r1 = m(input)
+        val r2 = (DynamicMigration.identity >>> m)(input)
+        val r3 = (m >>> DynamicMigration.identity)(input)
+        assertTrue(r1 == r2 && r2 == r3)
+      }
+    ),
+
+    suite("DynamicMigration - Reverse")(
+      test("RenameField is reversible") {
+        val migration = DynamicMigration.renameField("old", "new")
+        val reversed = migration.reverse
+        assertTrue(reversed.isDefined)
+        val input = record("old" -> int(1))
+        val migrated = migration(input)
+        val roundtrip = migrated.flatMap(v => reversed.get(v))
+        assertTrue(roundtrip == Right(input))
+      },
+      test("AddField with DropField forms reversible pair") {
+        val migration = DynamicMigration.dropField("temp", int(0))
+        val reversed = migration.reverse
+        assertTrue(reversed.isDefined)
+        // The reverse of drop (with default) is add
+        reversed.get.actions.head match {
+          case MigrationAction.AddField(_, "temp", _) => assertTrue(true)
+          case _ => assertTrue(false)
+        }
+      },
+      test("TransformValue with reverse is reversible") {
+        val migration = DynamicMigration(Vector(
+          MigrationAction.TransformValue(DynamicOptic.root.field("n"), "double", Some("halve"))
+        ))
+        val reversed = migration.reverse
+        assertTrue(reversed.isDefined)
+        val input = record("n" -> int(10))
+        val migrated = migration(input)
+        val roundtrip = migrated.flatMap(v => reversed.get(v))
+        assertTrue(roundtrip == Right(input))
+      },
+      test("TransformValue without reverse is not reversible") {
+        val migration = DynamicMigration(Vector(
+          MigrationAction.TransformValue(DynamicOptic.root.field("n"), "double", None)
+        ))
+        val reversed = migration.reverse
+        assertTrue(reversed.isEmpty)
+      },
+      test("Optionalize is not reversible") {
+        val migration = DynamicMigration.optionalize("name")
+        val reversed = migration.reverse
+        assertTrue(reversed.isEmpty)
+      },
+      test("FilterElements is not reversible") {
+        val migration = DynamicMigration(Vector(
+          MigrationAction.FilterElements(DynamicOptic.root.field("items"), "isPositive")
+        ))
+        val reversed = migration.reverse
+        assertTrue(reversed.isEmpty)
+      },
+      test("reversed migration actions are in reverse order") {
+        val m1 = DynamicMigration.renameField("a", "b")
+        val m2 = DynamicMigration.renameField("c", "d")
+        val combined = m1 >>> m2
+        val reversed = combined.reverse
+        assertTrue(reversed.isDefined)
+        reversed.get.actions match {
+          case Vector(
+            MigrationAction.RenameField(_, "d", "c"),
+            MigrationAction.RenameField(_, "b", "a")
+          ) => assertTrue(true)
+          case _ => assertTrue(false)
+        }
+      }
+    ),
+
+    suite("TransformRegistry")(
+      test("empty registry returns None for all lookups") {
+        val empty = TransformRegistry.empty
+        assertTrue(
+          empty.getTransform("any").isEmpty,
+          empty.getPredicate("any").isEmpty
+        )
+      },
+      test("registry returns registered transforms") {
+        val reg = TransformRegistry(
+          transforms = scala.collection.immutable.Map(
+            "id" -> ((dv: DynamicValue) => Right(dv))
+          ),
+          predicates = scala.collection.immutable.Map(
+            "always" -> ((_: DynamicValue) => true)
+          )
+        )
+        assertTrue(
+          reg.getTransform("id").isDefined,
+          reg.getPredicate("always").isDefined,
+          reg.getTransform("unknown").isEmpty
+        )
+      }
+    ),
+
+    suite("Migration.Builder")(
+      test("builds migration with multiple actions") {
+        // Using DynamicValue schemas for simplicity
+        implicit val dvSchema: Schema[DynamicValue] = Schema.dynamic
+
+        val migration = Migration.builder[DynamicValue, DynamicValue]
+          .addField("b", int(2))
+          .renameField("a", "aa")
+          .build
+
+        val input = record("a" -> int(1))
+        val result = migration(input)
+        assertTrue(result == Right(record("aa" -> int(1), "b" -> int(2))))
+      },
+      test("builder supports all action types") {
+        implicit val dvSchema: Schema[DynamicValue] = Schema.dynamic
+
+        // Just verify it compiles and builds
+        val builder = Migration.builder[DynamicValue, DynamicValue]
+          .addField("f", int(1))
+          .dropField("old")
+          .renameField("x", "y")
+          .optionalize("opt")
+          .mandate("req", str("default"))
+          .transformValue(DynamicOptic.root.field("v"), "uppercase")
+          .changeType(DynamicOptic.root.field("t"), "Int", "String", "intToString")
+          .renameCase("Old", "New")
+          .transformCase(DynamicOptic.root, "Case", "identity")
+          .addCase("NewCase")
+          .dropCase("OldCase", "NewCase")
+          .transformElements(DynamicOptic.root.field("seq"), "identity")
+          .transformKeys(DynamicOptic.root.field("map"), "identity")
+          .transformValues(DynamicOptic.root.field("map"), "identity")
+          .filterElements(DynamicOptic.root.field("seq"), "isPositive")
+          .filterEntries(DynamicOptic.root.field("map"), "keyIsName")
+
+        val migration = builder.build
+        assertTrue(migration.dynamicMigration.actions.length == 16)
+      }
+    ),
+
+    suite("Migration typed wrapper")(
+      test("identity migration returns same value") {
+        implicit val dvSchema: Schema[DynamicValue] = Schema.dynamic
+        val migration = Migration.identity[DynamicValue]
+        val input = record("a" -> int(1))
+        val result = migration(input)
+        assertTrue(result == Right(input))
+      },
+      test("fromDynamic creates migration from DynamicMigration") {
+        implicit val dvSchema: Schema[DynamicValue] = Schema.dynamic
+        val dynamic = DynamicMigration.addField("b", int(2))
+        val typed = Migration.fromDynamic[DynamicValue, DynamicValue](dynamic)
+        val input = record("a" -> int(1))
+        val result = typed(input)
+        assertTrue(result == Right(record("a" -> int(1), "b" -> int(2))))
+      },
+      test("typed migrations compose with andThen") {
+        implicit val dvSchema: Schema[DynamicValue] = Schema.dynamic
+        val m1 = Migration.fromDynamic[DynamicValue, DynamicValue](DynamicMigration.addField("b", int(2)))
+        val m2 = Migration.fromDynamic[DynamicValue, DynamicValue](DynamicMigration.addField("c", int(3)))
+        val combined = m1.andThen(m2)
+        val input = record("a" -> int(1))
+        val result = combined(input)
+        assertTrue(result == Right(record("a" -> int(1), "b" -> int(2), "c" -> int(3))))
+      },
+      test("typed migrations compose with >>>") {
+        implicit val dvSchema: Schema[DynamicValue] = Schema.dynamic
+        val m1 = Migration.fromDynamic[DynamicValue, DynamicValue](DynamicMigration.addField("b", int(2)))
+        val m2 = Migration.fromDynamic[DynamicValue, DynamicValue](DynamicMigration.addField("c", int(3)))
+        val combined = m1 >>> m2
+        val input = record("a" -> int(1))
+        val result = combined(input)
+        assertTrue(result == Right(record("a" -> int(1), "b" -> int(2), "c" -> int(3))))
+      },
+      test("typed migration reverse works") {
+        implicit val dvSchema: Schema[DynamicValue] = Schema.dynamic
+        val m = Migration.fromDynamic[DynamicValue, DynamicValue](
+          DynamicMigration.renameField("old", "new")
+        )
+        val reversed = m.reverse
+        assertTrue(reversed.isDefined)
+        val input = record("old" -> int(1))
+        val migrated = m(input)
+        val roundtrip = migrated.flatMap(v => reversed.get(v))
+        assertTrue(roundtrip == Right(input))
+      }
+    ),
+
+    suite("Error cases")(
+      test("PathNotFound when field doesn't exist in path") {
+        val path = DynamicOptic.root.field("nonexistent").field("child")
+        val migration = DynamicMigration.addField(path, "x", int(1))
+        val input = record("other" -> int(1))
+        val result = migration(input)
+        assertTrue(result.isLeft)
+        result match {
+          case Left(err) => assertTrue(err.message.contains("Path not found"))
+          case _ => assertTrue(false)
+        }
+      },
+      test("TypeMismatch when expected Record but got Primitive") {
+        val migration = DynamicMigration.addField("x", int(1))
+        val input = int(42)
+        val result = migration(input)
+        assertTrue(result.isLeft)
+        result match {
+          case Left(err) => assertTrue(err.message.contains("Type mismatch"))
+          case _ => assertTrue(false)
+        }
+      },
+      test("InvalidTransform when transform fails") {
+        val path = DynamicOptic.root.field("value")
+        val migration = DynamicMigration(Vector(
+          MigrationAction.TransformValue(path, "uppercase", None)
+        ))
+        val input = record("value" -> int(42))
+        val result = migration(input)
+        assertTrue(result.isLeft)
+        result match {
+          case Left(err) => assertTrue(err.message.contains("Invalid transform"))
+          case _ => assertTrue(false)
+        }
+      }
+    )
+  )
+}


### PR DESCRIPTION
## Summary

Implements a comprehensive migration system for ZIO Blocks Schema as requested in #519.

### Core Components

1. **MigrationError** - Structured error hierarchy with path information via DynamicOptic
2. **MigrationAction** - Serializable ADT with 16 action types (no closures)
3. **TransformRegistry** - Named transform lookup for serializable migrations
4. **DynamicMigration** - Untyped migration operating on DynamicValue
5. **Migration[A, B]** - Typed wrapper with schemas and fluent Builder API

### Key Features

- **Serializable by design**: All MigrationAction types are pure data - no lambdas
- **Complete action coverage**: AddField, DropField, RenameField, TransformValue, ChangeType, Optionalize, Mandate, RenameCase, TransformCase, AddCase, DropCase, TransformElements, TransformKeys, TransformValues, FilterElements, FilterEntries
- **Path-based operations**: Full DynamicOptic support for nested structures
- **Composable**: `andThen` / `>>>` operators, identity migrations
- **Bidirectional**: `reverse()` for reversible migrations
- **Type-safe**: Migration[A, B] carries schema information

### Laws

- **Identity**: `Migration.identity[A].apply(a) == Right(a)`
- **Associativity**: `(m1 >>> m2) >>> m3 == m1 >>> (m2 >>> m3)`
- **Structural Reverse**: roundtrip when all actions are reversible

## Test Plan

- [x] 66 comprehensive tests in MigrationSpec.scala
- [x] All 16 MigrationAction types tested
- [x] Path traversal (nested fields, variants, sequences, maps)
- [x] Composition and identity laws
- [x] Reversibility for applicable actions
- [x] Error cases (PathNotFound, TypeMismatch, InvalidTransform)
- [x] TransformRegistry integration
- [x] Builder API completeness
- [x] Typed Migration wrapper
- [x] `sbt schemaJVM/compile` passes
- [x] `sbt schemaJVM/test` passes (333/333 tests)

## Files Changed

- `schema/shared/src/main/scala/zio/blocks/schema/Migration.scala` (944 lines)
- `schema/shared/src/test/scala/zio/blocks/schema/MigrationSpec.scala` (795 lines)

Closes #519