### PR TITLE
feat: Add Thrift binary codec support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ lazy val root = project
     schema.js,
     schema.native,
     `schema-avro`,
+    `schema-thrift`,
     `schema-toon`.jvm,
     `schema-toon`.js,
     `schema-toon`.native,
@@ -171,6 +172,20 @@ lazy val `schema-avro` = project
           "io.github.kitlangton" %% "neotype" % "0.4.10" % Test
         )
     })
+  )
+
+lazy val `schema-thrift` = project
+  .settings(stdSettings("zio-blocks-schema-thrift"))
+  .dependsOn(schema.jvm)
+  .settings(buildInfoSettings("zio.blocks.schema.thrift"))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.apache.thrift"  % "libthrift"              % "0.20.0",
+      "jakarta.annotation" % "jakarta.annotation-api" % "3.0.0",
+      "dev.zio"           %% "zio-test"               % "2.1.24" % Test,
+      "dev.zio"           %% "zio-test-sbt"           % "2.1.24" % Test
+    )
   )
 
 lazy val `schema-toon` = crossProject(JSPlatform, JVMPlatform, NativePlatform)

--- a/schema-thrift/src/main/scala/zio/blocks/schema/thrift/ChunkTransport.scala
+++ b/schema-thrift/src/main/scala/zio/blocks/schema/thrift/ChunkTransport.scala
@@ -1,0 +1,72 @@
+package zio.blocks.schema.thrift
+
+import org.apache.thrift.TConfiguration
+import org.apache.thrift.transport.TTransport
+import org.apache.thrift.transport.TTransportException
+
+final class ChunkTransport(
+  private[this] var readBuffer: Array[Byte] = null,
+  private[this] var readPos: Int = 0,
+  private[this] var readLimit: Int = 0
+) extends TTransport {
+
+  private[this] var writeBuffer: Array[Byte] = new Array[Byte](64)
+  private[this] var writePos: Int            = 0
+
+  override def isOpen: Boolean = true
+
+  override def open(): Unit = ()
+
+  override def close(): Unit = ()
+
+  override def read(buf: Array[Byte], off: Int, len: Int): Int = {
+    if (readBuffer eq null) throw new TTransportException("No read buffer")
+    val available = readLimit - readPos
+    if (available <= 0) throw new TTransportException("Unexpected end of input")
+    val bytesToRead = Math.min(len, available)
+    System.arraycopy(readBuffer, readPos, buf, off, bytesToRead)
+    readPos += bytesToRead
+    bytesToRead
+  }
+
+  override def write(buf: Array[Byte], off: Int, len: Int): Unit = {
+    ensureCapacity(len)
+    System.arraycopy(buf, off, writeBuffer, writePos, len)
+    writePos += len
+  }
+
+  override def getBuffer: Array[Byte] = writeBuffer
+
+  override def getBufferPosition: Int = writePos
+
+  override def getConfiguration: TConfiguration = ChunkTransport.defaultConfig
+
+  override def updateKnownMessageSize(size: Long): Unit = ()
+
+  override def checkReadBytesAvailable(numBytes: Long): Unit = ()
+
+  def toByteArray: Array[Byte] = java.util.Arrays.copyOf(writeBuffer, writePos)
+
+  def reset(): Unit = {
+    writePos = 0
+    readPos = 0
+  }
+
+  def setReadBuffer(buffer: Array[Byte], offset: Int, length: Int): Unit = {
+    readBuffer = buffer
+    readPos = offset
+    readLimit = offset + length
+  }
+
+  private[this] def ensureCapacity(additional: Int): Unit = {
+    val newLen = writePos + additional
+    if (newLen > writeBuffer.length) {
+      val newSize = Math.max(writeBuffer.length << 1, newLen)
+      writeBuffer = java.util.Arrays.copyOf(writeBuffer, newSize)
+    }
+  }
+}
+
+object ChunkTransport {
+  private val defaultConfig: TConfiguration = new TConfiguration()
+}

--- a/schema-thrift/src/main/scala/zio/blocks/schema/thrift/ThriftBinaryCodec.scala
+++ b/schema-thrift/src/main/scala/zio/blocks/schema/thrift/ThriftBinaryCodec.scala
@@ -1,0 +1,146 @@
+package zio.blocks.schema.thrift
+
+import org.apache.thrift.protocol.TProtocol
+import zio.blocks.schema.SchemaError.ExpectationMismatch
+import zio.blocks.schema.{DynamicOptic, SchemaError}
+import zio.blocks.schema.binding.RegisterOffset
+import zio.blocks.schema.codec.BinaryCodec
+import java.nio.ByteBuffer
+import scala.collection.immutable.ArraySeq
+import scala.util.control.NonFatal
+
+abstract class ThriftBinaryCodec[A](val valueType: Int = ThriftBinaryCodec.objectType) extends BinaryCodec[A] {
+  val valueOffset: RegisterOffset.RegisterOffset = valueType match {
+    case ThriftBinaryCodec.objectType  => RegisterOffset(objects = 1)
+    case ThriftBinaryCodec.booleanType => RegisterOffset(booleans = 1)
+    case ThriftBinaryCodec.byteType    => RegisterOffset(bytes = 1)
+    case ThriftBinaryCodec.charType    => RegisterOffset(chars = 1)
+    case ThriftBinaryCodec.shortType   => RegisterOffset(shorts = 1)
+    case ThriftBinaryCodec.floatType   => RegisterOffset(floats = 1)
+    case ThriftBinaryCodec.intType     => RegisterOffset(ints = 1)
+    case ThriftBinaryCodec.doubleType  => RegisterOffset(doubles = 1)
+    case ThriftBinaryCodec.longType    => RegisterOffset(longs = 1)
+    case _                             => RegisterOffset.Zero
+  }
+
+  def decodeError(expectation: String): Nothing = throw new ThriftBinaryCodecError(Nil, expectation)
+
+  def decodeError(span: DynamicOptic.Node, error: Throwable): Nothing = error match {
+    case e: ThriftBinaryCodecError =>
+      e.spans = new ::(span, e.spans)
+      throw e
+    case _ =>
+      throw new ThriftBinaryCodecError(new ::(span, Nil), getMessage(error))
+  }
+
+  def decodeError(span1: DynamicOptic.Node, span2: DynamicOptic.Node, error: Throwable): Nothing = error match {
+    case e: ThriftBinaryCodecError =>
+      e.spans = new ::(span1, new ::(span2, e.spans))
+      throw e
+    case _ =>
+      throw new ThriftBinaryCodecError(new ::(span1, new ::(span2, Nil)), getMessage(error))
+  }
+
+  def decodeUnsafe(protocol: TProtocol): A
+
+  def encode(value: A, protocol: TProtocol): Unit
+
+  override def decode(input: ByteBuffer): Either[SchemaError, A] = {
+    var pos             = input.position
+    val len             = input.limit - pos
+    var bs: Array[Byte] = null
+    if (input.hasArray) bs = input.array()
+    else {
+      pos = 0
+      bs = new Array[Byte](len)
+      input.get(bs)
+    }
+    val transport = new ChunkTransport(bs, pos, len)
+    val protocol  = new org.apache.thrift.protocol.TCompactProtocol(transport)
+    decode(protocol)
+  }
+
+  override def encode(value: A, output: ByteBuffer): Unit = {
+    val transport = new ChunkTransport()
+    val protocol  = new org.apache.thrift.protocol.TCompactProtocol(transport)
+    encode(value, protocol)
+    output.put(transport.getBuffer, 0, transport.getBufferPosition)
+  }
+
+  def decode(input: Array[Byte]): Either[SchemaError, A] = {
+    val transport = new ChunkTransport(input, 0, input.length)
+    val protocol  = new org.apache.thrift.protocol.TCompactProtocol(transport)
+    decode(protocol)
+  }
+
+  def encode(value: A): Array[Byte] = {
+    val transport = new ChunkTransport()
+    val protocol  = new org.apache.thrift.protocol.TCompactProtocol(transport)
+    encode(value, protocol)
+    transport.toByteArray
+  }
+
+  def decode(input: java.io.InputStream): Either[SchemaError, A] = {
+    val transport = new org.apache.thrift.transport.TIOStreamTransport(input)
+    val protocol  = new org.apache.thrift.protocol.TCompactProtocol(transport)
+    decode(protocol)
+  }
+
+  def encode(value: A, output: java.io.OutputStream): Unit = {
+    val transport = new org.apache.thrift.transport.TIOStreamTransport(output)
+    val protocol  = new org.apache.thrift.protocol.TCompactProtocol(transport)
+    encode(value, protocol)
+    transport.flush()
+  }
+
+  private[this] def decode(protocol: TProtocol): Either[SchemaError, A] =
+    try new Right(decodeUnsafe(protocol))
+    catch {
+      case error if NonFatal(error) => new Left(toError(error))
+    }
+
+  private[this] def toError(error: Throwable): SchemaError = new SchemaError(
+    new ::(
+      error match {
+        case e: ThriftBinaryCodecError =>
+          var list  = e.spans
+          val array = new Array[DynamicOptic.Node](list.size)
+          var idx   = 0
+          while (list ne Nil) {
+            array(idx) = list.head
+            idx += 1
+            list = list.tail
+          }
+          new ExpectationMismatch(new DynamicOptic(ArraySeq.unsafeWrapArray(array)), e.getMessage)
+        case _ => new ExpectationMismatch(DynamicOptic.root, getMessage(error))
+      },
+      Nil
+    )
+  )
+
+  private[this] def getMessage(error: Throwable): String = error match {
+    case _: java.io.EOFException                            => "Unexpected end of input"
+    case _: org.apache.thrift.transport.TTransportException => "Unexpected end of input"
+    case e                                                  => e.getMessage
+  }
+}
+
+object ThriftBinaryCodec {
+  val objectType  = 0
+  val booleanType = 1
+  val byteType    = 2
+  val charType    = 3
+  val shortType   = 4
+  val floatType   = 5
+  val intType     = 6
+  val doubleType  = 7
+  val longType    = 8
+  val unitType    = 9
+
+  val maxCollectionSize: Int = Integer.MAX_VALUE - 8
+}
+
+private[thrift] class ThriftBinaryCodecError(var spans: List[DynamicOptic.Node], message: String)
+    extends Throwable(message, null, false, false) {
+  override def getMessage: String = message
+}

--- a/schema-thrift/src/main/scala/zio/blocks/schema/thrift/ThriftFormat.scala
+++ b/schema-thrift/src/main/scala/zio/blocks/schema/thrift/ThriftFormat.scala
@@ -1,0 +1,1465 @@
+package zio.blocks.schema.thrift
+
+import org.apache.thrift.protocol.{TField, TList, TMap, TProtocol, TStruct, TType}
+import zio.blocks.schema.binding.{Binding, BindingType, HasBinding, Registers, RegisterOffset}
+import zio.blocks.schema._
+import zio.blocks.schema.codec.BinaryFormat
+import zio.blocks.schema.derive.{BindingInstance, Deriver, InstanceOverride}
+import java.math.{BigInteger, MathContext}
+import java.nio.ByteBuffer
+import scala.util.control.NonFatal
+
+object ThriftFormat
+    extends BinaryFormat(
+      "application/x-thrift",
+      new Deriver[ThriftBinaryCodec] {
+        override def derivePrimitive[F[_, _], A](
+          primitiveType: PrimitiveType[A],
+          typeName: TypeName[A],
+          binding: Binding[BindingType.Primitive, A],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        ): Lazy[ThriftBinaryCodec[A]] =
+          Lazy(deriveCodec(new Reflect.Primitive(primitiveType, typeName, binding, doc, modifiers)))
+
+        override def deriveRecord[F[_, _], A](
+          fields: IndexedSeq[Term[F, A, ?]],
+          typeName: TypeName[A],
+          binding: Binding[BindingType.Record, A],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[ThriftBinaryCodec[A]] = Lazy {
+          deriveCodec(
+            new Reflect.Record(
+              fields.asInstanceOf[IndexedSeq[Term[Binding, A, ?]]],
+              typeName,
+              binding,
+              doc,
+              modifiers
+            )
+          )
+        }
+
+        override def deriveVariant[F[_, _], A](
+          cases: IndexedSeq[Term[F, A, ?]],
+          typeName: TypeName[A],
+          binding: Binding[BindingType.Variant, A],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[ThriftBinaryCodec[A]] = Lazy {
+          deriveCodec(
+            new Reflect.Variant(
+              cases.asInstanceOf[IndexedSeq[Term[Binding, A, ? <: A]]],
+              typeName,
+              binding,
+              doc,
+              modifiers
+            )
+          )
+        }
+
+        override def deriveSequence[F[_, _], C[_], A](
+          element: Reflect[F, A],
+          typeName: TypeName[C[A]],
+          binding: Binding[BindingType.Seq[C], C[A]],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[ThriftBinaryCodec[C[A]]] = Lazy {
+          deriveCodec(
+            new Reflect.Sequence(element.asInstanceOf[Reflect[Binding, A]], typeName, binding, doc, modifiers)
+          )
+        }
+
+        override def deriveMap[F[_, _], M[_, _], K, V](
+          key: Reflect[F, K],
+          value: Reflect[F, V],
+          typeName: TypeName[M[K, V]],
+          binding: Binding[BindingType.Map[M], M[K, V]],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[ThriftBinaryCodec[M[K, V]]] = Lazy {
+          deriveCodec(
+            new Reflect.Map(
+              key.asInstanceOf[Reflect[Binding, K]],
+              value.asInstanceOf[Reflect[Binding, V]],
+              typeName,
+              binding,
+              doc,
+              modifiers
+            )
+          )
+        }
+
+        override def deriveDynamic[F[_, _]](
+          binding: Binding[BindingType.Dynamic, DynamicValue],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[ThriftBinaryCodec[DynamicValue]] =
+          Lazy(deriveCodec(new Reflect.Dynamic(binding, TypeName.dynamicValue, doc, modifiers)))
+
+        def deriveWrapper[F[_, _], A, B](
+          wrapped: Reflect[F, B],
+          typeName: TypeName[A],
+          wrapperPrimitiveType: Option[PrimitiveType[A]],
+          binding: Binding[BindingType.Wrapper[A, B], A],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[ThriftBinaryCodec[A]] = Lazy {
+          deriveCodec(
+            new Reflect.Wrapper(
+              wrapped.asInstanceOf[Reflect[Binding, B]],
+              typeName,
+              wrapperPrimitiveType,
+              binding,
+              doc,
+              modifiers
+            )
+          )
+        }
+
+        override def instanceOverrides: IndexedSeq[InstanceOverride] = {
+          recursiveRecordCache.remove()
+          recordCounters.remove()
+          super.instanceOverrides
+        }
+
+        type Elem
+        type Key
+        type Value
+        type Wrapped
+        type Col[_]
+        type Map[_, _]
+        type TC[_]
+
+        private[this] val recursiveRecordCache =
+          new ThreadLocal[java.util.HashMap[TypeName[?], Array[ThriftBinaryCodec[?]]]] {
+            override def initialValue: java.util.HashMap[TypeName[?], Array[ThriftBinaryCodec[?]]] =
+              new java.util.HashMap
+          }
+        private[this] val recordCounters =
+          new ThreadLocal[java.util.HashMap[(String, String), Int]] {
+            override def initialValue: java.util.HashMap[(String, String), Int] = new java.util.HashMap
+          }
+
+        private[this] val unitCodec = new ThriftBinaryCodec[Unit](ThriftBinaryCodec.unitType) {
+          def decodeUnsafe(protocol: TProtocol): Unit        = ()
+          def encode(value: Unit, protocol: TProtocol): Unit = ()
+        }
+
+        private[this] val booleanCodec = new ThriftBinaryCodec[Boolean](ThriftBinaryCodec.booleanType) {
+          def decodeUnsafe(protocol: TProtocol): Boolean        = protocol.readBool()
+          def encode(value: Boolean, protocol: TProtocol): Unit = protocol.writeBool(value)
+        }
+
+        private[this] val byteCodec = new ThriftBinaryCodec[Byte](ThriftBinaryCodec.byteType) {
+          def decodeUnsafe(protocol: TProtocol): Byte        = protocol.readByte()
+          def encode(value: Byte, protocol: TProtocol): Unit = protocol.writeByte(value)
+        }
+
+        private[this] val shortCodec = new ThriftBinaryCodec[Short](ThriftBinaryCodec.shortType) {
+          def decodeUnsafe(protocol: TProtocol): Short        = protocol.readI16()
+          def encode(value: Short, protocol: TProtocol): Unit = protocol.writeI16(value)
+        }
+
+        private[this] val intCodec = new ThriftBinaryCodec[Int](ThriftBinaryCodec.intType) {
+          def decodeUnsafe(protocol: TProtocol): Int        = protocol.readI32()
+          def encode(value: Int, protocol: TProtocol): Unit = protocol.writeI32(value)
+        }
+
+        private[this] val longCodec = new ThriftBinaryCodec[Long](ThriftBinaryCodec.longType) {
+          def decodeUnsafe(protocol: TProtocol): Long        = protocol.readI64()
+          def encode(value: Long, protocol: TProtocol): Unit = protocol.writeI64(value)
+        }
+
+        private[this] val floatCodec = new ThriftBinaryCodec[Float](ThriftBinaryCodec.floatType) {
+          def decodeUnsafe(protocol: TProtocol): Float        = java.lang.Float.intBitsToFloat(protocol.readI32())
+          def encode(value: Float, protocol: TProtocol): Unit = protocol.writeI32(java.lang.Float.floatToIntBits(value))
+        }
+
+        private[this] val doubleCodec = new ThriftBinaryCodec[Double](ThriftBinaryCodec.doubleType) {
+          def decodeUnsafe(protocol: TProtocol): Double        = protocol.readDouble()
+          def encode(value: Double, protocol: TProtocol): Unit = protocol.writeDouble(value)
+        }
+
+        private[this] val charCodec = new ThriftBinaryCodec[Char](ThriftBinaryCodec.charType) {
+          def decodeUnsafe(protocol: TProtocol): Char = {
+            val x = protocol.readI32()
+            if (x >= Char.MinValue && x <= Char.MaxValue) x.toChar
+            else decodeError("Expected Char")
+          }
+          def encode(value: Char, protocol: TProtocol): Unit = protocol.writeI32(value)
+        }
+
+        private[this] val stringCodec = new ThriftBinaryCodec[String]() {
+          def decodeUnsafe(protocol: TProtocol): String        = protocol.readString()
+          def encode(value: String, protocol: TProtocol): Unit = protocol.writeString(value)
+        }
+
+        private[this] val bigIntCodec = new ThriftBinaryCodec[BigInt]() {
+          def decodeUnsafe(protocol: TProtocol): BigInt        = BigInt(protocol.readBinary().array())
+          def encode(value: BigInt, protocol: TProtocol): Unit =
+            protocol.writeBinary(ByteBuffer.wrap(value.toByteArray))
+        }
+
+        private[this] val bigDecimalCodec = new ThriftBinaryCodec[BigDecimal]() {
+          def decodeUnsafe(protocol: TProtocol): BigDecimal = {
+            protocol.readStructBegin()
+            readField(protocol, 1, TType.STRING)
+            val mantissa = protocol.readBinary().array()
+            readField(protocol, 2, TType.I32)
+            val scale = protocol.readI32()
+            readField(protocol, 3, TType.I32)
+            val precision = protocol.readI32()
+            readField(protocol, 4, TType.I32)
+            val roundingMode = java.math.RoundingMode.valueOf(protocol.readI32())
+            readFieldStop(protocol)
+            protocol.readStructEnd()
+            val mc = new MathContext(precision, roundingMode)
+            new BigDecimal(new java.math.BigDecimal(new BigInteger(mantissa), scale), mc)
+          }
+
+          def encode(value: BigDecimal, protocol: TProtocol): Unit = {
+            val bd = value.underlying
+            val mc = value.mc
+            protocol.writeStructBegin(emptyStruct)
+            protocol.writeFieldBegin(new TField("mantissa", TType.STRING, 1))
+            protocol.writeBinary(ByteBuffer.wrap(bd.unscaledValue.toByteArray))
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("scale", TType.I32, 2))
+            protocol.writeI32(bd.scale)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("precision", TType.I32, 3))
+            protocol.writeI32(mc.getPrecision)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("roundingMode", TType.I32, 4))
+            protocol.writeI32(mc.getRoundingMode.ordinal)
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+          }
+        }
+
+        private[this] val dayOfWeekCodec = new ThriftBinaryCodec[java.time.DayOfWeek]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.DayOfWeek        = java.time.DayOfWeek.of(protocol.readI32())
+          def encode(value: java.time.DayOfWeek, protocol: TProtocol): Unit = protocol.writeI32(value.getValue)
+        }
+
+        private[this] val durationCodec = new ThriftBinaryCodec[java.time.Duration]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.Duration = {
+            protocol.readStructBegin()
+            readField(protocol, 1, TType.I64)
+            val seconds = protocol.readI64()
+            readField(protocol, 2, TType.I32)
+            val nanos = protocol.readI32()
+            readFieldStop(protocol)
+            protocol.readStructEnd()
+            java.time.Duration.ofSeconds(seconds, nanos)
+          }
+
+          def encode(value: java.time.Duration, protocol: TProtocol): Unit = {
+            protocol.writeStructBegin(emptyStruct)
+            protocol.writeFieldBegin(new TField("seconds", TType.I64, 1))
+            protocol.writeI64(value.getSeconds)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("nanos", TType.I32, 2))
+            protocol.writeI32(value.getNano)
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+          }
+        }
+
+        private[this] val instantCodec = new ThriftBinaryCodec[java.time.Instant]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.Instant = {
+            protocol.readStructBegin()
+            readField(protocol, 1, TType.I64)
+            val epochSecond = protocol.readI64()
+            readField(protocol, 2, TType.I32)
+            val nano = protocol.readI32()
+            readFieldStop(protocol)
+            protocol.readStructEnd()
+            java.time.Instant.ofEpochSecond(epochSecond, nano)
+          }
+
+          def encode(value: java.time.Instant, protocol: TProtocol): Unit = {
+            protocol.writeStructBegin(emptyStruct)
+            protocol.writeFieldBegin(new TField("epochSecond", TType.I64, 1))
+            protocol.writeI64(value.getEpochSecond)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("nano", TType.I32, 2))
+            protocol.writeI32(value.getNano)
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+          }
+        }
+
+        private[this] val localDateCodec = new ThriftBinaryCodec[java.time.LocalDate]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.LocalDate = {
+            protocol.readStructBegin()
+            readField(protocol, 1, TType.I32)
+            val year = protocol.readI32()
+            readField(protocol, 2, TType.I32)
+            val month = protocol.readI32()
+            readField(protocol, 3, TType.I32)
+            val day = protocol.readI32()
+            readFieldStop(protocol)
+            protocol.readStructEnd()
+            java.time.LocalDate.of(year, month, day)
+          }
+
+          def encode(value: java.time.LocalDate, protocol: TProtocol): Unit = {
+            protocol.writeStructBegin(emptyStruct)
+            protocol.writeFieldBegin(new TField("year", TType.I32, 1))
+            protocol.writeI32(value.getYear)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("month", TType.I32, 2))
+            protocol.writeI32(value.getMonthValue)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("day", TType.I32, 3))
+            protocol.writeI32(value.getDayOfMonth)
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+          }
+        }
+
+        private[this] val localDateTimeCodec = new ThriftBinaryCodec[java.time.LocalDateTime]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.LocalDateTime = {
+            protocol.readStructBegin()
+            readField(protocol, 1, TType.I32)
+            val year = protocol.readI32()
+            readField(protocol, 2, TType.I32)
+            val month = protocol.readI32()
+            readField(protocol, 3, TType.I32)
+            val day = protocol.readI32()
+            readField(protocol, 4, TType.I32)
+            val hour = protocol.readI32()
+            readField(protocol, 5, TType.I32)
+            val minute = protocol.readI32()
+            readField(protocol, 6, TType.I32)
+            val second = protocol.readI32()
+            readField(protocol, 7, TType.I32)
+            val nano = protocol.readI32()
+            readFieldStop(protocol)
+            protocol.readStructEnd()
+            java.time.LocalDateTime.of(year, month, day, hour, minute, second, nano)
+          }
+
+          def encode(value: java.time.LocalDateTime, protocol: TProtocol): Unit = {
+            protocol.writeStructBegin(emptyStruct)
+            protocol.writeFieldBegin(new TField("year", TType.I32, 1))
+            protocol.writeI32(value.getYear)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("month", TType.I32, 2))
+            protocol.writeI32(value.getMonthValue)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("day", TType.I32, 3))
+            protocol.writeI32(value.getDayOfMonth)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("hour", TType.I32, 4))
+            protocol.writeI32(value.getHour)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("minute", TType.I32, 5))
+            protocol.writeI32(value.getMinute)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("second", TType.I32, 6))
+            protocol.writeI32(value.getSecond)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("nano", TType.I32, 7))
+            protocol.writeI32(value.getNano)
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+          }
+        }
+
+        private[this] val localTimeCodec = new ThriftBinaryCodec[java.time.LocalTime]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.LocalTime = {
+            protocol.readStructBegin()
+            readField(protocol, 1, TType.I32)
+            val hour = protocol.readI32()
+            readField(protocol, 2, TType.I32)
+            val minute = protocol.readI32()
+            readField(protocol, 3, TType.I32)
+            val second = protocol.readI32()
+            readField(protocol, 4, TType.I32)
+            val nano = protocol.readI32()
+            readFieldStop(protocol)
+            protocol.readStructEnd()
+            java.time.LocalTime.of(hour, minute, second, nano)
+          }
+
+          def encode(value: java.time.LocalTime, protocol: TProtocol): Unit = {
+            protocol.writeStructBegin(emptyStruct)
+            protocol.writeFieldBegin(new TField("hour", TType.I32, 1))
+            protocol.writeI32(value.getHour)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("minute", TType.I32, 2))
+            protocol.writeI32(value.getMinute)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("second", TType.I32, 3))
+            protocol.writeI32(value.getSecond)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("nano", TType.I32, 4))
+            protocol.writeI32(value.getNano)
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+          }
+        }
+
+        private[this] val monthCodec = new ThriftBinaryCodec[java.time.Month]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.Month        = java.time.Month.of(protocol.readI32())
+          def encode(value: java.time.Month, protocol: TProtocol): Unit = protocol.writeI32(value.getValue)
+        }
+
+        private[this] val monthDayCodec = new ThriftBinaryCodec[java.time.MonthDay]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.MonthDay = {
+            protocol.readStructBegin()
+            readField(protocol, 1, TType.I32)
+            val month = protocol.readI32()
+            readField(protocol, 2, TType.I32)
+            val day = protocol.readI32()
+            readFieldStop(protocol)
+            protocol.readStructEnd()
+            java.time.MonthDay.of(month, day)
+          }
+
+          def encode(value: java.time.MonthDay, protocol: TProtocol): Unit = {
+            protocol.writeStructBegin(emptyStruct)
+            protocol.writeFieldBegin(new TField("month", TType.I32, 1))
+            protocol.writeI32(value.getMonthValue)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("day", TType.I32, 2))
+            protocol.writeI32(value.getDayOfMonth)
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+          }
+        }
+
+        private[this] val offsetDateTimeCodec = new ThriftBinaryCodec[java.time.OffsetDateTime]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.OffsetDateTime = {
+            protocol.readStructBegin()
+            readField(protocol, 1, TType.I32)
+            val year = protocol.readI32()
+            readField(protocol, 2, TType.I32)
+            val month = protocol.readI32()
+            readField(protocol, 3, TType.I32)
+            val day = protocol.readI32()
+            readField(protocol, 4, TType.I32)
+            val hour = protocol.readI32()
+            readField(protocol, 5, TType.I32)
+            val minute = protocol.readI32()
+            readField(protocol, 6, TType.I32)
+            val second = protocol.readI32()
+            readField(protocol, 7, TType.I32)
+            val nano = protocol.readI32()
+            readField(protocol, 8, TType.I32)
+            val offsetSecond = protocol.readI32()
+            readFieldStop(protocol)
+            protocol.readStructEnd()
+            java.time.OffsetDateTime
+              .of(year, month, day, hour, minute, second, nano, java.time.ZoneOffset.ofTotalSeconds(offsetSecond))
+          }
+
+          def encode(value: java.time.OffsetDateTime, protocol: TProtocol): Unit = {
+            protocol.writeStructBegin(emptyStruct)
+            protocol.writeFieldBegin(new TField("year", TType.I32, 1))
+            protocol.writeI32(value.getYear)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("month", TType.I32, 2))
+            protocol.writeI32(value.getMonthValue)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("day", TType.I32, 3))
+            protocol.writeI32(value.getDayOfMonth)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("hour", TType.I32, 4))
+            protocol.writeI32(value.getHour)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("minute", TType.I32, 5))
+            protocol.writeI32(value.getMinute)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("second", TType.I32, 6))
+            protocol.writeI32(value.getSecond)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("nano", TType.I32, 7))
+            protocol.writeI32(value.getNano)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("offsetSecond", TType.I32, 8))
+            protocol.writeI32(value.getOffset.getTotalSeconds)
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+          }
+        }
+
+        private[this] val offsetTimeCodec = new ThriftBinaryCodec[java.time.OffsetTime]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.OffsetTime = {
+            protocol.readStructBegin()
+            readField(protocol, 1, TType.I32)
+            val hour = protocol.readI32()
+            readField(protocol, 2, TType.I32)
+            val minute = protocol.readI32()
+            readField(protocol, 3, TType.I32)
+            val second = protocol.readI32()
+            readField(protocol, 4, TType.I32)
+            val nano = protocol.readI32()
+            readField(protocol, 5, TType.I32)
+            val offsetSecond = protocol.readI32()
+            readFieldStop(protocol)
+            protocol.readStructEnd()
+            java.time.OffsetTime.of(hour, minute, second, nano, java.time.ZoneOffset.ofTotalSeconds(offsetSecond))
+          }
+
+          def encode(value: java.time.OffsetTime, protocol: TProtocol): Unit = {
+            protocol.writeStructBegin(emptyStruct)
+            protocol.writeFieldBegin(new TField("hour", TType.I32, 1))
+            protocol.writeI32(value.getHour)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("minute", TType.I32, 2))
+            protocol.writeI32(value.getMinute)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("second", TType.I32, 3))
+            protocol.writeI32(value.getSecond)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("nano", TType.I32, 4))
+            protocol.writeI32(value.getNano)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("offsetSecond", TType.I32, 5))
+            protocol.writeI32(value.getOffset.getTotalSeconds)
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+          }
+        }
+
+        private[this] val periodCodec = new ThriftBinaryCodec[java.time.Period]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.Period = {
+            protocol.readStructBegin()
+            readField(protocol, 1, TType.I32)
+            val years = protocol.readI32()
+            readField(protocol, 2, TType.I32)
+            val months = protocol.readI32()
+            readField(protocol, 3, TType.I32)
+            val days = protocol.readI32()
+            readFieldStop(protocol)
+            protocol.readStructEnd()
+            java.time.Period.of(years, months, days)
+          }
+
+          def encode(value: java.time.Period, protocol: TProtocol): Unit = {
+            protocol.writeStructBegin(emptyStruct)
+            protocol.writeFieldBegin(new TField("years", TType.I32, 1))
+            protocol.writeI32(value.getYears)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("months", TType.I32, 2))
+            protocol.writeI32(value.getMonths)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("days", TType.I32, 3))
+            protocol.writeI32(value.getDays)
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+          }
+        }
+
+        private[this] val yearCodec = new ThriftBinaryCodec[java.time.Year]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.Year        = java.time.Year.of(protocol.readI32())
+          def encode(value: java.time.Year, protocol: TProtocol): Unit = protocol.writeI32(value.getValue)
+        }
+
+        private[this] val yearMonthCodec = new ThriftBinaryCodec[java.time.YearMonth]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.YearMonth = {
+            protocol.readStructBegin()
+            readField(protocol, 1, TType.I32)
+            val year = protocol.readI32()
+            readField(protocol, 2, TType.I32)
+            val month = protocol.readI32()
+            readFieldStop(protocol)
+            protocol.readStructEnd()
+            java.time.YearMonth.of(year, month)
+          }
+
+          def encode(value: java.time.YearMonth, protocol: TProtocol): Unit = {
+            protocol.writeStructBegin(emptyStruct)
+            protocol.writeFieldBegin(new TField("year", TType.I32, 1))
+            protocol.writeI32(value.getYear)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("month", TType.I32, 2))
+            protocol.writeI32(value.getMonthValue)
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+          }
+        }
+
+        private[this] val zoneIdCodec = new ThriftBinaryCodec[java.time.ZoneId]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.ZoneId        = java.time.ZoneId.of(protocol.readString())
+          def encode(value: java.time.ZoneId, protocol: TProtocol): Unit = protocol.writeString(value.toString)
+        }
+
+        private[this] val zoneOffsetCodec = new ThriftBinaryCodec[java.time.ZoneOffset]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.ZoneOffset =
+            java.time.ZoneOffset.ofTotalSeconds(protocol.readI32())
+          def encode(value: java.time.ZoneOffset, protocol: TProtocol): Unit = protocol.writeI32(value.getTotalSeconds)
+        }
+
+        private[this] val zonedDateTimeCodec = new ThriftBinaryCodec[java.time.ZonedDateTime]() {
+          def decodeUnsafe(protocol: TProtocol): java.time.ZonedDateTime = {
+            protocol.readStructBegin()
+            readField(protocol, 1, TType.I32)
+            val year = protocol.readI32()
+            readField(protocol, 2, TType.I32)
+            val month = protocol.readI32()
+            readField(protocol, 3, TType.I32)
+            val day = protocol.readI32()
+            readField(protocol, 4, TType.I32)
+            val hour = protocol.readI32()
+            readField(protocol, 5, TType.I32)
+            val minute = protocol.readI32()
+            readField(protocol, 6, TType.I32)
+            val second = protocol.readI32()
+            readField(protocol, 7, TType.I32)
+            val nano = protocol.readI32()
+            readField(protocol, 8, TType.I32)
+            val offsetSecond = protocol.readI32()
+            readField(protocol, 9, TType.STRING)
+            val zoneId = protocol.readString()
+            readFieldStop(protocol)
+            protocol.readStructEnd()
+            java.time.ZonedDateTime.ofInstant(
+              java.time.LocalDateTime.of(year, month, day, hour, minute, second, nano),
+              java.time.ZoneOffset.ofTotalSeconds(offsetSecond),
+              java.time.ZoneId.of(zoneId)
+            )
+          }
+
+          def encode(value: java.time.ZonedDateTime, protocol: TProtocol): Unit = {
+            protocol.writeStructBegin(emptyStruct)
+            protocol.writeFieldBegin(new TField("year", TType.I32, 1))
+            protocol.writeI32(value.getYear)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("month", TType.I32, 2))
+            protocol.writeI32(value.getMonthValue)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("day", TType.I32, 3))
+            protocol.writeI32(value.getDayOfMonth)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("hour", TType.I32, 4))
+            protocol.writeI32(value.getHour)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("minute", TType.I32, 5))
+            protocol.writeI32(value.getMinute)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("second", TType.I32, 6))
+            protocol.writeI32(value.getSecond)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("nano", TType.I32, 7))
+            protocol.writeI32(value.getNano)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("offsetSecond", TType.I32, 8))
+            protocol.writeI32(value.getOffset.getTotalSeconds)
+            protocol.writeFieldEnd()
+            protocol.writeFieldBegin(new TField("zoneId", TType.STRING, 9))
+            protocol.writeString(value.getZone.toString)
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+          }
+        }
+
+        private[this] val currencyCodec = new ThriftBinaryCodec[java.util.Currency]() {
+          def decodeUnsafe(protocol: TProtocol): java.util.Currency =
+            java.util.Currency.getInstance(protocol.readString())
+          def encode(value: java.util.Currency, protocol: TProtocol): Unit = protocol.writeString(value.getCurrencyCode)
+        }
+
+        private[this] val uuidCodec = new ThriftBinaryCodec[java.util.UUID]() {
+          def decodeUnsafe(protocol: TProtocol): java.util.UUID = {
+            val hi = protocol.readI64()
+            val lo = protocol.readI64()
+            new java.util.UUID(hi, lo)
+          }
+
+          def encode(value: java.util.UUID, protocol: TProtocol): Unit = {
+            protocol.writeI64(value.getMostSignificantBits)
+            protocol.writeI64(value.getLeastSignificantBits)
+          }
+        }
+
+        private[this] val emptyStruct = new TStruct("")
+
+        private[this] def readField(protocol: TProtocol, expectedId: Short, expectedType: Byte): Unit = {
+          val field = protocol.readFieldBegin()
+          if (field.id != expectedId || field.`type` != expectedType) {
+            throw new ThriftBinaryCodecError(Nil, s"Expected field $expectedId of type $expectedType")
+          }
+        }
+
+        private[this] def readFieldStop(protocol: TProtocol): Unit = {
+          val field = protocol.readFieldBegin()
+          if (field.`type` != TType.STOP) {
+            throw new ThriftBinaryCodecError(Nil, "Expected field stop")
+          }
+        }
+
+        private[this] def getThriftType(codec: ThriftBinaryCodec[?]): Byte = codec.valueType match {
+          case ThriftBinaryCodec.booleanType => TType.BOOL
+          case ThriftBinaryCodec.byteType    => TType.BYTE
+          case ThriftBinaryCodec.shortType   => TType.I16
+          case ThriftBinaryCodec.intType     => TType.I32
+          case ThriftBinaryCodec.longType    => TType.I64
+          case ThriftBinaryCodec.floatType   => TType.I32
+          case ThriftBinaryCodec.doubleType  => TType.DOUBLE
+          case ThriftBinaryCodec.charType    => TType.I32
+          case ThriftBinaryCodec.unitType    => TType.STRUCT
+          case _                             => TType.STRUCT
+        }
+
+        private[this] def deriveCodec[F[_, _], A](reflect: Reflect[F, A]): ThriftBinaryCodec[A] = {
+          if (reflect.isPrimitive) {
+            val primitive = reflect.asPrimitive.get
+            if (primitive.primitiveBinding.isInstanceOf[Binding[?, ?]]) {
+              primitive.primitiveType match {
+                case _: PrimitiveType.Unit.type      => unitCodec
+                case _: PrimitiveType.Boolean        => booleanCodec
+                case _: PrimitiveType.Byte           => byteCodec
+                case _: PrimitiveType.Short          => shortCodec
+                case _: PrimitiveType.Int            => intCodec
+                case _: PrimitiveType.Long           => longCodec
+                case _: PrimitiveType.Float          => floatCodec
+                case _: PrimitiveType.Double         => doubleCodec
+                case _: PrimitiveType.Char           => charCodec
+                case _: PrimitiveType.String         => stringCodec
+                case _: PrimitiveType.BigInt         => bigIntCodec
+                case _: PrimitiveType.BigDecimal     => bigDecimalCodec
+                case _: PrimitiveType.DayOfWeek      => dayOfWeekCodec
+                case _: PrimitiveType.Duration       => durationCodec
+                case _: PrimitiveType.Instant        => instantCodec
+                case _: PrimitiveType.LocalDate      => localDateCodec
+                case _: PrimitiveType.LocalDateTime  => localDateTimeCodec
+                case _: PrimitiveType.LocalTime      => localTimeCodec
+                case _: PrimitiveType.Month          => monthCodec
+                case _: PrimitiveType.MonthDay       => monthDayCodec
+                case _: PrimitiveType.OffsetDateTime => offsetDateTimeCodec
+                case _: PrimitiveType.OffsetTime     => offsetTimeCodec
+                case _: PrimitiveType.Period         => periodCodec
+                case _: PrimitiveType.Year           => yearCodec
+                case _: PrimitiveType.YearMonth      => yearMonthCodec
+                case _: PrimitiveType.ZoneId         => zoneIdCodec
+                case _: PrimitiveType.ZoneOffset     => zoneOffsetCodec
+                case _: PrimitiveType.ZonedDateTime  => zonedDateTimeCodec
+                case _: PrimitiveType.Currency       => currencyCodec
+                case _: PrimitiveType.UUID           => uuidCodec
+              }
+            } else primitive.primitiveBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isVariant) {
+            val variant = reflect.asVariant.get
+            if (variant.variantBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding = variant.variantBinding.asInstanceOf[Binding.Variant[A]]
+              val cases   = variant.cases
+              val len     = cases.length
+              val codecs  = new Array[ThriftBinaryCodec[?]](len)
+              val types   = new Array[Byte](len)
+              var idx     = 0
+              while (idx < len) {
+                val codec = deriveCodec(cases(idx).value)
+                codecs(idx) = codec
+                types(idx) = getThriftType(codec)
+                idx += 1
+              }
+              new ThriftBinaryCodec[A]() {
+                private[this] val discriminator = binding.discriminator
+                private[this] val caseCodecs    = codecs
+                private[this] val caseTypes     = types
+
+                def decodeUnsafe(protocol: TProtocol): A = {
+                  protocol.readStructBegin()
+                  val field = protocol.readFieldBegin()
+                  val idx   = field.id.toInt - 1
+                  if (idx >= 0 && idx < caseCodecs.length) {
+                    val result =
+                      try caseCodecs(idx).asInstanceOf[ThriftBinaryCodec[A]].decodeUnsafe(protocol)
+                      catch {
+                        case error if NonFatal(error) => decodeError(new DynamicOptic.Node.Case(cases(idx).name), error)
+                      }
+                    protocol.readFieldEnd()
+                    readFieldStop(protocol)
+                    protocol.readStructEnd()
+                    result
+                  } else decodeError(s"Expected union field from 1 to ${caseCodecs.length}, got ${field.id}")
+                }
+
+                def encode(value: A, protocol: TProtocol): Unit = {
+                  val idx = discriminator.discriminate(value)
+                  protocol.writeStructBegin(emptyStruct)
+                  protocol.writeFieldBegin(new TField(cases(idx).name, caseTypes(idx), (idx + 1).toShort))
+                  caseCodecs(idx).asInstanceOf[ThriftBinaryCodec[A]].encode(value, protocol)
+                  protocol.writeFieldEnd()
+                  protocol.writeFieldStop()
+                  protocol.writeStructEnd()
+                }
+              }
+            } else variant.variantBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isSequence) {
+            val sequence = reflect.asSequenceUnknown.get.sequence
+            if (sequence.seqBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding  = sequence.seqBinding.asInstanceOf[Binding.Seq[Col, Elem]]
+              val codec    = deriveCodec(sequence.element).asInstanceOf[ThriftBinaryCodec[Elem]]
+              val elemType = getThriftType(codec)
+              new ThriftBinaryCodec[Col[Elem]]() {
+                private[this] val deconstructor = binding.deconstructor
+                private[this] val constructor   = binding.constructor
+                private[this] val elementCodec  = codec
+                private[this] val elementType   = elemType
+
+                def decodeUnsafe(protocol: TProtocol): Col[Elem] = {
+                  val list = protocol.readListBegin()
+                  val size = list.size
+                  if (size > ThriftBinaryCodec.maxCollectionSize) {
+                    decodeError(
+                      s"Expected collection size not greater than ${ThriftBinaryCodec.maxCollectionSize}, got $size"
+                    )
+                  }
+                  val builder = constructor.newObjectBuilder[Elem](size)
+                  var idx     = 0
+                  try {
+                    while (idx < size) {
+                      constructor.addObject(builder, elementCodec.decodeUnsafe(protocol))
+                      idx += 1
+                    }
+                  } catch {
+                    case error if NonFatal(error) =>
+                      decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                  }
+                  protocol.readListEnd()
+                  constructor.resultObject[Elem](builder)
+                }
+
+                def encode(value: Col[Elem], protocol: TProtocol): Unit = {
+                  val size = deconstructor.size(value)
+                  protocol.writeListBegin(new TList(elementType, size))
+                  val it = deconstructor.deconstruct(value)
+                  while (it.hasNext) elementCodec.encode(it.next(), protocol)
+                  protocol.writeListEnd()
+                }
+              }
+            } else sequence.seqBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isMap) {
+            val map = reflect.asMapUnknown.get.map
+            if (map.mapBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding  = map.mapBinding.asInstanceOf[Binding.Map[Map, Key, Value]]
+              val keyCodec = deriveCodec(map.key).asInstanceOf[ThriftBinaryCodec[Key]]
+              val valCodec = deriveCodec(map.value).asInstanceOf[ThriftBinaryCodec[Value]]
+              val keyType  = getThriftType(keyCodec)
+              val valType  = getThriftType(valCodec)
+              new ThriftBinaryCodec[Map[Key, Value]]() {
+                private[this] val deconstructor = binding.deconstructor
+                private[this] val constructor   = binding.constructor
+                private[this] val kCodec        = keyCodec
+                private[this] val vCodec        = valCodec
+                private[this] val kType         = keyType
+                private[this] val vType         = valType
+                private[this] val keyReflect    = map.key.asInstanceOf[Reflect.Bound[Key]]
+
+                def decodeUnsafe(protocol: TProtocol): Map[Key, Value] = {
+                  val thriftMap = protocol.readMapBegin()
+                  val size      = thriftMap.size
+                  if (size > ThriftBinaryCodec.maxCollectionSize) {
+                    decodeError(s"Expected map size not greater than ${ThriftBinaryCodec.maxCollectionSize}, got $size")
+                  }
+                  val builder = constructor.newObjectBuilder[Key, Value](size)
+                  var idx     = 0
+                  while (idx < size) {
+                    val k =
+                      try kCodec.decodeUnsafe(protocol)
+                      catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                      }
+                    val v =
+                      try vCodec.decodeUnsafe(protocol)
+                      catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtMapKey(keyReflect.toDynamicValue(k)), error)
+                      }
+                    constructor.addObject(builder, k, v)
+                    idx += 1
+                  }
+                  protocol.readMapEnd()
+                  constructor.resultObject[Key, Value](builder)
+                }
+
+                def encode(value: Map[Key, Value], protocol: TProtocol): Unit = {
+                  val size = deconstructor.size(value)
+                  protocol.writeMapBegin(new TMap(kType, vType, size))
+                  val it = deconstructor.deconstruct(value)
+                  while (it.hasNext) {
+                    val kv = it.next()
+                    kCodec.encode(deconstructor.getKey(kv), protocol)
+                    vCodec.encode(deconstructor.getValue(kv), protocol)
+                  }
+                  protocol.writeMapEnd()
+                }
+              }
+            } else map.mapBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isRecord) {
+            val record = reflect.asRecord.get
+            if (record.recordBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding     = record.recordBinding.asInstanceOf[Binding.Record[A]]
+              val fields      = record.fields
+              val isRecursive = fields.exists(_.value.isInstanceOf[Reflect.Deferred[F, ?]])
+              val typeName    = record.typeName
+              var codecs      = if (isRecursive) recursiveRecordCache.get.get(typeName) else null
+              var offset      = 0L
+              if (codecs eq null) {
+                val len = fields.length
+                codecs = new Array[ThriftBinaryCodec[?]](len)
+                if (isRecursive) recursiveRecordCache.get.put(typeName, codecs)
+                var idx = 0
+                while (idx < len) {
+                  val field = fields(idx)
+                  val codec = deriveCodec(field.value)
+                  codecs(idx) = codec
+                  offset = RegisterOffset.add(codec.valueOffset, offset)
+                  idx += 1
+                }
+              }
+              new ThriftBinaryCodec[A]() {
+                private[this] val deconstructor                = binding.deconstructor
+                private[this] val constructor                  = binding.constructor
+                private[this] val usedRegisters                = offset
+                private[this] val fieldCodecs                  = codecs
+                @volatile private[this] var types: Array[Byte] = null
+
+                private[this] def getTypes: Array[Byte] = {
+                  var t = types
+                  if (t eq null) {
+                    t = new Array[Byte](fieldCodecs.length)
+                    var i = 0
+                    while (i < fieldCodecs.length) {
+                      t(i) = getThriftType(fieldCodecs(i))
+                      i += 1
+                    }
+                    types = t
+                  }
+                  t
+                }
+
+                def decodeUnsafe(protocol: TProtocol): A = {
+                  val regs      = Registers(usedRegisters)
+                  var regOffset = 0L
+                  protocol.readStructBegin()
+                  val len = fieldCodecs.length
+                  var idx = 0
+                  try {
+                    while (idx < len) {
+                      val field = protocol.readFieldBegin()
+                      if (field.`type` == TType.STOP) {
+                        decodeError(s"Expected field ${idx + 1}, got STOP")
+                      }
+                      val codec = fieldCodecs(idx)
+                      codec.valueType match {
+                        case ThriftBinaryCodec.objectType =>
+                          regs
+                            .setObject(regOffset, codec.asInstanceOf[ThriftBinaryCodec[AnyRef]].decodeUnsafe(protocol))
+                        case ThriftBinaryCodec.intType =>
+                          regs.setInt(regOffset, codec.asInstanceOf[ThriftBinaryCodec[Int]].decodeUnsafe(protocol))
+                        case ThriftBinaryCodec.longType =>
+                          regs.setLong(regOffset, codec.asInstanceOf[ThriftBinaryCodec[Long]].decodeUnsafe(protocol))
+                        case ThriftBinaryCodec.floatType =>
+                          regs.setFloat(regOffset, codec.asInstanceOf[ThriftBinaryCodec[Float]].decodeUnsafe(protocol))
+                        case ThriftBinaryCodec.doubleType =>
+                          regs
+                            .setDouble(regOffset, codec.asInstanceOf[ThriftBinaryCodec[Double]].decodeUnsafe(protocol))
+                        case ThriftBinaryCodec.booleanType =>
+                          regs.setBoolean(
+                            regOffset,
+                            codec.asInstanceOf[ThriftBinaryCodec[Boolean]].decodeUnsafe(protocol)
+                          )
+                        case ThriftBinaryCodec.byteType =>
+                          regs.setByte(regOffset, codec.asInstanceOf[ThriftBinaryCodec[Byte]].decodeUnsafe(protocol))
+                        case ThriftBinaryCodec.charType =>
+                          regs.setChar(regOffset, codec.asInstanceOf[ThriftBinaryCodec[Char]].decodeUnsafe(protocol))
+                        case ThriftBinaryCodec.shortType =>
+                          regs.setShort(regOffset, codec.asInstanceOf[ThriftBinaryCodec[Short]].decodeUnsafe(protocol))
+                        case _ => codec.asInstanceOf[ThriftBinaryCodec[Unit]].decodeUnsafe(protocol)
+                      }
+                      protocol.readFieldEnd()
+                      regOffset += codec.valueOffset
+                      idx += 1
+                    }
+                    readFieldStop(protocol)
+                    protocol.readStructEnd()
+                    constructor.construct(regs, 0)
+                  } catch {
+                    case error if NonFatal(error) => decodeError(new DynamicOptic.Node.Field(fields(idx).name), error)
+                  }
+                }
+
+                def encode(value: A, protocol: TProtocol): Unit = {
+                  val regs      = Registers(usedRegisters)
+                  var regOffset = 0L
+                  deconstructor.deconstruct(regs, regOffset, value)
+                  protocol.writeStructBegin(emptyStruct)
+                  val len        = fieldCodecs.length
+                  val fieldTypes = getTypes
+                  var idx        = 0
+                  while (idx < len) {
+                    val codec = fieldCodecs(idx)
+                    protocol.writeFieldBegin(new TField(fields(idx).name, fieldTypes(idx), (idx + 1).toShort))
+                    codec.valueType match {
+                      case ThriftBinaryCodec.objectType =>
+                        codec.asInstanceOf[ThriftBinaryCodec[AnyRef]].encode(regs.getObject(regOffset), protocol)
+                      case ThriftBinaryCodec.intType =>
+                        codec.asInstanceOf[ThriftBinaryCodec[Int]].encode(regs.getInt(regOffset), protocol)
+                      case ThriftBinaryCodec.longType =>
+                        codec.asInstanceOf[ThriftBinaryCodec[Long]].encode(regs.getLong(regOffset), protocol)
+                      case ThriftBinaryCodec.floatType =>
+                        codec.asInstanceOf[ThriftBinaryCodec[Float]].encode(regs.getFloat(regOffset), protocol)
+                      case ThriftBinaryCodec.doubleType =>
+                        codec.asInstanceOf[ThriftBinaryCodec[Double]].encode(regs.getDouble(regOffset), protocol)
+                      case ThriftBinaryCodec.booleanType =>
+                        codec.asInstanceOf[ThriftBinaryCodec[Boolean]].encode(regs.getBoolean(regOffset), protocol)
+                      case ThriftBinaryCodec.byteType =>
+                        codec.asInstanceOf[ThriftBinaryCodec[Byte]].encode(regs.getByte(regOffset), protocol)
+                      case ThriftBinaryCodec.charType =>
+                        codec.asInstanceOf[ThriftBinaryCodec[Char]].encode(regs.getChar(regOffset), protocol)
+                      case ThriftBinaryCodec.shortType =>
+                        codec.asInstanceOf[ThriftBinaryCodec[Short]].encode(regs.getShort(regOffset), protocol)
+                      case _ => codec.asInstanceOf[ThriftBinaryCodec[Unit]].encode((), protocol)
+                    }
+                    protocol.writeFieldEnd()
+                    regOffset += codec.valueOffset
+                    idx += 1
+                  }
+                  protocol.writeFieldStop()
+                  protocol.writeStructEnd()
+                }
+              }
+            } else record.recordBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isWrapper) {
+            val wrapper = reflect.asWrapperUnknown.get.wrapper
+            if (wrapper.wrapperBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding = wrapper.wrapperBinding.asInstanceOf[Binding.Wrapper[A, Wrapped]]
+              val codec   = deriveCodec(wrapper.wrapped).asInstanceOf[ThriftBinaryCodec[Wrapped]]
+              new ThriftBinaryCodec[A](wrapper.wrapperPrimitiveType.fold(ThriftBinaryCodec.objectType) {
+                case _: PrimitiveType.Boolean   => ThriftBinaryCodec.booleanType
+                case _: PrimitiveType.Byte      => ThriftBinaryCodec.byteType
+                case _: PrimitiveType.Char      => ThriftBinaryCodec.charType
+                case _: PrimitiveType.Short     => ThriftBinaryCodec.shortType
+                case _: PrimitiveType.Float     => ThriftBinaryCodec.floatType
+                case _: PrimitiveType.Int       => ThriftBinaryCodec.intType
+                case _: PrimitiveType.Double    => ThriftBinaryCodec.doubleType
+                case _: PrimitiveType.Long      => ThriftBinaryCodec.longType
+                case _: PrimitiveType.Unit.type => ThriftBinaryCodec.unitType
+                case _                          => ThriftBinaryCodec.objectType
+              }) {
+                private[this] val unwrap       = binding.unwrap
+                private[this] val wrap         = binding.wrap
+                private[this] val wrappedCodec = codec
+
+                def decodeUnsafe(protocol: TProtocol): A = {
+                  val wrapped =
+                    try wrappedCodec.decodeUnsafe(protocol)
+                    catch {
+                      case error if NonFatal(error) => decodeError(DynamicOptic.Node.Wrapped, error)
+                    }
+                  wrap(wrapped) match {
+                    case Right(x)  => x
+                    case Left(err) => decodeError(err)
+                  }
+                }
+
+                def encode(value: A, protocol: TProtocol): Unit = wrappedCodec.encode(unwrap(value), protocol)
+              }
+            } else wrapper.wrapperBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else {
+            val dynamic = reflect.asDynamic.get
+            if (dynamic.dynamicBinding.isInstanceOf[Binding[?, ?]]) dynamicValueCodec
+            else dynamic.dynamicBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          }
+        }.asInstanceOf[ThriftBinaryCodec[A]]
+
+        private[this] val dynamicValueCodec = new ThriftBinaryCodec[DynamicValue]() {
+          private[this] val spanPrimitive = new DynamicOptic.Node.Case("Primitive")
+          private[this] val spanRecord    = new DynamicOptic.Node.Case("Record")
+          private[this] val spanVariant   = new DynamicOptic.Node.Case("Variant")
+          private[this] val spanSequence  = new DynamicOptic.Node.Case("Sequence")
+          private[this] val spanMap       = new DynamicOptic.Node.Case("Map")
+          private[this] val spanFields    = new DynamicOptic.Node.Field("fields")
+          private[this] val spanCaseName  = new DynamicOptic.Node.Field("caseName")
+          private[this] val spanValue     = new DynamicOptic.Node.Field("value")
+          private[this] val spanElements  = new DynamicOptic.Node.Field("elements")
+          private[this] val spanEntries   = new DynamicOptic.Node.Field("entries")
+          private[this] val span_1        = new DynamicOptic.Node.Field("_1")
+          private[this] val span_2        = new DynamicOptic.Node.Field("_2")
+
+          def decodeUnsafe(protocol: TProtocol): DynamicValue = {
+            protocol.readStructBegin()
+            val field  = protocol.readFieldBegin()
+            val result = (field.id: @scala.annotation.switch) match {
+              case 1 =>
+                try {
+                  protocol.readStructBegin()
+                  val primitiveField = protocol.readFieldBegin()
+                  val idx            = primitiveField.id.toInt - 1
+                  if (idx < 0 || idx > 29)
+                    decodeError(s"Expected primitive index from 1 to 30, got ${primitiveField.id}")
+                  val value =
+                    try {
+                      new DynamicValue.Primitive((idx: @scala.annotation.switch) match {
+                        case 0  => PrimitiveValue.Unit
+                        case 1  => new PrimitiveValue.Boolean(booleanCodec.decodeUnsafe(protocol))
+                        case 2  => new PrimitiveValue.Byte(byteCodec.decodeUnsafe(protocol))
+                        case 3  => new PrimitiveValue.Short(shortCodec.decodeUnsafe(protocol))
+                        case 4  => new PrimitiveValue.Int(intCodec.decodeUnsafe(protocol))
+                        case 5  => new PrimitiveValue.Long(longCodec.decodeUnsafe(protocol))
+                        case 6  => new PrimitiveValue.Float(floatCodec.decodeUnsafe(protocol))
+                        case 7  => new PrimitiveValue.Double(doubleCodec.decodeUnsafe(protocol))
+                        case 8  => new PrimitiveValue.Char(charCodec.decodeUnsafe(protocol))
+                        case 9  => new PrimitiveValue.String(stringCodec.decodeUnsafe(protocol))
+                        case 10 => new PrimitiveValue.BigInt(bigIntCodec.decodeUnsafe(protocol))
+                        case 11 => new PrimitiveValue.BigDecimal(bigDecimalCodec.decodeUnsafe(protocol))
+                        case 12 => new PrimitiveValue.DayOfWeek(dayOfWeekCodec.decodeUnsafe(protocol))
+                        case 13 => new PrimitiveValue.Duration(durationCodec.decodeUnsafe(protocol))
+                        case 14 => new PrimitiveValue.Instant(instantCodec.decodeUnsafe(protocol))
+                        case 15 => new PrimitiveValue.LocalDate(localDateCodec.decodeUnsafe(protocol))
+                        case 16 => new PrimitiveValue.LocalDateTime(localDateTimeCodec.decodeUnsafe(protocol))
+                        case 17 => new PrimitiveValue.LocalTime(localTimeCodec.decodeUnsafe(protocol))
+                        case 18 => new PrimitiveValue.Month(monthCodec.decodeUnsafe(protocol))
+                        case 19 => new PrimitiveValue.MonthDay(monthDayCodec.decodeUnsafe(protocol))
+                        case 20 => new PrimitiveValue.OffsetDateTime(offsetDateTimeCodec.decodeUnsafe(protocol))
+                        case 21 => new PrimitiveValue.OffsetTime(offsetTimeCodec.decodeUnsafe(protocol))
+                        case 22 => new PrimitiveValue.Period(periodCodec.decodeUnsafe(protocol))
+                        case 23 => new PrimitiveValue.Year(yearCodec.decodeUnsafe(protocol))
+                        case 24 => new PrimitiveValue.YearMonth(yearMonthCodec.decodeUnsafe(protocol))
+                        case 25 => new PrimitiveValue.ZoneId(zoneIdCodec.decodeUnsafe(protocol))
+                        case 26 => new PrimitiveValue.ZoneOffset(zoneOffsetCodec.decodeUnsafe(protocol))
+                        case 27 => new PrimitiveValue.ZonedDateTime(zonedDateTimeCodec.decodeUnsafe(protocol))
+                        case 28 => new PrimitiveValue.Currency(currencyCodec.decodeUnsafe(protocol))
+                        case _  => new PrimitiveValue.UUID(uuidCodec.decodeUnsafe(protocol))
+                      })
+                    } catch {
+                      case error if NonFatal(error) => decodeError(spanValue, error)
+                    }
+                  protocol.readFieldEnd()
+                  readFieldStop(protocol)
+                  protocol.readStructEnd()
+                  value
+                } catch {
+                  case error if NonFatal(error) => decodeError(spanPrimitive, error)
+                }
+              case 2 =>
+                try {
+                  val list = protocol.readListBegin()
+                  val size = list.size
+                  if (size > ThriftBinaryCodec.maxCollectionSize) {
+                    decodeError(
+                      s"Expected collection size not greater than ${ThriftBinaryCodec.maxCollectionSize}, got $size"
+                    )
+                  }
+                  val builder = Vector.newBuilder[(String, DynamicValue)]
+                  var idx     = 0
+                  while (idx < size) {
+                    protocol.readStructBegin()
+                    readField(protocol, 1, TType.STRING)
+                    val k =
+                      try protocol.readString()
+                      catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(idx), span_1, error)
+                      }
+                    protocol.readFieldEnd()
+                    readField(protocol, 2, TType.STRUCT)
+                    val v =
+                      try decodeUnsafe(protocol)
+                      catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(idx), span_2, error)
+                      }
+                    protocol.readFieldEnd()
+                    readFieldStop(protocol)
+                    protocol.readStructEnd()
+                    builder.addOne((k, v))
+                    idx += 1
+                  }
+                  protocol.readListEnd()
+                  new DynamicValue.Record(builder.result())
+                } catch {
+                  case error if NonFatal(error) => decodeError(spanRecord, spanFields, error)
+                }
+              case 3 =>
+                protocol.readStructBegin()
+                readField(protocol, 1, TType.STRING)
+                val caseName =
+                  try protocol.readString()
+                  catch {
+                    case error if NonFatal(error) => decodeError(spanVariant, spanCaseName, error)
+                  }
+                protocol.readFieldEnd()
+                readField(protocol, 2, TType.STRUCT)
+                val value =
+                  try decodeUnsafe(protocol)
+                  catch {
+                    case error if NonFatal(error) => decodeError(spanVariant, spanValue, error)
+                  }
+                protocol.readFieldEnd()
+                readFieldStop(protocol)
+                protocol.readStructEnd()
+                new DynamicValue.Variant(caseName, value)
+              case 4 =>
+                try {
+                  val list = protocol.readListBegin()
+                  val size = list.size
+                  if (size > ThriftBinaryCodec.maxCollectionSize) {
+                    decodeError(
+                      s"Expected collection size not greater than ${ThriftBinaryCodec.maxCollectionSize}, got $size"
+                    )
+                  }
+                  val builder = Vector.newBuilder[DynamicValue]
+                  var idx     = 0
+                  try {
+                    while (idx < size) {
+                      builder.addOne(decodeUnsafe(protocol))
+                      idx += 1
+                    }
+                  } catch {
+                    case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(idx), error)
+                  }
+                  protocol.readListEnd()
+                  new DynamicValue.Sequence(builder.result())
+                } catch {
+                  case error if NonFatal(error) => decodeError(spanSequence, spanElements, error)
+                }
+              case 5 =>
+                try {
+                  val list = protocol.readListBegin()
+                  val size = list.size
+                  if (size > ThriftBinaryCodec.maxCollectionSize) {
+                    decodeError(
+                      s"Expected collection size not greater than ${ThriftBinaryCodec.maxCollectionSize}, got $size"
+                    )
+                  }
+                  val builder = Vector.newBuilder[(DynamicValue, DynamicValue)]
+                  var idx     = 0
+                  while (idx < size) {
+                    protocol.readStructBegin()
+                    readField(protocol, 1, TType.STRUCT)
+                    val k =
+                      try decodeUnsafe(protocol)
+                      catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(idx), span_1, error)
+                      }
+                    protocol.readFieldEnd()
+                    readField(protocol, 2, TType.STRUCT)
+                    val v =
+                      try decodeUnsafe(protocol)
+                      catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(idx), span_2, error)
+                      }
+                    protocol.readFieldEnd()
+                    readFieldStop(protocol)
+                    protocol.readStructEnd()
+                    builder.addOne((k, v))
+                    idx += 1
+                  }
+                  protocol.readListEnd()
+                  new DynamicValue.Map(builder.result())
+                } catch {
+                  case error if NonFatal(error) => decodeError(spanMap, spanEntries, error)
+                }
+              case idx => decodeError(s"Expected DynamicValue field from 1 to 5, got $idx")
+            }
+            protocol.readFieldEnd()
+            readFieldStop(protocol)
+            protocol.readStructEnd()
+            result
+          }
+
+          def encode(value: DynamicValue, protocol: TProtocol): Unit = value match {
+            case primitive: DynamicValue.Primitive =>
+              protocol.writeStructBegin(emptyStruct)
+              protocol.writeFieldBegin(new TField("Primitive", TType.STRUCT, 1))
+              protocol.writeStructBegin(emptyStruct)
+              primitive.value match {
+                case _: PrimitiveValue.Unit.type =>
+                  protocol.writeFieldBegin(new TField("Unit", TType.STRUCT, 1))
+                  protocol.writeStructBegin(emptyStruct)
+                  protocol.writeFieldStop()
+                  protocol.writeStructEnd()
+                case v: PrimitiveValue.Boolean =>
+                  protocol.writeFieldBegin(new TField("Boolean", TType.BOOL, 2))
+                  booleanCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.Byte =>
+                  protocol.writeFieldBegin(new TField("Byte", TType.BYTE, 3))
+                  byteCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.Short =>
+                  protocol.writeFieldBegin(new TField("Short", TType.I16, 4))
+                  shortCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.Int =>
+                  protocol.writeFieldBegin(new TField("Int", TType.I32, 5))
+                  intCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.Long =>
+                  protocol.writeFieldBegin(new TField("Long", TType.I64, 6))
+                  longCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.Float =>
+                  protocol.writeFieldBegin(new TField("Float", TType.I32, 7))
+                  floatCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.Double =>
+                  protocol.writeFieldBegin(new TField("Double", TType.DOUBLE, 8))
+                  doubleCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.Char =>
+                  protocol.writeFieldBegin(new TField("Char", TType.I32, 9))
+                  charCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.String =>
+                  protocol.writeFieldBegin(new TField("String", TType.STRING, 10))
+                  stringCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.BigInt =>
+                  protocol.writeFieldBegin(new TField("BigInt", TType.STRING, 11))
+                  bigIntCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.BigDecimal =>
+                  protocol.writeFieldBegin(new TField("BigDecimal", TType.STRUCT, 12))
+                  bigDecimalCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.DayOfWeek =>
+                  protocol.writeFieldBegin(new TField("DayOfWeek", TType.I32, 13))
+                  dayOfWeekCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.Duration =>
+                  protocol.writeFieldBegin(new TField("Duration", TType.STRUCT, 14))
+                  durationCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.Instant =>
+                  protocol.writeFieldBegin(new TField("Instant", TType.STRUCT, 15))
+                  instantCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.LocalDate =>
+                  protocol.writeFieldBegin(new TField("LocalDate", TType.STRUCT, 16))
+                  localDateCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.LocalDateTime =>
+                  protocol.writeFieldBegin(new TField("LocalDateTime", TType.STRUCT, 17))
+                  localDateTimeCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.LocalTime =>
+                  protocol.writeFieldBegin(new TField("LocalTime", TType.STRUCT, 18))
+                  localTimeCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.Month =>
+                  protocol.writeFieldBegin(new TField("Month", TType.I32, 19))
+                  monthCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.MonthDay =>
+                  protocol.writeFieldBegin(new TField("MonthDay", TType.STRUCT, 20))
+                  monthDayCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.OffsetDateTime =>
+                  protocol.writeFieldBegin(new TField("OffsetDateTime", TType.STRUCT, 21))
+                  offsetDateTimeCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.OffsetTime =>
+                  protocol.writeFieldBegin(new TField("OffsetTime", TType.STRUCT, 22))
+                  offsetTimeCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.Period =>
+                  protocol.writeFieldBegin(new TField("Period", TType.STRUCT, 23))
+                  periodCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.Year =>
+                  protocol.writeFieldBegin(new TField("Year", TType.I32, 24))
+                  yearCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.YearMonth =>
+                  protocol.writeFieldBegin(new TField("YearMonth", TType.STRUCT, 25))
+                  yearMonthCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.ZoneId =>
+                  protocol.writeFieldBegin(new TField("ZoneId", TType.STRING, 26))
+                  zoneIdCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.ZoneOffset =>
+                  protocol.writeFieldBegin(new TField("ZoneOffset", TType.I32, 27))
+                  zoneOffsetCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.ZonedDateTime =>
+                  protocol.writeFieldBegin(new TField("ZonedDateTime", TType.STRUCT, 28))
+                  zonedDateTimeCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.Currency =>
+                  protocol.writeFieldBegin(new TField("Currency", TType.STRING, 29))
+                  currencyCodec.encode(v.value, protocol)
+                case v: PrimitiveValue.UUID =>
+                  protocol.writeFieldBegin(new TField("UUID", TType.STRUCT, 30))
+                  uuidCodec.encode(v.value, protocol)
+              }
+              protocol.writeFieldEnd()
+              protocol.writeFieldStop()
+              protocol.writeStructEnd()
+              protocol.writeFieldEnd()
+              protocol.writeFieldStop()
+              protocol.writeStructEnd()
+            case record: DynamicValue.Record =>
+              protocol.writeStructBegin(emptyStruct)
+              protocol.writeFieldBegin(new TField("Record", TType.LIST, 2))
+              val fields = record.fields
+              val size   = fields.length
+              protocol.writeListBegin(new TList(TType.STRUCT, size))
+              val it = fields.iterator
+              while (it.hasNext) {
+                val kv = it.next()
+                protocol.writeStructBegin(emptyStruct)
+                protocol.writeFieldBegin(new TField("name", TType.STRING, 1))
+                protocol.writeString(kv._1)
+                protocol.writeFieldEnd()
+                protocol.writeFieldBegin(new TField("value", TType.STRUCT, 2))
+                encode(kv._2, protocol)
+                protocol.writeFieldEnd()
+                protocol.writeFieldStop()
+                protocol.writeStructEnd()
+              }
+              protocol.writeListEnd()
+              protocol.writeFieldEnd()
+              protocol.writeFieldStop()
+              protocol.writeStructEnd()
+            case variant: DynamicValue.Variant =>
+              protocol.writeStructBegin(emptyStruct)
+              protocol.writeFieldBegin(new TField("Variant", TType.STRUCT, 3))
+              protocol.writeStructBegin(emptyStruct)
+              protocol.writeFieldBegin(new TField("caseName", TType.STRING, 1))
+              protocol.writeString(variant.caseName)
+              protocol.writeFieldEnd()
+              protocol.writeFieldBegin(new TField("value", TType.STRUCT, 2))
+              encode(variant.value, protocol)
+              protocol.writeFieldEnd()
+              protocol.writeFieldStop()
+              protocol.writeStructEnd()
+              protocol.writeFieldEnd()
+              protocol.writeFieldStop()
+              protocol.writeStructEnd()
+            case sequence: DynamicValue.Sequence =>
+              protocol.writeStructBegin(emptyStruct)
+              protocol.writeFieldBegin(new TField("Sequence", TType.LIST, 4))
+              val elements = sequence.elements
+              val size     = elements.length
+              protocol.writeListBegin(new TList(TType.STRUCT, size))
+              val it = elements.iterator
+              while (it.hasNext) encode(it.next(), protocol)
+              protocol.writeListEnd()
+              protocol.writeFieldEnd()
+              protocol.writeFieldStop()
+              protocol.writeStructEnd()
+            case map: DynamicValue.Map =>
+              protocol.writeStructBegin(emptyStruct)
+              protocol.writeFieldBegin(new TField("Map", TType.LIST, 5))
+              val entries = map.entries
+              val size    = entries.length
+              protocol.writeListBegin(new TList(TType.STRUCT, size))
+              val it = entries.iterator
+              while (it.hasNext) {
+                val kv = it.next()
+                protocol.writeStructBegin(emptyStruct)
+                protocol.writeFieldBegin(new TField("key", TType.STRUCT, 1))
+                encode(kv._1, protocol)
+                protocol.writeFieldEnd()
+                protocol.writeFieldBegin(new TField("value", TType.STRUCT, 2))
+                encode(kv._2, protocol)
+                protocol.writeFieldEnd()
+                protocol.writeFieldStop()
+                protocol.writeStructEnd()
+              }
+              protocol.writeListEnd()
+              protocol.writeFieldEnd()
+              protocol.writeFieldStop()
+              protocol.writeStructEnd()
+          }
+        }
+      }
+    )

--- a/schema-thrift/src/test/scala/zio/blocks/schema/thrift/ThriftFormatSpec.scala
+++ b/schema-thrift/src/test/scala/zio/blocks/schema/thrift/ThriftFormatSpec.scala
@@ -1,0 +1,654 @@
+package zio.blocks.schema.thrift
+
+import zio.blocks.schema._
+import zio.blocks.schema.thrift.ThriftTestUtils._
+import zio.blocks.schema.binding.Binding
+import zio.test._
+import java.time._
+import java.util.UUID
+import java.util.Currency
+import scala.collection.immutable.ArraySeq
+
+object ThriftFormatSpec extends ZIOSpecDefault {
+  def spec: Spec[TestEnvironment, Any] = suite("ThriftFormatSpec")(
+    suite("primitives")(
+      test("Unit") {
+        roundTrip(())
+      },
+      test("Boolean true") {
+        roundTrip(true)
+      },
+      test("Boolean false") {
+        roundTrip(false)
+      },
+      test("Byte") {
+        roundTrip(1: Byte) &&
+        roundTrip(Byte.MinValue) &&
+        roundTrip(Byte.MaxValue)
+      },
+      test("Short") {
+        roundTrip(1: Short) &&
+        roundTrip(Short.MinValue) &&
+        roundTrip(Short.MaxValue)
+      },
+      test("Int") {
+        roundTrip(1) &&
+        roundTrip(Int.MinValue) &&
+        roundTrip(Int.MaxValue)
+      },
+      test("Long") {
+        roundTrip(1L) &&
+        roundTrip(Long.MinValue) &&
+        roundTrip(Long.MaxValue)
+      },
+      test("Float") {
+        roundTrip(42.0f) &&
+        roundTrip(Float.MinValue) &&
+        roundTrip(Float.MaxValue) &&
+        roundTrip(Float.PositiveInfinity) &&
+        roundTrip(Float.NegativeInfinity)
+      },
+      test("Float NaN") {
+        val codec   = Schema[Float].derive(ThriftFormat.deriver)
+        val encoded = codec.encode(Float.NaN)
+        codec.decode(encoded) match {
+          case Right(decoded) => assertTrue(decoded.isNaN)
+          case Left(_)        => assertTrue(false)
+        }
+      },
+      test("Double") {
+        roundTrip(42.0) &&
+        roundTrip(Double.MinValue) &&
+        roundTrip(Double.MaxValue) &&
+        roundTrip(Double.PositiveInfinity) &&
+        roundTrip(Double.NegativeInfinity)
+      },
+      test("Double NaN") {
+        val codec   = Schema[Double].derive(ThriftFormat.deriver)
+        val encoded = codec.encode(Double.NaN)
+        codec.decode(encoded) match {
+          case Right(decoded) => assertTrue(decoded.isNaN)
+          case Left(_)        => assertTrue(false)
+        }
+      },
+      test("Char") {
+        roundTrip('7') &&
+        roundTrip(Char.MinValue) &&
+        roundTrip(Char.MaxValue)
+      },
+      test("String") {
+        roundTrip("Hello") &&
+        roundTrip("") &&
+        roundTrip("Unicode test: \u0041\u0042\u0043")
+      },
+      test("BigInt") {
+        roundTrip(BigInt("9" * 20)) &&
+        roundTrip(BigInt(0)) &&
+        roundTrip(BigInt(-1))
+      },
+      test("BigDecimal") {
+        roundTrip(BigDecimal("9." + "9" * 20 + "E+12345")) &&
+        roundTrip(BigDecimal(0)) &&
+        roundTrip(BigDecimal("123.456"))
+      },
+      test("DayOfWeek") {
+        roundTrip(java.time.DayOfWeek.WEDNESDAY) &&
+        roundTrip(java.time.DayOfWeek.MONDAY) &&
+        roundTrip(java.time.DayOfWeek.SUNDAY)
+      },
+      test("Duration") {
+        roundTrip(java.time.Duration.ofNanos(1234567890123456789L)) &&
+        roundTrip(java.time.Duration.ZERO) &&
+        roundTrip(java.time.Duration.ofDays(365))
+      },
+      test("Instant") {
+        roundTrip(java.time.Instant.parse("2025-07-18T08:29:13.121409459Z")) &&
+        roundTrip(java.time.Instant.EPOCH) &&
+        roundTrip(java.time.Instant.MIN) &&
+        roundTrip(java.time.Instant.MAX)
+      },
+      test("LocalDate") {
+        roundTrip(java.time.LocalDate.parse("2025-07-18")) &&
+        roundTrip(java.time.LocalDate.MIN) &&
+        roundTrip(java.time.LocalDate.MAX)
+      },
+      test("LocalDateTime") {
+        roundTrip(java.time.LocalDateTime.parse("2025-07-18T08:29:13.121409459")) &&
+        roundTrip(java.time.LocalDateTime.MIN) &&
+        roundTrip(java.time.LocalDateTime.MAX)
+      },
+      test("LocalTime") {
+        roundTrip(java.time.LocalTime.parse("08:29:13.121409459")) &&
+        roundTrip(java.time.LocalTime.MIN) &&
+        roundTrip(java.time.LocalTime.MAX)
+      },
+      test("Month") {
+        roundTrip(java.time.Month.of(12)) &&
+        roundTrip(java.time.Month.JANUARY) &&
+        roundTrip(java.time.Month.DECEMBER)
+      },
+      test("MonthDay") {
+        roundTrip(java.time.MonthDay.of(12, 31)) &&
+        roundTrip(java.time.MonthDay.of(1, 1))
+      },
+      test("OffsetDateTime") {
+        roundTrip(java.time.OffsetDateTime.parse("2025-07-18T08:29:13.121409459-07:00")) &&
+        roundTrip(java.time.OffsetDateTime.MIN) &&
+        roundTrip(java.time.OffsetDateTime.MAX)
+      },
+      test("OffsetTime") {
+        roundTrip(java.time.OffsetTime.parse("08:29:13.121409459-07:00")) &&
+        roundTrip(java.time.OffsetTime.MIN) &&
+        roundTrip(java.time.OffsetTime.MAX)
+      },
+      test("Period") {
+        roundTrip(java.time.Period.of(1, 12, 31)) &&
+        roundTrip(java.time.Period.ZERO)
+      },
+      test("Year") {
+        roundTrip(java.time.Year.of(2025)) &&
+        roundTrip(java.time.Year.MIN_VALUE) &&
+        roundTrip(java.time.Year.MAX_VALUE)
+      },
+      test("YearMonth") {
+        roundTrip(java.time.YearMonth.of(2025, 7)) &&
+        roundTrip(java.time.YearMonth.of(Year.MIN_VALUE, 1)) &&
+        roundTrip(java.time.YearMonth.of(Year.MAX_VALUE, 12))
+      },
+      test("ZoneId") {
+        roundTrip(java.time.ZoneId.of("UTC")) &&
+        roundTrip(java.time.ZoneId.of("America/New_York")) &&
+        roundTrip(java.time.ZoneId.of("Europe/London"))
+      },
+      test("ZoneOffset") {
+        roundTrip(java.time.ZoneOffset.ofTotalSeconds(3600)) &&
+        roundTrip(java.time.ZoneOffset.UTC) &&
+        roundTrip(java.time.ZoneOffset.MIN) &&
+        roundTrip(java.time.ZoneOffset.MAX)
+      },
+      test("ZonedDateTime") {
+        roundTrip(java.time.ZonedDateTime.parse("2025-07-18T08:29:13.121409459+02:00[Europe/Warsaw]"))
+      },
+      test("Currency") {
+        roundTrip(Currency.getInstance("USD")) &&
+        roundTrip(Currency.getInstance("EUR")) &&
+        roundTrip(Currency.getInstance("GBP"))
+      },
+      test("UUID") {
+        roundTrip(UUID.randomUUID()) &&
+        roundTrip(new UUID(0L, 0L)) &&
+        roundTrip(new UUID(Long.MaxValue, Long.MaxValue))
+      }
+    ),
+    suite("records")(
+      test("simple record") {
+        roundTrip(Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV"))
+      },
+      test("nested record") {
+        roundTrip(
+          Record2(
+            Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV"),
+            Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV")
+          )
+        )
+      },
+      test("recursive record") {
+        roundTrip(Recursive(1, List(Recursive(2, List(Recursive(3, Nil))))))
+      },
+      test("record with unit and variant fields") {
+        roundTrip(Record4((), Some("VVV"))) &&
+        roundTrip(Record4((), None))
+      },
+      test("record with empty fields") {
+        roundTrip(EmptyRecord())
+      },
+      test("record with all primitive fields") {
+        roundTrip(
+          AllPrimitives(
+            unit = (),
+            boolean = true,
+            byte = 42,
+            short = 1000,
+            int = 100000,
+            long = 10000000000L,
+            float = 3.14f,
+            double = 2.718281828,
+            char = 'X',
+            string = "test"
+          )
+        )
+      }
+    ),
+    suite("sequences")(
+      test("List of Int") {
+        roundTrip((1 to 100).toList)
+      },
+      test("Set of Long") {
+        roundTrip(Set(1L, 2L, 3L))
+      },
+      test("Vector of Double") {
+        roundTrip(Vector(1.0, 2.0, 3.0))
+      },
+      test("List of String") {
+        roundTrip(List("1", "2", "3"))
+      },
+      test("Empty List") {
+        roundTrip(List.empty[Int])
+      },
+      test("List of records") {
+        roundTrip(
+          List(
+            Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV"),
+            Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV")
+          )
+        )
+      },
+      test("List of recursive values") {
+        roundTrip(
+          List(
+            Recursive(1, List(Recursive(2, List(Recursive(3, Nil))))),
+            Recursive(4, List(Recursive(5, List(Recursive(6, Nil)))))
+          )
+        )
+      },
+      test("Nested lists") {
+        roundTrip(List(List(1, 2, 3), List(4, 5, 6)))
+      },
+      test("ArraySeq of Float") {
+        implicit val arraySeqOfFloatSchema: Schema[ArraySeq[Float]] = Schema.derived
+        roundTrip(ArraySeq(1.0f, 2.0f, 3.0f))
+      },
+      test("Array of Byte") {
+        implicit val arrayOfByteSchema: Schema[Array[Byte]] = Schema.derived
+        val arr                                             = Array[Byte](1, 2, 3, 4, 5)
+        val codec                                           = Schema[Array[Byte]].derive(ThriftFormat.deriver)
+        val encoded                                         = codec.encode(arr)
+        codec.decode(encoded) match {
+          case Right(decoded) => assertTrue(arr.sameElements(decoded))
+          case Left(_)        => assertTrue(false)
+        }
+      }
+    ),
+    suite("maps")(
+      test("Map with String keys and Int values") {
+        roundTrip(Map("a" -> 1, "b" -> 2, "c" -> 3))
+      },
+      test("Map with String keys and complex values") {
+        roundTrip(
+          Map(
+            "VVV" -> Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV"),
+            "WWW" -> Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV")
+          )
+        )
+      },
+      test("Map with Int keys and Long values") {
+        roundTrip(Map(1 -> 1L, 2 -> 2L))
+      },
+      test("Empty Map") {
+        roundTrip(Map.empty[String, Int])
+      },
+      test("Map with recursive values") {
+        roundTrip(
+          Map(
+            "VVV" -> Recursive(1, List(Recursive(2, List(Recursive(3, Nil))))),
+            "WWW" -> Recursive(4, List(Recursive(5, List(Recursive(6, Nil)))))
+          )
+        )
+      },
+      test("Nested maps") {
+        roundTrip(Map("outer" -> Map("inner1" -> 1, "inner2" -> 2)))
+      }
+    ),
+    suite("variants")(
+      test("constant values - TrafficLight") {
+        roundTrip[TrafficLight](TrafficLight.Green) &&
+        roundTrip[TrafficLight](TrafficLight.Yellow) &&
+        roundTrip[TrafficLight](TrafficLight.Red)
+      },
+      test("Option Some") {
+        roundTrip(Option(42))
+      },
+      test("Option None") {
+        roundTrip[Option[Int]](None)
+      },
+      test("Either Right") {
+        roundTrip[Either[String, Int]](Right(42))
+      },
+      test("Either Left") {
+        roundTrip[Either[String, Int]](Left("error"))
+      },
+      test("Sealed trait with data") {
+        roundTrip[Shape](Shape.Circle(5.0)) &&
+        roundTrip[Shape](Shape.Rectangle(3.0, 4.0)) &&
+        roundTrip[Shape](Shape.Point)
+      }
+    ),
+    suite("wrapper")(
+      test("UserId wrapper") {
+        roundTrip[UserId](UserId(1234567890123456789L))
+      },
+      test("Email wrapper with validation") {
+        roundTrip[Email](Email("john@gmail.com"))
+      },
+      test("Email decode error") {
+        val stringCodec = Schema[String].derive(ThriftFormat.deriver)
+        val bytes       = stringCodec.encode("invalid-email")
+        decodeError[Email](bytes, "Expected Email")
+      },
+      test("Record with wrapper fields") {
+        roundTrip[Record3](Record3(UserId(1234567890123456789L), Email("backup@gmail.com")))
+      }
+    ),
+    suite("dynamic value")(
+      test("Primitive Unit") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Unit))
+      },
+      test("Primitive Boolean") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Boolean(true)))
+      },
+      test("Primitive Byte") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Byte(1: Byte)))
+      },
+      test("Primitive Short") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Short(1: Short)))
+      },
+      test("Primitive Int") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Int(1)))
+      },
+      test("Primitive Long") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Long(1L)))
+      },
+      test("Primitive Float") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Float(1.0f)))
+      },
+      test("Primitive Double") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Double(1.0)))
+      },
+      test("Primitive Char") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Char('1')))
+      },
+      test("Primitive String") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.String("VVV")))
+      },
+      test("Primitive BigInt") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.BigInt(123)))
+      },
+      test("Primitive BigDecimal") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.BigDecimal(123.45)))
+      },
+      test("Primitive DayOfWeek") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.DayOfWeek(DayOfWeek.MONDAY)))
+      },
+      test("Primitive Duration") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Duration(Duration.ofSeconds(60))))
+      },
+      test("Primitive Instant") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Instant(Instant.EPOCH)))
+      },
+      test("Primitive LocalDate") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.LocalDate(LocalDate.MAX)))
+      },
+      test("Primitive LocalDateTime") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.LocalDateTime(LocalDateTime.MAX)))
+      },
+      test("Primitive LocalTime") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.LocalTime(LocalTime.MAX)))
+      },
+      test("Primitive Month") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Month(Month.MAY)))
+      },
+      test("Primitive MonthDay") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.MonthDay(MonthDay.of(Month.MAY, 1))))
+      },
+      test("Primitive OffsetDateTime") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.OffsetDateTime(OffsetDateTime.MAX)))
+      },
+      test("Primitive OffsetTime") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.OffsetTime(OffsetTime.MAX)))
+      },
+      test("Primitive Period") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Period(Period.ofDays(1))))
+      },
+      test("Primitive Year") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Year(Year.of(2025))))
+      },
+      test("Primitive YearMonth") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.YearMonth(YearMonth.of(2025, 1))))
+      },
+      test("Primitive ZoneId") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.ZoneId(ZoneId.of("UTC"))))
+      },
+      test("Primitive ZoneOffset") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.ZoneOffset(ZoneOffset.MAX)))
+      },
+      test("Primitive ZonedDateTime") {
+        roundTrip[DynamicValue](
+          DynamicValue.Primitive(
+            PrimitiveValue.ZonedDateTime(ZonedDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
+          )
+        )
+      },
+      test("Primitive Currency") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Currency(Currency.getInstance("USD"))))
+      },
+      test("Primitive UUID") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.UUID(UUID.randomUUID())))
+      },
+      test("Record dynamic value") {
+        roundTrip[DynamicValue](
+          DynamicValue.Record(
+            Vector(
+              ("i", DynamicValue.Primitive(PrimitiveValue.Int(1))),
+              ("s", DynamicValue.Primitive(PrimitiveValue.String("VVV")))
+            )
+          )
+        )
+      },
+      test("Variant dynamic value") {
+        roundTrip[DynamicValue](DynamicValue.Variant("Int", DynamicValue.Primitive(PrimitiveValue.Int(1))))
+      },
+      test("Sequence dynamic value") {
+        roundTrip[DynamicValue](
+          DynamicValue.Sequence(
+            Vector(
+              DynamicValue.Primitive(PrimitiveValue.Int(1)),
+              DynamicValue.Primitive(PrimitiveValue.String("VVV"))
+            )
+          )
+        )
+      },
+      test("Map dynamic value") {
+        roundTrip[DynamicValue](
+          DynamicValue.Map(
+            Vector(
+              (DynamicValue.Primitive(PrimitiveValue.Long(1L)), DynamicValue.Primitive(PrimitiveValue.Int(1))),
+              (DynamicValue.Primitive(PrimitiveValue.Long(2L)), DynamicValue.Primitive(PrimitiveValue.String("VVV")))
+            )
+          )
+        )
+      },
+      test("Dynamic value as record field values") {
+        val value = Dynamic(
+          DynamicValue.Primitive(PrimitiveValue.Int(1)),
+          DynamicValue.Map(
+            Vector(
+              (DynamicValue.Primitive(PrimitiveValue.Long(1L)), DynamicValue.Primitive(PrimitiveValue.Int(1))),
+              (DynamicValue.Primitive(PrimitiveValue.Long(2L)), DynamicValue.Primitive(PrimitiveValue.String("VVV")))
+            )
+          )
+        )
+        roundTrip[Dynamic](value)
+      }
+    ),
+    suite("edge cases")(
+      test("Empty string") {
+        roundTrip("")
+      },
+      test("Very long string") {
+        roundTrip("x" * 10000)
+      },
+      test("Large list") {
+        roundTrip((1 to 1000).toList)
+      },
+      test("Deeply nested structure") {
+        def buildNested(depth: Int): Recursive =
+          if (depth <= 0) Recursive(0, Nil)
+          else Recursive(depth, List(buildNested(depth - 1)))
+        roundTrip(buildNested(20))
+      },
+      test("Unicode in string") {
+        roundTrip("Hello \u4E16\u754C \uD83D\uDE00")
+      },
+      test("Special characters in string") {
+        roundTrip("Line1\nLine2\tTab\r\nCRLF")
+      }
+    ),
+    suite("error handling")(
+      test("decode empty bytes") {
+        decodeError[Int](Array.empty[Byte], "Unexpected end of input")
+      },
+      test("decode truncated data") {
+        decodeError[String](Array[Byte](100), "Unexpected end of input")
+      }
+    )
+  )
+
+  case class Record1(
+    bl: Boolean,
+    b: Byte,
+    sh: Short,
+    i: Int,
+    l: Long,
+    f: Float,
+    d: Double,
+    c: Char,
+    s: String
+  )
+
+  object Record1 extends CompanionOptics[Record1] {
+    implicit val schema: Schema[Record1] = Schema.derived
+
+    val i: Lens[Record1, Int] = $(_.i)
+  }
+
+  case class Record2(
+    r1_1: Record1,
+    r1_2: Record1
+  )
+
+  object Record2 extends CompanionOptics[Record2] {
+    implicit val schema: Schema[Record2] = Schema.derived
+
+    val r1_1: Lens[Record2, Record1] = $(_.r1_1)
+    val r1_2: Lens[Record2, Record1] = $(_.r1_2)
+    val r1_1_i: Lens[Record2, Int]   = $(_.r1_1.i)
+    val r1_2_i: Lens[Record2, Int]   = $(_.r1_2.i)
+  }
+
+  case class Recursive(i: Int, ln: List[Recursive])
+
+  object Recursive extends CompanionOptics[Recursive] {
+    implicit val schema: Schema[Recursive]   = Schema.derived
+    val i: Lens[Recursive, Int]              = $(_.i)
+    val ln: Lens[Recursive, List[Recursive]] = $(_.ln)
+  }
+
+  sealed trait TrafficLight
+
+  object TrafficLight {
+    implicit val schema: Schema[TrafficLight] = Schema.derived
+
+    case object Red extends TrafficLight
+
+    case object Yellow extends TrafficLight
+
+    case object Green extends TrafficLight
+  }
+
+  implicit val eitherSchema: Schema[Either[String, Int]] = Schema.derived
+
+  case class UserId(value: Long)
+
+  object UserId {
+    implicit val schema: Schema[UserId] = Schema.derived.wrapTotal(x => new UserId(x), _.value)
+  }
+
+  case class Email(value: String)
+
+  object Email {
+    private[this] val EmailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$".r
+
+    implicit val schema: Schema[Email] = new Schema(
+      new Reflect.Wrapper[Binding, Email, String](
+        Schema[String].reflect,
+        TypeName(Namespace(Seq("zio", "blocks", "thrift"), Seq("ThriftFormatSpec")), "Email"),
+        None,
+        new Binding.Wrapper(
+          {
+            case x @ EmailRegex(_*) => new Right(new Email(x))
+            case _                  => new Left("Expected Email")
+          },
+          _.value
+        )
+      )
+    )
+  }
+
+  case class Record3(userId: UserId, email: Email)
+
+  object Record3 {
+    implicit val schema: Schema[Record3] = Schema.derived
+  }
+
+  case class Record4(hidden: Unit, optKey: Option[String])
+
+  object Record4 extends CompanionOptics[Record4] {
+    implicit val schema: Schema[Record4] = Schema.derived
+
+    val hidden: Lens[Record4, Unit]               = $(_.hidden)
+    val optKey: Lens[Record4, Option[String]]     = $(_.optKey)
+    val optKey_None: Optional[Record4, None.type] = $(_.optKey.when[None.type])
+  }
+
+  case class Dynamic(primitive: DynamicValue, map: DynamicValue)
+
+  object Dynamic extends CompanionOptics[Dynamic] {
+    implicit val schema: Schema[Dynamic] = Schema.derived
+
+    val primitive: Lens[Dynamic, DynamicValue] = $(_.primitive)
+    val map: Lens[Dynamic, DynamicValue]       = $(_.map)
+  }
+
+  case class EmptyRecord()
+
+  object EmptyRecord {
+    implicit val schema: Schema[EmptyRecord] = Schema.derived
+  }
+
+  case class AllPrimitives(
+    unit: Unit,
+    boolean: Boolean,
+    byte: Byte,
+    short: Short,
+    int: Int,
+    long: Long,
+    float: Float,
+    double: Double,
+    char: Char,
+    string: String
+  )
+
+  object AllPrimitives {
+    implicit val schema: Schema[AllPrimitives] = Schema.derived
+  }
+
+  sealed trait Shape
+
+  object Shape {
+    implicit val schema: Schema[Shape] = Schema.derived
+
+    case class Circle(radius: Double)                   extends Shape
+    case class Rectangle(width: Double, height: Double) extends Shape
+    case object Point                                   extends Shape
+  }
+}

--- a/schema-thrift/src/test/scala/zio/blocks/schema/thrift/ThriftTestUtils.scala
+++ b/schema-thrift/src/test/scala/zio/blocks/schema/thrift/ThriftTestUtils.scala
@@ -1,0 +1,70 @@
+package zio.blocks.schema.thrift
+
+import zio.blocks.schema.{Schema, SchemaError}
+import zio.test.Assertion._
+import zio.test._
+import java.nio.ByteBuffer
+import java.util
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.immutable.ArraySeq
+
+object ThriftTestUtils {
+  private[this] val codecs = new ConcurrentHashMap[Schema[?], ThriftBinaryCodec[?]]()
+
+  private[this] def codec[A](schema: Schema[A]): ThriftBinaryCodec[A] =
+    codecs.computeIfAbsent(schema, _.derive(ThriftFormat.deriver)).asInstanceOf[ThriftBinaryCodec[A]]
+
+  def roundTrip[A](value: A)(implicit schema: Schema[A]): TestResult =
+    roundTrip(value, codec(schema))
+
+  def roundTrip[A](value: A, codec: ThriftBinaryCodec[A]): TestResult = {
+    val heapByteBuffer = ByteBuffer.allocate(maxBufSize)
+    codec.encode(value, heapByteBuffer)
+    val encodedBySchema1 = util.Arrays.copyOf(heapByteBuffer.array, heapByteBuffer.position)
+    val directByteBuffer = ByteBuffer.allocate(maxBufSize)
+    codec.encode(value, directByteBuffer)
+    val encodedBySchema2 = util.Arrays.copyOf(
+      {
+        val dup = directByteBuffer.duplicate()
+        val out = new Array[Byte](dup.position)
+        dup.position(0)
+        dup.get(out)
+        out
+      },
+      directByteBuffer.position
+    )
+    val output = new java.io.ByteArrayOutputStream(maxBufSize)
+    codec.encode(value, output)
+    output.close()
+    val encodedBySchema3 = output.toByteArray
+    val encodedBySchema4 = codec.encode(value)
+    assert(ArraySeq.unsafeWrapArray(encodedBySchema1))(equalTo(ArraySeq.unsafeWrapArray(encodedBySchema2))) &&
+    assert(ArraySeq.unsafeWrapArray(encodedBySchema1))(equalTo(ArraySeq.unsafeWrapArray(encodedBySchema3))) &&
+    assert(ArraySeq.unsafeWrapArray(encodedBySchema1))(equalTo(ArraySeq.unsafeWrapArray(encodedBySchema4))) &&
+    assert(codec.decode(encodedBySchema1))(isRight(equalTo(value))) &&
+    assert(codec.decode(toInputStream(encodedBySchema1)))(isRight(equalTo(value))) &&
+    assert(codec.decode(toHeapByteBuffer(encodedBySchema1)))(isRight(equalTo(value))) &&
+    assert(codec.decode(toDirectByteBuffer(encodedBySchema1)))(isRight(equalTo(value)))
+  }
+
+  def decodeError[A](bytes: Array[Byte], error: String)(implicit schema: Schema[A]): TestResult =
+    decodeError(bytes, codec(schema), error)
+
+  def decodeError[A](bytes: Array[Byte], codec: ThriftBinaryCodec[A], error: String): TestResult =
+    assert(codec.decode(bytes))(isLeft(hasError(error))) &&
+      assert(codec.decode(toInputStream(bytes)))(isLeft(hasError(error))) &&
+      assert(codec.decode(toHeapByteBuffer(bytes)))(isLeft(hasError(error))) &&
+      assert(codec.decode(toDirectByteBuffer(bytes)))(isLeft(hasError(error)))
+
+  private[this] def hasError(message: String) =
+    hasField[SchemaError, String]("getMessage", _.getMessage, containsString(message))
+
+  private[this] def toInputStream(bs: Array[Byte]): java.io.InputStream = new java.io.ByteArrayInputStream(bs)
+
+  private[this] def toHeapByteBuffer(bs: Array[Byte]): ByteBuffer = ByteBuffer.wrap(bs)
+
+  private[this] def toDirectByteBuffer(bs: Array[Byte]): ByteBuffer =
+    ByteBuffer.allocateDirect(maxBufSize).put(bs).position(0).limit(bs.length)
+
+  private[this] val maxBufSize = 65536
+}


### PR DESCRIPTION
## Summary

Port Thrift support from ZIO Schema v1 to ZIO Schema 2 in a new top-level `schema-thrift` project.

### Implementation includes:
- `ThriftBinaryCodec` abstract class extending `BinaryCodec[A]`
- `ThriftFormat` object with `Deriver[ThriftBinaryCodec]`
- `ChunkTransport` for bridging Thrift transport with byte arrays/buffers
- Support for all 30 primitive types (Unit, Boolean, Byte, Short, Int, Long, Float, Double, Char, String, BigInt, BigDecimal, all java.time types, Currency, UUID)
- Record, variant, sequence, map, dynamic value, and wrapper support
- Recursive type support via lazy initialization
- Comprehensive test suite with **108 tests**

### Deriver Methods Implemented:
- `derivePrimitive` - All primitive types
- `deriveRecord` - Case classes encoded as Thrift structs
- `deriveVariant` - Sealed traits encoded as Thrift unions
- `deriveSequence` - Collections encoded as Thrift lists
- `deriveMap` - Maps encoded as Thrift maps
- `deriveDynamic` - DynamicValue support
- `deriveWrapper` - Wrapper types with validation

### Dependencies:
- `org.apache.thrift:libthrift:0.20.0`
- `jakarta.annotation:jakarta.annotation-api:3.0.0`

## Test plan
- [x] All 108 tests pass
- [x] Format check passes
- [x] Compiles against latest main

/claim #681