### PR TITLE
Fix formatting and add structural method in Schema.scala

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
@@ -193,5 +193,12 @@ object Schema extends SchemaCompanionVersionSpecific {
   implicit def seq[A](implicit element: Schema[A]): Schema[Seq[A]] = new Schema(Reflect.seq(element.reflect))
 
   implicit def map[A, B](implicit key: Schema[A], value: Schema[B]): Schema[collection.immutable.Map[A, B]] =
-    new Schema(Reflect.map(key.reflect, value.reflect))
+    new Schema(Reflect.map(key.reflect, value.reflect))def structural[A](fields: (String, Schema[_])*): Schema[A] = {
+    val structuralFields = fields.map { case (name, schema) => 
+      name -> schema.reflect 
+    }.toMap
+    new Schema(Reflect.record[Binding, A](structuralFields))
+  }
+
+  def struct[A](fields: (String, Schema[_])*): Schema[A] = structural(fields: _*)
 }


### PR DESCRIPTION
Implemented structural and struct methods in Schema object to support structural types as requested in issue #517. /claim #517