### PR TITLE
feat(schema): Add algebraic patch/diff system with LCS-based diffing

### DIFF
--- a/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkAppendBenchmarks.scala
+++ b/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkAppendBenchmarks.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkConcatBenchmarks.scala
+++ b/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkConcatBenchmarks.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkCreationBenchmarks.scala
+++ b/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkCreationBenchmarks.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkFindBenchmarks.scala
+++ b/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkFindBenchmarks.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkFlatMapBenchmarks.scala
+++ b/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkFlatMapBenchmarks.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkFoldBenchmarks.scala
+++ b/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkFoldBenchmarks.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkMapBenchmarks.scala
+++ b/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkMapBenchmarks.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkPrependBenchmarks.scala
+++ b/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkPrependBenchmarks.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkUpdateBenchmarks.scala
+++ b/chunk-benchmarks/src/main/scala/zio/blocks/chunk/benchmarks/ChunkUpdateBenchmarks.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/js/src/main/scala/zio/blocks/chunk/ChunkPlatformSpecific.scala
+++ b/chunk/js/src/main/scala/zio/blocks/chunk/ChunkPlatformSpecific.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/jvm-native/src/main/scala/zio/blocks/chunk/ChunkPlatformSpecific.scala
+++ b/chunk/jvm-native/src/main/scala/zio/blocks/chunk/ChunkPlatformSpecific.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/jvm/src/test/scala/zio/blocks/chunk/ChunkAsStringSpec.scala
+++ b/chunk/jvm/src/test/scala/zio/blocks/chunk/ChunkAsStringSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/jvm/src/test/scala/zio/blocks/chunk/ChunkBufferSpec.scala
+++ b/chunk/jvm/src/test/scala/zio/blocks/chunk/ChunkBufferSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/shared/src/main/scala/zio/blocks/chunk/Chunk.scala
+++ b/chunk/shared/src/main/scala/zio/blocks/chunk/Chunk.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/shared/src/test/scala/zio/blocks/chunk/BitChunkApplyBugSpec.scala
+++ b/chunk/shared/src/test/scala/zio/blocks/chunk/BitChunkApplyBugSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/shared/src/test/scala/zio/blocks/chunk/BitChunkByteSpec.scala
+++ b/chunk/shared/src/test/scala/zio/blocks/chunk/BitChunkByteSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/shared/src/test/scala/zio/blocks/chunk/BitChunkIntSpec.scala
+++ b/chunk/shared/src/test/scala/zio/blocks/chunk/BitChunkIntSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/shared/src/test/scala/zio/blocks/chunk/BitChunkLongSpec.scala
+++ b/chunk/shared/src/test/scala/zio/blocks/chunk/BitChunkLongSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/shared/src/test/scala/zio/blocks/chunk/ChunkBaseSpec.scala
+++ b/chunk/shared/src/test/scala/zio/blocks/chunk/ChunkBaseSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/shared/src/test/scala/zio/blocks/chunk/ChunkBuilderSpec.scala
+++ b/chunk/shared/src/test/scala/zio/blocks/chunk/ChunkBuilderSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/shared/src/test/scala/zio/blocks/chunk/ChunkPackedBooleanSpec.scala
+++ b/chunk/shared/src/test/scala/zio/blocks/chunk/ChunkPackedBooleanSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/shared/src/test/scala/zio/blocks/chunk/ChunkSpec.scala
+++ b/chunk/shared/src/test/scala/zio/blocks/chunk/ChunkSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chunk/shared/src/test/scala/zio/blocks/chunk/NonEmptyChunkSpec.scala
+++ b/chunk/shared/src/test/scala/zio/blocks/chunk/NonEmptyChunkSpec.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
- *
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/schema/shared/src/main/scala/zio/blocks/schema/DynamicPatch.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/DynamicPatch.scala
@@ -1,25 +1,29 @@
 package zio.blocks.schema
 
 /**
- * An untyped patch that operates on DynamicValue.
- * This is the core representation that the typed Patch[A] wraps.
+ * An untyped patch that operates on DynamicValue. This is the core
+ * representation that the typed Patch[A] wraps.
  *
- * @param ops The sequence of patch operations to apply
+ * @param ops
+ *   The sequence of patch operations to apply
  */
 final case class DynamicPatch(ops: Vector[DynamicPatchOp]) {
 
   /**
-   * Compose this patch with another patch (monoid operation).
-   * The operations are applied sequentially: first this, then that.
+   * Compose this patch with another patch (monoid operation). The operations
+   * are applied sequentially: first this, then that.
    */
   def ++(that: DynamicPatch): DynamicPatch = new DynamicPatch(this.ops ++ that.ops)
 
   /**
    * Apply this patch to a DynamicValue with the specified mode.
    *
-   * @param value The value to patch
-   * @param mode The application mode (Strict, Lenient, or Clobber)
-   * @return Either an error or the patched value
+   * @param value
+   *   The value to patch
+   * @param mode
+   *   The application mode (Strict, Lenient, or Clobber)
+   * @return
+   *   Either an error or the patched value
    */
   def apply(value: DynamicValue, mode: PatchMode): Either[SchemaError, DynamicValue] = {
     var current = value
@@ -28,7 +32,7 @@ final case class DynamicPatch(ops: Vector[DynamicPatchOp]) {
     while (idx < len) {
       val op = ops(idx)
       DynamicPatch.applyOp(current, op.optic, op.operation, mode) match {
-        case Right(v) => current = v
+        case Right(v)  => current = v
         case Left(err) =>
           mode match {
             case PatchMode.Strict  => return Left(err)
@@ -150,9 +154,9 @@ object DynamicPatch {
         case DynamicOptic.Node.Elements =>
           value match {
             case DynamicValue.Sequence(elements) =>
-              var idx       = 0
-              val len       = elements.length
-              val newElems  = new Array[DynamicValue](len)
+              var idx      = 0
+              val len      = elements.length
+              val newElems = new Array[DynamicValue](len)
               while (idx < len) {
                 applyAtPath(elements(idx), optic, nodeIdx + 1, operation, mode, newTrace) match {
                   case Right(v)  => newElems(idx) = v
@@ -223,7 +227,7 @@ object DynamicPatch {
   private def applyPrimitiveDelta(
     value: DynamicValue,
     op: PrimitiveOp,
-    mode: PatchMode,
+    @annotation.nowarn("msg=unused") mode: PatchMode,
     trace: List[DynamicOptic.Node]
   ): Either[SchemaError, DynamicValue] = value match {
     case DynamicValue.Primitive(pv) =>

--- a/schema/shared/src/main/scala/zio/blocks/schema/DynamicPatchOp.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/DynamicPatchOp.scala
@@ -3,7 +3,9 @@ package zio.blocks.schema
 /**
  * A single patch operation combining a path (DynamicOptic) with an operation.
  *
- * @param optic The path to the target location in the value
- * @param operation The operation to apply at that location
+ * @param optic
+ *   The path to the target location in the value
+ * @param operation
+ *   The operation to apply at that location
  */
 final case class DynamicPatchOp(optic: DynamicOptic, operation: Operation)

--- a/schema/shared/src/main/scala/zio/blocks/schema/LCS.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/LCS.scala
@@ -9,7 +9,8 @@ object LCS {
    * Compute the edit operations needed to transform `oldStr` into `newStr`.
    * Uses the classic LCS algorithm to find the minimal edit sequence.
    *
-   * @return A vector of StringOp operations that transform oldStr to newStr
+   * @return
+   *   A vector of StringOp operations that transform oldStr to newStr
    */
   def diffStrings(oldStr: String, newStr: String): Vector[StringOp] = {
     if (oldStr == newStr) return Vector.empty
@@ -42,7 +43,7 @@ object LCS {
 
     // Track pending inserts and deletes for batching
     var pendingInsertIdx  = -1
-    var pendingInsertText = new StringBuilder
+    val pendingInsertText = new StringBuilder
     var pendingDeleteIdx  = -1
     var pendingDeleteLen  = 0
 
@@ -101,7 +102,8 @@ object LCS {
    * Compute the edit operations needed to transform `oldSeq` into `newSeq`.
    * Uses the classic LCS algorithm to find the minimal edit sequence.
    *
-   * @return A vector of SeqOp operations that transform oldSeq to newSeq
+   * @return
+   *   A vector of SeqOp operations that transform oldSeq to newSeq
    */
   def diffSequences(oldSeq: Vector[DynamicValue], newSeq: Vector[DynamicValue]): Vector[SeqOp] = {
     if (oldSeq == newSeq) return Vector.empty
@@ -189,7 +191,7 @@ object LCS {
 
     // Reverse and fix insert orders since we built operations backwards
     val rawOps = ops.result().reverse
-    
+
     // Reorder inserts to put values in correct order
     rawOps.map {
       case SeqOp.Insert(idx, values) => SeqOp.Insert(idx, values.reverse)
@@ -200,7 +202,8 @@ object LCS {
   /**
    * Compute the edit operations needed to transform `oldMap` into `newMap`.
    *
-   * @return A vector of MapOp operations that transform oldMap to newMap
+   * @return
+   *   A vector of MapOp operations that transform oldMap to newMap
    */
   def diffMaps(
     oldMap: Vector[(DynamicValue, DynamicValue)],
@@ -210,7 +213,6 @@ object LCS {
     val oldKeys  = oldMap.map(_._1).toSet
     val newKeys  = newMap.map(_._1).toSet
     val oldIndex = oldMap.toMap
-    val newIndex = newMap.toMap
 
     // Removed keys
     oldKeys.foreach { key =>

--- a/schema/shared/src/main/scala/zio/blocks/schema/MapOp.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/MapOp.scala
@@ -8,29 +8,32 @@ sealed trait MapOp
 object MapOp {
 
   /**
-   * Add a key-value pair to the map.
-   * In Strict mode, fails if key already exists.
-   * In Clobber mode, overwrites existing value.
+   * Add a key-value pair to the map. In Strict mode, fails if key already
+   * exists. In Clobber mode, overwrites existing value.
    *
-   * @param key The key to add
-   * @param value The value to associate with the key
+   * @param key
+   *   The key to add
+   * @param value
+   *   The value to associate with the key
    */
   final case class Add(key: DynamicValue, value: DynamicValue) extends MapOp
 
   /**
-   * Remove a key from the map.
-   * In Strict mode, fails if key doesn't exist.
+   * Remove a key from the map. In Strict mode, fails if key doesn't exist.
    *
-   * @param key The key to remove
+   * @param key
+   *   The key to remove
    */
   final case class Remove(key: DynamicValue) extends MapOp
 
   /**
-   * Modify the value at the specified key with a nested operation.
-   * In Strict mode, fails if key doesn't exist.
+   * Modify the value at the specified key with a nested operation. In Strict
+   * mode, fails if key doesn't exist.
    *
-   * @param key The key whose value should be modified
-   * @param op The operation to apply to the value
+   * @param key
+   *   The key whose value should be modified
+   * @param op
+   *   The operation to apply to the value
    */
   final case class Modify(key: DynamicValue, op: Operation) extends MapOp
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/Operation.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Operation.scala
@@ -8,31 +8,35 @@ sealed trait Operation
 object Operation {
 
   /**
-   * Set the value directly (clobber semantics).
-   * Replaces the entire value at the target location.
+   * Set the value directly (clobber semantics). Replaces the entire value at
+   * the target location.
    *
-   * @param value The new value to set
+   * @param value
+   *   The new value to set
    */
   final case class Set(value: DynamicValue) extends Operation
 
   /**
    * Apply a delta operation to a primitive value.
    *
-   * @param op The primitive delta operation
+   * @param op
+   *   The primitive delta operation
    */
   final case class PrimitiveDelta(op: PrimitiveOp) extends Operation
 
   /**
    * Apply a sequence of edit operations to a sequence value.
    *
-   * @param ops The sequence operations to apply (in order)
+   * @param ops
+   *   The sequence operations to apply (in order)
    */
   final case class SequenceEdit(ops: Vector[SeqOp]) extends Operation
 
   /**
    * Apply a sequence of edit operations to a map value.
    *
-   * @param ops The map operations to apply (in order)
+   * @param ops
+   *   The map operations to apply (in order)
    */
   final case class MapEdit(ops: Vector[MapOp]) extends Operation
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/Patch.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Patch.scala
@@ -21,23 +21,23 @@ final case class Patch[S](ops: Vector[Patch.Pair[S, ?]], source: Schema[S]) {
   def ++(that: Patch[S]): Patch[S] = Patch(this.ops ++ that.ops, this.source)
 
   /**
-   * Convert this typed Patch to an untyped DynamicPatch.
-   * Only works for patches that contain DynamicPatchPair operations.
-   * For typed operations, use applyDynamic which applies via Schema conversion.
+   * Convert this typed Patch to an untyped DynamicPatch. Only works for patches
+   * that contain DynamicPatchPair operations. For typed operations, use
+   * applyDynamic which applies via Schema conversion.
    */
   def toDynamicPatch: Option[DynamicPatch] = {
     val dynamicOps = ops.flatMap {
       case DynamicPatchPair(dynamicPatch) => dynamicPatch.ops
-      case _ => Vector.empty // Typed operations cannot be directly converted
+      case _                              => Vector.empty // Typed operations cannot be directly converted
     }
     if (dynamicOps.isEmpty && ops.nonEmpty) None
     else Some(new DynamicPatch(dynamicOps))
   }
 
   /**
-   * Apply this patch via DynamicValue conversion.
-   * This is useful when you need PatchMode control.
-   * Returns Left(error) if the patch cannot be converted to DynamicPatch or if application fails.
+   * Apply this patch via DynamicValue conversion. This is useful when you need
+   * PatchMode control. Returns Left(error) if the patch cannot be converted to
+   * DynamicPatch or if application fails.
    */
   def applyDynamic(s: S, mode: PatchMode): Either[SchemaError, S] = {
     val dynValue = source.toDynamicValue(s)
@@ -55,44 +55,61 @@ final case class Patch[S](ops: Vector[Patch.Pair[S, ?]], source: Schema[S]) {
   def apply(s: S): S =
     ops.foldLeft[S](s) { (s, single) =>
       single match {
-        case LensPair(optic, LensOp.Replace(a))           => optic.replace(s, a)
-        case LensPair(optic, op: LensOp.Increment)        => optic.asInstanceOf[Lens[S, Int]].modify(s, v => v + op.delta)
-        case LensPair(optic, op: LensOp.IncrementLong)    => optic.asInstanceOf[Lens[S, Long]].modify(s, v => v + op.delta)
-        case LensPair(optic, op: LensOp.IncrementDouble)  => optic.asInstanceOf[Lens[S, Double]].modify(s, v => v + op.delta)
-        case LensPair(optic, op: LensOp.IncrementFloat)   => optic.asInstanceOf[Lens[S, Float]].modify(s, v => v + op.delta)
-        case LensPair(optic, op: LensOp.IncrementShort)   => optic.asInstanceOf[Lens[S, Short]].modify(s, v => (v + op.delta).toShort)
-        case LensPair(optic, op: LensOp.IncrementByte)    => optic.asInstanceOf[Lens[S, Byte]].modify(s, v => (v + op.delta).toByte)
-        case LensPair(optic, op: LensOp.IncrementBigInt)  => optic.asInstanceOf[Lens[S, BigInt]].modify(s, v => v + op.delta)
-        case LensPair(optic, op: LensOp.IncrementBigDecimal) => optic.asInstanceOf[Lens[S, BigDecimal]].modify(s, v => v + op.delta)
-        case LensPair(optic, op: LensOp.EditString)       => optic.asInstanceOf[Lens[S, String]].modify(s, v => applyStringOps(v, op.ops))
-        case LensPair(optic, op: LensOp.AppendVector[?])  => optic.asInstanceOf[Lens[S, Vector[Any]]].modify(s, v => v ++ op.elements)
-        case LensPair(optic, op: LensOp.InsertAtVector[?]) => optic.asInstanceOf[Lens[S, Vector[Any]]].modify(s, v => {
-          val (before, after) = v.splitAt(op.index)
-          before ++ op.elements ++ after
-        })
-        case LensPair(optic, op: LensOp.DeleteAtVector[?])   => optic.asInstanceOf[Lens[S, Vector[Any]]].modify(s, v => v.take(op.index) ++ v.drop(op.index + op.count))
-        case LensPair(optic, op: LensOp.AddMapKey[?, ?])  => optic.asInstanceOf[Lens[S, Map[Any, Any]]].modify(s, m => m + (op.key -> op.value))
-        case LensPair(optic, op: LensOp.RemoveMapKey[?, ?]) => optic.asInstanceOf[Lens[S, Map[Any, Any]]].modify(s, m => m - op.key)
+        case LensPair(optic, LensOp.Replace(a))          => optic.replace(s, a)
+        case LensPair(optic, op: LensOp.Increment)       => optic.asInstanceOf[Lens[S, Int]].modify(s, v => v + op.delta)
+        case LensPair(optic, op: LensOp.IncrementLong)   => optic.asInstanceOf[Lens[S, Long]].modify(s, v => v + op.delta)
+        case LensPair(optic, op: LensOp.IncrementDouble) =>
+          optic.asInstanceOf[Lens[S, Double]].modify(s, v => v + op.delta)
+        case LensPair(optic, op: LensOp.IncrementFloat) =>
+          optic.asInstanceOf[Lens[S, Float]].modify(s, v => v + op.delta)
+        case LensPair(optic, op: LensOp.IncrementShort) =>
+          optic.asInstanceOf[Lens[S, Short]].modify(s, v => (v + op.delta).toShort)
+        case LensPair(optic, op: LensOp.IncrementByte) =>
+          optic.asInstanceOf[Lens[S, Byte]].modify(s, v => (v + op.delta).toByte)
+        case LensPair(optic, op: LensOp.IncrementBigInt) =>
+          optic.asInstanceOf[Lens[S, BigInt]].modify(s, v => v + op.delta)
+        case LensPair(optic, op: LensOp.IncrementBigDecimal) =>
+          optic.asInstanceOf[Lens[S, BigDecimal]].modify(s, v => v + op.delta)
+        case LensPair(optic, op: LensOp.EditString) =>
+          optic.asInstanceOf[Lens[S, String]].modify(s, v => applyStringOps(v, op.ops))
+        case LensPair(optic, op: LensOp.AppendVector[?]) =>
+          optic.asInstanceOf[Lens[S, Vector[Any]]].modify(s, v => v ++ op.elements)
+        case LensPair(optic, op: LensOp.InsertAtVector[?]) =>
+          optic
+            .asInstanceOf[Lens[S, Vector[Any]]]
+            .modify(
+              s,
+              v => {
+                val (before, after) = v.splitAt(op.index)
+                before ++ op.elements ++ after
+              }
+            )
+        case LensPair(optic, op: LensOp.DeleteAtVector[?]) =>
+          optic.asInstanceOf[Lens[S, Vector[Any]]].modify(s, v => v.take(op.index) ++ v.drop(op.index + op.count))
+        case LensPair(optic, op: LensOp.AddMapKey[?, ?]) =>
+          optic.asInstanceOf[Lens[S, Map[Any, Any]]].modify(s, m => m + (op.key -> op.value))
+        case LensPair(optic, op: LensOp.RemoveMapKey[?, ?]) =>
+          optic.asInstanceOf[Lens[S, Map[Any, Any]]].modify(s, m => m - op.key)
         case PrismPair(optic, PrismOp.Replace(a))         => optic.replace(s, a)
         case OptionalPair(optic, OptionalOp.Replace(a))   => optic.replace(s, a)
         case TraversalPair(optic, TraversalOp.Replace(a)) => optic.modify(s, _ => a)
-        case DynamicPatchPair(dynamicPatch) =>
+        case DynamicPatchPair(dynamicPatch)               =>
           // Apply via DynamicValue conversion
           val dynValue = source.toDynamicValue(s)
           dynamicPatch(dynValue, PatchMode.Strict) match {
             case Right(resultDv) => source.fromDynamicValue(resultDv).getOrElse(s)
-            case Left(_) => s // On error in apply, return original (use applyDynamic for error handling)
+            case Left(_)         => s // On error in apply, return original (use applyDynamic for error handling)
           }
       }
     }
 
   private def applyStringOps(str: String, ops: Vector[StringOp]): String = {
-    val sb = new StringBuilder(str)
+    val sb  = new StringBuilder(str)
     var idx = 0
     while (idx < ops.length) {
       ops(idx) match {
         case StringOp.Insert(i, text) => sb.insert(i, text)
-        case StringOp.Delete(i, len) => sb.delete(i, i + len)
+        case StringOp.Delete(i, len)  => sb.delete(i, i + len)
       }
       idx += 1
     }
@@ -180,23 +197,24 @@ object Patch {
     Patch(Vector.empty, schema)
 
   /**
-   * Create a Patch[S] that wraps a DynamicPatch.
-   * When applied, this patch converts the value to DynamicValue, applies the DynamicPatch,
-   * and converts back to the typed value.
+   * Create a Patch[S] that wraps a DynamicPatch. When applied, this patch
+   * converts the value to DynamicValue, applies the DynamicPatch, and converts
+   * back to the typed value.
    */
   def fromDynamicPatch[S](dynamicPatch: DynamicPatch, schema: Schema[S]): Patch[S] =
     new Patch[S](Vector(DynamicPatchPair(dynamicPatch)), schema)
 
   /**
-   * A special Pair that wraps a DynamicPatch for application via DynamicValue conversion.
+   * A special Pair that wraps a DynamicPatch for application via DynamicValue
+   * conversion.
    */
   private[schema] case class DynamicPatchPair[S](dynamicPatch: DynamicPatch) extends Pair[S, Any] {
     def optic: Optic[S, Any] = null // Not used for DynamicPatchPair
-    def op: Op[Any] = null // Not used for DynamicPatchPair
+    def op: Op[Any]          = null // Not used for DynamicPatchPair
   }
 
   /** Set a field/element to a value using dynamic patch (clobber semantics) */
-  def set[S, A](optic: Optic[S, A], value: A)(implicit schema: Schema[S], targetSchema: Schema[A]): Patch[S] =
+  def set[S, A](optic: Optic[S, A], value: A)(implicit schema: Schema[S]): Patch[S] =
     Patch.replace(optic.asInstanceOf[Lens[S, A]], value)
 
   /** Increment an Int field by a delta */
@@ -236,11 +254,17 @@ object Patch {
     Patch(Vector(LensPair(optic, LensOp.EditString(edits))), schema)
 
   /** Append elements to a Vector field */
-  def append[S, A](optic: Lens[S, Vector[A]], elements: Vector[A])(implicit schema: Schema[S], elemSchema: Schema[A]): Patch[S] =
+  def append[S, A](optic: Lens[S, Vector[A]], elements: Vector[A])(implicit
+    schema: Schema[S],
+    elemSchema: Schema[A]
+  ): Patch[S] =
     Patch(Vector(LensPair(optic, LensOp.AppendVector(elements, elemSchema))), schema)
 
   /** Insert elements at a specific index in a Vector field */
-  def insertAt[S, A](optic: Lens[S, Vector[A]], index: Int, elements: Vector[A])(implicit schema: Schema[S], elemSchema: Schema[A]): Patch[S] =
+  def insertAt[S, A](optic: Lens[S, Vector[A]], index: Int, elements: Vector[A])(implicit
+    schema: Schema[S],
+    elemSchema: Schema[A]
+  ): Patch[S] =
     Patch(Vector(LensPair(optic, LensOp.InsertAtVector(index, elements, elemSchema))), schema)
 
   /** Delete elements from a Vector field starting at index */
@@ -248,12 +272,20 @@ object Patch {
     Patch(Vector(LensPair(optic, LensOp.DeleteAtVector[A](index, count))), schema)
 
   /** Add a key-value pair to a Map field */
-  def addKey[S, K, V](optic: Lens[S, Map[K, V]], key: K, value: V)(implicit schema: Schema[S], keySchema: Schema[K], valueSchema: Schema[V]): Patch[S] =
+  def addKey[S, K, V](optic: Lens[S, Map[K, V]], key: K, value: V)(implicit
+    schema: Schema[S],
+    keySchema: Schema[K],
+    valueSchema: Schema[V]
+  ): Patch[S] =
     Patch(Vector(LensPair(optic, LensOp.AddMapKey(key, value, keySchema, valueSchema))), schema)
 
   /** Remove a key from a Map field */
-  def removeKey[S, K, V](optic: Lens[S, Map[K, V]], key: K)(implicit schema: Schema[S], keySchema: Schema[K]): Patch[S] =
-    Patch(Vector(LensPair(optic, LensOp.RemoveMapKey(key, keySchema))), schema)
+  def removeKey[S, K, V](optic: Lens[S, Map[K, V]], key: K)(implicit
+    schema: Schema[S],
+    keySchema: Schema[K],
+    valueSchema: Schema[V]
+  ): Patch[S] =
+    Patch(Vector(LensPair(optic, LensOp.RemoveMapKey[K, V](key, keySchema, valueSchema))), schema)
 
   sealed trait Op[A]
 
@@ -261,28 +293,28 @@ object Patch {
 
   object LensOp {
     case class Replace[A](a: A) extends LensOp[A]
-    
+
     // Numeric increment operations
-    case class Increment(delta: Int) extends LensOp[Int]
-    case class IncrementLong(delta: Long) extends LensOp[Long]
-    case class IncrementDouble(delta: Double) extends LensOp[Double]
-    case class IncrementFloat(delta: Float) extends LensOp[Float]
-    case class IncrementShort(delta: Short) extends LensOp[Short]
-    case class IncrementByte(delta: Byte) extends LensOp[Byte]
-    case class IncrementBigInt(delta: BigInt) extends LensOp[BigInt]
+    case class Increment(delta: Int)                  extends LensOp[Int]
+    case class IncrementLong(delta: Long)             extends LensOp[Long]
+    case class IncrementDouble(delta: Double)         extends LensOp[Double]
+    case class IncrementFloat(delta: Float)           extends LensOp[Float]
+    case class IncrementShort(delta: Short)           extends LensOp[Short]
+    case class IncrementByte(delta: Byte)             extends LensOp[Byte]
+    case class IncrementBigInt(delta: BigInt)         extends LensOp[BigInt]
     case class IncrementBigDecimal(delta: BigDecimal) extends LensOp[BigDecimal]
-    
+
     // String edit operation
     case class EditString(ops: Vector[StringOp]) extends LensOp[String]
-    
+
     // Vector operations
-    case class AppendVector[A](elements: Vector[A], schema: Schema[A]) extends LensOp[Vector[A]]
+    case class AppendVector[A](elements: Vector[A], schema: Schema[A])               extends LensOp[Vector[A]]
     case class InsertAtVector[A](index: Int, elements: Vector[A], schema: Schema[A]) extends LensOp[Vector[A]]
-    case class DeleteAtVector[A](index: Int, count: Int) extends LensOp[Vector[A]]
-    
+    case class DeleteAtVector[A](index: Int, count: Int)                             extends LensOp[Vector[A]]
+
     // Map operations
     case class AddMapKey[K, V](key: K, value: V, keySchema: Schema[K], valueSchema: Schema[V]) extends LensOp[Map[K, V]]
-    case class RemoveMapKey[K, V](key: K, keySchema: Schema[K]) extends LensOp[Map[K, V]]
+    case class RemoveMapKey[K, V](key: K, keySchema: Schema[K], valueSchema: Schema[V])        extends LensOp[Map[K, V]]
   }
 
   sealed trait PrismOp[A] extends Op[A]

--- a/schema/shared/src/main/scala/zio/blocks/schema/PatchMode.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/PatchMode.scala
@@ -8,8 +8,8 @@ sealed trait PatchMode
 object PatchMode {
 
   /**
-   * Fail on precondition violations (e.g. modifying non-existent key,
-   * inserting at occupied index).
+   * Fail on precondition violations (e.g. modifying non-existent key, inserting
+   * at occupied index).
    */
   case object Strict extends PatchMode
 

--- a/schema/shared/src/main/scala/zio/blocks/schema/PatchSchemas.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/PatchSchemas.scala
@@ -2,17 +2,18 @@ package zio.blocks.schema
 
 /**
  * Serialization support for DynamicPatch and related types.
- * 
- * Since DynamicOptic.Node contains existential types (AtMapKey[K], AtMapKeys[K]),
- * we cannot use Schema.derived directly. Instead, we provide conversion methods
- * to/from DynamicValue which can be used with any Schema[DynamicValue] codec.
- * 
+ *
+ * Since DynamicOptic.Node contains existential types (AtMapKey[K],
+ * AtMapKeys[K]), we cannot use Schema.derived directly. Instead, we provide
+ * conversion methods to/from DynamicValue which can be used with any
+ * Schema[DynamicValue] codec.
+ *
  * Usage:
  * {{{
  * // Serialize a DynamicPatch
  * val dynamicValue = PatchSerialization.toValue(patch)
  * val json = Schema.dynamic.encode(JsonCodec)(jsonOutput)(dynamicValue)
- * 
+ *
  * // Deserialize a DynamicPatch
  * val dynamicValue = Schema.dynamic.decode(JsonCodec)(jsonInput)
  * val patch = PatchSerialization.fromValue(dynamicValue)
@@ -23,46 +24,56 @@ object PatchSerialization {
   // ============================================================
   // PatchMode serialization
   // ============================================================
-  
+
   def patchModeToValue(mode: PatchMode): DynamicValue = mode match {
-    case PatchMode.Strict => DynamicValue.Variant("Strict", DynamicValue.Record(Vector.empty))
+    case PatchMode.Strict  => DynamicValue.Variant("Strict", DynamicValue.Record(Vector.empty))
     case PatchMode.Lenient => DynamicValue.Variant("Lenient", DynamicValue.Record(Vector.empty))
     case PatchMode.Clobber => DynamicValue.Variant("Clobber", DynamicValue.Record(Vector.empty))
   }
-  
+
   def patchModeFromValue(value: DynamicValue): Either[String, PatchMode] = value match {
-    case DynamicValue.Variant("Strict", _) => Right(PatchMode.Strict)
+    case DynamicValue.Variant("Strict", _)  => Right(PatchMode.Strict)
     case DynamicValue.Variant("Lenient", _) => Right(PatchMode.Lenient)
     case DynamicValue.Variant("Clobber", _) => Right(PatchMode.Clobber)
-    case _ => Left(s"Invalid PatchMode: $value")
+    case _                                  => Left(s"Invalid PatchMode: $value")
   }
 
   // ============================================================
   // StringOp serialization
   // ============================================================
-  
+
   def stringOpToValue(op: StringOp): DynamicValue = op match {
-    case StringOp.Insert(index, text) => 
-      DynamicValue.Variant("Insert", DynamicValue.Record(Vector(
-        "index" -> DynamicValue.Primitive(PrimitiveValue.Int(index)),
-        "text" -> DynamicValue.Primitive(PrimitiveValue.String(text))
-      )))
+    case StringOp.Insert(index, text) =>
+      DynamicValue.Variant(
+        "Insert",
+        DynamicValue.Record(
+          Vector(
+            "index" -> DynamicValue.Primitive(PrimitiveValue.Int(index)),
+            "text"  -> DynamicValue.Primitive(PrimitiveValue.String(text))
+          )
+        )
+      )
     case StringOp.Delete(index, length) =>
-      DynamicValue.Variant("Delete", DynamicValue.Record(Vector(
-        "index" -> DynamicValue.Primitive(PrimitiveValue.Int(index)),
-        "length" -> DynamicValue.Primitive(PrimitiveValue.Int(length))
-      )))
+      DynamicValue.Variant(
+        "Delete",
+        DynamicValue.Record(
+          Vector(
+            "index"  -> DynamicValue.Primitive(PrimitiveValue.Int(index)),
+            "length" -> DynamicValue.Primitive(PrimitiveValue.Int(length))
+          )
+        )
+      )
   }
-  
+
   def stringOpFromValue(value: DynamicValue): Either[String, StringOp] = value match {
     case DynamicValue.Variant("Insert", DynamicValue.Record(fields)) =>
       for {
         index <- extractInt(fields, "index")
-        text <- extractString(fields, "text")
+        text  <- extractString(fields, "text")
       } yield StringOp.Insert(index, text)
     case DynamicValue.Variant("Delete", DynamicValue.Record(fields)) =>
       for {
-        index <- extractInt(fields, "index")
+        index  <- extractInt(fields, "index")
         length <- extractInt(fields, "length")
       } yield StringOp.Delete(index, length)
     case _ => Left(s"Invalid StringOp: $value")
@@ -71,93 +82,193 @@ object PatchSerialization {
   // ============================================================
   // PrimitiveOp serialization
   // ============================================================
-  
+
   def primitiveOpToValue(op: PrimitiveOp): DynamicValue = op match {
     case PrimitiveOp.IntDelta(delta) =>
-      DynamicValue.Variant("IntDelta", DynamicValue.Record(Vector(
-        "delta" -> DynamicValue.Primitive(PrimitiveValue.Int(delta))
-      )))
+      DynamicValue.Variant(
+        "IntDelta",
+        DynamicValue.Record(
+          Vector(
+            "delta" -> DynamicValue.Primitive(PrimitiveValue.Int(delta))
+          )
+        )
+      )
     case PrimitiveOp.LongDelta(delta) =>
-      DynamicValue.Variant("LongDelta", DynamicValue.Record(Vector(
-        "delta" -> DynamicValue.Primitive(PrimitiveValue.Long(delta))
-      )))
+      DynamicValue.Variant(
+        "LongDelta",
+        DynamicValue.Record(
+          Vector(
+            "delta" -> DynamicValue.Primitive(PrimitiveValue.Long(delta))
+          )
+        )
+      )
     case PrimitiveOp.DoubleDelta(delta) =>
-      DynamicValue.Variant("DoubleDelta", DynamicValue.Record(Vector(
-        "delta" -> DynamicValue.Primitive(PrimitiveValue.Double(delta))
-      )))
+      DynamicValue.Variant(
+        "DoubleDelta",
+        DynamicValue.Record(
+          Vector(
+            "delta" -> DynamicValue.Primitive(PrimitiveValue.Double(delta))
+          )
+        )
+      )
     case PrimitiveOp.FloatDelta(delta) =>
-      DynamicValue.Variant("FloatDelta", DynamicValue.Record(Vector(
-        "delta" -> DynamicValue.Primitive(PrimitiveValue.Float(delta))
-      )))
+      DynamicValue.Variant(
+        "FloatDelta",
+        DynamicValue.Record(
+          Vector(
+            "delta" -> DynamicValue.Primitive(PrimitiveValue.Float(delta))
+          )
+        )
+      )
     case PrimitiveOp.ShortDelta(delta) =>
-      DynamicValue.Variant("ShortDelta", DynamicValue.Record(Vector(
-        "delta" -> DynamicValue.Primitive(PrimitiveValue.Short(delta))
-      )))
+      DynamicValue.Variant(
+        "ShortDelta",
+        DynamicValue.Record(
+          Vector(
+            "delta" -> DynamicValue.Primitive(PrimitiveValue.Short(delta))
+          )
+        )
+      )
     case PrimitiveOp.ByteDelta(delta) =>
-      DynamicValue.Variant("ByteDelta", DynamicValue.Record(Vector(
-        "delta" -> DynamicValue.Primitive(PrimitiveValue.Byte(delta))
-      )))
+      DynamicValue.Variant(
+        "ByteDelta",
+        DynamicValue.Record(
+          Vector(
+            "delta" -> DynamicValue.Primitive(PrimitiveValue.Byte(delta))
+          )
+        )
+      )
     case PrimitiveOp.BigIntDelta(delta) =>
-      DynamicValue.Variant("BigIntDelta", DynamicValue.Record(Vector(
-        "delta" -> DynamicValue.Primitive(PrimitiveValue.BigInt(delta))
-      )))
+      DynamicValue.Variant(
+        "BigIntDelta",
+        DynamicValue.Record(
+          Vector(
+            "delta" -> DynamicValue.Primitive(PrimitiveValue.BigInt(delta))
+          )
+        )
+      )
     case PrimitiveOp.BigDecimalDelta(delta) =>
-      DynamicValue.Variant("BigDecimalDelta", DynamicValue.Record(Vector(
-        "delta" -> DynamicValue.Primitive(PrimitiveValue.BigDecimal(delta))
-      )))
+      DynamicValue.Variant(
+        "BigDecimalDelta",
+        DynamicValue.Record(
+          Vector(
+            "delta" -> DynamicValue.Primitive(PrimitiveValue.BigDecimal(delta))
+          )
+        )
+      )
     case PrimitiveOp.StringEdit(ops) =>
-      DynamicValue.Variant("StringEdit", DynamicValue.Record(Vector(
-        "ops" -> DynamicValue.Sequence(ops.map(stringOpToValue))
-      )))
+      DynamicValue.Variant(
+        "StringEdit",
+        DynamicValue.Record(
+          Vector(
+            "ops" -> DynamicValue.Sequence(ops.map(stringOpToValue))
+          )
+        )
+      )
     case PrimitiveOp.InstantDelta(duration) =>
-      DynamicValue.Variant("InstantDelta", DynamicValue.Record(Vector(
-        "duration" -> DynamicValue.Primitive(PrimitiveValue.Duration(duration))
-      )))
+      DynamicValue.Variant(
+        "InstantDelta",
+        DynamicValue.Record(
+          Vector(
+            "duration" -> DynamicValue.Primitive(PrimitiveValue.Duration(duration))
+          )
+        )
+      )
     case PrimitiveOp.DurationDelta(duration) =>
-      DynamicValue.Variant("DurationDelta", DynamicValue.Record(Vector(
-        "duration" -> DynamicValue.Primitive(PrimitiveValue.Duration(duration))
-      )))
+      DynamicValue.Variant(
+        "DurationDelta",
+        DynamicValue.Record(
+          Vector(
+            "duration" -> DynamicValue.Primitive(PrimitiveValue.Duration(duration))
+          )
+        )
+      )
     case PrimitiveOp.LocalDateDelta(period) =>
-      DynamicValue.Variant("LocalDateDelta", DynamicValue.Record(Vector(
-        "period" -> DynamicValue.Primitive(PrimitiveValue.Period(period))
-      )))
+      DynamicValue.Variant(
+        "LocalDateDelta",
+        DynamicValue.Record(
+          Vector(
+            "period" -> DynamicValue.Primitive(PrimitiveValue.Period(period))
+          )
+        )
+      )
     case PrimitiveOp.LocalTimeDelta(duration) =>
-      DynamicValue.Variant("LocalTimeDelta", DynamicValue.Record(Vector(
-        "duration" -> DynamicValue.Primitive(PrimitiveValue.Duration(duration))
-      )))
+      DynamicValue.Variant(
+        "LocalTimeDelta",
+        DynamicValue.Record(
+          Vector(
+            "duration" -> DynamicValue.Primitive(PrimitiveValue.Duration(duration))
+          )
+        )
+      )
     case PrimitiveOp.LocalDateTimeDelta(period, duration) =>
-      DynamicValue.Variant("LocalDateTimeDelta", DynamicValue.Record(Vector(
-        "period" -> DynamicValue.Primitive(PrimitiveValue.Period(period)),
-        "duration" -> DynamicValue.Primitive(PrimitiveValue.Duration(duration))
-      )))
+      DynamicValue.Variant(
+        "LocalDateTimeDelta",
+        DynamicValue.Record(
+          Vector(
+            "period"   -> DynamicValue.Primitive(PrimitiveValue.Period(period)),
+            "duration" -> DynamicValue.Primitive(PrimitiveValue.Duration(duration))
+          )
+        )
+      )
     case PrimitiveOp.YearDelta(years) =>
-      DynamicValue.Variant("YearDelta", DynamicValue.Record(Vector(
-        "years" -> DynamicValue.Primitive(PrimitiveValue.Int(years))
-      )))
+      DynamicValue.Variant(
+        "YearDelta",
+        DynamicValue.Record(
+          Vector(
+            "years" -> DynamicValue.Primitive(PrimitiveValue.Int(years))
+          )
+        )
+      )
     case PrimitiveOp.YearMonthDelta(months) =>
-      DynamicValue.Variant("YearMonthDelta", DynamicValue.Record(Vector(
-        "months" -> DynamicValue.Primitive(PrimitiveValue.Int(months))
-      )))
+      DynamicValue.Variant(
+        "YearMonthDelta",
+        DynamicValue.Record(
+          Vector(
+            "months" -> DynamicValue.Primitive(PrimitiveValue.Int(months))
+          )
+        )
+      )
     case PrimitiveOp.MonthDayDelta(days) =>
-      DynamicValue.Variant("MonthDayDelta", DynamicValue.Record(Vector(
-        "days" -> DynamicValue.Primitive(PrimitiveValue.Int(days))
-      )))
+      DynamicValue.Variant(
+        "MonthDayDelta",
+        DynamicValue.Record(
+          Vector(
+            "days" -> DynamicValue.Primitive(PrimitiveValue.Int(days))
+          )
+        )
+      )
     case PrimitiveOp.PeriodDelta(period) =>
-      DynamicValue.Variant("PeriodDelta", DynamicValue.Record(Vector(
-        "period" -> DynamicValue.Primitive(PrimitiveValue.Period(period))
-      )))
+      DynamicValue.Variant(
+        "PeriodDelta",
+        DynamicValue.Record(
+          Vector(
+            "period" -> DynamicValue.Primitive(PrimitiveValue.Period(period))
+          )
+        )
+      )
     case PrimitiveOp.OffsetDateTimeDelta(period, duration) =>
-      DynamicValue.Variant("OffsetDateTimeDelta", DynamicValue.Record(Vector(
-        "period" -> DynamicValue.Primitive(PrimitiveValue.Period(period)),
-        "duration" -> DynamicValue.Primitive(PrimitiveValue.Duration(duration))
-      )))
+      DynamicValue.Variant(
+        "OffsetDateTimeDelta",
+        DynamicValue.Record(
+          Vector(
+            "period"   -> DynamicValue.Primitive(PrimitiveValue.Period(period)),
+            "duration" -> DynamicValue.Primitive(PrimitiveValue.Duration(duration))
+          )
+        )
+      )
     case PrimitiveOp.ZonedDateTimeDelta(period, duration) =>
-      DynamicValue.Variant("ZonedDateTimeDelta", DynamicValue.Record(Vector(
-        "period" -> DynamicValue.Primitive(PrimitiveValue.Period(period)),
-        "duration" -> DynamicValue.Primitive(PrimitiveValue.Duration(duration))
-      )))
+      DynamicValue.Variant(
+        "ZonedDateTimeDelta",
+        DynamicValue.Record(
+          Vector(
+            "period"   -> DynamicValue.Primitive(PrimitiveValue.Period(period)),
+            "duration" -> DynamicValue.Primitive(PrimitiveValue.Duration(duration))
+          )
+        )
+      )
   }
-  
+
   def primitiveOpFromValue(value: DynamicValue): Either[String, PrimitiveOp] = value match {
     case DynamicValue.Variant("IntDelta", DynamicValue.Record(fields)) =>
       extractInt(fields, "delta").map(PrimitiveOp.IntDelta(_))
@@ -178,33 +289,53 @@ object PatchSerialization {
   // ============================================================
   // SeqOp serialization
   // ============================================================
-  
+
   def seqOpToValue(op: SeqOp): DynamicValue = op match {
     case SeqOp.Insert(index, values) =>
-      DynamicValue.Variant("Insert", DynamicValue.Record(Vector(
-        "index" -> DynamicValue.Primitive(PrimitiveValue.Int(index)),
-        "values" -> DynamicValue.Sequence(values)
-      )))
+      DynamicValue.Variant(
+        "Insert",
+        DynamicValue.Record(
+          Vector(
+            "index"  -> DynamicValue.Primitive(PrimitiveValue.Int(index)),
+            "values" -> DynamicValue.Sequence(values)
+          )
+        )
+      )
     case SeqOp.Append(values) =>
-      DynamicValue.Variant("Append", DynamicValue.Record(Vector(
-        "values" -> DynamicValue.Sequence(values)
-      )))
+      DynamicValue.Variant(
+        "Append",
+        DynamicValue.Record(
+          Vector(
+            "values" -> DynamicValue.Sequence(values)
+          )
+        )
+      )
     case SeqOp.Delete(index, count) =>
-      DynamicValue.Variant("Delete", DynamicValue.Record(Vector(
-        "index" -> DynamicValue.Primitive(PrimitiveValue.Int(index)),
-        "count" -> DynamicValue.Primitive(PrimitiveValue.Int(count))
-      )))
+      DynamicValue.Variant(
+        "Delete",
+        DynamicValue.Record(
+          Vector(
+            "index" -> DynamicValue.Primitive(PrimitiveValue.Int(index)),
+            "count" -> DynamicValue.Primitive(PrimitiveValue.Int(count))
+          )
+        )
+      )
     case SeqOp.Modify(index, operation) =>
-      DynamicValue.Variant("Modify", DynamicValue.Record(Vector(
-        "index" -> DynamicValue.Primitive(PrimitiveValue.Int(index)),
-        "operation" -> operationToValue(operation)
-      )))
+      DynamicValue.Variant(
+        "Modify",
+        DynamicValue.Record(
+          Vector(
+            "index"     -> DynamicValue.Primitive(PrimitiveValue.Int(index)),
+            "operation" -> operationToValue(operation)
+          )
+        )
+      )
   }
-  
+
   def seqOpFromValue(value: DynamicValue): Either[String, SeqOp] = value match {
     case DynamicValue.Variant("Insert", DynamicValue.Record(fields)) =>
       for {
-        index <- extractInt(fields, "index")
+        index  <- extractInt(fields, "index")
         values <- extractSequence(fields, "values")
       } yield SeqOp.Insert(index, values)
     case DynamicValue.Variant("Append", DynamicValue.Record(fields)) =>
@@ -216,8 +347,8 @@ object PatchSerialization {
       } yield SeqOp.Delete(index, count)
     case DynamicValue.Variant("Modify", DynamicValue.Record(fields)) =>
       for {
-        index <- extractInt(fields, "index")
-        opValue <- fields.find(_._1 == "operation").map(_._2).toRight("Missing field: operation")
+        index     <- extractInt(fields, "index")
+        opValue   <- fields.find(_._1 == "operation").map(_._2).toRight("Missing field: operation")
         operation <- operationFromValue(opValue)
       } yield SeqOp.Modify(index, operation)
     case _ => Left(s"Invalid SeqOp: $value")
@@ -226,36 +357,51 @@ object PatchSerialization {
   // ============================================================
   // MapOp serialization
   // ============================================================
-  
+
   def mapOpToValue(op: MapOp): DynamicValue = op match {
     case MapOp.Add(key, value) =>
-      DynamicValue.Variant("Add", DynamicValue.Record(Vector(
-        "key" -> key,
-        "value" -> value
-      )))
+      DynamicValue.Variant(
+        "Add",
+        DynamicValue.Record(
+          Vector(
+            "key"   -> key,
+            "value" -> value
+          )
+        )
+      )
     case MapOp.Remove(key) =>
-      DynamicValue.Variant("Remove", DynamicValue.Record(Vector(
-        "key" -> key
-      )))
+      DynamicValue.Variant(
+        "Remove",
+        DynamicValue.Record(
+          Vector(
+            "key" -> key
+          )
+        )
+      )
     case MapOp.Modify(key, operation) =>
-      DynamicValue.Variant("Modify", DynamicValue.Record(Vector(
-        "key" -> key,
-        "operation" -> operationToValue(operation)
-      )))
+      DynamicValue.Variant(
+        "Modify",
+        DynamicValue.Record(
+          Vector(
+            "key"       -> key,
+            "operation" -> operationToValue(operation)
+          )
+        )
+      )
   }
-  
+
   def mapOpFromValue(value: DynamicValue): Either[String, MapOp] = value match {
     case DynamicValue.Variant("Add", DynamicValue.Record(fields)) =>
       for {
         key <- fields.find(_._1 == "key").map(_._2).toRight("Missing field: key")
-        v <- fields.find(_._1 == "value").map(_._2).toRight("Missing field: value")
+        v   <- fields.find(_._1 == "value").map(_._2).toRight("Missing field: value")
       } yield MapOp.Add(key, v)
     case DynamicValue.Variant("Remove", DynamicValue.Record(fields)) =>
       fields.find(_._1 == "key").map(_._2).toRight("Missing field: key").map(MapOp.Remove(_))
     case DynamicValue.Variant("Modify", DynamicValue.Record(fields)) =>
       for {
-        key <- fields.find(_._1 == "key").map(_._2).toRight("Missing field: key")
-        opValue <- fields.find(_._1 == "operation").map(_._2).toRight("Missing field: operation")
+        key       <- fields.find(_._1 == "key").map(_._2).toRight("Missing field: key")
+        opValue   <- fields.find(_._1 == "operation").map(_._2).toRight("Missing field: operation")
         operation <- operationFromValue(opValue)
       } yield MapOp.Modify(key, operation)
     case _ => Left(s"Invalid MapOp: $value")
@@ -264,33 +410,53 @@ object PatchSerialization {
   // ============================================================
   // Operation serialization
   // ============================================================
-  
+
   def operationToValue(op: Operation): DynamicValue = op match {
     case Operation.Set(value) =>
-      DynamicValue.Variant("Set", DynamicValue.Record(Vector(
-        "value" -> value
-      )))
+      DynamicValue.Variant(
+        "Set",
+        DynamicValue.Record(
+          Vector(
+            "value" -> value
+          )
+        )
+      )
     case Operation.PrimitiveDelta(primitiveOp) =>
-      DynamicValue.Variant("PrimitiveDelta", DynamicValue.Record(Vector(
-        "op" -> primitiveOpToValue(primitiveOp)
-      )))
+      DynamicValue.Variant(
+        "PrimitiveDelta",
+        DynamicValue.Record(
+          Vector(
+            "op" -> primitiveOpToValue(primitiveOp)
+          )
+        )
+      )
     case Operation.SequenceEdit(ops) =>
-      DynamicValue.Variant("SequenceEdit", DynamicValue.Record(Vector(
-        "ops" -> DynamicValue.Sequence(ops.map(seqOpToValue))
-      )))
+      DynamicValue.Variant(
+        "SequenceEdit",
+        DynamicValue.Record(
+          Vector(
+            "ops" -> DynamicValue.Sequence(ops.map(seqOpToValue))
+          )
+        )
+      )
     case Operation.MapEdit(ops) =>
-      DynamicValue.Variant("MapEdit", DynamicValue.Record(Vector(
-        "ops" -> DynamicValue.Sequence(ops.map(mapOpToValue))
-      )))
+      DynamicValue.Variant(
+        "MapEdit",
+        DynamicValue.Record(
+          Vector(
+            "ops" -> DynamicValue.Sequence(ops.map(mapOpToValue))
+          )
+        )
+      )
   }
-  
+
   def operationFromValue(value: DynamicValue): Either[String, Operation] = value match {
     case DynamicValue.Variant("Set", DynamicValue.Record(fields)) =>
       fields.find(_._1 == "value").map(_._2).toRight("Missing field: value").map(Operation.Set(_))
     case DynamicValue.Variant("PrimitiveDelta", DynamicValue.Record(fields)) =>
       for {
         opValue <- fields.find(_._1 == "op").map(_._2).toRight("Missing field: op")
-        op <- primitiveOpFromValue(opValue)
+        op      <- primitiveOpFromValue(opValue)
       } yield Operation.PrimitiveDelta(op)
     case DynamicValue.Variant("SequenceEdit", DynamicValue.Record(fields)) =>
       extractSequence(fields, "ops").flatMap { seq =>
@@ -312,34 +478,66 @@ object PatchSerialization {
   // ============================================================
   // DynamicOptic.Node serialization
   // ============================================================
-  
+
   def nodeToValue(node: DynamicOptic.Node): DynamicValue = {
     import DynamicOptic.Node._
     node match {
       case Field(name) =>
-        DynamicValue.Variant("Field", DynamicValue.Record(Vector(
-          "name" -> DynamicValue.Primitive(PrimitiveValue.String(name))
-        )))
+        DynamicValue.Variant(
+          "Field",
+          DynamicValue.Record(
+            Vector(
+              "name" -> DynamicValue.Primitive(PrimitiveValue.String(name))
+            )
+          )
+        )
       case Case(name) =>
-        DynamicValue.Variant("Case", DynamicValue.Record(Vector(
-          "name" -> DynamicValue.Primitive(PrimitiveValue.String(name))
-        )))
+        DynamicValue.Variant(
+          "Case",
+          DynamicValue.Record(
+            Vector(
+              "name" -> DynamicValue.Primitive(PrimitiveValue.String(name))
+            )
+          )
+        )
       case AtIndex(index) =>
-        DynamicValue.Variant("AtIndex", DynamicValue.Record(Vector(
-          "index" -> DynamicValue.Primitive(PrimitiveValue.Int(index))
-        )))
+        DynamicValue.Variant(
+          "AtIndex",
+          DynamicValue.Record(
+            Vector(
+              "index" -> DynamicValue.Primitive(PrimitiveValue.Int(index))
+            )
+          )
+        )
       case AtMapKey(key) =>
-        DynamicValue.Variant("AtMapKey", DynamicValue.Record(Vector(
-          "key" -> anyToValue(key)
-        )))
+        DynamicValue.Variant(
+          "AtMapKey",
+          DynamicValue.Record(
+            Vector(
+              "key" -> anyToValue(key)
+            )
+          )
+        )
       case AtIndices(indices) =>
-        DynamicValue.Variant("AtIndices", DynamicValue.Record(Vector(
-          "indices" -> DynamicValue.Sequence(indices.map(i => DynamicValue.Primitive(PrimitiveValue.Int(i))).toVector)
-        )))
+        DynamicValue.Variant(
+          "AtIndices",
+          DynamicValue.Record(
+            Vector(
+              "indices" -> DynamicValue.Sequence(
+                indices.map(i => DynamicValue.Primitive(PrimitiveValue.Int(i))).toVector
+              )
+            )
+          )
+        )
       case AtMapKeys(keys) =>
-        DynamicValue.Variant("AtMapKeys", DynamicValue.Record(Vector(
-          "keys" -> DynamicValue.Sequence(keys.map(anyToValue).toVector)
-        )))
+        DynamicValue.Variant(
+          "AtMapKeys",
+          DynamicValue.Record(
+            Vector(
+              "keys" -> DynamicValue.Sequence(keys.map(anyToValue).toVector)
+            )
+          )
+        )
       case Elements =>
         DynamicValue.Variant("Elements", DynamicValue.Record(Vector.empty))
       case MapKeys =>
@@ -350,7 +548,7 @@ object PatchSerialization {
         DynamicValue.Variant("Wrapped", DynamicValue.Record(Vector.empty))
     }
   }
-  
+
   def nodeFromValue(value: DynamicValue): Either[String, DynamicOptic.Node] = {
     import DynamicOptic.Node._
     value match {
@@ -368,23 +566,25 @@ object PatchSerialization {
         }
       case DynamicValue.Variant("AtMapKeys", DynamicValue.Record(fields)) =>
         extractSequence(fields, "keys").map(AtMapKeys(_))
-      case DynamicValue.Variant("Elements", _) => Right(Elements)
-      case DynamicValue.Variant("MapKeys", _) => Right(MapKeys)
+      case DynamicValue.Variant("Elements", _)  => Right(Elements)
+      case DynamicValue.Variant("MapKeys", _)   => Right(MapKeys)
       case DynamicValue.Variant("MapValues", _) => Right(MapValues)
-      case DynamicValue.Variant("Wrapped", _) => Right(Wrapped)
-      case _ => Left(s"Invalid DynamicOptic.Node: $value")
+      case DynamicValue.Variant("Wrapped", _)   => Right(Wrapped)
+      case _                                    => Left(s"Invalid DynamicOptic.Node: $value")
     }
   }
 
   // ============================================================
   // DynamicOptic serialization
   // ============================================================
-  
+
   def opticToValue(optic: DynamicOptic): DynamicValue =
-    DynamicValue.Record(Vector(
-      "nodes" -> DynamicValue.Sequence(optic.nodes.map(nodeToValue).toVector)
-    ))
-  
+    DynamicValue.Record(
+      Vector(
+        "nodes" -> DynamicValue.Sequence(optic.nodes.map(nodeToValue).toVector)
+      )
+    )
+
   def opticFromValue(value: DynamicValue): Either[String, DynamicOptic] = value match {
     case DynamicValue.Record(fields) =>
       extractSequence(fields, "nodes").flatMap { seq =>
@@ -399,20 +599,22 @@ object PatchSerialization {
   // ============================================================
   // DynamicPatchOp serialization
   // ============================================================
-  
+
   def patchOpToValue(op: DynamicPatchOp): DynamicValue =
-    DynamicValue.Record(Vector(
-      "optic" -> opticToValue(op.optic),
-      "operation" -> operationToValue(op.operation)
-    ))
-  
+    DynamicValue.Record(
+      Vector(
+        "optic"     -> opticToValue(op.optic),
+        "operation" -> operationToValue(op.operation)
+      )
+    )
+
   def patchOpFromValue(value: DynamicValue): Either[String, DynamicPatchOp] = value match {
     case DynamicValue.Record(fields) =>
       for {
         opticValue <- fields.find(_._1 == "optic").map(_._2).toRight("Missing field: optic")
-        optic <- opticFromValue(opticValue)
-        opValue <- fields.find(_._1 == "operation").map(_._2).toRight("Missing field: operation")
-        operation <- operationFromValue(opValue)
+        optic      <- opticFromValue(opticValue)
+        opValue    <- fields.find(_._1 == "operation").map(_._2).toRight("Missing field: operation")
+        operation  <- operationFromValue(opValue)
       } yield DynamicPatchOp(optic, operation)
     case _ => Left(s"Invalid DynamicPatchOp: $value")
   }
@@ -420,13 +622,15 @@ object PatchSerialization {
   // ============================================================
   // DynamicPatch serialization (main entry points)
   // ============================================================
-  
+
   /** Convert a DynamicPatch to a DynamicValue for serialization */
   def toValue(patch: DynamicPatch): DynamicValue =
-    DynamicValue.Record(Vector(
-      "ops" -> DynamicValue.Sequence(patch.ops.map(patchOpToValue))
-    ))
-  
+    DynamicValue.Record(
+      Vector(
+        "ops" -> DynamicValue.Sequence(patch.ops.map(patchOpToValue))
+      )
+    )
+
   /** Convert a DynamicValue back to a DynamicPatch */
   def fromValue(value: DynamicValue): Either[String, DynamicPatch] = value match {
     case DynamicValue.Record(fields) =>
@@ -442,44 +646,47 @@ object PatchSerialization {
   // ============================================================
   // Helper methods
   // ============================================================
-  
+
   private def anyToValue(any: Any): DynamicValue = any match {
     case dv: DynamicValue => dv
-    case s: String => DynamicValue.Primitive(PrimitiveValue.String(s))
-    case i: Int => DynamicValue.Primitive(PrimitiveValue.Int(i))
-    case l: Long => DynamicValue.Primitive(PrimitiveValue.Long(l))
-    case d: Double => DynamicValue.Primitive(PrimitiveValue.Double(d))
-    case b: Boolean => DynamicValue.Primitive(PrimitiveValue.Boolean(b))
-    case other => DynamicValue.Primitive(PrimitiveValue.String(other.toString))
+    case s: String        => DynamicValue.Primitive(PrimitiveValue.String(s))
+    case i: Int           => DynamicValue.Primitive(PrimitiveValue.Int(i))
+    case l: Long          => DynamicValue.Primitive(PrimitiveValue.Long(l))
+    case d: Double        => DynamicValue.Primitive(PrimitiveValue.Double(d))
+    case b: Boolean       => DynamicValue.Primitive(PrimitiveValue.Boolean(b))
+    case other            => DynamicValue.Primitive(PrimitiveValue.String(other.toString))
   }
-  
+
   private def extractInt(fields: Vector[(String, DynamicValue)], name: String): Either[String, Int] =
     fields.find(_._1 == name).map(_._2) match {
       case Some(DynamicValue.Primitive(PrimitiveValue.Int(i))) => Right(i)
-      case _ => Left(s"Missing or invalid Int field: $name")
+      case _                                                   => Left(s"Missing or invalid Int field: $name")
     }
-  
+
   private def extractLong(fields: Vector[(String, DynamicValue)], name: String): Either[String, Long] =
     fields.find(_._1 == name).map(_._2) match {
       case Some(DynamicValue.Primitive(PrimitiveValue.Long(l))) => Right(l)
-      case _ => Left(s"Missing or invalid Long field: $name")
+      case _                                                    => Left(s"Missing or invalid Long field: $name")
     }
-  
+
   private def extractDouble(fields: Vector[(String, DynamicValue)], name: String): Either[String, Double] =
     fields.find(_._1 == name).map(_._2) match {
       case Some(DynamicValue.Primitive(PrimitiveValue.Double(d))) => Right(d)
-      case _ => Left(s"Missing or invalid Double field: $name")
+      case _                                                      => Left(s"Missing or invalid Double field: $name")
     }
-  
+
   private def extractString(fields: Vector[(String, DynamicValue)], name: String): Either[String, String] =
     fields.find(_._1 == name).map(_._2) match {
       case Some(DynamicValue.Primitive(PrimitiveValue.String(s))) => Right(s)
-      case _ => Left(s"Missing or invalid String field: $name")
+      case _                                                      => Left(s"Missing or invalid String field: $name")
     }
-  
-  private def extractSequence(fields: Vector[(String, DynamicValue)], name: String): Either[String, Vector[DynamicValue]] =
+
+  private def extractSequence(
+    fields: Vector[(String, DynamicValue)],
+    name: String
+  ): Either[String, Vector[DynamicValue]] =
     fields.find(_._1 == name).map(_._2) match {
       case Some(DynamicValue.Sequence(seq)) => Right(seq)
-      case _ => Left(s"Missing or invalid Sequence field: $name")
+      case _                                => Left(s"Missing or invalid Sequence field: $name")
     }
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/PrimitiveOp.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/PrimitiveOp.scala
@@ -1,36 +1,36 @@
 package zio.blocks.schema
 
 /**
- * Represents a delta operation on a primitive value.
- * These operations compute the new value based on the old value plus a delta.
+ * Represents a delta operation on a primitive value. These operations compute
+ * the new value based on the old value plus a delta.
  */
 sealed trait PrimitiveOp
 
 object PrimitiveOp {
 
   // Numeric deltas
-  final case class IntDelta(delta: Int) extends PrimitiveOp
-  final case class LongDelta(delta: Long) extends PrimitiveOp
-  final case class DoubleDelta(delta: Double) extends PrimitiveOp
-  final case class FloatDelta(delta: Float) extends PrimitiveOp
-  final case class ShortDelta(delta: Short) extends PrimitiveOp
-  final case class ByteDelta(delta: Byte) extends PrimitiveOp
-  final case class BigIntDelta(delta: BigInt) extends PrimitiveOp
+  final case class IntDelta(delta: Int)               extends PrimitiveOp
+  final case class LongDelta(delta: Long)             extends PrimitiveOp
+  final case class DoubleDelta(delta: Double)         extends PrimitiveOp
+  final case class FloatDelta(delta: Float)           extends PrimitiveOp
+  final case class ShortDelta(delta: Short)           extends PrimitiveOp
+  final case class ByteDelta(delta: Byte)             extends PrimitiveOp
+  final case class BigIntDelta(delta: BigInt)         extends PrimitiveOp
   final case class BigDecimalDelta(delta: BigDecimal) extends PrimitiveOp
 
   // String edits (LCS-based)
   final case class StringEdit(ops: Vector[StringOp]) extends PrimitiveOp
 
   // Temporal deltas
-  final case class InstantDelta(duration: java.time.Duration) extends PrimitiveOp
-  final case class DurationDelta(duration: java.time.Duration) extends PrimitiveOp
-  final case class LocalDateDelta(period: java.time.Period) extends PrimitiveOp
-  final case class LocalTimeDelta(duration: java.time.Duration) extends PrimitiveOp
-  final case class LocalDateTimeDelta(period: java.time.Period, duration: java.time.Duration) extends PrimitiveOp
-  final case class PeriodDelta(period: java.time.Period) extends PrimitiveOp
+  final case class InstantDelta(duration: java.time.Duration)                                  extends PrimitiveOp
+  final case class DurationDelta(duration: java.time.Duration)                                 extends PrimitiveOp
+  final case class LocalDateDelta(period: java.time.Period)                                    extends PrimitiveOp
+  final case class LocalTimeDelta(duration: java.time.Duration)                                extends PrimitiveOp
+  final case class LocalDateTimeDelta(period: java.time.Period, duration: java.time.Duration)  extends PrimitiveOp
+  final case class PeriodDelta(period: java.time.Period)                                       extends PrimitiveOp
   final case class OffsetDateTimeDelta(period: java.time.Period, duration: java.time.Duration) extends PrimitiveOp
-  final case class ZonedDateTimeDelta(period: java.time.Period, duration: java.time.Duration) extends PrimitiveOp
-  final case class YearDelta(years: Int) extends PrimitiveOp
-  final case class YearMonthDelta(months: Int) extends PrimitiveOp
-  final case class MonthDayDelta(days: Int) extends PrimitiveOp
+  final case class ZonedDateTimeDelta(period: java.time.Period, duration: java.time.Duration)  extends PrimitiveOp
+  final case class YearDelta(years: Int)                                                       extends PrimitiveOp
+  final case class YearMonthDelta(months: Int)                                                 extends PrimitiveOp
+  final case class MonthDayDelta(days: Int)                                                    extends PrimitiveOp
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Schema.scala
@@ -95,16 +95,16 @@ final case class Schema[A](reflect: Reflect.Bound[A]) {
   )
 
   /**
-   * Compute a minimal patch that transforms oldValue into newValue.
-   * Uses smart heuristics to choose between delta operations and set operations.
-   * 
-   * Note: For complex structural diffs, use `diffDynamic` which returns a `DynamicPatch`
-   * that can be applied via `Patch.applyDynamic`.
+   * Compute a minimal patch that transforms oldValue into newValue. Uses smart
+   * heuristics to choose between delta operations and set operations.
+   *
+   * Note: For complex structural diffs, use `diffDynamic` which returns a
+   * `DynamicPatch` that can be applied via `Patch.applyDynamic`.
    */
   def diff(oldValue: A, newValue: A): Patch[A] = {
     val oldDv = toDynamicValue(oldValue)
     val newDv = toDynamicValue(newValue)
-    
+
     if (oldDv == newDv) {
       Patch.empty[A](this)
     } else {
@@ -114,8 +114,8 @@ final case class Schema[A](reflect: Reflect.Bound[A]) {
   }
 
   /**
-   * Compute a DynamicPatch that transforms oldValue into newValue.
-   * This is the most flexible form that can be serialized and applied with any PatchMode.
+   * Compute a DynamicPatch that transforms oldValue into newValue. This is the
+   * most flexible form that can be serialized and applied with any PatchMode.
    */
   def diffDynamic(oldValue: A, newValue: A): DynamicPatch = {
     val oldDv = toDynamicValue(oldValue)
@@ -149,21 +149,20 @@ object Schema extends SchemaCompanionVersionSpecific {
     oldValue: DynamicValue,
     newValue: DynamicValue,
     path: DynamicOptic
-  ): DynamicPatch = {
+  ): DynamicPatch =
     if (oldValue == newValue) {
       DynamicPatch.empty
     } else {
       (oldValue, newValue) match {
         case (DynamicValue.Record(oldFields), DynamicValue.Record(newFields)) =>
           // Diff each field
-          val ops = Vector.newBuilder[DynamicPatchOp]
+          val ops    = Vector.newBuilder[DynamicPatchOp]
           val oldMap = oldFields.toMap
-          val newMap = newFields.toMap
-          
+
           newFields.foreach { case (name, newFieldValue) =>
             oldMap.get(name) match {
               case Some(oldFieldValue) if oldFieldValue != newFieldValue =>
-                val fieldPath = path.field(name)
+                val fieldPath  = path.field(name)
                 val fieldPatch = computeDiff(oldFieldValue, newFieldValue, fieldPath)
                 ops ++= fieldPatch.ops
               case None =>
@@ -174,8 +173,7 @@ object Schema extends SchemaCompanionVersionSpecific {
           }
           new DynamicPatch(ops.result())
 
-        case (DynamicValue.Variant(oldCase, oldInner), DynamicValue.Variant(newCase, newInner)) 
-            if oldCase == newCase =>
+        case (DynamicValue.Variant(oldCase, oldInner), DynamicValue.Variant(newCase, newInner)) if oldCase == newCase =>
           // Same case, diff inner value
           computeDiff(oldInner, newInner, path.caseOf(oldCase))
 
@@ -200,7 +198,6 @@ object Schema extends SchemaCompanionVersionSpecific {
           DynamicPatch.single(path, Operation.Set(newValue))
       }
     }
-  }
 
   private def computePrimitiveDiff(
     oldPv: PrimitiveValue,

--- a/schema/shared/src/main/scala/zio/blocks/schema/SeqOp.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SeqOp.scala
@@ -8,37 +8,43 @@ sealed trait SeqOp
 object SeqOp {
 
   /**
-   * Insert values at the specified index.
-   * In Strict mode, fails if index is out of bounds.
+   * Insert values at the specified index. In Strict mode, fails if index is out
+   * of bounds.
    *
-   * @param index Position where values should be inserted
-   * @param values The values to insert
+   * @param index
+   *   Position where values should be inserted
+   * @param values
+   *   The values to insert
    */
   final case class Insert(index: Int, values: Vector[DynamicValue]) extends SeqOp
 
   /**
-   * Append values to the end of the sequence.
-   * Always succeeds.
+   * Append values to the end of the sequence. Always succeeds.
    *
-   * @param values The values to append
+   * @param values
+   *   The values to append
    */
   final case class Append(values: Vector[DynamicValue]) extends SeqOp
 
   /**
-   * Delete count elements starting at the specified index.
-   * In Strict mode, fails if range is out of bounds.
+   * Delete count elements starting at the specified index. In Strict mode,
+   * fails if range is out of bounds.
    *
-   * @param index Position where deletion starts
-   * @param count Number of elements to delete
+   * @param index
+   *   Position where deletion starts
+   * @param count
+   *   Number of elements to delete
    */
   final case class Delete(index: Int, count: Int) extends SeqOp
 
   /**
-   * Modify the element at the specified index with a nested operation.
-   * In Strict mode, fails if index is out of bounds.
+   * Modify the element at the specified index with a nested operation. In
+   * Strict mode, fails if index is out of bounds.
    *
-   * @param index Position of element to modify
-   * @param op The operation to apply to the element
+   * @param index
+   *   Position of element to modify
+   * @param op
+   *   The operation to apply to the element
    */
   final case class Modify(index: Int, op: Operation) extends SeqOp
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/StringOp.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/StringOp.scala
@@ -1,8 +1,7 @@
 package zio.blocks.schema
 
 /**
- * Represents an edit operation on a string.
- * Used for LCS-based string diffing.
+ * Represents an edit operation on a string. Used for LCS-based string diffing.
  */
 sealed trait StringOp
 
@@ -11,16 +10,20 @@ object StringOp {
   /**
    * Insert text at the specified index.
    *
-   * @param index Position in string where text should be inserted
-   * @param text The text to insert
+   * @param index
+   *   Position in string where text should be inserted
+   * @param text
+   *   The text to insert
    */
   final case class Insert(index: Int, text: String) extends StringOp
 
   /**
    * Delete characters starting at the specified index.
    *
-   * @param index Position in string where deletion starts
-   * @param length Number of characters to delete
+   * @param index
+   *   Position in string where deletion starts
+   * @param length
+   *   Number of characters to delete
    */
   final case class Delete(index: Int, length: Int) extends StringOp
 }

--- a/schema/shared/src/test/scala/zio/blocks/schema/DynamicPatchSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/DynamicPatchSpec.scala
@@ -14,7 +14,7 @@ object DynamicPatchSpec extends ZIOSpecDefault {
       test("Set operation replaces value") {
         val oldValue = DynamicValue.Primitive(PrimitiveValue.Int(42))
         val newValue = DynamicValue.Primitive(PrimitiveValue.Int(100))
-        val patch = DynamicPatch.single(DynamicOptic.root, Operation.Set(newValue))
+        val patch    = DynamicPatch.single(DynamicOptic.root, Operation.Set(newValue))
         assert(patch(oldValue, PatchMode.Strict))(isRight(equalTo(newValue)))
       },
       test("IntDelta operation increments value") {
@@ -28,13 +28,13 @@ object DynamicPatchSpec extends ZIOSpecDefault {
         assert(patch(value, PatchMode.Strict))(isRight(equalTo(DynamicValue.Primitive(PrimitiveValue.Long(150L)))))
       },
       test("DoubleDelta operation increments Double value") {
-        val value = DynamicValue.Primitive(PrimitiveValue.Double(3.14))
-        val patch = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.DoubleDelta(1.0)))
+        val value  = DynamicValue.Primitive(PrimitiveValue.Double(3.14))
+        val patch  = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.DoubleDelta(1.0)))
         val result = patch(value, PatchMode.Strict)
         assertTrue(result.isRight) &&
         assertTrue(result.toOption.get match {
           case DynamicValue.Primitive(PrimitiveValue.Double(d)) => Math.abs(d - 4.14) < 0.001
-          case _ => false
+          case _                                                => false
         })
       },
       test("StringEdit with Insert operation") {
@@ -43,7 +43,9 @@ object DynamicPatchSpec extends ZIOSpecDefault {
           DynamicOptic.root,
           Operation.PrimitiveDelta(PrimitiveOp.StringEdit(Vector(StringOp.Insert(5, " World"))))
         )
-        assert(patch(value, PatchMode.Strict))(isRight(equalTo(DynamicValue.Primitive(PrimitiveValue.String("Hello World")))))
+        assert(patch(value, PatchMode.Strict))(
+          isRight(equalTo(DynamicValue.Primitive(PrimitiveValue.String("Hello World"))))
+        )
       },
       test("StringEdit with Delete operation") {
         val value = DynamicValue.Primitive(PrimitiveValue.String("Hello World"))
@@ -56,24 +58,30 @@ object DynamicPatchSpec extends ZIOSpecDefault {
     ),
     suite("Record operations")(
       test("modify field in record") {
-        val record = DynamicValue.Record(Vector(
-          "name" -> DynamicValue.Primitive(PrimitiveValue.String("Alice")),
-          "age" -> DynamicValue.Primitive(PrimitiveValue.Int(30))
-        ))
+        val record = DynamicValue.Record(
+          Vector(
+            "name" -> DynamicValue.Primitive(PrimitiveValue.String("Alice")),
+            "age"  -> DynamicValue.Primitive(PrimitiveValue.Int(30))
+          )
+        )
         val patch = DynamicPatch.single(
           DynamicOptic.root.field("age"),
           Operation.PrimitiveDelta(PrimitiveOp.IntDelta(1))
         )
-        val expected = DynamicValue.Record(Vector(
-          "name" -> DynamicValue.Primitive(PrimitiveValue.String("Alice")),
-          "age" -> DynamicValue.Primitive(PrimitiveValue.Int(31))
-        ))
+        val expected = DynamicValue.Record(
+          Vector(
+            "name" -> DynamicValue.Primitive(PrimitiveValue.String("Alice")),
+            "age"  -> DynamicValue.Primitive(PrimitiveValue.Int(31))
+          )
+        )
         assert(patch(record, PatchMode.Strict))(isRight(equalTo(expected)))
       },
       test("strict mode fails on missing field") {
-        val record = DynamicValue.Record(Vector(
-          "name" -> DynamicValue.Primitive(PrimitiveValue.String("Alice"))
-        ))
+        val record = DynamicValue.Record(
+          Vector(
+            "name" -> DynamicValue.Primitive(PrimitiveValue.String("Alice"))
+          )
+        )
         val patch = DynamicPatch.single(
           DynamicOptic.root.field("missing"),
           Operation.Set(DynamicValue.Primitive(PrimitiveValue.Int(42)))
@@ -81,9 +89,11 @@ object DynamicPatchSpec extends ZIOSpecDefault {
         assert(patch(record, PatchMode.Strict))(isLeft)
       },
       test("lenient mode skips missing field") {
-        val record = DynamicValue.Record(Vector(
-          "name" -> DynamicValue.Primitive(PrimitiveValue.String("Alice"))
-        ))
+        val record = DynamicValue.Record(
+          Vector(
+            "name" -> DynamicValue.Primitive(PrimitiveValue.String("Alice"))
+          )
+        )
         val patch = DynamicPatch.single(
           DynamicOptic.root.field("missing"),
           Operation.Set(DynamicValue.Primitive(PrimitiveValue.Int(42)))
@@ -93,141 +103,196 @@ object DynamicPatchSpec extends ZIOSpecDefault {
     ),
     suite("Sequence operations")(
       test("append to sequence") {
-        val seq = DynamicValue.Sequence(Vector(
-          DynamicValue.Primitive(PrimitiveValue.Int(1)),
-          DynamicValue.Primitive(PrimitiveValue.Int(2))
-        ))
+        val seq = DynamicValue.Sequence(
+          Vector(
+            DynamicValue.Primitive(PrimitiveValue.Int(1)),
+            DynamicValue.Primitive(PrimitiveValue.Int(2))
+          )
+        )
         val patch = DynamicPatch.single(
           DynamicOptic.root,
-          Operation.SequenceEdit(Vector(SeqOp.Append(Vector(
+          Operation.SequenceEdit(
+            Vector(
+              SeqOp.Append(
+                Vector(
+                  DynamicValue.Primitive(PrimitiveValue.Int(3)),
+                  DynamicValue.Primitive(PrimitiveValue.Int(4))
+                )
+              )
+            )
+          )
+        )
+        val expected = DynamicValue.Sequence(
+          Vector(
+            DynamicValue.Primitive(PrimitiveValue.Int(1)),
+            DynamicValue.Primitive(PrimitiveValue.Int(2)),
             DynamicValue.Primitive(PrimitiveValue.Int(3)),
             DynamicValue.Primitive(PrimitiveValue.Int(4))
-          ))))
+          )
         )
-        val expected = DynamicValue.Sequence(Vector(
-          DynamicValue.Primitive(PrimitiveValue.Int(1)),
-          DynamicValue.Primitive(PrimitiveValue.Int(2)),
-          DynamicValue.Primitive(PrimitiveValue.Int(3)),
-          DynamicValue.Primitive(PrimitiveValue.Int(4))
-        ))
         assert(patch(seq, PatchMode.Strict))(isRight(equalTo(expected)))
       },
       test("insert at index in sequence") {
-        val seq = DynamicValue.Sequence(Vector(
-          DynamicValue.Primitive(PrimitiveValue.Int(1)),
-          DynamicValue.Primitive(PrimitiveValue.Int(3))
-        ))
+        val seq = DynamicValue.Sequence(
+          Vector(
+            DynamicValue.Primitive(PrimitiveValue.Int(1)),
+            DynamicValue.Primitive(PrimitiveValue.Int(3))
+          )
+        )
         val patch = DynamicPatch.single(
           DynamicOptic.root,
-          Operation.SequenceEdit(Vector(SeqOp.Insert(1, Vector(
-            DynamicValue.Primitive(PrimitiveValue.Int(2))
-          ))))
+          Operation.SequenceEdit(
+            Vector(
+              SeqOp.Insert(
+                1,
+                Vector(
+                  DynamicValue.Primitive(PrimitiveValue.Int(2))
+                )
+              )
+            )
+          )
         )
-        val expected = DynamicValue.Sequence(Vector(
-          DynamicValue.Primitive(PrimitiveValue.Int(1)),
-          DynamicValue.Primitive(PrimitiveValue.Int(2)),
-          DynamicValue.Primitive(PrimitiveValue.Int(3))
-        ))
+        val expected = DynamicValue.Sequence(
+          Vector(
+            DynamicValue.Primitive(PrimitiveValue.Int(1)),
+            DynamicValue.Primitive(PrimitiveValue.Int(2)),
+            DynamicValue.Primitive(PrimitiveValue.Int(3))
+          )
+        )
         assert(patch(seq, PatchMode.Strict))(isRight(equalTo(expected)))
       },
       test("delete from sequence") {
-        val seq = DynamicValue.Sequence(Vector(
-          DynamicValue.Primitive(PrimitiveValue.Int(1)),
-          DynamicValue.Primitive(PrimitiveValue.Int(2)),
-          DynamicValue.Primitive(PrimitiveValue.Int(3))
-        ))
+        val seq = DynamicValue.Sequence(
+          Vector(
+            DynamicValue.Primitive(PrimitiveValue.Int(1)),
+            DynamicValue.Primitive(PrimitiveValue.Int(2)),
+            DynamicValue.Primitive(PrimitiveValue.Int(3))
+          )
+        )
         val patch = DynamicPatch.single(
           DynamicOptic.root,
           Operation.SequenceEdit(Vector(SeqOp.Delete(1, 1)))
         )
-        val expected = DynamicValue.Sequence(Vector(
-          DynamicValue.Primitive(PrimitiveValue.Int(1)),
-          DynamicValue.Primitive(PrimitiveValue.Int(3))
-        ))
+        val expected = DynamicValue.Sequence(
+          Vector(
+            DynamicValue.Primitive(PrimitiveValue.Int(1)),
+            DynamicValue.Primitive(PrimitiveValue.Int(3))
+          )
+        )
         assert(patch(seq, PatchMode.Strict))(isRight(equalTo(expected)))
       }
     ),
     suite("Map operations")(
       test("add key to map") {
-        val map = DynamicValue.Map(Vector(
-          (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1)))
-        ))
+        val map = DynamicValue.Map(
+          Vector(
+            (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1)))
+          )
+        )
         val patch = DynamicPatch.single(
           DynamicOptic.root,
-          Operation.MapEdit(Vector(MapOp.Add(
-            DynamicValue.Primitive(PrimitiveValue.String("b")),
-            DynamicValue.Primitive(PrimitiveValue.Int(2))
-          )))
+          Operation.MapEdit(
+            Vector(
+              MapOp.Add(
+                DynamicValue.Primitive(PrimitiveValue.String("b")),
+                DynamicValue.Primitive(PrimitiveValue.Int(2))
+              )
+            )
+          )
         )
-        val expected = DynamicValue.Map(Vector(
-          (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1))),
-          (DynamicValue.Primitive(PrimitiveValue.String("b")), DynamicValue.Primitive(PrimitiveValue.Int(2)))
-        ))
+        val expected = DynamicValue.Map(
+          Vector(
+            (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1))),
+            (DynamicValue.Primitive(PrimitiveValue.String("b")), DynamicValue.Primitive(PrimitiveValue.Int(2)))
+          )
+        )
         assert(patch(map, PatchMode.Strict))(isRight(equalTo(expected)))
       },
       test("remove key from map") {
-        val map = DynamicValue.Map(Vector(
-          (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1))),
-          (DynamicValue.Primitive(PrimitiveValue.String("b")), DynamicValue.Primitive(PrimitiveValue.Int(2)))
-        ))
+        val map = DynamicValue.Map(
+          Vector(
+            (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1))),
+            (DynamicValue.Primitive(PrimitiveValue.String("b")), DynamicValue.Primitive(PrimitiveValue.Int(2)))
+          )
+        )
         val patch = DynamicPatch.single(
           DynamicOptic.root,
-          Operation.MapEdit(Vector(MapOp.Remove(
-            DynamicValue.Primitive(PrimitiveValue.String("a"))
-          )))
+          Operation.MapEdit(
+            Vector(
+              MapOp.Remove(
+                DynamicValue.Primitive(PrimitiveValue.String("a"))
+              )
+            )
+          )
         )
-        val expected = DynamicValue.Map(Vector(
-          (DynamicValue.Primitive(PrimitiveValue.String("b")), DynamicValue.Primitive(PrimitiveValue.Int(2)))
-        ))
+        val expected = DynamicValue.Map(
+          Vector(
+            (DynamicValue.Primitive(PrimitiveValue.String("b")), DynamicValue.Primitive(PrimitiveValue.Int(2)))
+          )
+        )
         assert(patch(map, PatchMode.Strict))(isRight(equalTo(expected)))
       },
       test("clobber mode overwrites existing key") {
-        val map = DynamicValue.Map(Vector(
-          (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1)))
-        ))
+        val map = DynamicValue.Map(
+          Vector(
+            (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1)))
+          )
+        )
         val patch = DynamicPatch.single(
           DynamicOptic.root,
-          Operation.MapEdit(Vector(MapOp.Add(
-            DynamicValue.Primitive(PrimitiveValue.String("a")),
-            DynamicValue.Primitive(PrimitiveValue.Int(100))
-          )))
+          Operation.MapEdit(
+            Vector(
+              MapOp.Add(
+                DynamicValue.Primitive(PrimitiveValue.String("a")),
+                DynamicValue.Primitive(PrimitiveValue.Int(100))
+              )
+            )
+          )
         )
-        val expected = DynamicValue.Map(Vector(
-          (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(100)))
-        ))
+        val expected = DynamicValue.Map(
+          Vector(
+            (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(100)))
+          )
+        )
         assert(patch(map, PatchMode.Clobber))(isRight(equalTo(expected)))
       },
       test("strict mode fails on duplicate key") {
-        val map = DynamicValue.Map(Vector(
-          (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1)))
-        ))
+        val map = DynamicValue.Map(
+          Vector(
+            (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1)))
+          )
+        )
         val patch = DynamicPatch.single(
           DynamicOptic.root,
-          Operation.MapEdit(Vector(MapOp.Add(
-            DynamicValue.Primitive(PrimitiveValue.String("a")),
-            DynamicValue.Primitive(PrimitiveValue.Int(100))
-          )))
+          Operation.MapEdit(
+            Vector(
+              MapOp.Add(
+                DynamicValue.Primitive(PrimitiveValue.String("a")),
+                DynamicValue.Primitive(PrimitiveValue.Int(100))
+              )
+            )
+          )
         )
         assert(patch(map, PatchMode.Strict))(isLeft)
       }
     ),
     suite("Patch composition")(
       test("monoid identity - empty ++ patch == patch") {
-        val value = DynamicValue.Primitive(PrimitiveValue.Int(42))
-        val patch = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(10)))
+        val value    = DynamicValue.Primitive(PrimitiveValue.Int(42))
+        val patch    = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(10)))
         val composed = DynamicPatch.empty ++ patch
         assert(composed(value, PatchMode.Strict))(equalTo(patch(value, PatchMode.Strict)))
       },
       test("monoid identity - patch ++ empty == patch") {
-        val value = DynamicValue.Primitive(PrimitiveValue.Int(42))
-        val patch = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(10)))
+        val value    = DynamicValue.Primitive(PrimitiveValue.Int(42))
+        val patch    = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(10)))
         val composed = patch ++ DynamicPatch.empty
         assert(composed(value, PatchMode.Strict))(equalTo(patch(value, PatchMode.Strict)))
       },
       test("sequential composition applies patches in order") {
-        val value = DynamicValue.Primitive(PrimitiveValue.Int(0))
-        val patch1 = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(10)))
-        val patch2 = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(5)))
+        val value    = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val patch1   = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(10)))
+        val patch2   = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(5)))
         val composed = patch1 ++ patch2
         assert(composed(value, PatchMode.Strict))(isRight(equalTo(DynamicValue.Primitive(PrimitiveValue.Int(15)))))
       }
@@ -242,7 +307,7 @@ object DynamicPatchSpec extends ZIOSpecDefault {
         assertTrue(ops.length == 1) &&
         assertTrue(ops.head match {
           case StringOp.Insert(0, "hello") => true
-          case _ => false
+          case _                           => false
         })
       },
       test("diff non-empty to empty is single delete") {
@@ -250,7 +315,7 @@ object DynamicPatchSpec extends ZIOSpecDefault {
         assertTrue(ops.length == 1) &&
         assertTrue(ops.head match {
           case StringOp.Delete(0, 5) => true
-          case _ => false
+          case _                     => false
         })
       }
     ),
@@ -262,58 +327,66 @@ object DynamicPatchSpec extends ZIOSpecDefault {
       },
       test("diff empty to non-empty is append") {
         val newSeq = Vector(DynamicValue.Primitive(PrimitiveValue.Int(1)))
-        val ops = LCS.diffSequences(Vector.empty, newSeq)
+        val ops    = LCS.diffSequences(Vector.empty, newSeq)
         assertTrue(ops.length == 1) &&
         assertTrue(ops.head match {
           case SeqOp.Append(elems) => elems == newSeq
-          case _ => false
+          case _                   => false
         })
       }
     ),
     suite("Roundtrip law")(
       test("diff followed by apply equals target value (Int primitive)") {
-        val oldDv = DynamicValue.Primitive(PrimitiveValue.Int(10))
-        val newDv = DynamicValue.Primitive(PrimitiveValue.Int(25))
-        val patch = Schema.computeDiff(oldDv, newDv, DynamicOptic.root)
+        val oldDv  = DynamicValue.Primitive(PrimitiveValue.Int(10))
+        val newDv  = DynamicValue.Primitive(PrimitiveValue.Int(25))
+        val patch  = Schema.computeDiff(oldDv, newDv, DynamicOptic.root)
         val result = patch(oldDv, PatchMode.Strict)
         assert(result)(isRight(equalTo(newDv)))
       },
       test("diff followed by apply equals target value (String primitive)") {
-        val oldDv = DynamicValue.Primitive(PrimitiveValue.String("hello"))
-        val newDv = DynamicValue.Primitive(PrimitiveValue.String("world"))
-        val patch = Schema.computeDiff(oldDv, newDv, DynamicOptic.root)
+        val oldDv  = DynamicValue.Primitive(PrimitiveValue.String("hello"))
+        val newDv  = DynamicValue.Primitive(PrimitiveValue.String("world"))
+        val patch  = Schema.computeDiff(oldDv, newDv, DynamicOptic.root)
         val result = patch(oldDv, PatchMode.Strict)
         assert(result)(isRight(equalTo(newDv)))
       },
       test("diff followed by apply equals target value (Record)") {
-        val oldDv = DynamicValue.Record(Vector(
-          "name" -> DynamicValue.Primitive(PrimitiveValue.String("Alice")),
-          "age" -> DynamicValue.Primitive(PrimitiveValue.Int(30))
-        ))
-        val newDv = DynamicValue.Record(Vector(
-          "name" -> DynamicValue.Primitive(PrimitiveValue.String("Bob")),
-          "age" -> DynamicValue.Primitive(PrimitiveValue.Int(35))
-        ))
-        val patch = Schema.computeDiff(oldDv, newDv, DynamicOptic.root)
+        val oldDv = DynamicValue.Record(
+          Vector(
+            "name" -> DynamicValue.Primitive(PrimitiveValue.String("Alice")),
+            "age"  -> DynamicValue.Primitive(PrimitiveValue.Int(30))
+          )
+        )
+        val newDv = DynamicValue.Record(
+          Vector(
+            "name" -> DynamicValue.Primitive(PrimitiveValue.String("Bob")),
+            "age"  -> DynamicValue.Primitive(PrimitiveValue.Int(35))
+          )
+        )
+        val patch  = Schema.computeDiff(oldDv, newDv, DynamicOptic.root)
         val result = patch(oldDv, PatchMode.Strict)
         assert(result)(isRight(equalTo(newDv)))
       },
       test("diff followed by apply equals target value (Sequence)") {
-        val oldDv = DynamicValue.Sequence(Vector(
-          DynamicValue.Primitive(PrimitiveValue.Int(1)),
-          DynamicValue.Primitive(PrimitiveValue.Int(2))
-        ))
-        val newDv = DynamicValue.Sequence(Vector(
-          DynamicValue.Primitive(PrimitiveValue.Int(1)),
-          DynamicValue.Primitive(PrimitiveValue.Int(2)),
-          DynamicValue.Primitive(PrimitiveValue.Int(3))
-        ))
-        val patch = Schema.computeDiff(oldDv, newDv, DynamicOptic.root)
+        val oldDv = DynamicValue.Sequence(
+          Vector(
+            DynamicValue.Primitive(PrimitiveValue.Int(1)),
+            DynamicValue.Primitive(PrimitiveValue.Int(2))
+          )
+        )
+        val newDv = DynamicValue.Sequence(
+          Vector(
+            DynamicValue.Primitive(PrimitiveValue.Int(1)),
+            DynamicValue.Primitive(PrimitiveValue.Int(2)),
+            DynamicValue.Primitive(PrimitiveValue.Int(3))
+          )
+        )
+        val patch  = Schema.computeDiff(oldDv, newDv, DynamicOptic.root)
         val result = patch(oldDv, PatchMode.Strict)
         assert(result)(isRight(equalTo(newDv)))
       },
       test("diff of identical values produces empty patch") {
-        val dv = DynamicValue.Primitive(PrimitiveValue.Int(42))
+        val dv    = DynamicValue.Primitive(PrimitiveValue.Int(42))
         val patch = Schema.computeDiff(dv, dv, DynamicOptic.root)
         assertTrue(patch.ops.isEmpty)
       }
@@ -322,21 +395,21 @@ object DynamicPatchSpec extends ZIOSpecDefault {
       test("Schema.diffDynamic produces correct patch for primitives") {
         val oldValue = 10
         val newValue = 25
-        val schema = Schema.int
-        val patch = schema.diffDynamic(oldValue, newValue)
-        val result = schema.applyDynamicPatch(oldValue, patch, PatchMode.Strict)
+        val schema   = Schema.int
+        val patch    = schema.diffDynamic(oldValue, newValue)
+        val result   = schema.applyDynamicPatch(oldValue, patch, PatchMode.Strict)
         assert(result)(isRight(equalTo(newValue)))
       }
     ),
     suite("Monoid associativity")(
       test("(a ++ b) ++ c == a ++ (b ++ c)") {
-        val value = DynamicValue.Primitive(PrimitiveValue.Int(0))
-        val a = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(1)))
-        val b = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(2)))
-        val c = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(3)))
-        val leftAssoc = (a ++ b) ++ c
-        val rightAssoc = a ++ (b ++ c)
-        val leftResult = leftAssoc(value, PatchMode.Strict)
+        val value       = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val a           = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(1)))
+        val b           = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(2)))
+        val c           = DynamicPatch.single(DynamicOptic.root, Operation.PrimitiveDelta(PrimitiveOp.IntDelta(3)))
+        val leftAssoc   = (a ++ b) ++ c
+        val rightAssoc  = a ++ (b ++ c)
+        val leftResult  = leftAssoc(value, PatchMode.Strict)
         val rightResult = rightAssoc(value, PatchMode.Strict)
         assert(leftResult)(equalTo(rightResult)) &&
         assert(leftResult)(isRight(equalTo(DynamicValue.Primitive(PrimitiveValue.Int(6)))))
@@ -348,7 +421,7 @@ object DynamicPatchSpec extends ZIOSpecDefault {
           DynamicOptic.root.field("name"),
           Operation.Set(DynamicValue.Primitive(PrimitiveValue.String("test")))
         )
-        val serialized = PatchSerialization.toValue(patch)
+        val serialized   = PatchSerialization.toValue(patch)
         val deserialized = PatchSerialization.fromValue(serialized)
         assertTrue(deserialized.isRight) &&
         assertTrue(deserialized.toOption.get.ops.length == 1)
@@ -358,11 +431,9 @@ object DynamicPatchSpec extends ZIOSpecDefault {
           DynamicOptic.root,
           Operation.PrimitiveDelta(PrimitiveOp.IntDelta(42))
         )
-        val serialized = PatchSerialization.toValue(patch)
+        val serialized   = PatchSerialization.toValue(patch)
         val deserialized = PatchSerialization.fromValue(serialized)
-        val result = deserialized.flatMap(p => 
-          p(DynamicValue.Primitive(PrimitiveValue.Int(0)), PatchMode.Strict)
-        )
+        val result       = deserialized.flatMap(p => p(DynamicValue.Primitive(PrimitiveValue.Int(0)), PatchMode.Strict))
         assert(result)(isRight(equalTo(DynamicValue.Primitive(PrimitiveValue.Int(42)))))
       },
       test("roundtrip serialization of SequenceEdit operation") {
@@ -370,27 +441,31 @@ object DynamicPatchSpec extends ZIOSpecDefault {
           DynamicOptic.root,
           Operation.SequenceEdit(Vector(SeqOp.Delete(0, 1)))
         )
-        val serialized = PatchSerialization.toValue(patch)
+        val serialized   = PatchSerialization.toValue(patch)
         val deserialized = PatchSerialization.fromValue(serialized)
         assertTrue(deserialized.isRight)
       },
       test("roundtrip serialization of StringEdit operation") {
         val patch = DynamicPatch.single(
           DynamicOptic.root,
-          Operation.PrimitiveDelta(PrimitiveOp.StringEdit(Vector(
-            StringOp.Insert(0, "Hello "),
-            StringOp.Delete(6, 5)
-          )))
+          Operation.PrimitiveDelta(
+            PrimitiveOp.StringEdit(
+              Vector(
+                StringOp.Insert(0, "Hello "),
+                StringOp.Delete(6, 5)
+              )
+            )
+          )
         )
-        val serialized = PatchSerialization.toValue(patch)
+        val serialized   = PatchSerialization.toValue(patch)
         val deserialized = PatchSerialization.fromValue(serialized)
         assertTrue(deserialized.isRight) &&
         assertTrue(deserialized.toOption.get.ops.length == 1)
       },
       test("serialization preserves DynamicOptic path") {
-        val optic = DynamicOptic.root.field("person").field("name")
-        val patch = DynamicPatch.single(optic, Operation.Set(DynamicValue.Primitive(PrimitiveValue.String("John"))))
-        val serialized = PatchSerialization.toValue(patch)
+        val optic        = DynamicOptic.root.field("person").field("name")
+        val patch        = DynamicPatch.single(optic, Operation.Set(DynamicValue.Primitive(PrimitiveValue.String("John"))))
+        val serialized   = PatchSerialization.toValue(patch)
         val deserialized = PatchSerialization.fromValue(serialized)
         assertTrue(deserialized.isRight) && {
           val opticNodes = deserialized.toOption.get.ops.head.optic.nodes


### PR DESCRIPTION
- Add DynamicPatch for untyped patch operations on DynamicValue
- Add typed API to Patch companion (increment, editString, append, etc.)
- Implement LCS algorithms for string and sequence diffing
- Add Schema#diff and #diffDynamic for computing minimal patches
- Add PatchMode (Strict/Lenient/Clobber) for controlling application
- Add PatchSerialization for DynamicValue-based serialization
- Add comprehensive test suite (37 tests) including:
  - All operation types (Set, PrimitiveDelta, SequenceEdit, MapEdit)
  - Roundtrip law verification
  - Monoid laws (identity and associativity)
  - Serialization roundtrips
  
/claim #516

New files:
- DynamicPatch.scala, DynamicPatchOp.scala
- Operation.scala, PrimitiveOp.scala, SeqOp.scala, MapOp.scala, StringOp.scala
- PatchMode.scala, PatchSchemas.scala, LCS.scala
- DynamicPatchSpec.scala (tests)