### PR TITLE
feat: Add MessagePack binary codec support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ lazy val root = project
     schema.js,
     schema.native,
     `schema-avro`,
+    `schema-messagepack`,
     `schema-toon`.jvm,
     `schema-toon`.js,
     `schema-toon`.native,
@@ -171,6 +172,19 @@ lazy val `schema-avro` = project
           "io.github.kitlangton" %% "neotype" % "0.4.10" % Test
         )
     })
+  )
+
+lazy val `schema-messagepack` = project
+  .settings(stdSettings("zio-blocks-schema-messagepack"))
+  .dependsOn(schema.jvm)
+  .settings(buildInfoSettings("zio.blocks.schema.messagepack"))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.msgpack" % "msgpack-core" % "0.9.8",
+      "dev.zio"    %% "zio-test"     % "2.1.24" % Test,
+      "dev.zio"    %% "zio-test-sbt" % "2.1.24" % Test
+    )
   )
 
 lazy val `schema-toon` = crossProject(JSPlatform, JVMPlatform, NativePlatform)

--- a/schema-messagepack/src/main/scala/zio/blocks/schema/messagepack/MessagePackBinaryCodec.scala
+++ b/schema-messagepack/src/main/scala/zio/blocks/schema/messagepack/MessagePackBinaryCodec.scala
@@ -1,0 +1,161 @@
+package zio.blocks.schema.messagepack
+
+import org.msgpack.core.{MessagePack, MessagePacker, MessageUnpacker}
+import org.msgpack.core.buffer.ArrayBufferOutput
+import zio.blocks.schema.SchemaError.ExpectationMismatch
+import zio.blocks.schema.{DynamicOptic, SchemaError}
+import zio.blocks.schema.binding.RegisterOffset
+import zio.blocks.schema.codec.BinaryCodec
+import java.nio.ByteBuffer
+import scala.collection.immutable.ArraySeq
+import scala.util.control.NonFatal
+
+abstract class MessagePackBinaryCodec[A](val valueType: Int = MessagePackBinaryCodec.objectType)
+    extends BinaryCodec[A] {
+  val valueOffset: RegisterOffset.RegisterOffset = valueType match {
+    case MessagePackBinaryCodec.objectType  => RegisterOffset(objects = 1)
+    case MessagePackBinaryCodec.booleanType => RegisterOffset(booleans = 1)
+    case MessagePackBinaryCodec.byteType    => RegisterOffset(bytes = 1)
+    case MessagePackBinaryCodec.charType    => RegisterOffset(chars = 1)
+    case MessagePackBinaryCodec.shortType   => RegisterOffset(shorts = 1)
+    case MessagePackBinaryCodec.floatType   => RegisterOffset(floats = 1)
+    case MessagePackBinaryCodec.intType     => RegisterOffset(ints = 1)
+    case MessagePackBinaryCodec.doubleType  => RegisterOffset(doubles = 1)
+    case MessagePackBinaryCodec.longType    => RegisterOffset(longs = 1)
+    case _                                  => RegisterOffset.Zero
+  }
+
+  def decodeError(expectation: String): Nothing = throw new MessagePackBinaryCodecError(Nil, expectation)
+
+  def decodeError(span: DynamicOptic.Node, error: Throwable): Nothing = error match {
+    case e: MessagePackBinaryCodecError =>
+      e.spans = new ::(span, e.spans)
+      throw e
+    case _ =>
+      throw new MessagePackBinaryCodecError(new ::(span, Nil), getMessage(error))
+  }
+
+  def decodeError(span1: DynamicOptic.Node, span2: DynamicOptic.Node, error: Throwable): Nothing = error match {
+    case e: MessagePackBinaryCodecError =>
+      e.spans = new ::(span1, new ::(span2, e.spans))
+      throw e
+    case _ =>
+      throw new MessagePackBinaryCodecError(new ::(span1, new ::(span2, Nil)), getMessage(error))
+  }
+
+  def decodeUnsafe(unpacker: MessageUnpacker): A
+
+  def encodeUnsafe(packer: MessagePacker, value: A): Unit
+
+  override def decode(input: ByteBuffer): Either[SchemaError, A] = {
+    var pos             = input.position
+    val len             = input.limit - pos
+    var bs: Array[Byte] = null
+    if (input.hasArray) bs = input.array()
+    else {
+      pos = 0
+      bs = new Array[Byte](len)
+      input.get(bs)
+    }
+    decode(MessagePack.newDefaultUnpacker(bs, pos, len))
+  }
+
+  override def encode(value: A, output: ByteBuffer): Unit = {
+    val bufferOutput = new ArrayBufferOutput()
+    val packer       = MessagePack.newDefaultPacker(bufferOutput)
+    encodeUnsafe(packer, value)
+    packer.flush()
+    output.put(bufferOutput.toByteArray)
+  }
+
+  def decode(input: Array[Byte]): Either[SchemaError, A] =
+    decode(MessagePack.newDefaultUnpacker(input))
+
+  def encode(value: A): Array[Byte] = {
+    val output = new ArrayBufferOutput()
+    val packer = MessagePack.newDefaultPacker(output)
+    encodeUnsafe(packer, value)
+    packer.flush()
+    output.toByteArray
+  }
+
+  def decode(input: java.io.InputStream): Either[SchemaError, A] =
+    decode(MessagePack.newDefaultUnpacker(input))
+
+  def encode(value: A, output: java.io.OutputStream): Unit = {
+    val packer = MessagePack.newDefaultPacker(output)
+    encodeUnsafe(packer, value)
+    packer.flush()
+  }
+
+  private[this] def decode(unpacker: MessageUnpacker): Either[SchemaError, A] =
+    try new Right(decodeUnsafe(unpacker))
+    catch {
+      case error if NonFatal(error) => new Left(toError(error))
+    }
+
+  private[this] def toError(error: Throwable): SchemaError = new SchemaError(
+    new ::(
+      error match {
+        case e: MessagePackBinaryCodecError =>
+          var list  = e.spans
+          val array = new Array[DynamicOptic.Node](list.size)
+          var idx   = 0
+          while (list ne Nil) {
+            array(idx) = list.head
+            idx += 1
+            list = list.tail
+          }
+          new ExpectationMismatch(new DynamicOptic(ArraySeq.unsafeWrapArray(array)), e.getMessage)
+        case _ => new ExpectationMismatch(DynamicOptic.root, getMessage(error))
+      },
+      Nil
+    )
+  )
+
+  private[this] def getMessage(error: Throwable): String = error match {
+    case _: java.io.EOFException                                => "Unexpected end of input"
+    case _: org.msgpack.core.MessageInsufficientBufferException => "Unexpected end of input"
+    case e                                                      => e.getMessage
+  }
+}
+
+object MessagePackBinaryCodec {
+  val objectType  = 0
+  val booleanType = 1
+  val byteType    = 2
+  val charType    = 3
+  val shortType   = 4
+  val floatType   = 5
+  val intType     = 6
+  val doubleType  = 7
+  val longType    = 8
+  val unitType    = 9
+
+  val maxCollectionSize: Int = Integer.MAX_VALUE - 8
+}
+
+private class MessagePackBinaryCodecError(var spans: List[DynamicOptic.Node], message: String)
+    extends Throwable(message, null, false, false) {
+  override def getMessage: String = message
+}
+
+private class ByteArrayOutputStream extends java.io.OutputStream {
+  private[this] var buf   = new Array[Byte](64)
+  private[this] var count = 0
+
+  override def write(b: Int): Unit = {
+    if (count >= buf.length) buf = java.util.Arrays.copyOf(buf, buf.length << 1)
+    buf(count) = b.toByte
+    count += 1
+  }
+
+  override def write(bs: Array[Byte], off: Int, len: Int): Unit = {
+    val newLen = count + len
+    if (newLen > buf.length) buf = java.util.Arrays.copyOf(buf, Math.max(buf.length << 1, newLen))
+    System.arraycopy(bs, off, buf, count, len)
+    count = newLen
+  }
+
+  def toByteArray: Array[Byte] = java.util.Arrays.copyOf(buf, count)
+}

--- a/schema-messagepack/src/main/scala/zio/blocks/schema/messagepack/MessagePackFormat.scala
+++ b/schema-messagepack/src/main/scala/zio/blocks/schema/messagepack/MessagePackFormat.scala
@@ -1,0 +1,1743 @@
+package zio.blocks.schema.messagepack
+
+import org.msgpack.core.{MessagePacker, MessageUnpacker}
+import zio.blocks.schema.binding.{Binding, BindingType, HasBinding, Registers, RegisterOffset}
+import zio.blocks.schema.binding.SeqDeconstructor._
+import zio.blocks.schema._
+import zio.blocks.schema.codec.BinaryFormat
+import zio.blocks.schema.derive.{BindingInstance, Deriver, InstanceOverride}
+import java.math.{BigInteger, MathContext}
+import scala.util.control.NonFatal
+
+object MessagePackFormat
+    extends BinaryFormat(
+      "application/msgpack",
+      new Deriver[MessagePackBinaryCodec] {
+        override def derivePrimitive[F[_, _], A](
+          primitiveType: PrimitiveType[A],
+          typeName: TypeName[A],
+          binding: Binding[BindingType.Primitive, A],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        ): Lazy[MessagePackBinaryCodec[A]] =
+          Lazy(deriveCodec(new Reflect.Primitive(primitiveType, typeName, binding, doc, modifiers)))
+
+        override def deriveRecord[F[_, _], A](
+          fields: IndexedSeq[Term[F, A, ?]],
+          typeName: TypeName[A],
+          binding: Binding[BindingType.Record, A],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[MessagePackBinaryCodec[A]] = Lazy {
+          deriveCodec(
+            new Reflect.Record(
+              fields.asInstanceOf[IndexedSeq[Term[Binding, A, ?]]],
+              typeName,
+              binding,
+              doc,
+              modifiers
+            )
+          )
+        }
+
+        override def deriveVariant[F[_, _], A](
+          cases: IndexedSeq[Term[F, A, ?]],
+          typeName: TypeName[A],
+          binding: Binding[BindingType.Variant, A],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[MessagePackBinaryCodec[A]] = Lazy {
+          deriveCodec(
+            new Reflect.Variant(
+              cases.asInstanceOf[IndexedSeq[Term[Binding, A, ? <: A]]],
+              typeName,
+              binding,
+              doc,
+              modifiers
+            )
+          )
+        }
+
+        override def deriveSequence[F[_, _], C[_], A](
+          element: Reflect[F, A],
+          typeName: TypeName[C[A]],
+          binding: Binding[BindingType.Seq[C], C[A]],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[MessagePackBinaryCodec[C[A]]] = Lazy {
+          deriveCodec(
+            new Reflect.Sequence(element.asInstanceOf[Reflect[Binding, A]], typeName, binding, doc, modifiers)
+          )
+        }
+
+        override def deriveMap[F[_, _], M[_, _], K, V](
+          key: Reflect[F, K],
+          value: Reflect[F, V],
+          typeName: TypeName[M[K, V]],
+          binding: Binding[BindingType.Map[M], M[K, V]],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[MessagePackBinaryCodec[M[K, V]]] = Lazy {
+          deriveCodec(
+            new Reflect.Map(
+              key.asInstanceOf[Reflect[Binding, K]],
+              value.asInstanceOf[Reflect[Binding, V]],
+              typeName,
+              binding,
+              doc,
+              modifiers
+            )
+          )
+        }
+
+        override def deriveDynamic[F[_, _]](
+          binding: Binding[BindingType.Dynamic, DynamicValue],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[MessagePackBinaryCodec[DynamicValue]] =
+          Lazy(deriveCodec(new Reflect.Dynamic(binding, TypeName.dynamicValue, doc, modifiers)))
+
+        def deriveWrapper[F[_, _], A, B](
+          wrapped: Reflect[F, B],
+          typeName: TypeName[A],
+          wrapperPrimitiveType: Option[PrimitiveType[A]],
+          binding: Binding[BindingType.Wrapper[A, B], A],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[MessagePackBinaryCodec[A]] = Lazy {
+          deriveCodec(
+            new Reflect.Wrapper(
+              wrapped.asInstanceOf[Reflect[Binding, B]],
+              typeName,
+              wrapperPrimitiveType,
+              binding,
+              doc,
+              modifiers
+            )
+          )
+        }
+
+        override def instanceOverrides: IndexedSeq[InstanceOverride] = {
+          recursiveRecordCache.remove()
+          super.instanceOverrides
+        }
+
+        type Elem
+        type Key
+        type Value
+        type Wrapped
+        type Col[_]
+        type Map[_, _]
+        type TC[_]
+
+        private[this] val recursiveRecordCache =
+          new ThreadLocal[java.util.HashMap[TypeName[?], Array[MessagePackBinaryCodec[?]]]] {
+            override def initialValue: java.util.HashMap[TypeName[?], Array[MessagePackBinaryCodec[?]]] =
+              new java.util.HashMap
+          }
+
+        private[this] val unitCodec = new MessagePackBinaryCodec[Unit](MessagePackBinaryCodec.unitType) {
+          def decodeUnsafe(unpacker: MessageUnpacker): Unit = unpacker.unpackNil()
+
+          def encodeUnsafe(packer: MessagePacker, value: Unit): Unit = packer.packNil()
+        }
+
+        private[this] val booleanCodec = new MessagePackBinaryCodec[Boolean](MessagePackBinaryCodec.booleanType) {
+          def decodeUnsafe(unpacker: MessageUnpacker): Boolean = unpacker.unpackBoolean()
+
+          def encodeUnsafe(packer: MessagePacker, value: Boolean): Unit = packer.packBoolean(value)
+        }
+
+        private[this] val byteCodec = new MessagePackBinaryCodec[Byte](MessagePackBinaryCodec.byteType) {
+          def decodeUnsafe(unpacker: MessageUnpacker): Byte = unpacker.unpackByte()
+
+          def encodeUnsafe(packer: MessagePacker, value: Byte): Unit = packer.packByte(value)
+        }
+
+        private[this] val shortCodec = new MessagePackBinaryCodec[Short](MessagePackBinaryCodec.shortType) {
+          def decodeUnsafe(unpacker: MessageUnpacker): Short = unpacker.unpackShort()
+
+          def encodeUnsafe(packer: MessagePacker, value: Short): Unit = packer.packShort(value)
+        }
+
+        private[this] val intCodec = new MessagePackBinaryCodec[Int](MessagePackBinaryCodec.intType) {
+          def decodeUnsafe(unpacker: MessageUnpacker): Int = unpacker.unpackInt()
+
+          def encodeUnsafe(packer: MessagePacker, value: Int): Unit = packer.packInt(value)
+        }
+
+        private[this] val longCodec = new MessagePackBinaryCodec[Long](MessagePackBinaryCodec.longType) {
+          def decodeUnsafe(unpacker: MessageUnpacker): Long = unpacker.unpackLong()
+
+          def encodeUnsafe(packer: MessagePacker, value: Long): Unit = packer.packLong(value)
+        }
+
+        private[this] val floatCodec = new MessagePackBinaryCodec[Float](MessagePackBinaryCodec.floatType) {
+          def decodeUnsafe(unpacker: MessageUnpacker): Float = unpacker.unpackFloat()
+
+          def encodeUnsafe(packer: MessagePacker, value: Float): Unit = packer.packFloat(value)
+        }
+
+        private[this] val doubleCodec = new MessagePackBinaryCodec[Double](MessagePackBinaryCodec.doubleType) {
+          def decodeUnsafe(unpacker: MessageUnpacker): Double = unpacker.unpackDouble()
+
+          def encodeUnsafe(packer: MessagePacker, value: Double): Unit = packer.packDouble(value)
+        }
+
+        private[this] val charCodec = new MessagePackBinaryCodec[Char](MessagePackBinaryCodec.charType) {
+          def decodeUnsafe(unpacker: MessageUnpacker): Char = {
+            val x = unpacker.unpackInt()
+            if (x >= Char.MinValue && x <= Char.MaxValue) x.toChar
+            else decodeError("Expected Char")
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: Char): Unit = packer.packInt(value.toInt)
+        }
+
+        private[this] val stringCodec = new MessagePackBinaryCodec[String]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): String = unpacker.unpackString()
+
+          def encodeUnsafe(packer: MessagePacker, value: String): Unit = packer.packString(value)
+        }
+
+        private[this] val bigIntCodec = new MessagePackBinaryCodec[BigInt]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): BigInt = {
+            val len = unpacker.unpackBinaryHeader()
+            val bs  = new Array[Byte](len)
+            unpacker.readPayload(bs)
+            BigInt(bs)
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: BigInt): Unit = {
+            val bs = value.toByteArray
+            packer.packBinaryHeader(bs.length)
+            packer.writePayload(bs)
+          }
+        }
+
+        private[this] val bigDecimalCodec = new MessagePackBinaryCodec[BigDecimal]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): BigDecimal = {
+            val mapSize = unpacker.unpackMapHeader()
+            if (mapSize != 4) decodeError("Expected BigDecimal map with 4 fields")
+            var mantissa: Array[Byte]                = null
+            var scale: Int                           = 0
+            var precision: Int                       = 0
+            var roundingMode: java.math.RoundingMode = null
+            var idx                                  = 0
+            while (idx < 4) {
+              val key = unpacker.unpackString()
+              key match {
+                case "mantissa" =>
+                  val len = unpacker.unpackBinaryHeader()
+                  mantissa = new Array[Byte](len)
+                  unpacker.readPayload(mantissa)
+                case "scale"        => scale = unpacker.unpackInt()
+                case "precision"    => precision = unpacker.unpackInt()
+                case "roundingMode" => roundingMode = java.math.RoundingMode.valueOf(unpacker.unpackInt())
+                case _              => decodeError(s"Unexpected field: $key")
+              }
+              idx += 1
+            }
+            val mc = new MathContext(precision, roundingMode)
+            new BigDecimal(new java.math.BigDecimal(new BigInteger(mantissa), scale), mc)
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: BigDecimal): Unit = {
+            val bd = value.underlying
+            val mc = value.mc
+            packer.packMapHeader(4)
+            packer.packString("mantissa")
+            val mantissa = bd.unscaledValue.toByteArray
+            packer.packBinaryHeader(mantissa.length)
+            packer.writePayload(mantissa)
+            packer.packString("scale")
+            packer.packInt(bd.scale)
+            packer.packString("precision")
+            packer.packInt(mc.getPrecision)
+            packer.packString("roundingMode")
+            packer.packInt(mc.getRoundingMode.ordinal)
+          }
+        }
+
+        private[this] val dayOfWeekCodec = new MessagePackBinaryCodec[java.time.DayOfWeek]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.DayOfWeek =
+            java.time.DayOfWeek.of(unpacker.unpackInt())
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.DayOfWeek): Unit =
+            packer.packInt(value.getValue)
+        }
+
+        private[this] val durationCodec = new MessagePackBinaryCodec[java.time.Duration]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.Duration = {
+            val mapSize = unpacker.unpackMapHeader()
+            if (mapSize != 2) decodeError("Expected Duration map with 2 fields")
+            var seconds: Long = 0
+            var nanos: Int    = 0
+            var idx           = 0
+            while (idx < 2) {
+              val key = unpacker.unpackString()
+              key match {
+                case "seconds" => seconds = unpacker.unpackLong()
+                case "nanos"   => nanos = unpacker.unpackInt()
+                case _         => decodeError(s"Unexpected field: $key")
+              }
+              idx += 1
+            }
+            java.time.Duration.ofSeconds(seconds, nanos)
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.Duration): Unit = {
+            packer.packMapHeader(2)
+            packer.packString("seconds")
+            packer.packLong(value.getSeconds)
+            packer.packString("nanos")
+            packer.packInt(value.getNano)
+          }
+        }
+
+        private[this] val instantCodec = new MessagePackBinaryCodec[java.time.Instant]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.Instant = {
+            val mapSize = unpacker.unpackMapHeader()
+            if (mapSize != 2) decodeError("Expected Instant map with 2 fields")
+            var epochSecond: Long = 0
+            var nano: Int         = 0
+            var idx               = 0
+            while (idx < 2) {
+              val key = unpacker.unpackString()
+              key match {
+                case "epochSecond" => epochSecond = unpacker.unpackLong()
+                case "nano"        => nano = unpacker.unpackInt()
+                case _             => decodeError(s"Unexpected field: $key")
+              }
+              idx += 1
+            }
+            java.time.Instant.ofEpochSecond(epochSecond, nano)
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.Instant): Unit = {
+            packer.packMapHeader(2)
+            packer.packString("epochSecond")
+            packer.packLong(value.getEpochSecond)
+            packer.packString("nano")
+            packer.packInt(value.getNano)
+          }
+        }
+
+        private[this] val localDateCodec = new MessagePackBinaryCodec[java.time.LocalDate]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.LocalDate = {
+            val mapSize = unpacker.unpackMapHeader()
+            if (mapSize != 3) decodeError("Expected LocalDate map with 3 fields")
+            var year: Int  = 0
+            var month: Int = 0
+            var day: Int   = 0
+            var idx        = 0
+            while (idx < 3) {
+              val key = unpacker.unpackString()
+              key match {
+                case "year"  => year = unpacker.unpackInt()
+                case "month" => month = unpacker.unpackInt()
+                case "day"   => day = unpacker.unpackInt()
+                case _       => decodeError(s"Unexpected field: $key")
+              }
+              idx += 1
+            }
+            java.time.LocalDate.of(year, month, day)
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.LocalDate): Unit = {
+            packer.packMapHeader(3)
+            packer.packString("year")
+            packer.packInt(value.getYear)
+            packer.packString("month")
+            packer.packInt(value.getMonthValue)
+            packer.packString("day")
+            packer.packInt(value.getDayOfMonth)
+          }
+        }
+
+        private[this] val localDateTimeCodec = new MessagePackBinaryCodec[java.time.LocalDateTime]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.LocalDateTime = {
+            val mapSize = unpacker.unpackMapHeader()
+            if (mapSize != 7) decodeError("Expected LocalDateTime map with 7 fields")
+            var year: Int   = 0
+            var month: Int  = 0
+            var day: Int    = 0
+            var hour: Int   = 0
+            var minute: Int = 0
+            var second: Int = 0
+            var nano: Int   = 0
+            var idx         = 0
+            while (idx < 7) {
+              val key = unpacker.unpackString()
+              key match {
+                case "year"   => year = unpacker.unpackInt()
+                case "month"  => month = unpacker.unpackInt()
+                case "day"    => day = unpacker.unpackInt()
+                case "hour"   => hour = unpacker.unpackInt()
+                case "minute" => minute = unpacker.unpackInt()
+                case "second" => second = unpacker.unpackInt()
+                case "nano"   => nano = unpacker.unpackInt()
+                case _        => decodeError(s"Unexpected field: $key")
+              }
+              idx += 1
+            }
+            java.time.LocalDateTime.of(year, month, day, hour, minute, second, nano)
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.LocalDateTime): Unit = {
+            packer.packMapHeader(7)
+            packer.packString("year")
+            packer.packInt(value.getYear)
+            packer.packString("month")
+            packer.packInt(value.getMonthValue)
+            packer.packString("day")
+            packer.packInt(value.getDayOfMonth)
+            packer.packString("hour")
+            packer.packInt(value.getHour)
+            packer.packString("minute")
+            packer.packInt(value.getMinute)
+            packer.packString("second")
+            packer.packInt(value.getSecond)
+            packer.packString("nano")
+            packer.packInt(value.getNano)
+          }
+        }
+
+        private[this] val localTimeCodec = new MessagePackBinaryCodec[java.time.LocalTime]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.LocalTime = {
+            val mapSize = unpacker.unpackMapHeader()
+            if (mapSize != 4) decodeError("Expected LocalTime map with 4 fields")
+            var hour: Int   = 0
+            var minute: Int = 0
+            var second: Int = 0
+            var nano: Int   = 0
+            var idx         = 0
+            while (idx < 4) {
+              val key = unpacker.unpackString()
+              key match {
+                case "hour"   => hour = unpacker.unpackInt()
+                case "minute" => minute = unpacker.unpackInt()
+                case "second" => second = unpacker.unpackInt()
+                case "nano"   => nano = unpacker.unpackInt()
+                case _        => decodeError(s"Unexpected field: $key")
+              }
+              idx += 1
+            }
+            java.time.LocalTime.of(hour, minute, second, nano)
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.LocalTime): Unit = {
+            packer.packMapHeader(4)
+            packer.packString("hour")
+            packer.packInt(value.getHour)
+            packer.packString("minute")
+            packer.packInt(value.getMinute)
+            packer.packString("second")
+            packer.packInt(value.getSecond)
+            packer.packString("nano")
+            packer.packInt(value.getNano)
+          }
+        }
+
+        private[this] val monthCodec = new MessagePackBinaryCodec[java.time.Month]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.Month =
+            java.time.Month.of(unpacker.unpackInt())
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.Month): Unit =
+            packer.packInt(value.getValue)
+        }
+
+        private[this] val monthDayCodec = new MessagePackBinaryCodec[java.time.MonthDay]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.MonthDay = {
+            val mapSize = unpacker.unpackMapHeader()
+            if (mapSize != 2) decodeError("Expected MonthDay map with 2 fields")
+            var month: Int = 0
+            var day: Int   = 0
+            var idx        = 0
+            while (idx < 2) {
+              val key = unpacker.unpackString()
+              key match {
+                case "month" => month = unpacker.unpackInt()
+                case "day"   => day = unpacker.unpackInt()
+                case _       => decodeError(s"Unexpected field: $key")
+              }
+              idx += 1
+            }
+            java.time.MonthDay.of(month, day)
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.MonthDay): Unit = {
+            packer.packMapHeader(2)
+            packer.packString("month")
+            packer.packInt(value.getMonthValue)
+            packer.packString("day")
+            packer.packInt(value.getDayOfMonth)
+          }
+        }
+
+        private[this] val offsetDateTimeCodec = new MessagePackBinaryCodec[java.time.OffsetDateTime]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.OffsetDateTime = {
+            val mapSize = unpacker.unpackMapHeader()
+            if (mapSize != 8) decodeError("Expected OffsetDateTime map with 8 fields")
+            var year: Int         = 0
+            var month: Int        = 0
+            var day: Int          = 0
+            var hour: Int         = 0
+            var minute: Int       = 0
+            var second: Int       = 0
+            var nano: Int         = 0
+            var offsetSecond: Int = 0
+            var idx               = 0
+            while (idx < 8) {
+              val key = unpacker.unpackString()
+              key match {
+                case "year"         => year = unpacker.unpackInt()
+                case "month"        => month = unpacker.unpackInt()
+                case "day"          => day = unpacker.unpackInt()
+                case "hour"         => hour = unpacker.unpackInt()
+                case "minute"       => minute = unpacker.unpackInt()
+                case "second"       => second = unpacker.unpackInt()
+                case "nano"         => nano = unpacker.unpackInt()
+                case "offsetSecond" => offsetSecond = unpacker.unpackInt()
+                case _              => decodeError(s"Unexpected field: $key")
+              }
+              idx += 1
+            }
+            java.time.OffsetDateTime
+              .of(year, month, day, hour, minute, second, nano, java.time.ZoneOffset.ofTotalSeconds(offsetSecond))
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.OffsetDateTime): Unit = {
+            packer.packMapHeader(8)
+            packer.packString("year")
+            packer.packInt(value.getYear)
+            packer.packString("month")
+            packer.packInt(value.getMonthValue)
+            packer.packString("day")
+            packer.packInt(value.getDayOfMonth)
+            packer.packString("hour")
+            packer.packInt(value.getHour)
+            packer.packString("minute")
+            packer.packInt(value.getMinute)
+            packer.packString("second")
+            packer.packInt(value.getSecond)
+            packer.packString("nano")
+            packer.packInt(value.getNano)
+            packer.packString("offsetSecond")
+            packer.packInt(value.getOffset.getTotalSeconds)
+          }
+        }
+
+        private[this] val offsetTimeCodec = new MessagePackBinaryCodec[java.time.OffsetTime]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.OffsetTime = {
+            val mapSize = unpacker.unpackMapHeader()
+            if (mapSize != 5) decodeError("Expected OffsetTime map with 5 fields")
+            var hour: Int         = 0
+            var minute: Int       = 0
+            var second: Int       = 0
+            var nano: Int         = 0
+            var offsetSecond: Int = 0
+            var idx               = 0
+            while (idx < 5) {
+              val key = unpacker.unpackString()
+              key match {
+                case "hour"         => hour = unpacker.unpackInt()
+                case "minute"       => minute = unpacker.unpackInt()
+                case "second"       => second = unpacker.unpackInt()
+                case "nano"         => nano = unpacker.unpackInt()
+                case "offsetSecond" => offsetSecond = unpacker.unpackInt()
+                case _              => decodeError(s"Unexpected field: $key")
+              }
+              idx += 1
+            }
+            java.time.OffsetTime.of(hour, minute, second, nano, java.time.ZoneOffset.ofTotalSeconds(offsetSecond))
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.OffsetTime): Unit = {
+            packer.packMapHeader(5)
+            packer.packString("hour")
+            packer.packInt(value.getHour)
+            packer.packString("minute")
+            packer.packInt(value.getMinute)
+            packer.packString("second")
+            packer.packInt(value.getSecond)
+            packer.packString("nano")
+            packer.packInt(value.getNano)
+            packer.packString("offsetSecond")
+            packer.packInt(value.getOffset.getTotalSeconds)
+          }
+        }
+
+        private[this] val periodCodec = new MessagePackBinaryCodec[java.time.Period]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.Period = {
+            val mapSize = unpacker.unpackMapHeader()
+            if (mapSize != 3) decodeError("Expected Period map with 3 fields")
+            var years: Int  = 0
+            var months: Int = 0
+            var days: Int   = 0
+            var idx         = 0
+            while (idx < 3) {
+              val key = unpacker.unpackString()
+              key match {
+                case "years"  => years = unpacker.unpackInt()
+                case "months" => months = unpacker.unpackInt()
+                case "days"   => days = unpacker.unpackInt()
+                case _        => decodeError(s"Unexpected field: $key")
+              }
+              idx += 1
+            }
+            java.time.Period.of(years, months, days)
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.Period): Unit = {
+            packer.packMapHeader(3)
+            packer.packString("years")
+            packer.packInt(value.getYears)
+            packer.packString("months")
+            packer.packInt(value.getMonths)
+            packer.packString("days")
+            packer.packInt(value.getDays)
+          }
+        }
+
+        private[this] val yearCodec = new MessagePackBinaryCodec[java.time.Year]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.Year =
+            java.time.Year.of(unpacker.unpackInt())
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.Year): Unit =
+            packer.packInt(value.getValue)
+        }
+
+        private[this] val yearMonthCodec = new MessagePackBinaryCodec[java.time.YearMonth]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.YearMonth = {
+            val mapSize = unpacker.unpackMapHeader()
+            if (mapSize != 2) decodeError("Expected YearMonth map with 2 fields")
+            var year: Int  = 0
+            var month: Int = 0
+            var idx        = 0
+            while (idx < 2) {
+              val key = unpacker.unpackString()
+              key match {
+                case "year"  => year = unpacker.unpackInt()
+                case "month" => month = unpacker.unpackInt()
+                case _       => decodeError(s"Unexpected field: $key")
+              }
+              idx += 1
+            }
+            java.time.YearMonth.of(year, month)
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.YearMonth): Unit = {
+            packer.packMapHeader(2)
+            packer.packString("year")
+            packer.packInt(value.getYear)
+            packer.packString("month")
+            packer.packInt(value.getMonthValue)
+          }
+        }
+
+        private[this] val zoneIdCodec = new MessagePackBinaryCodec[java.time.ZoneId]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.ZoneId =
+            java.time.ZoneId.of(unpacker.unpackString())
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.ZoneId): Unit =
+            packer.packString(value.toString)
+        }
+
+        private[this] val zoneOffsetCodec = new MessagePackBinaryCodec[java.time.ZoneOffset]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.ZoneOffset =
+            java.time.ZoneOffset.ofTotalSeconds(unpacker.unpackInt())
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.ZoneOffset): Unit =
+            packer.packInt(value.getTotalSeconds)
+        }
+
+        private[this] val zonedDateTimeCodec = new MessagePackBinaryCodec[java.time.ZonedDateTime]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.time.ZonedDateTime = {
+            val mapSize = unpacker.unpackMapHeader()
+            if (mapSize != 9) decodeError("Expected ZonedDateTime map with 9 fields")
+            var year: Int         = 0
+            var month: Int        = 0
+            var day: Int          = 0
+            var hour: Int         = 0
+            var minute: Int       = 0
+            var second: Int       = 0
+            var nano: Int         = 0
+            var offsetSecond: Int = 0
+            var zoneId: String    = null
+            var idx               = 0
+            while (idx < 9) {
+              val key = unpacker.unpackString()
+              key match {
+                case "year"         => year = unpacker.unpackInt()
+                case "month"        => month = unpacker.unpackInt()
+                case "day"          => day = unpacker.unpackInt()
+                case "hour"         => hour = unpacker.unpackInt()
+                case "minute"       => minute = unpacker.unpackInt()
+                case "second"       => second = unpacker.unpackInt()
+                case "nano"         => nano = unpacker.unpackInt()
+                case "offsetSecond" => offsetSecond = unpacker.unpackInt()
+                case "zoneId"       => zoneId = unpacker.unpackString()
+                case _              => decodeError(s"Unexpected field: $key")
+              }
+              idx += 1
+            }
+            java.time.ZonedDateTime.ofInstant(
+              java.time.LocalDateTime.of(year, month, day, hour, minute, second, nano),
+              java.time.ZoneOffset.ofTotalSeconds(offsetSecond),
+              java.time.ZoneId.of(zoneId)
+            )
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: java.time.ZonedDateTime): Unit = {
+            packer.packMapHeader(9)
+            packer.packString("year")
+            packer.packInt(value.getYear)
+            packer.packString("month")
+            packer.packInt(value.getMonthValue)
+            packer.packString("day")
+            packer.packInt(value.getDayOfMonth)
+            packer.packString("hour")
+            packer.packInt(value.getHour)
+            packer.packString("minute")
+            packer.packInt(value.getMinute)
+            packer.packString("second")
+            packer.packInt(value.getSecond)
+            packer.packString("nano")
+            packer.packInt(value.getNano)
+            packer.packString("offsetSecond")
+            packer.packInt(value.getOffset.getTotalSeconds)
+            packer.packString("zoneId")
+            packer.packString(value.getZone.toString)
+          }
+        }
+
+        private[this] val currencyCodec = new MessagePackBinaryCodec[java.util.Currency]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.util.Currency =
+            java.util.Currency.getInstance(unpacker.unpackString())
+
+          def encodeUnsafe(packer: MessagePacker, value: java.util.Currency): Unit =
+            packer.packString(value.getCurrencyCode)
+        }
+
+        private[this] val uuidCodec = new MessagePackBinaryCodec[java.util.UUID]() {
+          def decodeUnsafe(unpacker: MessageUnpacker): java.util.UUID = {
+            val len = unpacker.unpackBinaryHeader()
+            if (len != 16) decodeError(s"Expected UUID binary with 16 bytes, got $len")
+            val bs = new Array[Byte](16)
+            unpacker.readPayload(bs)
+            val hi =
+              (bs(0) & 0xff).toLong << 56 |
+                (bs(1) & 0xff).toLong << 48 |
+                (bs(2) & 0xff).toLong << 40 |
+                (bs(3) & 0xff).toLong << 32 |
+                (bs(4) & 0xff).toLong << 24 |
+                (bs(5) & 0xff) << 16 |
+                (bs(6) & 0xff) << 8 |
+                (bs(7) & 0xff)
+            val lo =
+              (bs(8) & 0xff).toLong << 56 |
+                (bs(9) & 0xff).toLong << 48 |
+                (bs(10) & 0xff).toLong << 40 |
+                (bs(11) & 0xff).toLong << 32 |
+                (bs(12) & 0xff).toLong << 24 |
+                (bs(13) & 0xff) << 16 |
+                (bs(14) & 0xff) << 8 |
+                (bs(15) & 0xff)
+            new java.util.UUID(hi, lo)
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: java.util.UUID): Unit = {
+            val hi = value.getMostSignificantBits
+            val lo = value.getLeastSignificantBits
+            val bs = Array(
+              (hi >> 56).toByte,
+              (hi >> 48).toByte,
+              (hi >> 40).toByte,
+              (hi >> 32).toByte,
+              (hi >> 24).toByte,
+              (hi >> 16).toByte,
+              (hi >> 8).toByte,
+              hi.toByte,
+              (lo >> 56).toByte,
+              (lo >> 48).toByte,
+              (lo >> 40).toByte,
+              (lo >> 32).toByte,
+              (lo >> 24).toByte,
+              (lo >> 16).toByte,
+              (lo >> 8).toByte,
+              lo.toByte
+            )
+            packer.packBinaryHeader(16)
+            packer.writePayload(bs)
+          }
+        }
+
+        private[this] def deriveCodec[F[_, _], A](reflect: Reflect[F, A]): MessagePackBinaryCodec[A] = {
+          if (reflect.isPrimitive) {
+            val primitive = reflect.asPrimitive.get
+            if (primitive.primitiveBinding.isInstanceOf[Binding[?, ?]]) {
+              primitive.primitiveType match {
+                case _: PrimitiveType.Unit.type      => unitCodec
+                case _: PrimitiveType.Boolean        => booleanCodec
+                case _: PrimitiveType.Byte           => byteCodec
+                case _: PrimitiveType.Short          => shortCodec
+                case _: PrimitiveType.Int            => intCodec
+                case _: PrimitiveType.Long           => longCodec
+                case _: PrimitiveType.Float          => floatCodec
+                case _: PrimitiveType.Double         => doubleCodec
+                case _: PrimitiveType.Char           => charCodec
+                case _: PrimitiveType.String         => stringCodec
+                case _: PrimitiveType.BigInt         => bigIntCodec
+                case _: PrimitiveType.BigDecimal     => bigDecimalCodec
+                case _: PrimitiveType.DayOfWeek      => dayOfWeekCodec
+                case _: PrimitiveType.Duration       => durationCodec
+                case _: PrimitiveType.Instant        => instantCodec
+                case _: PrimitiveType.LocalDate      => localDateCodec
+                case _: PrimitiveType.LocalDateTime  => localDateTimeCodec
+                case _: PrimitiveType.LocalTime      => localTimeCodec
+                case _: PrimitiveType.Month          => monthCodec
+                case _: PrimitiveType.MonthDay       => monthDayCodec
+                case _: PrimitiveType.OffsetDateTime => offsetDateTimeCodec
+                case _: PrimitiveType.OffsetTime     => offsetTimeCodec
+                case _: PrimitiveType.Period         => periodCodec
+                case _: PrimitiveType.Year           => yearCodec
+                case _: PrimitiveType.YearMonth      => yearMonthCodec
+                case _: PrimitiveType.ZoneId         => zoneIdCodec
+                case _: PrimitiveType.ZoneOffset     => zoneOffsetCodec
+                case _: PrimitiveType.ZonedDateTime  => zonedDateTimeCodec
+                case _: PrimitiveType.Currency       => currencyCodec
+                case _: PrimitiveType.UUID           => uuidCodec
+              }
+            } else primitive.primitiveBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isVariant) {
+            val variant = reflect.asVariant.get
+            if (variant.variantBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding = variant.variantBinding.asInstanceOf[Binding.Variant[A]]
+              val cases   = variant.cases
+              val len     = cases.length
+              val codecs  = new Array[MessagePackBinaryCodec[?]](len)
+              var idx     = 0
+              while (idx < len) {
+                codecs(idx) = deriveCodec(cases(idx).value)
+                idx += 1
+              }
+              new MessagePackBinaryCodec[A]() {
+                private[this] val discriminator = binding.discriminator
+                private[this] val caseCodecs    = codecs
+                private[this] val caseNames     = cases.map(_.name)
+
+                def decodeUnsafe(unpacker: MessageUnpacker): A = {
+                  val mapSize = unpacker.unpackMapHeader()
+                  if (mapSize != 1) decodeError(s"Expected variant map with 1 field, got $mapSize")
+                  val caseName = unpacker.unpackString()
+                  var idx      = 0
+                  while (idx < caseNames.length && caseNames(idx) != caseName) idx += 1
+                  if (idx >= caseNames.length) decodeError(s"Unknown variant case: $caseName")
+                  try caseCodecs(idx).asInstanceOf[MessagePackBinaryCodec[A]].decodeUnsafe(unpacker)
+                  catch {
+                    case error if NonFatal(error) => decodeError(new DynamicOptic.Node.Case(caseName), error)
+                  }
+                }
+
+                def encodeUnsafe(packer: MessagePacker, value: A): Unit = {
+                  val idx = discriminator.discriminate(value)
+                  packer.packMapHeader(1)
+                  packer.packString(caseNames(idx))
+                  caseCodecs(idx).asInstanceOf[MessagePackBinaryCodec[A]].encodeUnsafe(packer, value)
+                }
+              }
+            } else variant.variantBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isSequence) {
+            val sequence = reflect.asSequenceUnknown.get.sequence
+            if (sequence.seqBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding = sequence.seqBinding.asInstanceOf[Binding.Seq[Col, Elem]]
+              val codec   = deriveCodec(sequence.element).asInstanceOf[MessagePackBinaryCodec[Elem]]
+              codec.valueType match {
+                case MessagePackBinaryCodec.booleanType
+                    if binding.deconstructor.isInstanceOf[SpecializedIndexed[Col]] =>
+                  new MessagePackBinaryCodec[Col[Boolean]]() {
+                    private[this] val deconstructor = binding.deconstructor.asInstanceOf[SpecializedIndexed[Col]]
+                    private[this] val constructor   = binding.constructor
+                    private[this] val elementCodec  = codec.asInstanceOf[MessagePackBinaryCodec[Boolean]]
+
+                    def decodeUnsafe(unpacker: MessageUnpacker): Col[Boolean] = {
+                      val size = unpacker.unpackArrayHeader()
+                      if (size > MessagePackBinaryCodec.maxCollectionSize)
+                        decodeError(
+                          s"Expected collection size not greater than ${MessagePackBinaryCodec.maxCollectionSize}, got $size"
+                        )
+                      val builder = constructor.newBooleanBuilder()
+                      var idx     = 0
+                      while (idx < size) {
+                        try constructor.addBoolean(builder, elementCodec.decodeUnsafe(unpacker))
+                        catch {
+                          case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                        }
+                        idx += 1
+                      }
+                      constructor.resultBoolean(builder)
+                    }
+
+                    def encodeUnsafe(packer: MessagePacker, value: Col[Boolean]): Unit = {
+                      val size = deconstructor.size(value)
+                      packer.packArrayHeader(size)
+                      val it = deconstructor.deconstruct(value)
+                      while (it.hasNext) elementCodec.encodeUnsafe(packer, it.next())
+                    }
+                  }
+                case MessagePackBinaryCodec.byteType if binding.deconstructor.isInstanceOf[SpecializedIndexed[Col]] =>
+                  new MessagePackBinaryCodec[Col[Byte]]() {
+                    private[this] val deconstructor = binding.deconstructor.asInstanceOf[SpecializedIndexed[Col]]
+                    private[this] val constructor   = binding.constructor
+                    private[this] val elementCodec  = codec.asInstanceOf[MessagePackBinaryCodec[Byte]]
+
+                    def decodeUnsafe(unpacker: MessageUnpacker): Col[Byte] = {
+                      val size = unpacker.unpackArrayHeader()
+                      if (size > MessagePackBinaryCodec.maxCollectionSize)
+                        decodeError(
+                          s"Expected collection size not greater than ${MessagePackBinaryCodec.maxCollectionSize}, got $size"
+                        )
+                      val builder = constructor.newByteBuilder()
+                      var idx     = 0
+                      while (idx < size) {
+                        try constructor.addByte(builder, elementCodec.decodeUnsafe(unpacker))
+                        catch {
+                          case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                        }
+                        idx += 1
+                      }
+                      constructor.resultByte(builder)
+                    }
+
+                    def encodeUnsafe(packer: MessagePacker, value: Col[Byte]): Unit = {
+                      val size = deconstructor.size(value)
+                      packer.packArrayHeader(size)
+                      val it = deconstructor.deconstruct(value)
+                      while (it.hasNext) elementCodec.encodeUnsafe(packer, it.next())
+                    }
+                  }
+                case MessagePackBinaryCodec.charType if binding.deconstructor.isInstanceOf[SpecializedIndexed[Col]] =>
+                  new MessagePackBinaryCodec[Col[Char]]() {
+                    private[this] val deconstructor = binding.deconstructor.asInstanceOf[SpecializedIndexed[Col]]
+                    private[this] val constructor   = binding.constructor
+                    private[this] val elementCodec  = codec.asInstanceOf[MessagePackBinaryCodec[Char]]
+
+                    def decodeUnsafe(unpacker: MessageUnpacker): Col[Char] = {
+                      val size = unpacker.unpackArrayHeader()
+                      if (size > MessagePackBinaryCodec.maxCollectionSize)
+                        decodeError(
+                          s"Expected collection size not greater than ${MessagePackBinaryCodec.maxCollectionSize}, got $size"
+                        )
+                      val builder = constructor.newCharBuilder()
+                      var idx     = 0
+                      while (idx < size) {
+                        try constructor.addChar(builder, elementCodec.decodeUnsafe(unpacker))
+                        catch {
+                          case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                        }
+                        idx += 1
+                      }
+                      constructor.resultChar(builder)
+                    }
+
+                    def encodeUnsafe(packer: MessagePacker, value: Col[Char]): Unit = {
+                      val size = deconstructor.size(value)
+                      packer.packArrayHeader(size)
+                      val it = deconstructor.deconstruct(value)
+                      while (it.hasNext) elementCodec.encodeUnsafe(packer, it.next())
+                    }
+                  }
+                case MessagePackBinaryCodec.shortType if binding.deconstructor.isInstanceOf[SpecializedIndexed[Col]] =>
+                  new MessagePackBinaryCodec[Col[Short]]() {
+                    private[this] val deconstructor = binding.deconstructor.asInstanceOf[SpecializedIndexed[Col]]
+                    private[this] val constructor   = binding.constructor
+                    private[this] val elementCodec  = codec.asInstanceOf[MessagePackBinaryCodec[Short]]
+
+                    def decodeUnsafe(unpacker: MessageUnpacker): Col[Short] = {
+                      val size = unpacker.unpackArrayHeader()
+                      if (size > MessagePackBinaryCodec.maxCollectionSize)
+                        decodeError(
+                          s"Expected collection size not greater than ${MessagePackBinaryCodec.maxCollectionSize}, got $size"
+                        )
+                      val builder = constructor.newShortBuilder()
+                      var idx     = 0
+                      while (idx < size) {
+                        try constructor.addShort(builder, elementCodec.decodeUnsafe(unpacker))
+                        catch {
+                          case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                        }
+                        idx += 1
+                      }
+                      constructor.resultShort(builder)
+                    }
+
+                    def encodeUnsafe(packer: MessagePacker, value: Col[Short]): Unit = {
+                      val size = deconstructor.size(value)
+                      packer.packArrayHeader(size)
+                      val it = deconstructor.deconstruct(value)
+                      while (it.hasNext) elementCodec.encodeUnsafe(packer, it.next())
+                    }
+                  }
+                case MessagePackBinaryCodec.floatType if binding.deconstructor.isInstanceOf[SpecializedIndexed[Col]] =>
+                  new MessagePackBinaryCodec[Col[Float]]() {
+                    private[this] val deconstructor = binding.deconstructor.asInstanceOf[SpecializedIndexed[Col]]
+                    private[this] val constructor   = binding.constructor
+                    private[this] val elementCodec  = codec.asInstanceOf[MessagePackBinaryCodec[Float]]
+
+                    def decodeUnsafe(unpacker: MessageUnpacker): Col[Float] = {
+                      val size = unpacker.unpackArrayHeader()
+                      if (size > MessagePackBinaryCodec.maxCollectionSize)
+                        decodeError(
+                          s"Expected collection size not greater than ${MessagePackBinaryCodec.maxCollectionSize}, got $size"
+                        )
+                      val builder = constructor.newFloatBuilder()
+                      var idx     = 0
+                      while (idx < size) {
+                        try constructor.addFloat(builder, elementCodec.decodeUnsafe(unpacker))
+                        catch {
+                          case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                        }
+                        idx += 1
+                      }
+                      constructor.resultFloat(builder)
+                    }
+
+                    def encodeUnsafe(packer: MessagePacker, value: Col[Float]): Unit = {
+                      val size = deconstructor.size(value)
+                      packer.packArrayHeader(size)
+                      val it = deconstructor.deconstruct(value)
+                      while (it.hasNext) elementCodec.encodeUnsafe(packer, it.next())
+                    }
+                  }
+                case MessagePackBinaryCodec.intType if binding.deconstructor.isInstanceOf[SpecializedIndexed[Col]] =>
+                  new MessagePackBinaryCodec[Col[Int]]() {
+                    private[this] val deconstructor = binding.deconstructor.asInstanceOf[SpecializedIndexed[Col]]
+                    private[this] val constructor   = binding.constructor
+                    private[this] val elementCodec  = codec.asInstanceOf[MessagePackBinaryCodec[Int]]
+
+                    def decodeUnsafe(unpacker: MessageUnpacker): Col[Int] = {
+                      val size = unpacker.unpackArrayHeader()
+                      if (size > MessagePackBinaryCodec.maxCollectionSize)
+                        decodeError(
+                          s"Expected collection size not greater than ${MessagePackBinaryCodec.maxCollectionSize}, got $size"
+                        )
+                      val builder = constructor.newIntBuilder()
+                      var idx     = 0
+                      while (idx < size) {
+                        try constructor.addInt(builder, elementCodec.decodeUnsafe(unpacker))
+                        catch {
+                          case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                        }
+                        idx += 1
+                      }
+                      constructor.resultInt(builder)
+                    }
+
+                    def encodeUnsafe(packer: MessagePacker, value: Col[Int]): Unit = {
+                      val size = deconstructor.size(value)
+                      packer.packArrayHeader(size)
+                      val it = deconstructor.deconstruct(value)
+                      while (it.hasNext) elementCodec.encodeUnsafe(packer, it.next())
+                    }
+                  }
+                case MessagePackBinaryCodec.doubleType if binding.deconstructor.isInstanceOf[SpecializedIndexed[Col]] =>
+                  new MessagePackBinaryCodec[Col[Double]]() {
+                    private[this] val deconstructor = binding.deconstructor.asInstanceOf[SpecializedIndexed[Col]]
+                    private[this] val constructor   = binding.constructor
+                    private[this] val elementCodec  = codec.asInstanceOf[MessagePackBinaryCodec[Double]]
+
+                    def decodeUnsafe(unpacker: MessageUnpacker): Col[Double] = {
+                      val size = unpacker.unpackArrayHeader()
+                      if (size > MessagePackBinaryCodec.maxCollectionSize)
+                        decodeError(
+                          s"Expected collection size not greater than ${MessagePackBinaryCodec.maxCollectionSize}, got $size"
+                        )
+                      val builder = constructor.newDoubleBuilder()
+                      var idx     = 0
+                      while (idx < size) {
+                        try constructor.addDouble(builder, elementCodec.decodeUnsafe(unpacker))
+                        catch {
+                          case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                        }
+                        idx += 1
+                      }
+                      constructor.resultDouble(builder)
+                    }
+
+                    def encodeUnsafe(packer: MessagePacker, value: Col[Double]): Unit = {
+                      val size = deconstructor.size(value)
+                      packer.packArrayHeader(size)
+                      val it = deconstructor.deconstruct(value)
+                      while (it.hasNext) elementCodec.encodeUnsafe(packer, it.next())
+                    }
+                  }
+                case MessagePackBinaryCodec.longType if binding.deconstructor.isInstanceOf[SpecializedIndexed[Col]] =>
+                  new MessagePackBinaryCodec[Col[Long]]() {
+                    private[this] val deconstructor = binding.deconstructor.asInstanceOf[SpecializedIndexed[Col]]
+                    private[this] val constructor   = binding.constructor
+                    private[this] val elementCodec  = codec.asInstanceOf[MessagePackBinaryCodec[Long]]
+
+                    def decodeUnsafe(unpacker: MessageUnpacker): Col[Long] = {
+                      val size = unpacker.unpackArrayHeader()
+                      if (size > MessagePackBinaryCodec.maxCollectionSize)
+                        decodeError(
+                          s"Expected collection size not greater than ${MessagePackBinaryCodec.maxCollectionSize}, got $size"
+                        )
+                      val builder = constructor.newLongBuilder()
+                      var idx     = 0
+                      while (idx < size) {
+                        try constructor.addLong(builder, elementCodec.decodeUnsafe(unpacker))
+                        catch {
+                          case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                        }
+                        idx += 1
+                      }
+                      constructor.resultLong(builder)
+                    }
+
+                    def encodeUnsafe(packer: MessagePacker, value: Col[Long]): Unit = {
+                      val size = deconstructor.size(value)
+                      packer.packArrayHeader(size)
+                      val it = deconstructor.deconstruct(value)
+                      while (it.hasNext) elementCodec.encodeUnsafe(packer, it.next())
+                    }
+                  }
+                case _ =>
+                  new MessagePackBinaryCodec[Col[Elem]]() {
+                    private[this] val deconstructor = binding.deconstructor
+                    private[this] val constructor   = binding.constructor
+                    private[this] val elementCodec  = codec
+
+                    def decodeUnsafe(unpacker: MessageUnpacker): Col[Elem] = {
+                      val size = unpacker.unpackArrayHeader()
+                      if (size > MessagePackBinaryCodec.maxCollectionSize)
+                        decodeError(
+                          s"Expected collection size not greater than ${MessagePackBinaryCodec.maxCollectionSize}, got $size"
+                        )
+                      val builder = constructor.newObjectBuilder[Elem](size)
+                      var idx     = 0
+                      while (idx < size) {
+                        try constructor.addObject(builder, elementCodec.decodeUnsafe(unpacker))
+                        catch {
+                          case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                        }
+                        idx += 1
+                      }
+                      constructor.resultObject[Elem](builder)
+                    }
+
+                    def encodeUnsafe(packer: MessagePacker, value: Col[Elem]): Unit = {
+                      val size = deconstructor.size(value)
+                      packer.packArrayHeader(size)
+                      val it = deconstructor.deconstruct(value)
+                      while (it.hasNext) elementCodec.encodeUnsafe(packer, it.next())
+                    }
+                  }
+              }
+            } else sequence.seqBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isMap) {
+            val map = reflect.asMapUnknown.get.map
+            if (map.mapBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding = map.mapBinding.asInstanceOf[Binding.Map[Map, Key, Value]]
+              val codec1  = deriveCodec(map.key).asInstanceOf[MessagePackBinaryCodec[Key]]
+              val codec2  = deriveCodec(map.value).asInstanceOf[MessagePackBinaryCodec[Value]]
+              new MessagePackBinaryCodec[Map[Key, Value]]() {
+                private[this] val deconstructor = binding.deconstructor
+                private[this] val constructor   = binding.constructor
+                private[this] val keyCodec      = codec1
+                private[this] val valueCodec    = codec2
+                private[this] val keyReflect    = map.key.asInstanceOf[Reflect.Bound[Key]]
+
+                def decodeUnsafe(unpacker: MessageUnpacker): Map[Key, Value] = {
+                  val size = unpacker.unpackMapHeader()
+                  if (size > MessagePackBinaryCodec.maxCollectionSize)
+                    decodeError(
+                      s"Expected map size not greater than ${MessagePackBinaryCodec.maxCollectionSize}, got $size"
+                    )
+                  val builder = constructor.newObjectBuilder[Key, Value](size)
+                  var idx     = 0
+                  while (idx < size) {
+                    val k =
+                      try keyCodec.decodeUnsafe(unpacker)
+                      catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                      }
+                    val v =
+                      try valueCodec.decodeUnsafe(unpacker)
+                      catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtMapKey(keyReflect.toDynamicValue(k)), error)
+                      }
+                    constructor.addObject(builder, k, v)
+                    idx += 1
+                  }
+                  constructor.resultObject[Key, Value](builder)
+                }
+
+                def encodeUnsafe(packer: MessagePacker, value: Map[Key, Value]): Unit = {
+                  val size = deconstructor.size(value)
+                  packer.packMapHeader(size)
+                  val it = deconstructor.deconstruct(value)
+                  while (it.hasNext) {
+                    val kv = it.next()
+                    keyCodec.encodeUnsafe(packer, deconstructor.getKey(kv))
+                    valueCodec.encodeUnsafe(packer, deconstructor.getValue(kv))
+                  }
+                }
+              }
+            } else map.mapBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isRecord) {
+            val record = reflect.asRecord.get
+            if (record.recordBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding     = record.recordBinding.asInstanceOf[Binding.Record[A]]
+              val fields      = record.fields
+              val isRecursive = fields.exists(_.value.isInstanceOf[Reflect.Deferred[F, ?]])
+              val typeName    = record.typeName
+              var codecs      = if (isRecursive) recursiveRecordCache.get.get(typeName) else null
+              var offset      = 0L
+              if (codecs eq null) {
+                val len = fields.length
+                codecs = new Array[MessagePackBinaryCodec[?]](len)
+                if (isRecursive) recursiveRecordCache.get.put(typeName, codecs)
+                var idx = 0
+                while (idx < len) {
+                  val field = fields(idx)
+                  val codec = deriveCodec(field.value)
+                  codecs(idx) = codec
+                  offset = RegisterOffset.add(codec.valueOffset, offset)
+                  idx += 1
+                }
+              }
+              new MessagePackBinaryCodec[A]() {
+                private[this] val deconstructor = binding.deconstructor
+                private[this] val constructor   = binding.constructor
+                private[this] val usedRegisters = offset
+                private[this] val fieldCodecs   = codecs
+                private[this] val fieldNames    = fields.map(_.name)
+
+                def decodeUnsafe(unpacker: MessageUnpacker): A = {
+                  val mapSize = unpacker.unpackMapHeader()
+                  if (mapSize != fieldCodecs.length)
+                    decodeError(s"Expected record map with ${fieldCodecs.length} fields, got $mapSize")
+                  val regs = Registers(usedRegisters)
+                  val len  = fieldCodecs.length
+                  var idx  = 0
+                  try {
+                    while (idx < len) {
+                      val fieldName = unpacker.unpackString()
+                      var fieldIdx  = 0
+                      while (fieldIdx < fieldNames.length && fieldNames(fieldIdx) != fieldName) fieldIdx += 1
+                      if (fieldIdx >= fieldNames.length) decodeError(s"Unknown field: $fieldName")
+
+                      var fieldOffset = 0L
+                      var i           = 0
+                      while (i < fieldIdx) {
+                        fieldOffset += fieldCodecs(i).valueOffset
+                        i += 1
+                      }
+
+                      val codec = fieldCodecs(fieldIdx)
+                      codec.valueType match {
+                        case MessagePackBinaryCodec.objectType =>
+                          regs.setObject(
+                            fieldOffset,
+                            codec.asInstanceOf[MessagePackBinaryCodec[AnyRef]].decodeUnsafe(unpacker)
+                          )
+                        case MessagePackBinaryCodec.intType =>
+                          regs
+                            .setInt(fieldOffset, codec.asInstanceOf[MessagePackBinaryCodec[Int]].decodeUnsafe(unpacker))
+                        case MessagePackBinaryCodec.longType =>
+                          regs.setLong(
+                            fieldOffset,
+                            codec.asInstanceOf[MessagePackBinaryCodec[Long]].decodeUnsafe(unpacker)
+                          )
+                        case MessagePackBinaryCodec.floatType =>
+                          regs.setFloat(
+                            fieldOffset,
+                            codec.asInstanceOf[MessagePackBinaryCodec[Float]].decodeUnsafe(unpacker)
+                          )
+                        case MessagePackBinaryCodec.doubleType =>
+                          regs.setDouble(
+                            fieldOffset,
+                            codec.asInstanceOf[MessagePackBinaryCodec[Double]].decodeUnsafe(unpacker)
+                          )
+                        case MessagePackBinaryCodec.booleanType =>
+                          regs.setBoolean(
+                            fieldOffset,
+                            codec.asInstanceOf[MessagePackBinaryCodec[Boolean]].decodeUnsafe(unpacker)
+                          )
+                        case MessagePackBinaryCodec.byteType =>
+                          regs.setByte(
+                            fieldOffset,
+                            codec.asInstanceOf[MessagePackBinaryCodec[Byte]].decodeUnsafe(unpacker)
+                          )
+                        case MessagePackBinaryCodec.charType =>
+                          regs.setChar(
+                            fieldOffset,
+                            codec.asInstanceOf[MessagePackBinaryCodec[Char]].decodeUnsafe(unpacker)
+                          )
+                        case MessagePackBinaryCodec.shortType =>
+                          regs.setShort(
+                            fieldOffset,
+                            codec.asInstanceOf[MessagePackBinaryCodec[Short]].decodeUnsafe(unpacker)
+                          )
+                        case _ => codec.asInstanceOf[MessagePackBinaryCodec[Unit]].decodeUnsafe(unpacker)
+                      }
+                      idx += 1
+                    }
+                    constructor.construct(regs, 0)
+                  } catch {
+                    case error if NonFatal(error) =>
+                      val fieldName = if (idx < fieldNames.length) fieldNames(idx) else s"field_$idx"
+                      decodeError(new DynamicOptic.Node.Field(fieldName), error)
+                  }
+                }
+
+                def encodeUnsafe(packer: MessagePacker, value: A): Unit = {
+                  val regs      = Registers(usedRegisters)
+                  var regOffset = 0L
+                  deconstructor.deconstruct(regs, regOffset, value)
+                  val len = fieldCodecs.length
+                  packer.packMapHeader(len)
+                  var idx = 0
+                  while (idx < len) {
+                    packer.packString(fieldNames(idx))
+                    val codec = fieldCodecs(idx)
+                    codec.valueType match {
+                      case MessagePackBinaryCodec.objectType =>
+                        codec
+                          .asInstanceOf[MessagePackBinaryCodec[AnyRef]]
+                          .encodeUnsafe(packer, regs.getObject(regOffset))
+                      case MessagePackBinaryCodec.intType =>
+                        codec.asInstanceOf[MessagePackBinaryCodec[Int]].encodeUnsafe(packer, regs.getInt(regOffset))
+                      case MessagePackBinaryCodec.longType =>
+                        codec.asInstanceOf[MessagePackBinaryCodec[Long]].encodeUnsafe(packer, regs.getLong(regOffset))
+                      case MessagePackBinaryCodec.floatType =>
+                        codec.asInstanceOf[MessagePackBinaryCodec[Float]].encodeUnsafe(packer, regs.getFloat(regOffset))
+                      case MessagePackBinaryCodec.doubleType =>
+                        codec
+                          .asInstanceOf[MessagePackBinaryCodec[Double]]
+                          .encodeUnsafe(packer, regs.getDouble(regOffset))
+                      case MessagePackBinaryCodec.booleanType =>
+                        codec
+                          .asInstanceOf[MessagePackBinaryCodec[Boolean]]
+                          .encodeUnsafe(packer, regs.getBoolean(regOffset))
+                      case MessagePackBinaryCodec.byteType =>
+                        codec.asInstanceOf[MessagePackBinaryCodec[Byte]].encodeUnsafe(packer, regs.getByte(regOffset))
+                      case MessagePackBinaryCodec.charType =>
+                        codec.asInstanceOf[MessagePackBinaryCodec[Char]].encodeUnsafe(packer, regs.getChar(regOffset))
+                      case MessagePackBinaryCodec.shortType =>
+                        codec.asInstanceOf[MessagePackBinaryCodec[Short]].encodeUnsafe(packer, regs.getShort(regOffset))
+                      case _ => codec.asInstanceOf[MessagePackBinaryCodec[Unit]].encodeUnsafe(packer, ())
+                    }
+                    regOffset += codec.valueOffset
+                    idx += 1
+                  }
+                }
+              }
+            } else record.recordBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isWrapper) {
+            val wrapper = reflect.asWrapperUnknown.get.wrapper
+            if (wrapper.wrapperBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding = wrapper.wrapperBinding.asInstanceOf[Binding.Wrapper[A, Wrapped]]
+              val codec   = deriveCodec(wrapper.wrapped).asInstanceOf[MessagePackBinaryCodec[Wrapped]]
+              new MessagePackBinaryCodec[A](wrapper.wrapperPrimitiveType.fold(MessagePackBinaryCodec.objectType) {
+                case _: PrimitiveType.Boolean   => MessagePackBinaryCodec.booleanType
+                case _: PrimitiveType.Byte      => MessagePackBinaryCodec.byteType
+                case _: PrimitiveType.Char      => MessagePackBinaryCodec.charType
+                case _: PrimitiveType.Short     => MessagePackBinaryCodec.shortType
+                case _: PrimitiveType.Float     => MessagePackBinaryCodec.floatType
+                case _: PrimitiveType.Int       => MessagePackBinaryCodec.intType
+                case _: PrimitiveType.Double    => MessagePackBinaryCodec.doubleType
+                case _: PrimitiveType.Long      => MessagePackBinaryCodec.longType
+                case _: PrimitiveType.Unit.type => MessagePackBinaryCodec.unitType
+                case _                          => MessagePackBinaryCodec.objectType
+              }) {
+                private[this] val unwrap       = binding.unwrap
+                private[this] val wrap         = binding.wrap
+                private[this] val wrappedCodec = codec
+
+                def decodeUnsafe(unpacker: MessageUnpacker): A = {
+                  val wrapped =
+                    try wrappedCodec.decodeUnsafe(unpacker)
+                    catch {
+                      case error if NonFatal(error) => decodeError(DynamicOptic.Node.Wrapped, error)
+                    }
+                  wrap(wrapped) match {
+                    case Right(x)  => x
+                    case Left(err) => decodeError(err)
+                  }
+                }
+
+                def encodeUnsafe(packer: MessagePacker, value: A): Unit =
+                  wrappedCodec.encodeUnsafe(packer, unwrap(value))
+              }
+            } else wrapper.wrapperBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else {
+            val dynamic = reflect.asDynamic.get
+            if (dynamic.dynamicBinding.isInstanceOf[Binding[?, ?]]) dynamicValueCodec
+            else dynamic.dynamicBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          }
+        }.asInstanceOf[MessagePackBinaryCodec[A]]
+
+        private[this] val dynamicValueCodec = new MessagePackBinaryCodec[DynamicValue]() {
+          private[this] val spanPrimitive = new DynamicOptic.Node.Case("Primitive")
+          private[this] val spanRecord    = new DynamicOptic.Node.Case("Record")
+          private[this] val spanVariant   = new DynamicOptic.Node.Case("Variant")
+          private[this] val spanSequence  = new DynamicOptic.Node.Case("Sequence")
+          private[this] val spanMap       = new DynamicOptic.Node.Case("Map")
+          private[this] val spanFields    = new DynamicOptic.Node.Field("fields")
+          private[this] val spanCaseName  = new DynamicOptic.Node.Field("caseName")
+          private[this] val spanValue     = new DynamicOptic.Node.Field("value")
+          private[this] val spanElements  = new DynamicOptic.Node.Field("elements")
+          private[this] val spanEntries   = new DynamicOptic.Node.Field("entries")
+          private[this] val span_1        = new DynamicOptic.Node.Field("_1")
+          private[this] val span_2        = new DynamicOptic.Node.Field("_2")
+
+          def decodeUnsafe(unpacker: MessageUnpacker): DynamicValue = {
+            val mapSize = unpacker.unpackMapHeader()
+            if (mapSize != 1) decodeError(s"Expected DynamicValue variant map with 1 field, got $mapSize")
+            val caseName = unpacker.unpackString()
+            caseName match {
+              case "Primitive" =>
+                try {
+                  val innerMapSize = unpacker.unpackMapHeader()
+                  if (innerMapSize != 1) decodeError("Expected Primitive map with 1 field")
+                  val valueKey = unpacker.unpackString()
+                  if (valueKey != "value") decodeError(s"Expected 'value' field, got $valueKey")
+                  val typeMapSize = unpacker.unpackMapHeader()
+                  if (typeMapSize != 1) decodeError("Expected primitive type map with 1 field")
+                  val typeName = unpacker.unpackString()
+                  try {
+                    new DynamicValue.Primitive(typeName match {
+                      case "Unit" =>
+                        unpacker.unpackNil()
+                        PrimitiveValue.Unit
+                      case "Boolean"       => new PrimitiveValue.Boolean(booleanCodec.decodeUnsafe(unpacker))
+                      case "Byte"          => new PrimitiveValue.Byte(byteCodec.decodeUnsafe(unpacker))
+                      case "Short"         => new PrimitiveValue.Short(shortCodec.decodeUnsafe(unpacker))
+                      case "Int"           => new PrimitiveValue.Int(intCodec.decodeUnsafe(unpacker))
+                      case "Long"          => new PrimitiveValue.Long(longCodec.decodeUnsafe(unpacker))
+                      case "Float"         => new PrimitiveValue.Float(floatCodec.decodeUnsafe(unpacker))
+                      case "Double"        => new PrimitiveValue.Double(doubleCodec.decodeUnsafe(unpacker))
+                      case "Char"          => new PrimitiveValue.Char(charCodec.decodeUnsafe(unpacker))
+                      case "String"        => new PrimitiveValue.String(stringCodec.decodeUnsafe(unpacker))
+                      case "BigInt"        => new PrimitiveValue.BigInt(bigIntCodec.decodeUnsafe(unpacker))
+                      case "BigDecimal"    => new PrimitiveValue.BigDecimal(bigDecimalCodec.decodeUnsafe(unpacker))
+                      case "DayOfWeek"     => new PrimitiveValue.DayOfWeek(dayOfWeekCodec.decodeUnsafe(unpacker))
+                      case "Duration"      => new PrimitiveValue.Duration(durationCodec.decodeUnsafe(unpacker))
+                      case "Instant"       => new PrimitiveValue.Instant(instantCodec.decodeUnsafe(unpacker))
+                      case "LocalDate"     => new PrimitiveValue.LocalDate(localDateCodec.decodeUnsafe(unpacker))
+                      case "LocalDateTime" =>
+                        new PrimitiveValue.LocalDateTime(localDateTimeCodec.decodeUnsafe(unpacker))
+                      case "LocalTime"      => new PrimitiveValue.LocalTime(localTimeCodec.decodeUnsafe(unpacker))
+                      case "Month"          => new PrimitiveValue.Month(monthCodec.decodeUnsafe(unpacker))
+                      case "MonthDay"       => new PrimitiveValue.MonthDay(monthDayCodec.decodeUnsafe(unpacker))
+                      case "OffsetDateTime" =>
+                        new PrimitiveValue.OffsetDateTime(offsetDateTimeCodec.decodeUnsafe(unpacker))
+                      case "OffsetTime"    => new PrimitiveValue.OffsetTime(offsetTimeCodec.decodeUnsafe(unpacker))
+                      case "Period"        => new PrimitiveValue.Period(periodCodec.decodeUnsafe(unpacker))
+                      case "Year"          => new PrimitiveValue.Year(yearCodec.decodeUnsafe(unpacker))
+                      case "YearMonth"     => new PrimitiveValue.YearMonth(yearMonthCodec.decodeUnsafe(unpacker))
+                      case "ZoneId"        => new PrimitiveValue.ZoneId(zoneIdCodec.decodeUnsafe(unpacker))
+                      case "ZoneOffset"    => new PrimitiveValue.ZoneOffset(zoneOffsetCodec.decodeUnsafe(unpacker))
+                      case "ZonedDateTime" =>
+                        new PrimitiveValue.ZonedDateTime(zonedDateTimeCodec.decodeUnsafe(unpacker))
+                      case "Currency" => new PrimitiveValue.Currency(currencyCodec.decodeUnsafe(unpacker))
+                      case "UUID"     => new PrimitiveValue.UUID(uuidCodec.decodeUnsafe(unpacker))
+                      case _          => decodeError(s"Unknown primitive type: $typeName")
+                    })
+                  } catch {
+                    case error if NonFatal(error) => decodeError(spanValue, error)
+                  }
+                } catch {
+                  case error if NonFatal(error) => decodeError(spanPrimitive, error)
+                }
+              case "Record" =>
+                try {
+                  val innerMapSize = unpacker.unpackMapHeader()
+                  if (innerMapSize != 1) decodeError("Expected Record map with 1 field")
+                  val fieldsKey = unpacker.unpackString()
+                  if (fieldsKey != "fields") decodeError(s"Expected 'fields' key, got $fieldsKey")
+                  val size = unpacker.unpackArrayHeader()
+                  if (size > MessagePackBinaryCodec.maxCollectionSize)
+                    decodeError(
+                      s"Expected collection size not greater than ${MessagePackBinaryCodec.maxCollectionSize}, got $size"
+                    )
+                  val builder = Vector.newBuilder[(String, DynamicValue)]
+                  var idx     = 0
+                  while (idx < size) {
+                    val entryMapSize = unpacker.unpackMapHeader()
+                    if (entryMapSize != 2) decodeError(s"Expected field entry with 2 fields, got $entryMapSize")
+                    val k =
+                      try {
+                        val nameKey = unpacker.unpackString()
+                        if (nameKey != "name") decodeError(s"Expected 'name' key, got $nameKey")
+                        unpacker.unpackString()
+                      } catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(idx), span_1, error)
+                      }
+                    val v =
+                      try {
+                        val valueKey = unpacker.unpackString()
+                        if (valueKey != "value") decodeError(s"Expected 'value' key, got $valueKey")
+                        decodeUnsafe(unpacker)
+                      } catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(idx), span_2, error)
+                      }
+                    builder.addOne((k, v))
+                    idx += 1
+                  }
+                  new DynamicValue.Record(builder.result())
+                } catch {
+                  case error if NonFatal(error) => decodeError(spanRecord, spanFields, error)
+                }
+              case "Variant" =>
+                val innerMapSize = unpacker.unpackMapHeader()
+                if (innerMapSize != 2) decodeError("Expected Variant map with 2 fields")
+                var variantCaseName: String    = null
+                var variantValue: DynamicValue = null
+                var idx                        = 0
+                while (idx < 2) {
+                  val key = unpacker.unpackString()
+                  key match {
+                    case "caseName" =>
+                      try variantCaseName = unpacker.unpackString()
+                      catch {
+                        case error if NonFatal(error) => decodeError(spanVariant, spanCaseName, error)
+                      }
+                    case "value" =>
+                      try variantValue = decodeUnsafe(unpacker)
+                      catch {
+                        case error if NonFatal(error) => decodeError(spanVariant, spanValue, error)
+                      }
+                    case _ => decodeError(s"Unexpected field: $key")
+                  }
+                  idx += 1
+                }
+                new DynamicValue.Variant(variantCaseName, variantValue)
+              case "Sequence" =>
+                try {
+                  val innerMapSize = unpacker.unpackMapHeader()
+                  if (innerMapSize != 1) decodeError("Expected Sequence map with 1 field")
+                  val elementsKey = unpacker.unpackString()
+                  if (elementsKey != "elements") decodeError(s"Expected 'elements' key, got $elementsKey")
+                  val size = unpacker.unpackArrayHeader()
+                  if (size > MessagePackBinaryCodec.maxCollectionSize)
+                    decodeError(
+                      s"Expected collection size not greater than ${MessagePackBinaryCodec.maxCollectionSize}, got $size"
+                    )
+                  val builder = Vector.newBuilder[DynamicValue]
+                  var idx     = 0
+                  while (idx < size) {
+                    try builder.addOne(decodeUnsafe(unpacker))
+                    catch {
+                      case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                    }
+                    idx += 1
+                  }
+                  new DynamicValue.Sequence(builder.result())
+                } catch {
+                  case error if NonFatal(error) => decodeError(spanSequence, spanElements, error)
+                }
+              case "Map" =>
+                try {
+                  val innerMapSize = unpacker.unpackMapHeader()
+                  if (innerMapSize != 1) decodeError("Expected Map map with 1 field")
+                  val entriesKey = unpacker.unpackString()
+                  if (entriesKey != "entries") decodeError(s"Expected 'entries' key, got $entriesKey")
+                  val size = unpacker.unpackArrayHeader()
+                  if (size > MessagePackBinaryCodec.maxCollectionSize)
+                    decodeError(
+                      s"Expected collection size not greater than ${MessagePackBinaryCodec.maxCollectionSize}, got $size"
+                    )
+                  val builder = Vector.newBuilder[(DynamicValue, DynamicValue)]
+                  var idx     = 0
+                  while (idx < size) {
+                    val entryMapSize = unpacker.unpackMapHeader()
+                    if (entryMapSize != 2) decodeError(s"Expected entry with 2 fields, got $entryMapSize")
+                    val k =
+                      try {
+                        val keyKey = unpacker.unpackString()
+                        if (keyKey != "key") decodeError(s"Expected 'key' key, got $keyKey")
+                        decodeUnsafe(unpacker)
+                      } catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(idx), span_1, error)
+                      }
+                    val v =
+                      try {
+                        val valueKey = unpacker.unpackString()
+                        if (valueKey != "value") decodeError(s"Expected 'value' key, got $valueKey")
+                        decodeUnsafe(unpacker)
+                      } catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(idx), span_2, error)
+                      }
+                    builder.addOne((k, v))
+                    idx += 1
+                  }
+                  new DynamicValue.Map(builder.result())
+                } catch {
+                  case error if NonFatal(error) => decodeError(spanMap, spanEntries, error)
+                }
+              case _ => decodeError(s"Unknown DynamicValue case: $caseName")
+            }
+          }
+
+          def encodeUnsafe(packer: MessagePacker, value: DynamicValue): Unit = value match {
+            case primitive: DynamicValue.Primitive =>
+              packer.packMapHeader(1)
+              packer.packString("Primitive")
+              packer.packMapHeader(1)
+              packer.packString("value")
+              packer.packMapHeader(1)
+              primitive.value match {
+                case _: PrimitiveValue.Unit.type =>
+                  packer.packString("Unit")
+                  packer.packNil()
+                case v: PrimitiveValue.Boolean =>
+                  packer.packString("Boolean")
+                  booleanCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.Byte =>
+                  packer.packString("Byte")
+                  byteCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.Short =>
+                  packer.packString("Short")
+                  shortCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.Int =>
+                  packer.packString("Int")
+                  intCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.Long =>
+                  packer.packString("Long")
+                  longCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.Float =>
+                  packer.packString("Float")
+                  floatCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.Double =>
+                  packer.packString("Double")
+                  doubleCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.Char =>
+                  packer.packString("Char")
+                  charCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.String =>
+                  packer.packString("String")
+                  stringCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.BigInt =>
+                  packer.packString("BigInt")
+                  bigIntCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.BigDecimal =>
+                  packer.packString("BigDecimal")
+                  bigDecimalCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.DayOfWeek =>
+                  packer.packString("DayOfWeek")
+                  dayOfWeekCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.Duration =>
+                  packer.packString("Duration")
+                  durationCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.Instant =>
+                  packer.packString("Instant")
+                  instantCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.LocalDate =>
+                  packer.packString("LocalDate")
+                  localDateCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.LocalDateTime =>
+                  packer.packString("LocalDateTime")
+                  localDateTimeCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.LocalTime =>
+                  packer.packString("LocalTime")
+                  localTimeCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.Month =>
+                  packer.packString("Month")
+                  monthCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.MonthDay =>
+                  packer.packString("MonthDay")
+                  monthDayCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.OffsetDateTime =>
+                  packer.packString("OffsetDateTime")
+                  offsetDateTimeCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.OffsetTime =>
+                  packer.packString("OffsetTime")
+                  offsetTimeCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.Period =>
+                  packer.packString("Period")
+                  periodCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.Year =>
+                  packer.packString("Year")
+                  yearCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.YearMonth =>
+                  packer.packString("YearMonth")
+                  yearMonthCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.ZoneId =>
+                  packer.packString("ZoneId")
+                  zoneIdCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.ZoneOffset =>
+                  packer.packString("ZoneOffset")
+                  zoneOffsetCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.ZonedDateTime =>
+                  packer.packString("ZonedDateTime")
+                  zonedDateTimeCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.Currency =>
+                  packer.packString("Currency")
+                  currencyCodec.encodeUnsafe(packer, v.value)
+                case v: PrimitiveValue.UUID =>
+                  packer.packString("UUID")
+                  uuidCodec.encodeUnsafe(packer, v.value)
+              }
+            case record: DynamicValue.Record =>
+              packer.packMapHeader(1)
+              packer.packString("Record")
+              packer.packMapHeader(1)
+              packer.packString("fields")
+              val fields = record.fields
+              packer.packArrayHeader(fields.length)
+              val it = fields.iterator
+              while (it.hasNext) {
+                val kv = it.next()
+                packer.packMapHeader(2)
+                packer.packString("name")
+                packer.packString(kv._1)
+                packer.packString("value")
+                encodeUnsafe(packer, kv._2)
+              }
+            case variant: DynamicValue.Variant =>
+              packer.packMapHeader(1)
+              packer.packString("Variant")
+              packer.packMapHeader(2)
+              packer.packString("caseName")
+              packer.packString(variant.caseName)
+              packer.packString("value")
+              encodeUnsafe(packer, variant.value)
+            case sequence: DynamicValue.Sequence =>
+              packer.packMapHeader(1)
+              packer.packString("Sequence")
+              packer.packMapHeader(1)
+              packer.packString("elements")
+              val elements = sequence.elements
+              packer.packArrayHeader(elements.length)
+              val it = elements.iterator
+              while (it.hasNext) encodeUnsafe(packer, it.next())
+            case map: DynamicValue.Map =>
+              packer.packMapHeader(1)
+              packer.packString("Map")
+              packer.packMapHeader(1)
+              packer.packString("entries")
+              val entries = map.entries
+              packer.packArrayHeader(entries.length)
+              val it = entries.iterator
+              while (it.hasNext) {
+                val kv = it.next()
+                packer.packMapHeader(2)
+                packer.packString("key")
+                encodeUnsafe(packer, kv._1)
+                packer.packString("value")
+                encodeUnsafe(packer, kv._2)
+              }
+          }
+        }
+      }
+    )

--- a/schema-messagepack/src/test/scala/zio/blocks/schema/messagepack/MessagePackFormatSpec.scala
+++ b/schema-messagepack/src/test/scala/zio/blocks/schema/messagepack/MessagePackFormatSpec.scala
@@ -1,0 +1,693 @@
+package zio.blocks.schema.messagepack
+
+import zio.blocks.schema._
+import zio.blocks.schema.messagepack.MessagePackTestUtils._
+import zio.blocks.schema.binding.Binding
+import zio.test._
+import java.time._
+import java.util.UUID
+import java.util.Currency
+import scala.collection.immutable.ArraySeq
+
+object MessagePackFormatSpec extends ZIOSpecDefault {
+  def spec: Spec[TestEnvironment, Any] = suite("MessagePackFormatSpec")(
+    suite("primitives")(
+      test("Unit") {
+        roundTrip(())
+      },
+      test("Boolean") {
+        roundTrip(true) &&
+        roundTrip(false) &&
+        decodeError[Boolean](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("Byte") {
+        roundTrip(1: Byte) &&
+        roundTrip(Byte.MinValue) &&
+        roundTrip(Byte.MaxValue) &&
+        decodeError[Byte](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("Short") {
+        roundTrip(1: Short) &&
+        roundTrip(Short.MinValue) &&
+        roundTrip(Short.MaxValue) &&
+        decodeError[Short](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("Int") {
+        roundTrip(1) &&
+        roundTrip(Int.MinValue) &&
+        roundTrip(Int.MaxValue) &&
+        decodeError[Int](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("Long") {
+        roundTrip(1L) &&
+        roundTrip(Long.MinValue) &&
+        roundTrip(Long.MaxValue) &&
+        decodeError[Long](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("Float") {
+        roundTrip(42.0f) &&
+        roundTrip(Float.MinValue) &&
+        roundTrip(Float.MaxValue) &&
+        roundTrip(Float.NaN) &&
+        roundTrip(Float.PositiveInfinity) &&
+        roundTrip(Float.NegativeInfinity) &&
+        decodeError[Float](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("Double") {
+        roundTrip(42.0) &&
+        roundTrip(Double.MinValue) &&
+        roundTrip(Double.MaxValue) &&
+        roundTrip(Double.NaN) &&
+        roundTrip(Double.PositiveInfinity) &&
+        roundTrip(Double.NegativeInfinity) &&
+        decodeError[Double](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("Char") {
+        roundTrip('7') &&
+        roundTrip(Char.MinValue) &&
+        roundTrip(Char.MaxValue) &&
+        decodeError[Char](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("String") {
+        roundTrip("Hello") &&
+        roundTrip("") &&
+        roundTrip("Hello World with unicode characters") &&
+        decodeError[String](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("BigInt") {
+        roundTrip(BigInt("9" * 20)) &&
+        roundTrip(BigInt(0)) &&
+        roundTrip(BigInt(-1)) &&
+        roundTrip(BigInt(Long.MaxValue) * 2)
+      },
+      test("BigDecimal") {
+        roundTrip(BigDecimal("9." + "9" * 20 + "E+12345")) &&
+        roundTrip(BigDecimal(0)) &&
+        roundTrip(BigDecimal("123.456"))
+      },
+      test("DayOfWeek") {
+        roundTrip(java.time.DayOfWeek.WEDNESDAY) &&
+        roundTrip(java.time.DayOfWeek.MONDAY) &&
+        roundTrip(java.time.DayOfWeek.SUNDAY)
+      },
+      test("Duration") {
+        roundTrip(java.time.Duration.ofNanos(1234567890123456789L)) &&
+        roundTrip(java.time.Duration.ZERO) &&
+        roundTrip(java.time.Duration.ofDays(365))
+      },
+      test("Instant") {
+        roundTrip(java.time.Instant.parse("2025-07-18T08:29:13.121409459Z")) &&
+        roundTrip(java.time.Instant.EPOCH) &&
+        roundTrip(java.time.Instant.now())
+      },
+      test("LocalDate") {
+        roundTrip(java.time.LocalDate.parse("2025-07-18")) &&
+        roundTrip(java.time.LocalDate.MIN) &&
+        roundTrip(java.time.LocalDate.MAX)
+      },
+      test("LocalDateTime") {
+        roundTrip(java.time.LocalDateTime.parse("2025-07-18T08:29:13.121409459")) &&
+        roundTrip(java.time.LocalDateTime.MIN) &&
+        roundTrip(java.time.LocalDateTime.MAX)
+      },
+      test("LocalTime") {
+        roundTrip(java.time.LocalTime.parse("08:29:13.121409459")) &&
+        roundTrip(java.time.LocalTime.MIN) &&
+        roundTrip(java.time.LocalTime.MAX)
+      },
+      test("Month") {
+        roundTrip(java.time.Month.of(12)) &&
+        roundTrip(java.time.Month.JANUARY) &&
+        roundTrip(java.time.Month.DECEMBER)
+      },
+      test("MonthDay") {
+        roundTrip(java.time.MonthDay.of(12, 31)) &&
+        roundTrip(java.time.MonthDay.of(1, 1))
+      },
+      test("OffsetDateTime") {
+        roundTrip(java.time.OffsetDateTime.parse("2025-07-18T08:29:13.121409459-07:00")) &&
+        roundTrip(java.time.OffsetDateTime.MIN) &&
+        roundTrip(java.time.OffsetDateTime.MAX)
+      },
+      test("OffsetTime") {
+        roundTrip(java.time.OffsetTime.parse("08:29:13.121409459-07:00")) &&
+        roundTrip(java.time.OffsetTime.MIN) &&
+        roundTrip(java.time.OffsetTime.MAX)
+      },
+      test("Period") {
+        roundTrip(java.time.Period.of(1, 12, 31)) &&
+        roundTrip(java.time.Period.ZERO) &&
+        roundTrip(java.time.Period.ofDays(100))
+      },
+      test("Year") {
+        roundTrip(java.time.Year.of(2025)) &&
+        roundTrip(java.time.Year.MIN_VALUE) &&
+        roundTrip(java.time.Year.MAX_VALUE)
+      },
+      test("YearMonth") {
+        roundTrip(java.time.YearMonth.of(2025, 7)) &&
+        roundTrip(java.time.YearMonth.of(2000, 1))
+      },
+      test("ZoneId") {
+        roundTrip(java.time.ZoneId.of("UTC")) &&
+        roundTrip(java.time.ZoneId.of("America/New_York")) &&
+        roundTrip(java.time.ZoneId.of("Europe/London"))
+      },
+      test("ZoneOffset") {
+        roundTrip(java.time.ZoneOffset.ofTotalSeconds(3600)) &&
+        roundTrip(java.time.ZoneOffset.UTC) &&
+        roundTrip(java.time.ZoneOffset.MIN) &&
+        roundTrip(java.time.ZoneOffset.MAX)
+      },
+      test("ZonedDateTime") {
+        roundTrip(java.time.ZonedDateTime.parse("2025-07-18T08:29:13.121409459+02:00[Europe/Warsaw]")) &&
+        roundTrip(java.time.ZonedDateTime.now())
+      },
+      test("Currency") {
+        roundTrip(Currency.getInstance("USD")) &&
+        roundTrip(Currency.getInstance("EUR")) &&
+        roundTrip(Currency.getInstance("GBP"))
+      },
+      test("UUID") {
+        roundTrip(UUID.randomUUID()) &&
+        roundTrip(new UUID(0L, 0L)) &&
+        roundTrip(new UUID(Long.MaxValue, Long.MaxValue))
+      }
+    ),
+    suite("records")(
+      test("simple record") {
+        roundTrip(Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV")) &&
+        decodeError[Record1](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("nested record") {
+        roundTrip(
+          Record2(
+            Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV"),
+            Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV")
+          )
+        )
+      },
+      test("recursive record") {
+        roundTrip(Recursive(1, List(Recursive(2, List(Recursive(3, Nil))))))
+      },
+      test("record with unit and variant fields") {
+        roundTrip(Record4((), Some("VVV"))) &&
+        roundTrip(Record4((), None))
+      },
+      test("empty record") {
+        roundTrip(EmptyRecord())
+      }
+    ),
+    suite("sequences")(
+      test("primitive values") {
+        implicit val arrayOfUnitSchema: Schema[Array[Unit]]         = Schema.derived
+        implicit val arrayOfBooleanSchema: Schema[Array[Boolean]]   = Schema.derived
+        implicit val arrayOfByteSchema: Schema[Array[Byte]]         = Schema.derived
+        implicit val arrayOfShortSchema: Schema[Array[Short]]       = Schema.derived
+        implicit val arrayOfCharSchema: Schema[Array[Char]]         = Schema.derived
+        implicit val arrayOfFloatSchema: Schema[Array[Float]]       = Schema.derived
+        implicit val arrayOfIntSchema: Schema[Array[Int]]           = Schema.derived
+        implicit val arrayOfDoubleSchema: Schema[Array[Double]]     = Schema.derived
+        implicit val arrayOfLongSchema: Schema[Array[Long]]         = Schema.derived
+        implicit val arraySeqOfFloatSchema: Schema[ArraySeq[Float]] = Schema.derived
+
+        roundTrip(Array[Unit]((), (), ())) &&
+        roundTrip(Array[Boolean](true, false, true)) &&
+        roundTrip(Array[Byte](1: Byte, 2: Byte, 3: Byte)) &&
+        roundTrip(Array[Short](1: Short, 2: Short, 3: Short)) &&
+        roundTrip(Array('1', '2', '3')) &&
+        roundTrip(Array[Float](1.0f, 2.0f, 3.0f)) &&
+        roundTrip(Array[Int](1, 2, 3)) &&
+        roundTrip(Array[Double](1.0, 2.0, 3.0)) &&
+        roundTrip(Array[Long](1, 2, 3)) &&
+        roundTrip((1 to 100).toList) &&
+        roundTrip(Set(1L, 2L, 3L)) &&
+        roundTrip(ArraySeq(1.0f, 2.0f, 3.0f)) &&
+        roundTrip(Vector(1.0, 2.0, 3.0)) &&
+        roundTrip(List("1", "2", "3")) &&
+        roundTrip(List(BigInt(1), BigInt(2), BigInt(3))) &&
+        roundTrip(List(BigDecimal(1.0), BigDecimal(2.0), BigDecimal(3.0))) &&
+        roundTrip(List(java.time.LocalDate.of(2025, 1, 1), java.time.LocalDate.of(2025, 1, 2))) &&
+        roundTrip((1 to 32).map(x => new java.util.UUID(x, x)).toList) &&
+        decodeError[List[Int]](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("complex values") {
+        roundTrip(
+          List(
+            Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV"),
+            Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV")
+          )
+        )
+      },
+      test("recursive values") {
+        roundTrip(
+          List(
+            Recursive(1, List(Recursive(2, List(Recursive(3, Nil))))),
+            Recursive(4, List(Recursive(5, List(Recursive(6, Nil)))))
+          )
+        )
+      },
+      test("empty sequences") {
+        roundTrip(List.empty[Int]) &&
+        roundTrip(Vector.empty[String]) &&
+        roundTrip(Set.empty[Long])
+      }
+    ),
+    suite("maps")(
+      test("string keys and primitive values") {
+        roundTrip(Map("VVV" -> (), "WWW" -> ())) &&
+        roundTrip(Map("VVV" -> true, "WWW" -> false)) &&
+        roundTrip(Map("VVV" -> (1: Byte), "WWW" -> (2: Byte))) &&
+        roundTrip(Map("VVV" -> (1: Short), "WWW" -> (2: Short))) &&
+        roundTrip(Map("VVV" -> '1', "WWW" -> '2')) &&
+        roundTrip(Map("VVV" -> 1, "WWW" -> 2)) &&
+        roundTrip(Map("VVV" -> 1L, "WWW" -> 2L)) &&
+        roundTrip(Map("VVV" -> 1.0f, "WWW" -> 2.0f)) &&
+        roundTrip(Map("VVV" -> 1.0, "WWW" -> 2.0)) &&
+        roundTrip(Map("VVV" -> "1", "WWW" -> "2")) &&
+        roundTrip(Map("VVV" -> BigInt(1), "WWW" -> BigInt(2))) &&
+        roundTrip(Map("VVV" -> BigDecimal(1.0), "WWW" -> BigDecimal(2.0))) &&
+        roundTrip(Map("VVV" -> java.time.LocalDate.of(2025, 1, 1), "WWW" -> java.time.LocalDate.of(2025, 1, 2))) &&
+        roundTrip(Map("VVV" -> new java.util.UUID(1L, 1L), "WWW" -> new java.util.UUID(2L, 2L))) &&
+        decodeError[Map[String, Int]](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("string keys and complex values") {
+        roundTrip(
+          Map(
+            "VVV" -> Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV"),
+            "WWW" -> Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV")
+          )
+        )
+      },
+      test("string keys and recursive values") {
+        roundTrip(
+          Map(
+            "VVV" -> Recursive(1, List(Recursive(2, List(Recursive(3, Nil))))),
+            "WWW" -> Recursive(4, List(Recursive(5, List(Recursive(6, Nil)))))
+          )
+        )
+      },
+      test("non string key map") {
+        roundTrip(Map(1 -> 1L, 2 -> 2L)) &&
+        decodeError[Map[Int, Long]](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("non string key with recursive values") {
+        roundTrip(
+          Map(
+            Recursive(1, List(Recursive(2, List(Recursive(3, Nil))))) -> 1,
+            Recursive(4, List(Recursive(5, List(Recursive(6, Nil))))) -> 2
+          )
+        )
+      },
+      test("nested maps") {
+        roundTrip(Map("VVV" -> Map(1 -> 1L, 2 -> 2L))) &&
+        roundTrip(Map(Map(1 -> 1L, 2 -> 2L) -> "WWW"))
+      },
+      test("empty maps") {
+        roundTrip(Map.empty[String, Int]) &&
+        roundTrip(Map.empty[Int, String])
+      }
+    ),
+    suite("variants")(
+      test("constant values") {
+        roundTrip[TrafficLight](TrafficLight.Green) &&
+        roundTrip[TrafficLight](TrafficLight.Yellow) &&
+        roundTrip[TrafficLight](TrafficLight.Red)
+      },
+      test("option") {
+        roundTrip(Option(42)) &&
+        roundTrip[Option[Int]](None)
+      },
+      test("either") {
+        roundTrip[Either[String, Int]](Right(42)) &&
+        roundTrip[Either[String, Int]](Left("VVV"))
+      },
+      test("nested variants") {
+        roundTrip[Either[Option[Int], Either[String, Boolean]]](Right(Left("hello"))) &&
+        roundTrip[Either[Option[Int], Either[String, Boolean]]](Left(Some(42))) &&
+        roundTrip[Either[Option[Int], Either[String, Boolean]]](Left(None))
+      }
+    ),
+    suite("wrapper")(
+      test("top-level") {
+        roundTrip[UserId](UserId(1234567890123456789L)) &&
+        roundTrip[Email](Email("john@gmail.com"))
+      },
+      test("as a record field") {
+        roundTrip[Record3](Record3(UserId(1234567890123456789L), Email("backup@gmail.com")))
+      }
+    ),
+    suite("dynamic value")(
+      test("top-level primitives") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Unit)) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Boolean(true))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Byte(1: Byte))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Short(1: Short))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Int(1))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Long(1L))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Float(1.0f))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Double(1.0))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Char('1'))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.String("VVV"))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.BigInt(123))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.BigDecimal(123.45))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.DayOfWeek(DayOfWeek.MONDAY))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Duration(Duration.ofSeconds(60)))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Instant(Instant.EPOCH))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.LocalDate(LocalDate.MAX))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.LocalDateTime(LocalDateTime.MAX))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.LocalTime(LocalTime.MAX))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Month(Month.MAY))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.MonthDay(MonthDay.of(Month.MAY, 1)))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.OffsetDateTime(OffsetDateTime.MAX))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.OffsetTime(OffsetTime.MAX))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Period(Period.ofDays(1)))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Year(Year.of(2025)))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.YearMonth(YearMonth.of(2025, 1)))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.ZoneId(ZoneId.of("UTC")))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.ZoneOffset(ZoneOffset.MAX))) &&
+        roundTrip[DynamicValue](
+          DynamicValue.Primitive(
+            PrimitiveValue.ZonedDateTime(ZonedDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
+          )
+        ) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Currency(Currency.getInstance("USD")))) &&
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.UUID(UUID.randomUUID())))
+      },
+      test("record") {
+        roundTrip[DynamicValue](
+          DynamicValue.Record(
+            Vector(
+              ("i", DynamicValue.Primitive(PrimitiveValue.Int(1))),
+              ("s", DynamicValue.Primitive(PrimitiveValue.String("VVV")))
+            )
+          )
+        )
+      },
+      test("variant") {
+        roundTrip[DynamicValue](DynamicValue.Variant("Int", DynamicValue.Primitive(PrimitiveValue.Int(1))))
+      },
+      test("sequence") {
+        roundTrip[DynamicValue](
+          DynamicValue.Sequence(
+            Vector(
+              DynamicValue.Primitive(PrimitiveValue.Int(1)),
+              DynamicValue.Primitive(PrimitiveValue.String("VVV"))
+            )
+          )
+        )
+      },
+      test("map") {
+        roundTrip[DynamicValue](
+          DynamicValue.Map(
+            Vector(
+              (DynamicValue.Primitive(PrimitiveValue.Long(1L)), DynamicValue.Primitive(PrimitiveValue.Int(1))),
+              (DynamicValue.Primitive(PrimitiveValue.Long(2L)), DynamicValue.Primitive(PrimitiveValue.String("VVV")))
+            )
+          )
+        )
+      },
+      test("nested dynamic values") {
+        roundTrip[DynamicValue](
+          DynamicValue.Record(
+            Vector(
+              (
+                "nested",
+                DynamicValue.Sequence(
+                  Vector(
+                    DynamicValue.Map(
+                      Vector(
+                        (
+                          DynamicValue.Primitive(PrimitiveValue.String("key")),
+                          DynamicValue.Variant("Some", DynamicValue.Primitive(PrimitiveValue.Int(42)))
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      },
+      test("as record field values") {
+        val value = Dynamic(
+          DynamicValue.Primitive(PrimitiveValue.Int(1)),
+          DynamicValue.Map(
+            Vector(
+              (DynamicValue.Primitive(PrimitiveValue.Long(1L)), DynamicValue.Primitive(PrimitiveValue.Int(1))),
+              (DynamicValue.Primitive(PrimitiveValue.Long(2L)), DynamicValue.Primitive(PrimitiveValue.String("VVV")))
+            )
+          )
+        )
+        roundTrip[Dynamic](value)
+      }
+    ),
+    suite("edge cases")(
+      test("deeply nested structures") {
+        def createNested(depth: Int): Recursive =
+          if (depth <= 0) Recursive(0, Nil)
+          else Recursive(depth, List(createNested(depth - 1)))
+        roundTrip(createNested(10))
+      },
+      test("large collections") {
+        roundTrip((1 to 1000).toList) &&
+        roundTrip((1 to 1000).map(i => s"item$i" -> i).toMap)
+      },
+      test("special string values") {
+        roundTrip("") &&
+        roundTrip(" ") &&
+        roundTrip("\n\t\r") &&
+        roundTrip("hello\u0000world") &&
+        roundTrip("Unicode: \u00e9\u00e8\u00ea")
+      },
+      test("boundary number values") {
+        roundTrip(Byte.MinValue) &&
+        roundTrip(Byte.MaxValue) &&
+        roundTrip(Short.MinValue) &&
+        roundTrip(Short.MaxValue) &&
+        roundTrip(Int.MinValue) &&
+        roundTrip(Int.MaxValue) &&
+        roundTrip(Long.MinValue) &&
+        roundTrip(Long.MaxValue)
+      },
+      test("zero values") {
+        roundTrip(0: Byte) &&
+        roundTrip(0: Short) &&
+        roundTrip(0) &&
+        roundTrip(0L) &&
+        roundTrip(0.0f) &&
+        roundTrip(0.0)
+      },
+      test("negative values") {
+        roundTrip(-1: Byte) &&
+        roundTrip(-1: Short) &&
+        roundTrip(-1) &&
+        roundTrip(-1L) &&
+        roundTrip(-1.0f) &&
+        roundTrip(-1.0)
+      },
+      test("multiple records in list") {
+        roundTrip(List.fill(100)(Record1(true, 1, 2, 3, 4L, 5.0f, 6.0, '7', "test")))
+      },
+      test("deeply nested maps") {
+        roundTrip(Map("a" -> Map("b" -> Map("c" -> Map("d" -> 1)))))
+      },
+      test("mixed collection types") {
+        roundTrip(List(Vector(1, 2, 3), Vector(4, 5, 6))) &&
+        roundTrip(Vector(List(1, 2, 3), List(4, 5, 6)))
+      },
+      test("option in list") {
+        roundTrip(List(Some(1), None, Some(3)))
+      },
+      test("either in list") {
+        roundTrip(List[Either[String, Int]](Right(1), Left("error"), Right(3)))
+      },
+      test("record with all field types") {
+        roundTrip(
+          AllFieldTypes(
+            true,
+            1,
+            2,
+            3,
+            4L,
+            5.0f,
+            6.0,
+            'x',
+            "test",
+            BigInt(123),
+            BigDecimal("123.456"),
+            java.time.LocalDate.now(),
+            java.time.LocalTime.now(),
+            java.util.UUID.randomUUID()
+          )
+        )
+      },
+      test("very long string") {
+        roundTrip("a" * 10000)
+      },
+      test("unicode strings") {
+        roundTrip("Cafe") &&
+        roundTrip("Hallo") &&
+        roundTrip("Nihao")
+      },
+      test("nested option") {
+        roundTrip[Option[Option[Int]]](Some(Some(42))) &&
+        roundTrip[Option[Option[Int]]](Some(None)) &&
+        roundTrip[Option[Option[Int]]](None)
+      },
+      test("list of either") {
+        implicit val listEitherSchema: Schema[List[Either[String, Int]]] = Schema.derived
+        roundTrip(List(Right(1), Left("a"), Right(2)))
+      },
+      test("map with complex values") {
+        roundTrip(Map("k1" -> List(1, 2, 3), "k2" -> List(4, 5, 6)))
+      },
+      test("variant with record payload") {
+        roundTrip[Either[Record1, Record1]](Left(Record1(true, 1, 2, 3, 4L, 5.0f, 6.0, '7', "test"))) &&
+        roundTrip[Either[Record1, Record1]](Right(Record1(false, 2, 3, 4, 5L, 6.0f, 7.0, '8', "test2")))
+      },
+      test("empty and non-empty strings in record") {
+        roundTrip(Record1(true, 1, 2, 3, 4L, 5.0f, 6.0, '7', "")) &&
+        roundTrip(Record1(true, 1, 2, 3, 4L, 5.0f, 6.0, '7', "non-empty"))
+      }
+    )
+  )
+
+  implicit val eitherRecord1Schema: Schema[Either[Record1, Record1]] = Schema.derived
+  implicit val nestedOptionSchema: Schema[Option[Option[Int]]]       = Schema.derived
+
+  case class Record1(
+    bl: Boolean,
+    b: Byte,
+    sh: Short,
+    i: Int,
+    l: Long,
+    f: Float,
+    d: Double,
+    c: Char,
+    s: String
+  )
+
+  object Record1 extends CompanionOptics[Record1] {
+    implicit val schema: Schema[Record1] = Schema.derived
+
+    val i: Lens[Record1, Int] = $(_.i)
+  }
+
+  case class Record2(
+    r1_1: Record1,
+    r1_2: Record1
+  )
+
+  object Record2 extends CompanionOptics[Record2] {
+    implicit val schema: Schema[Record2] = Schema.derived
+
+    val r1_1: Lens[Record2, Record1] = $(_.r1_1)
+    val r1_2: Lens[Record2, Record1] = $(_.r1_2)
+    val r1_1_i: Lens[Record2, Int]   = $(_.r1_1.i)
+    val r1_2_i: Lens[Record2, Int]   = $(_.r1_2.i)
+  }
+
+  case class Recursive(i: Int, ln: List[Recursive])
+
+  object Recursive extends CompanionOptics[Recursive] {
+    implicit val schema: Schema[Recursive]   = Schema.derived
+    val i: Lens[Recursive, Int]              = $(_.i)
+    val ln: Lens[Recursive, List[Recursive]] = $(_.ln)
+  }
+
+  sealed trait TrafficLight
+
+  object TrafficLight {
+    implicit val schema: Schema[TrafficLight] = Schema.derived
+
+    case object Red extends TrafficLight
+
+    case object Yellow extends TrafficLight
+
+    case object Green extends TrafficLight
+  }
+
+  implicit val eitherSchema: Schema[Either[String, Int]]                                = Schema.derived
+  implicit val nestedEitherSchema: Schema[Either[Option[Int], Either[String, Boolean]]] = Schema.derived
+
+  case class UserId(value: Long)
+
+  object UserId {
+    implicit val schema: Schema[UserId] = Schema.derived.wrapTotal(x => new UserId(x), _.value)
+  }
+
+  case class Email(value: String)
+
+  object Email {
+    private[this] val EmailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$".r
+
+    implicit val schema: Schema[Email] = new Schema(
+      new Reflect.Wrapper[Binding, Email, String](
+        Schema[String].reflect,
+        TypeName(Namespace(Seq("zio", "blocks", "messagepack"), Seq("MessagePackFormatSpec")), "Email"),
+        None,
+        new Binding.Wrapper(
+          {
+            case x @ EmailRegex(_*) => new Right(new Email(x))
+            case _                  => new Left("Expected Email")
+          },
+          _.value
+        )
+      )
+    )
+  }
+
+  case class Record3(userId: UserId, email: Email)
+
+  object Record3 {
+    implicit val schema: Schema[Record3] = Schema.derived
+  }
+
+  case class Record4(hidden: Unit, optKey: Option[String])
+
+  object Record4 extends CompanionOptics[Record4] {
+    implicit val schema: Schema[Record4] = Schema.derived
+
+    val hidden: Lens[Record4, Unit]               = $(_.hidden)
+    val optKey: Lens[Record4, Option[String]]     = $(_.optKey)
+    val optKey_None: Optional[Record4, None.type] = $(_.optKey.when[None.type])
+  }
+
+  case class Dynamic(primitive: DynamicValue, map: DynamicValue)
+
+  object Dynamic extends CompanionOptics[Dynamic] {
+    implicit val schema: Schema[Dynamic] = Schema.derived
+
+    val primitive: Lens[Dynamic, DynamicValue] = $(_.primitive)
+    val map: Lens[Dynamic, DynamicValue]       = $(_.map)
+  }
+
+  case class EmptyRecord()
+
+  object EmptyRecord {
+    implicit val schema: Schema[EmptyRecord] = Schema.derived
+  }
+
+  case class AllFieldTypes(
+    b: Boolean,
+    by: Byte,
+    sh: Short,
+    i: Int,
+    l: Long,
+    f: Float,
+    d: Double,
+    c: Char,
+    s: String,
+    bi: BigInt,
+    bd: BigDecimal,
+    ld: java.time.LocalDate,
+    lt: java.time.LocalTime,
+    uuid: java.util.UUID
+  )
+
+  object AllFieldTypes {
+    implicit val schema: Schema[AllFieldTypes] = Schema.derived
+  }
+}

--- a/schema-messagepack/src/test/scala/zio/blocks/schema/messagepack/MessagePackTestUtils.scala
+++ b/schema-messagepack/src/test/scala/zio/blocks/schema/messagepack/MessagePackTestUtils.scala
@@ -1,0 +1,88 @@
+package zio.blocks.schema.messagepack
+
+import zio.blocks.schema.{Schema, SchemaError}
+import zio.test.Assertion._
+import zio.test._
+import java.nio.ByteBuffer
+import java.util
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.immutable.ArraySeq
+
+object MessagePackTestUtils {
+  private[this] val codecs = new ConcurrentHashMap[Schema[?], MessagePackBinaryCodec[?]]()
+
+  private[this] def codec[A](schema: Schema[A]): MessagePackBinaryCodec[A] =
+    codecs.computeIfAbsent(schema, _.derive(MessagePackFormat.deriver)).asInstanceOf[MessagePackBinaryCodec[A]]
+
+  def roundTrip[A](value: A)(implicit schema: Schema[A]): TestResult =
+    roundTrip(value, codec(schema))
+
+  def roundTrip[A](value: A, codec: MessagePackBinaryCodec[A]): TestResult = {
+    val heapByteBuffer = ByteBuffer.allocate(maxBufSize)
+    codec.encode(value, heapByteBuffer)
+    val encodedBySchema1 = util.Arrays.copyOf(heapByteBuffer.array, heapByteBuffer.position)
+    val directByteBuffer = ByteBuffer.allocate(maxBufSize)
+    codec.encode(value, directByteBuffer)
+    val encodedBySchema2 = util.Arrays.copyOf(
+      {
+        val dup = directByteBuffer.duplicate()
+        val out = new Array[Byte](dup.position)
+        dup.position(0)
+        dup.get(out)
+        out
+      },
+      directByteBuffer.position
+    )
+    val output = new java.io.ByteArrayOutputStream(maxBufSize)
+    codec.encode(value, output)
+    output.close()
+    val encodedBySchema3 = output.toByteArray
+    val encodedBySchema4 = codec.encode(value)
+    assert(ArraySeq.unsafeWrapArray(encodedBySchema1))(equalTo(ArraySeq.unsafeWrapArray(encodedBySchema2))) &&
+    assert(ArraySeq.unsafeWrapArray(encodedBySchema1))(equalTo(ArraySeq.unsafeWrapArray(encodedBySchema3))) &&
+    assert(ArraySeq.unsafeWrapArray(encodedBySchema1))(equalTo(ArraySeq.unsafeWrapArray(encodedBySchema4))) &&
+    assert(codec.decode(encodedBySchema1))(isRight(customEquals(value))) &&
+    assert(codec.decode(toInputStream(encodedBySchema1)))(isRight(customEquals(value))) &&
+    assert(codec.decode(toHeapByteBuffer(encodedBySchema1)))(isRight(customEquals(value))) &&
+    assert(codec.decode(toDirectByteBuffer(encodedBySchema1)))(isRight(customEquals(value)))
+  }
+
+  private def customEquals[A](expected: A): Assertion[A] = Assertion.assertion("customEquals") { actual =>
+    (expected, actual) match {
+      case (f1: Float, f2: Float)                   => java.lang.Float.compare(f1, f2) == 0
+      case (d1: Double, d2: Double)                 => java.lang.Double.compare(d1, d2) == 0
+      case (a1: Array[Unit], a2: Array[Unit])       => java.util.Arrays.equals(a1.map(_ => 1), a2.map(_ => 1))
+      case (a1: Array[Boolean], a2: Array[Boolean]) => java.util.Arrays.equals(a1, a2)
+      case (a1: Array[Byte], a2: Array[Byte])       => java.util.Arrays.equals(a1, a2)
+      case (a1: Array[Short], a2: Array[Short])     => java.util.Arrays.equals(a1, a2)
+      case (a1: Array[Char], a2: Array[Char])       => java.util.Arrays.equals(a1, a2)
+      case (a1: Array[Int], a2: Array[Int])         => java.util.Arrays.equals(a1, a2)
+      case (a1: Array[Long], a2: Array[Long])       => java.util.Arrays.equals(a1, a2)
+      case (a1: Array[Float], a2: Array[Float])     => java.util.Arrays.equals(a1, a2)
+      case (a1: Array[Double], a2: Array[Double])   => java.util.Arrays.equals(a1, a2)
+      case (a1: Array[AnyRef], a2: Array[AnyRef])   => java.util.Arrays.deepEquals(a1, a2)
+      case _                                        => expected == actual
+    }
+  }
+
+  def decodeError[A](bytes: Array[Byte], error: String)(implicit schema: Schema[A]): TestResult =
+    decodeError(bytes, codec(schema), error)
+
+  def decodeError[A](bytes: Array[Byte], codec: MessagePackBinaryCodec[A], error: String): TestResult =
+    assert(codec.decode(bytes))(isLeft(hasError(error))) &&
+      assert(codec.decode(toInputStream(bytes)))(isLeft(hasError(error))) &&
+      assert(codec.decode(toHeapByteBuffer(bytes)))(isLeft(hasError(error))) &&
+      assert(codec.decode(toDirectByteBuffer(bytes)))(isLeft(hasError(error)))
+
+  private[this] def hasError(message: String) =
+    hasField[SchemaError, String]("getMessage", _.getMessage, containsString(message))
+
+  private[this] def toInputStream(bs: Array[Byte]): java.io.InputStream = new java.io.ByteArrayInputStream(bs)
+
+  private[this] def toHeapByteBuffer(bs: Array[Byte]): ByteBuffer = ByteBuffer.wrap(bs)
+
+  private[this] def toDirectByteBuffer(bs: Array[Byte]): ByteBuffer =
+    ByteBuffer.allocateDirect(maxBufSize).put(bs).position(0).limit(bs.length)
+
+  private[this] val maxBufSize = 65536
+}


### PR DESCRIPTION
## Summary

Port MessagePack support from ZIO Schema v1 to ZIO Schema 2 in a new top-level `schema-messagepack` project.

### Implementation includes:
- `MessagePackBinaryCodec` abstract class extending `BinaryCodec[A]`
- `MessagePackFormat` object with `Deriver[MessagePackBinaryCodec]`
- Support for all 30 primitive types (Unit, Boolean, Byte, Short, Int, Long, Float, Double, Char, String, BigInt, BigDecimal, all java.time types, Currency, UUID)
- Record, variant, sequence, map, dynamic value, and wrapper support
- Recursive type support via ThreadLocal cache
- Comprehensive test suite with **78 tests**

### Deriver Methods Implemented:
- `derivePrimitive` - All primitive types
- `deriveRecord` - Case classes encoded as MessagePack maps
- `deriveVariant` - Sealed traits encoded as single-entry maps
- `deriveSequence` - Collections encoded as MessagePack arrays
- `deriveMap` - Maps encoded as MessagePack maps
- `deriveDynamic` - DynamicValue support
- `deriveWrapper` - Wrapper types with validation

## Test plan
- [x] All 78 tests pass
- [x] Format check passes
- [x] Compiles against latest main

/claim #682