### PR TITLE
Escape $ in Scaladoc

### DIFF
--- a/schema-toon/src/main/scala/zio/blocks/schema/toon/DiscriminatorKind.scala
+++ b/schema-toon/src/main/scala/zio/blocks/schema/toon/DiscriminatorKind.scala
@@ -27,7 +27,7 @@ object DiscriminatorKind {
   /**
    * Represents a discriminator strategy where a specific field in the TOON
    * record is used to identify the subtype of a sealed hierarchy, e.g.
-   * `$type: SubtypeIdentifier` followed by the record fields.
+   * `\$type: SubtypeIdentifier` followed by the record fields.
    *
    * Can be used only for serializing sealed hierarchy subtypes of non-abstract
    * classes only (not union types).


### PR DESCRIPTION
This $ makes the CI publishing step fail since the merge of the Toon codec.

Verified that the escape works at intended:
<img width="293" height="140" alt="Screenshot 2026-01-15 at 11 17 49" src="https://github.com/user-attachments/assets/7838bbf4-7e65-4121-a9e3-3941ecefbf06" />
