### PR TITLE
Add a way to get the key value pair as a tuple in MapDeconstructor

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/binding/MapDeconstructor.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/binding/MapDeconstructor.scala
@@ -12,6 +12,8 @@ trait MapDeconstructor[M[_, _]] {
   def getKey[K, V](kv: KeyValue[K, V]): K
 
   def getValue[K, V](kv: KeyValue[K, V]): V
+
+  def getKeyValue[K, V](kv: KeyValue[K, V]): (K, V)
 }
 
 object MapDeconstructor {
@@ -27,5 +29,7 @@ object MapDeconstructor {
     def getKey[K, V](kv: (K, V)): K = kv._1
 
     def getValue[K, V](kv: (K, V)): V = kv._2
+
+    def getKeyValue[K, V](kv: (K, V)): (K, V) = kv
   }
 }


### PR DESCRIPTION
Creating a new tuple with `(getKey(kv), getValue(kv))` is a bit pity since it's already a tuple in the main case.