### PR TITLE
feat: Add BSON binary codec support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ lazy val root = project
     schema.js,
     schema.native,
     `schema-avro`,
+    `schema-bson`,
     `schema-toon`.jvm,
     `schema-toon`.js,
     `schema-toon`.native,
@@ -171,6 +172,19 @@ lazy val `schema-avro` = project
           "io.github.kitlangton" %% "neotype" % "0.4.10" % Test
         )
     })
+  )
+
+lazy val `schema-bson` = project
+  .settings(stdSettings("zio-blocks-schema-bson"))
+  .dependsOn(schema.jvm)
+  .settings(buildInfoSettings("zio.blocks.schema.bson"))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.mongodb" % "bson"         % "5.2.0",
+      "dev.zio"    %% "zio-test"     % "2.1.24" % Test,
+      "dev.zio"    %% "zio-test-sbt" % "2.1.24" % Test
+    )
   )
 
 lazy val `schema-toon` = crossProject(JSPlatform, JVMPlatform, NativePlatform)

--- a/schema-bson/src/main/scala/zio/blocks/schema/bson/BsonBinaryCodec.scala
+++ b/schema-bson/src/main/scala/zio/blocks/schema/bson/BsonBinaryCodec.scala
@@ -1,0 +1,178 @@
+package zio.blocks.schema.bson
+
+import org.bson.io.{BasicOutputBuffer, ByteBufferBsonInput}
+import org.bson.{BsonBinaryReader, BsonBinaryWriter, ByteBufNIO}
+import zio.blocks.schema.SchemaError.ExpectationMismatch
+import zio.blocks.schema.{DynamicOptic, SchemaError}
+import zio.blocks.schema.binding.RegisterOffset
+import zio.blocks.schema.codec.BinaryCodec
+import java.nio.ByteBuffer
+import scala.collection.immutable.ArraySeq
+import scala.util.control.NonFatal
+
+abstract class BsonBinaryCodec[A](val valueType: Int = BsonBinaryCodec.objectType) extends BinaryCodec[A] {
+  val valueOffset: RegisterOffset.RegisterOffset = valueType match {
+    case BsonBinaryCodec.objectType  => RegisterOffset(objects = 1)
+    case BsonBinaryCodec.booleanType => RegisterOffset(booleans = 1)
+    case BsonBinaryCodec.byteType    => RegisterOffset(bytes = 1)
+    case BsonBinaryCodec.charType    => RegisterOffset(chars = 1)
+    case BsonBinaryCodec.shortType   => RegisterOffset(shorts = 1)
+    case BsonBinaryCodec.floatType   => RegisterOffset(floats = 1)
+    case BsonBinaryCodec.intType     => RegisterOffset(ints = 1)
+    case BsonBinaryCodec.doubleType  => RegisterOffset(doubles = 1)
+    case BsonBinaryCodec.longType    => RegisterOffset(longs = 1)
+    case _                           => RegisterOffset.Zero
+  }
+
+  def decodeError(expectation: String): Nothing = throw new BsonBinaryCodecError(Nil, expectation)
+
+  def decodeError(span: DynamicOptic.Node, error: Throwable): Nothing = error match {
+    case e: BsonBinaryCodecError =>
+      e.spans = new ::(span, e.spans)
+      throw e
+    case _ =>
+      throw new BsonBinaryCodecError(new ::(span, Nil), getMessage(error))
+  }
+
+  def decodeError(span1: DynamicOptic.Node, span2: DynamicOptic.Node, error: Throwable): Nothing = error match {
+    case e: BsonBinaryCodecError =>
+      e.spans = new ::(span1, new ::(span2, e.spans))
+      throw e
+    case _ =>
+      throw new BsonBinaryCodecError(new ::(span1, new ::(span2, Nil)), getMessage(error))
+  }
+
+  def decodeUnsafe(reader: BsonBinaryReader): A
+
+  def encodeUnsafe(value: A, writer: BsonBinaryWriter): Unit
+
+  override def decode(input: ByteBuffer): Either[SchemaError, A] = {
+    val byteBuf   = new ByteBufNIO(input)
+    val bsonInput = new ByteBufferBsonInput(byteBuf)
+    val reader    = new BsonBinaryReader(bsonInput)
+    try {
+      reader.readStartDocument()
+      reader.readName("v")
+      val result = decodeUnsafe(reader)
+      reader.readEndDocument()
+      new Right(result)
+    } catch {
+      case error if NonFatal(error) => new Left(toError(error))
+    } finally {
+      reader.close()
+    }
+  }
+
+  override def encode(value: A, output: ByteBuffer): Unit = {
+    val buffer = new BasicOutputBuffer()
+    val writer = new BsonBinaryWriter(buffer)
+    try {
+      writer.writeStartDocument()
+      writer.writeName("v")
+      encodeUnsafe(value, writer)
+      writer.writeEndDocument()
+      writer.flush()
+      val bytes = buffer.toByteArray
+      output.put(bytes)
+    } finally {
+      writer.close()
+      buffer.close()
+    }
+  }
+
+  def decode(input: Array[Byte]): Either[SchemaError, A] =
+    decode(ByteBuffer.wrap(input))
+
+  def encode(value: A): Array[Byte] = {
+    val buffer = new BasicOutputBuffer()
+    val writer = new BsonBinaryWriter(buffer)
+    try {
+      writer.writeStartDocument()
+      writer.writeName("v")
+      encodeUnsafe(value, writer)
+      writer.writeEndDocument()
+      writer.flush()
+      buffer.toByteArray
+    } finally {
+      writer.close()
+      buffer.close()
+    }
+  }
+
+  def decode(input: java.io.InputStream): Either[SchemaError, A] = {
+    val bytes = input.readAllBytes()
+    decode(bytes)
+  }
+
+  def encode(value: A, output: java.io.OutputStream): Unit = {
+    val bytes = encode(value)
+    output.write(bytes)
+  }
+
+  private[this] def toError(error: Throwable): SchemaError = new SchemaError(
+    new ::(
+      error match {
+        case e: BsonBinaryCodecError =>
+          var list  = e.spans
+          val array = new Array[DynamicOptic.Node](list.size)
+          var idx   = 0
+          while (list ne Nil) {
+            array(idx) = list.head
+            idx += 1
+            list = list.tail
+          }
+          new ExpectationMismatch(new DynamicOptic(ArraySeq.unsafeWrapArray(array)), e.getMessage)
+        case _ => new ExpectationMismatch(DynamicOptic.root, getMessage(error))
+      },
+      Nil
+    )
+  )
+
+  private[this] def getMessage(error: Throwable): String = error match {
+    case _: java.io.EOFException                         => "Unexpected end of input"
+    case _: org.bson.BsonSerializationException          => "BSON serialization error: " + error.getMessage
+    case _: org.bson.BsonInvalidOperationException       => "Invalid BSON operation: " + error.getMessage
+    case e if e.getMessage != null && e.getMessage != "" => e.getMessage
+    case _                                               => "Unknown BSON error"
+  }
+}
+
+object BsonBinaryCodec {
+  val objectType  = 0
+  val booleanType = 1
+  val byteType    = 2
+  val charType    = 3
+  val shortType   = 4
+  val floatType   = 5
+  val intType     = 6
+  val doubleType  = 7
+  val longType    = 8
+  val unitType    = 9
+
+  val maxCollectionSize: Int = Integer.MAX_VALUE - 8
+}
+
+private[bson] class BsonBinaryCodecError(var spans: List[DynamicOptic.Node], message: String)
+    extends Throwable(message, null, false, false) {
+  override def getMessage: String = message
+}
+
+private[bson] class ByteArrayOutputStream extends java.io.OutputStream {
+  private[this] var buf   = new Array[Byte](64)
+  private[this] var count = 0
+
+  override def write(b: Int): Unit = {
+    if (count >= buf.length) buf = java.util.Arrays.copyOf(buf, buf.length << 1)
+    buf(count) = b.toByte
+    count += 1
+  }
+
+  override def write(bs: Array[Byte], off: Int, len: Int): Unit = {
+    val newLen = count + len
+    if (newLen > buf.length) buf = java.util.Arrays.copyOf(buf, Math.max(buf.length << 1, newLen))
+    System.arraycopy(bs, off, buf, count, len)
+    count = newLen
+  }
+
+  def toByteArray: Array[Byte] = java.util.Arrays.copyOf(buf, count)
+}

--- a/schema-bson/src/main/scala/zio/blocks/schema/bson/BsonFormat.scala
+++ b/schema-bson/src/main/scala/zio/blocks/schema/bson/BsonFormat.scala
@@ -1,0 +1,1620 @@
+package zio.blocks.schema.bson
+
+import org.bson._
+import zio.blocks.schema.binding.{Binding, BindingType, HasBinding, Registers, RegisterOffset}
+import zio.blocks.schema._
+import zio.blocks.schema.codec.BinaryFormat
+import zio.blocks.schema.derive.{BindingInstance, Deriver, InstanceOverride}
+import java.math.{BigInteger, MathContext}
+import scala.util.control.NonFatal
+
+object BsonFormat
+    extends BinaryFormat(
+      "application/bson",
+      new Deriver[BsonBinaryCodec] {
+        override def derivePrimitive[F[_, _], A](
+          primitiveType: PrimitiveType[A],
+          typeName: TypeName[A],
+          binding: Binding[BindingType.Primitive, A],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        ): Lazy[BsonBinaryCodec[A]] =
+          Lazy(deriveCodec(new Reflect.Primitive(primitiveType, typeName, binding, doc, modifiers)))
+
+        override def deriveRecord[F[_, _], A](
+          fields: IndexedSeq[Term[F, A, ?]],
+          typeName: TypeName[A],
+          binding: Binding[BindingType.Record, A],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[BsonBinaryCodec[A]] = Lazy {
+          deriveCodec(
+            new Reflect.Record(
+              fields.asInstanceOf[IndexedSeq[Term[Binding, A, ?]]],
+              typeName,
+              binding,
+              doc,
+              modifiers
+            )
+          )
+        }
+
+        override def deriveVariant[F[_, _], A](
+          cases: IndexedSeq[Term[F, A, ?]],
+          typeName: TypeName[A],
+          binding: Binding[BindingType.Variant, A],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[BsonBinaryCodec[A]] = Lazy {
+          deriveCodec(
+            new Reflect.Variant(
+              cases.asInstanceOf[IndexedSeq[Term[Binding, A, ? <: A]]],
+              typeName,
+              binding,
+              doc,
+              modifiers
+            )
+          )
+        }
+
+        override def deriveSequence[F[_, _], C[_], A](
+          element: Reflect[F, A],
+          typeName: TypeName[C[A]],
+          binding: Binding[BindingType.Seq[C], C[A]],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[BsonBinaryCodec[C[A]]] = Lazy {
+          deriveCodec(
+            new Reflect.Sequence(element.asInstanceOf[Reflect[Binding, A]], typeName, binding, doc, modifiers)
+          )
+        }
+
+        override def deriveMap[F[_, _], M[_, _], K, V](
+          key: Reflect[F, K],
+          value: Reflect[F, V],
+          typeName: TypeName[M[K, V]],
+          binding: Binding[BindingType.Map[M], M[K, V]],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[BsonBinaryCodec[M[K, V]]] = Lazy {
+          deriveCodec(
+            new Reflect.Map(
+              key.asInstanceOf[Reflect[Binding, K]],
+              value.asInstanceOf[Reflect[Binding, V]],
+              typeName,
+              binding,
+              doc,
+              modifiers
+            )
+          )
+        }
+
+        override def deriveDynamic[F[_, _]](
+          binding: Binding[BindingType.Dynamic, DynamicValue],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[BsonBinaryCodec[DynamicValue]] =
+          Lazy(deriveCodec(new Reflect.Dynamic(binding, TypeName.dynamicValue, doc, modifiers)))
+
+        def deriveWrapper[F[_, _], A, B](
+          wrapped: Reflect[F, B],
+          typeName: TypeName[A],
+          wrapperPrimitiveType: Option[PrimitiveType[A]],
+          binding: Binding[BindingType.Wrapper[A, B], A],
+          doc: Doc,
+          modifiers: Seq[Modifier.Reflect]
+        )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[BsonBinaryCodec[A]] = Lazy {
+          deriveCodec(
+            new Reflect.Wrapper(
+              wrapped.asInstanceOf[Reflect[Binding, B]],
+              typeName,
+              wrapperPrimitiveType,
+              binding,
+              doc,
+              modifiers
+            )
+          )
+        }
+
+        override def instanceOverrides: IndexedSeq[InstanceOverride] = {
+          recursiveRecordCache.remove()
+          recordCounters.remove()
+          super.instanceOverrides
+        }
+
+        type Elem
+        type Key
+        type Value
+        type Wrapped
+        type Col[_]
+        type Map[_, _]
+        type TC[_]
+
+        private[this] val recursiveRecordCache =
+          new ThreadLocal[java.util.HashMap[TypeName[?], Array[BsonBinaryCodec[?]]]] {
+            override def initialValue: java.util.HashMap[TypeName[?], Array[BsonBinaryCodec[?]]] =
+              new java.util.HashMap
+          }
+        private[this] val recordCounters =
+          new ThreadLocal[java.util.HashMap[(String, String), Int]] {
+            override def initialValue: java.util.HashMap[(String, String), Int] = new java.util.HashMap
+          }
+
+        private[this] val unitCodec = new BsonBinaryCodec[Unit](BsonBinaryCodec.unitType) {
+          def decodeUnsafe(reader: BsonBinaryReader): Unit =
+            reader.readNull()
+
+          def encodeUnsafe(value: Unit, writer: BsonBinaryWriter): Unit =
+            writer.writeNull()
+        }
+
+        private[this] val booleanCodec = new BsonBinaryCodec[Boolean](BsonBinaryCodec.booleanType) {
+          def decodeUnsafe(reader: BsonBinaryReader): Boolean = reader.readBoolean()
+
+          def encodeUnsafe(value: Boolean, writer: BsonBinaryWriter): Unit = writer.writeBoolean(value)
+        }
+
+        private[this] val byteCodec = new BsonBinaryCodec[Byte](BsonBinaryCodec.byteType) {
+          def decodeUnsafe(reader: BsonBinaryReader): Byte = {
+            val x = reader.readInt32()
+            if (x >= Byte.MinValue && x <= Byte.MaxValue) x.toByte
+            else decodeError("Expected Byte")
+          }
+
+          def encodeUnsafe(value: Byte, writer: BsonBinaryWriter): Unit = writer.writeInt32(value.toInt)
+        }
+
+        private[this] val shortCodec = new BsonBinaryCodec[Short](BsonBinaryCodec.shortType) {
+          def decodeUnsafe(reader: BsonBinaryReader): Short = {
+            val x = reader.readInt32()
+            if (x >= Short.MinValue && x <= Short.MaxValue) x.toShort
+            else decodeError("Expected Short")
+          }
+
+          def encodeUnsafe(value: Short, writer: BsonBinaryWriter): Unit = writer.writeInt32(value.toInt)
+        }
+
+        private[this] val intCodec = new BsonBinaryCodec[Int](BsonBinaryCodec.intType) {
+          def decodeUnsafe(reader: BsonBinaryReader): Int = reader.readInt32()
+
+          def encodeUnsafe(value: Int, writer: BsonBinaryWriter): Unit = writer.writeInt32(value)
+        }
+
+        private[this] val longCodec = new BsonBinaryCodec[Long](BsonBinaryCodec.longType) {
+          def decodeUnsafe(reader: BsonBinaryReader): Long = reader.readInt64()
+
+          def encodeUnsafe(value: Long, writer: BsonBinaryWriter): Unit = writer.writeInt64(value)
+        }
+
+        private[this] val floatCodec = new BsonBinaryCodec[Float](BsonBinaryCodec.floatType) {
+          def decodeUnsafe(reader: BsonBinaryReader): Float = reader.readDouble().toFloat
+
+          def encodeUnsafe(value: Float, writer: BsonBinaryWriter): Unit = writer.writeDouble(value.toDouble)
+        }
+
+        private[this] val doubleCodec = new BsonBinaryCodec[Double](BsonBinaryCodec.doubleType) {
+          def decodeUnsafe(reader: BsonBinaryReader): Double = reader.readDouble()
+
+          def encodeUnsafe(value: Double, writer: BsonBinaryWriter): Unit = writer.writeDouble(value)
+        }
+
+        private[this] val charCodec = new BsonBinaryCodec[Char](BsonBinaryCodec.charType) {
+          def decodeUnsafe(reader: BsonBinaryReader): Char = {
+            val x = reader.readInt32()
+            if (x >= Char.MinValue && x <= Char.MaxValue) x.toChar
+            else decodeError("Expected Char")
+          }
+
+          def encodeUnsafe(value: Char, writer: BsonBinaryWriter): Unit = writer.writeInt32(value.toInt)
+        }
+
+        private[this] val stringCodec = new BsonBinaryCodec[String]() {
+          def decodeUnsafe(reader: BsonBinaryReader): String = reader.readString()
+
+          def encodeUnsafe(value: String, writer: BsonBinaryWriter): Unit = writer.writeString(value)
+        }
+
+        private[this] val bigIntCodec = new BsonBinaryCodec[BigInt]() {
+          def decodeUnsafe(reader: BsonBinaryReader): BigInt = {
+            val binary = reader.readBinaryData()
+            BigInt(binary.getData)
+          }
+
+          def encodeUnsafe(value: BigInt, writer: BsonBinaryWriter): Unit =
+            writer.writeBinaryData(new BsonBinary(value.toByteArray))
+        }
+
+        private[this] val bigDecimalCodec = new BsonBinaryCodec[BigDecimal]() {
+          def decodeUnsafe(reader: BsonBinaryReader): BigDecimal = {
+            reader.readStartDocument()
+            reader.readName("mantissa")
+            val mantissa = reader.readBinaryData().getData
+            reader.readName("scale")
+            val scale = reader.readInt32()
+            reader.readName("precision")
+            val precision = reader.readInt32()
+            reader.readName("roundingMode")
+            val roundingMode = java.math.RoundingMode.valueOf(reader.readInt32())
+            reader.readEndDocument()
+            val mc = new MathContext(precision, roundingMode)
+            new BigDecimal(new java.math.BigDecimal(new BigInteger(mantissa), scale), mc)
+          }
+
+          def encodeUnsafe(value: BigDecimal, writer: BsonBinaryWriter): Unit = {
+            val bd = value.underlying
+            val mc = value.mc
+            writer.writeStartDocument()
+            writer.writeName("mantissa")
+            writer.writeBinaryData(new BsonBinary(bd.unscaledValue.toByteArray))
+            writer.writeName("scale")
+            writer.writeInt32(bd.scale)
+            writer.writeName("precision")
+            writer.writeInt32(mc.getPrecision)
+            writer.writeName("roundingMode")
+            writer.writeInt32(mc.getRoundingMode.ordinal)
+            writer.writeEndDocument()
+          }
+        }
+
+        private[this] val dayOfWeekCodec = new BsonBinaryCodec[java.time.DayOfWeek]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.DayOfWeek = java.time.DayOfWeek.of(reader.readInt32())
+
+          def encodeUnsafe(value: java.time.DayOfWeek, writer: BsonBinaryWriter): Unit =
+            writer.writeInt32(value.getValue)
+        }
+
+        private[this] val durationCodec = new BsonBinaryCodec[java.time.Duration]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.Duration = {
+            reader.readStartDocument()
+            reader.readName("seconds")
+            val seconds = reader.readInt64()
+            reader.readName("nanos")
+            val nanos = reader.readInt32()
+            reader.readEndDocument()
+            java.time.Duration.ofSeconds(seconds, nanos)
+          }
+
+          def encodeUnsafe(value: java.time.Duration, writer: BsonBinaryWriter): Unit = {
+            writer.writeStartDocument()
+            writer.writeName("seconds")
+            writer.writeInt64(value.getSeconds)
+            writer.writeName("nanos")
+            writer.writeInt32(value.getNano)
+            writer.writeEndDocument()
+          }
+        }
+
+        private[this] val instantCodec = new BsonBinaryCodec[java.time.Instant]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.Instant = {
+            reader.readStartDocument()
+            reader.readName("epochSecond")
+            val epochSecond = reader.readInt64()
+            reader.readName("nano")
+            val nano = reader.readInt32()
+            reader.readEndDocument()
+            java.time.Instant.ofEpochSecond(epochSecond, nano)
+          }
+
+          def encodeUnsafe(value: java.time.Instant, writer: BsonBinaryWriter): Unit = {
+            writer.writeStartDocument()
+            writer.writeName("epochSecond")
+            writer.writeInt64(value.getEpochSecond)
+            writer.writeName("nano")
+            writer.writeInt32(value.getNano)
+            writer.writeEndDocument()
+          }
+        }
+
+        private[this] val localDateCodec = new BsonBinaryCodec[java.time.LocalDate]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.LocalDate = {
+            reader.readStartDocument()
+            reader.readName("year")
+            val year = reader.readInt32()
+            reader.readName("month")
+            val month = reader.readInt32()
+            reader.readName("day")
+            val day = reader.readInt32()
+            reader.readEndDocument()
+            java.time.LocalDate.of(year, month, day)
+          }
+
+          def encodeUnsafe(value: java.time.LocalDate, writer: BsonBinaryWriter): Unit = {
+            writer.writeStartDocument()
+            writer.writeName("year")
+            writer.writeInt32(value.getYear)
+            writer.writeName("month")
+            writer.writeInt32(value.getMonthValue)
+            writer.writeName("day")
+            writer.writeInt32(value.getDayOfMonth)
+            writer.writeEndDocument()
+          }
+        }
+
+        private[this] val localDateTimeCodec = new BsonBinaryCodec[java.time.LocalDateTime]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.LocalDateTime = {
+            reader.readStartDocument()
+            reader.readName("year")
+            val year = reader.readInt32()
+            reader.readName("month")
+            val month = reader.readInt32()
+            reader.readName("day")
+            val day = reader.readInt32()
+            reader.readName("hour")
+            val hour = reader.readInt32()
+            reader.readName("minute")
+            val minute = reader.readInt32()
+            reader.readName("second")
+            val second = reader.readInt32()
+            reader.readName("nano")
+            val nano = reader.readInt32()
+            reader.readEndDocument()
+            java.time.LocalDateTime.of(year, month, day, hour, minute, second, nano)
+          }
+
+          def encodeUnsafe(value: java.time.LocalDateTime, writer: BsonBinaryWriter): Unit = {
+            writer.writeStartDocument()
+            writer.writeName("year")
+            writer.writeInt32(value.getYear)
+            writer.writeName("month")
+            writer.writeInt32(value.getMonthValue)
+            writer.writeName("day")
+            writer.writeInt32(value.getDayOfMonth)
+            writer.writeName("hour")
+            writer.writeInt32(value.getHour)
+            writer.writeName("minute")
+            writer.writeInt32(value.getMinute)
+            writer.writeName("second")
+            writer.writeInt32(value.getSecond)
+            writer.writeName("nano")
+            writer.writeInt32(value.getNano)
+            writer.writeEndDocument()
+          }
+        }
+
+        private[this] val localTimeCodec = new BsonBinaryCodec[java.time.LocalTime]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.LocalTime = {
+            reader.readStartDocument()
+            reader.readName("hour")
+            val hour = reader.readInt32()
+            reader.readName("minute")
+            val minute = reader.readInt32()
+            reader.readName("second")
+            val second = reader.readInt32()
+            reader.readName("nano")
+            val nano = reader.readInt32()
+            reader.readEndDocument()
+            java.time.LocalTime.of(hour, minute, second, nano)
+          }
+
+          def encodeUnsafe(value: java.time.LocalTime, writer: BsonBinaryWriter): Unit = {
+            writer.writeStartDocument()
+            writer.writeName("hour")
+            writer.writeInt32(value.getHour)
+            writer.writeName("minute")
+            writer.writeInt32(value.getMinute)
+            writer.writeName("second")
+            writer.writeInt32(value.getSecond)
+            writer.writeName("nano")
+            writer.writeInt32(value.getNano)
+            writer.writeEndDocument()
+          }
+        }
+
+        private[this] val monthCodec = new BsonBinaryCodec[java.time.Month]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.Month = java.time.Month.of(reader.readInt32())
+
+          def encodeUnsafe(value: java.time.Month, writer: BsonBinaryWriter): Unit = writer.writeInt32(value.getValue)
+        }
+
+        private[this] val monthDayCodec = new BsonBinaryCodec[java.time.MonthDay]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.MonthDay = {
+            reader.readStartDocument()
+            reader.readName("month")
+            val month = reader.readInt32()
+            reader.readName("day")
+            val day = reader.readInt32()
+            reader.readEndDocument()
+            java.time.MonthDay.of(month, day)
+          }
+
+          def encodeUnsafe(value: java.time.MonthDay, writer: BsonBinaryWriter): Unit = {
+            writer.writeStartDocument()
+            writer.writeName("month")
+            writer.writeInt32(value.getMonthValue)
+            writer.writeName("day")
+            writer.writeInt32(value.getDayOfMonth)
+            writer.writeEndDocument()
+          }
+        }
+
+        private[this] val offsetDateTimeCodec = new BsonBinaryCodec[java.time.OffsetDateTime]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.OffsetDateTime = {
+            reader.readStartDocument()
+            reader.readName("year")
+            val year = reader.readInt32()
+            reader.readName("month")
+            val month = reader.readInt32()
+            reader.readName("day")
+            val day = reader.readInt32()
+            reader.readName("hour")
+            val hour = reader.readInt32()
+            reader.readName("minute")
+            val minute = reader.readInt32()
+            reader.readName("second")
+            val second = reader.readInt32()
+            reader.readName("nano")
+            val nano = reader.readInt32()
+            reader.readName("offsetSecond")
+            val offsetSecond = reader.readInt32()
+            reader.readEndDocument()
+            java.time.OffsetDateTime
+              .of(year, month, day, hour, minute, second, nano, java.time.ZoneOffset.ofTotalSeconds(offsetSecond))
+          }
+
+          def encodeUnsafe(value: java.time.OffsetDateTime, writer: BsonBinaryWriter): Unit = {
+            writer.writeStartDocument()
+            writer.writeName("year")
+            writer.writeInt32(value.getYear)
+            writer.writeName("month")
+            writer.writeInt32(value.getMonthValue)
+            writer.writeName("day")
+            writer.writeInt32(value.getDayOfMonth)
+            writer.writeName("hour")
+            writer.writeInt32(value.getHour)
+            writer.writeName("minute")
+            writer.writeInt32(value.getMinute)
+            writer.writeName("second")
+            writer.writeInt32(value.getSecond)
+            writer.writeName("nano")
+            writer.writeInt32(value.getNano)
+            writer.writeName("offsetSecond")
+            writer.writeInt32(value.getOffset.getTotalSeconds)
+            writer.writeEndDocument()
+          }
+        }
+
+        private[this] val offsetTimeCodec = new BsonBinaryCodec[java.time.OffsetTime]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.OffsetTime = {
+            reader.readStartDocument()
+            reader.readName("hour")
+            val hour = reader.readInt32()
+            reader.readName("minute")
+            val minute = reader.readInt32()
+            reader.readName("second")
+            val second = reader.readInt32()
+            reader.readName("nano")
+            val nano = reader.readInt32()
+            reader.readName("offsetSecond")
+            val offsetSecond = reader.readInt32()
+            reader.readEndDocument()
+            java.time.OffsetTime.of(hour, minute, second, nano, java.time.ZoneOffset.ofTotalSeconds(offsetSecond))
+          }
+
+          def encodeUnsafe(value: java.time.OffsetTime, writer: BsonBinaryWriter): Unit = {
+            writer.writeStartDocument()
+            writer.writeName("hour")
+            writer.writeInt32(value.getHour)
+            writer.writeName("minute")
+            writer.writeInt32(value.getMinute)
+            writer.writeName("second")
+            writer.writeInt32(value.getSecond)
+            writer.writeName("nano")
+            writer.writeInt32(value.getNano)
+            writer.writeName("offsetSecond")
+            writer.writeInt32(value.getOffset.getTotalSeconds)
+            writer.writeEndDocument()
+          }
+        }
+
+        private[this] val periodCodec = new BsonBinaryCodec[java.time.Period]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.Period = {
+            reader.readStartDocument()
+            reader.readName("years")
+            val years = reader.readInt32()
+            reader.readName("months")
+            val months = reader.readInt32()
+            reader.readName("days")
+            val days = reader.readInt32()
+            reader.readEndDocument()
+            java.time.Period.of(years, months, days)
+          }
+
+          def encodeUnsafe(value: java.time.Period, writer: BsonBinaryWriter): Unit = {
+            writer.writeStartDocument()
+            writer.writeName("years")
+            writer.writeInt32(value.getYears)
+            writer.writeName("months")
+            writer.writeInt32(value.getMonths)
+            writer.writeName("days")
+            writer.writeInt32(value.getDays)
+            writer.writeEndDocument()
+          }
+        }
+
+        private[this] val yearCodec = new BsonBinaryCodec[java.time.Year]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.Year = java.time.Year.of(reader.readInt32())
+
+          def encodeUnsafe(value: java.time.Year, writer: BsonBinaryWriter): Unit = writer.writeInt32(value.getValue)
+        }
+
+        private[this] val yearMonthCodec = new BsonBinaryCodec[java.time.YearMonth]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.YearMonth = {
+            reader.readStartDocument()
+            reader.readName("year")
+            val year = reader.readInt32()
+            reader.readName("month")
+            val month = reader.readInt32()
+            reader.readEndDocument()
+            java.time.YearMonth.of(year, month)
+          }
+
+          def encodeUnsafe(value: java.time.YearMonth, writer: BsonBinaryWriter): Unit = {
+            writer.writeStartDocument()
+            writer.writeName("year")
+            writer.writeInt32(value.getYear)
+            writer.writeName("month")
+            writer.writeInt32(value.getMonthValue)
+            writer.writeEndDocument()
+          }
+        }
+
+        private[this] val zoneIdCodec = new BsonBinaryCodec[java.time.ZoneId]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.ZoneId = java.time.ZoneId.of(reader.readString())
+
+          def encodeUnsafe(value: java.time.ZoneId, writer: BsonBinaryWriter): Unit = writer.writeString(value.toString)
+        }
+
+        private[this] val zoneOffsetCodec = new BsonBinaryCodec[java.time.ZoneOffset]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.ZoneOffset =
+            java.time.ZoneOffset.ofTotalSeconds(reader.readInt32())
+
+          def encodeUnsafe(value: java.time.ZoneOffset, writer: BsonBinaryWriter): Unit =
+            writer.writeInt32(value.getTotalSeconds)
+        }
+
+        private[this] val zonedDateTimeCodec = new BsonBinaryCodec[java.time.ZonedDateTime]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.time.ZonedDateTime = {
+            reader.readStartDocument()
+            reader.readName("year")
+            val year = reader.readInt32()
+            reader.readName("month")
+            val month = reader.readInt32()
+            reader.readName("day")
+            val day = reader.readInt32()
+            reader.readName("hour")
+            val hour = reader.readInt32()
+            reader.readName("minute")
+            val minute = reader.readInt32()
+            reader.readName("second")
+            val second = reader.readInt32()
+            reader.readName("nano")
+            val nano = reader.readInt32()
+            reader.readName("offsetSecond")
+            val offsetSecond = reader.readInt32()
+            reader.readName("zoneId")
+            val zoneId = reader.readString()
+            reader.readEndDocument()
+            java.time.ZonedDateTime.ofInstant(
+              java.time.LocalDateTime.of(year, month, day, hour, minute, second, nano),
+              java.time.ZoneOffset.ofTotalSeconds(offsetSecond),
+              java.time.ZoneId.of(zoneId)
+            )
+          }
+
+          def encodeUnsafe(value: java.time.ZonedDateTime, writer: BsonBinaryWriter): Unit = {
+            writer.writeStartDocument()
+            writer.writeName("year")
+            writer.writeInt32(value.getYear)
+            writer.writeName("month")
+            writer.writeInt32(value.getMonthValue)
+            writer.writeName("day")
+            writer.writeInt32(value.getDayOfMonth)
+            writer.writeName("hour")
+            writer.writeInt32(value.getHour)
+            writer.writeName("minute")
+            writer.writeInt32(value.getMinute)
+            writer.writeName("second")
+            writer.writeInt32(value.getSecond)
+            writer.writeName("nano")
+            writer.writeInt32(value.getNano)
+            writer.writeName("offsetSecond")
+            writer.writeInt32(value.getOffset.getTotalSeconds)
+            writer.writeName("zoneId")
+            writer.writeString(value.getZone.toString)
+            writer.writeEndDocument()
+          }
+        }
+
+        private[this] val currencyCodec = new BsonBinaryCodec[java.util.Currency]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.util.Currency =
+            java.util.Currency.getInstance(reader.readString())
+
+          def encodeUnsafe(value: java.util.Currency, writer: BsonBinaryWriter): Unit =
+            writer.writeString(value.getCurrencyCode)
+        }
+
+        private[this] val uuidCodec = new BsonBinaryCodec[java.util.UUID]() {
+          def decodeUnsafe(reader: BsonBinaryReader): java.util.UUID = {
+            val binary = reader.readBinaryData()
+            val bs     = binary.getData
+            val hi     =
+              (bs(0) & 0xff).toLong << 56 |
+                (bs(1) & 0xff).toLong << 48 |
+                (bs(2) & 0xff).toLong << 40 |
+                (bs(3) & 0xff).toLong << 32 |
+                (bs(4) & 0xff).toLong << 24 |
+                (bs(5) & 0xff) << 16 |
+                (bs(6) & 0xff) << 8 |
+                (bs(7) & 0xff)
+            val lo =
+              (bs(8) & 0xff).toLong << 56 |
+                (bs(9) & 0xff).toLong << 48 |
+                (bs(10) & 0xff).toLong << 40 |
+                (bs(11) & 0xff).toLong << 32 |
+                (bs(12) & 0xff).toLong << 24 |
+                (bs(13) & 0xff) << 16 |
+                (bs(14) & 0xff) << 8 |
+                (bs(15) & 0xff)
+            new java.util.UUID(hi, lo)
+          }
+
+          def encodeUnsafe(value: java.util.UUID, writer: BsonBinaryWriter): Unit = {
+            val hi = value.getMostSignificantBits
+            val lo = value.getLeastSignificantBits
+            val bs = Array(
+              (hi >> 56).toByte,
+              (hi >> 48).toByte,
+              (hi >> 40).toByte,
+              (hi >> 32).toByte,
+              (hi >> 24).toByte,
+              (hi >> 16).toByte,
+              (hi >> 8).toByte,
+              hi.toByte,
+              (lo >> 56).toByte,
+              (lo >> 48).toByte,
+              (lo >> 40).toByte,
+              (lo >> 32).toByte,
+              (lo >> 24).toByte,
+              (lo >> 16).toByte,
+              (lo >> 8).toByte,
+              lo.toByte
+            )
+            writer.writeBinaryData(new BsonBinary(BsonBinarySubType.UUID_STANDARD, bs))
+          }
+        }
+
+        private[this] def deriveCodec[F[_, _], A](reflect: Reflect[F, A]): BsonBinaryCodec[A] = {
+          if (reflect.isPrimitive) {
+            val primitive = reflect.asPrimitive.get
+            if (primitive.primitiveBinding.isInstanceOf[Binding[?, ?]]) {
+              primitive.primitiveType match {
+                case _: PrimitiveType.Unit.type      => unitCodec
+                case _: PrimitiveType.Boolean        => booleanCodec
+                case _: PrimitiveType.Byte           => byteCodec
+                case _: PrimitiveType.Short          => shortCodec
+                case _: PrimitiveType.Int            => intCodec
+                case _: PrimitiveType.Long           => longCodec
+                case _: PrimitiveType.Float          => floatCodec
+                case _: PrimitiveType.Double         => doubleCodec
+                case _: PrimitiveType.Char           => charCodec
+                case _: PrimitiveType.String         => stringCodec
+                case _: PrimitiveType.BigInt         => bigIntCodec
+                case _: PrimitiveType.BigDecimal     => bigDecimalCodec
+                case _: PrimitiveType.DayOfWeek      => dayOfWeekCodec
+                case _: PrimitiveType.Duration       => durationCodec
+                case _: PrimitiveType.Instant        => instantCodec
+                case _: PrimitiveType.LocalDate      => localDateCodec
+                case _: PrimitiveType.LocalDateTime  => localDateTimeCodec
+                case _: PrimitiveType.LocalTime      => localTimeCodec
+                case _: PrimitiveType.Month          => monthCodec
+                case _: PrimitiveType.MonthDay       => monthDayCodec
+                case _: PrimitiveType.OffsetDateTime => offsetDateTimeCodec
+                case _: PrimitiveType.OffsetTime     => offsetTimeCodec
+                case _: PrimitiveType.Period         => periodCodec
+                case _: PrimitiveType.Year           => yearCodec
+                case _: PrimitiveType.YearMonth      => yearMonthCodec
+                case _: PrimitiveType.ZoneId         => zoneIdCodec
+                case _: PrimitiveType.ZoneOffset     => zoneOffsetCodec
+                case _: PrimitiveType.ZonedDateTime  => zonedDateTimeCodec
+                case _: PrimitiveType.Currency       => currencyCodec
+                case _: PrimitiveType.UUID           => uuidCodec
+              }
+            } else primitive.primitiveBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isVariant) {
+            val variant = reflect.asVariant.get
+            if (variant.variantBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding = variant.variantBinding.asInstanceOf[Binding.Variant[A]]
+              val cases   = variant.cases
+              val len     = cases.length
+              val codecs  = new Array[BsonBinaryCodec[?]](len)
+              val names   = new Array[String](len)
+              var idx     = 0
+              while (idx < len) {
+                codecs(idx) = deriveCodec(cases(idx).value)
+                names(idx) = cases(idx).name
+                idx += 1
+              }
+              new BsonBinaryCodec[A]() {
+                private[this] val discriminator = binding.discriminator
+                private[this] val caseCodecs    = codecs
+                private[this] val caseNames     = names
+
+                def decodeUnsafe(reader: BsonBinaryReader): A = {
+                  reader.readStartDocument()
+                  reader.readName("_type")
+                  val typeName = reader.readString()
+                  var idx      = 0
+                  while (idx < caseNames.length && caseNames(idx) != typeName) idx += 1
+                  if (idx >= caseNames.length) decodeError(s"Unknown variant type: $typeName")
+                  reader.readName("value")
+                  val result =
+                    try caseCodecs(idx).asInstanceOf[BsonBinaryCodec[A]].decodeUnsafe(reader)
+                    catch {
+                      case error if NonFatal(error) => decodeError(new DynamicOptic.Node.Case(caseNames(idx)), error)
+                    }
+                  reader.readEndDocument()
+                  result
+                }
+
+                def encodeUnsafe(value: A, writer: BsonBinaryWriter): Unit = {
+                  val idx = discriminator.discriminate(value)
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString(caseNames(idx))
+                  writer.writeName("value")
+                  caseCodecs(idx).asInstanceOf[BsonBinaryCodec[A]].encodeUnsafe(value, writer)
+                  writer.writeEndDocument()
+                }
+              }
+            } else variant.variantBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isSequence) {
+            val sequence = reflect.asSequenceUnknown.get.sequence
+            if (sequence.seqBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding = sequence.seqBinding.asInstanceOf[Binding.Seq[Col, Elem]]
+              val codec   = deriveCodec(sequence.element).asInstanceOf[BsonBinaryCodec[Elem]]
+              new BsonBinaryCodec[Col[Elem]]() {
+                private[this] val deconstructor = binding.deconstructor
+                private[this] val constructor   = binding.constructor
+                private[this] val elementCodec  = codec
+
+                def decodeUnsafe(reader: BsonBinaryReader): Col[Elem] = {
+                  val builder = constructor.newObjectBuilder[Elem](8)
+                  reader.readStartArray()
+                  var count = 0
+                  while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                    try {
+                      constructor.addObject(builder, elementCodec.decodeUnsafe(reader))
+                      count += 1
+                    } catch {
+                      case error if NonFatal(error) =>
+                        decodeError(new DynamicOptic.Node.AtIndex(count), error)
+                    }
+                  }
+                  reader.readEndArray()
+                  constructor.resultObject[Elem](builder)
+                }
+
+                def encodeUnsafe(value: Col[Elem], writer: BsonBinaryWriter): Unit = {
+                  writer.writeStartArray()
+                  val it = deconstructor.deconstruct(value)
+                  while (it.hasNext) elementCodec.encodeUnsafe(it.next(), writer)
+                  writer.writeEndArray()
+                }
+              }
+            } else sequence.seqBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isMap) {
+            val map = reflect.asMapUnknown.get.map
+            if (map.mapBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding     = map.mapBinding.asInstanceOf[Binding.Map[Map, Key, Value]]
+              val codec1      = deriveCodec(map.key).asInstanceOf[BsonBinaryCodec[Key]]
+              val codec2      = deriveCodec(map.value).asInstanceOf[BsonBinaryCodec[Value]]
+              val isStringKey = map.key.asPrimitive match {
+                case Some(primitiveKey) => primitiveKey.primitiveType.isInstanceOf[PrimitiveType.String]
+                case _                  => false
+              }
+              if (isStringKey) {
+                new BsonBinaryCodec[Map[Key, Value]]() {
+                  private[this] val deconstructor = binding.deconstructor
+                  private[this] val constructor   = binding.constructor
+                  private[this] val valueCodec    = codec2
+                  private[this] val keyReflect    = map.key.asInstanceOf[Reflect.Bound[Key]]
+
+                  def decodeUnsafe(reader: BsonBinaryReader): Map[Key, Value] = {
+                    val builder = constructor.newObjectBuilder[Key, Value](8)
+                    reader.readStartDocument()
+                    while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                      val k = reader.readName().asInstanceOf[Key]
+                      val v =
+                        try valueCodec.decodeUnsafe(reader)
+                        catch {
+                          case error if NonFatal(error) =>
+                            decodeError(new DynamicOptic.Node.AtMapKey(keyReflect.toDynamicValue(k)), error)
+                        }
+                      constructor.addObject(builder, k, v)
+                    }
+                    reader.readEndDocument()
+                    constructor.resultObject[Key, Value](builder)
+                  }
+
+                  def encodeUnsafe(value: Map[Key, Value], writer: BsonBinaryWriter): Unit = {
+                    writer.writeStartDocument()
+                    val it = deconstructor.deconstruct(value)
+                    while (it.hasNext) {
+                      val kv = it.next()
+                      writer.writeName(deconstructor.getKey(kv).asInstanceOf[String])
+                      valueCodec.encodeUnsafe(deconstructor.getValue(kv), writer)
+                    }
+                    writer.writeEndDocument()
+                  }
+                }
+              } else {
+                new BsonBinaryCodec[Map[Key, Value]]() {
+                  private[this] val deconstructor = binding.deconstructor
+                  private[this] val constructor   = binding.constructor
+                  private[this] val keyCodec      = codec1
+                  private[this] val valueCodec    = codec2
+                  private[this] val keyReflect    = map.key.asInstanceOf[Reflect.Bound[Key]]
+
+                  def decodeUnsafe(reader: BsonBinaryReader): Map[Key, Value] = {
+                    val builder = constructor.newObjectBuilder[Key, Value](8)
+                    reader.readStartArray()
+                    var count = 0
+                    while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                      reader.readStartDocument()
+                      reader.readName("_1")
+                      val k =
+                        try keyCodec.decodeUnsafe(reader)
+                        catch {
+                          case error if NonFatal(error) =>
+                            decodeError(new DynamicOptic.Node.AtIndex(count), error)
+                        }
+                      reader.readName("_2")
+                      val v =
+                        try valueCodec.decodeUnsafe(reader)
+                        catch {
+                          case error if NonFatal(error) =>
+                            decodeError(new DynamicOptic.Node.AtMapKey(keyReflect.toDynamicValue(k)), error)
+                        }
+                      reader.readEndDocument()
+                      constructor.addObject(builder, k, v)
+                      count += 1
+                    }
+                    reader.readEndArray()
+                    constructor.resultObject[Key, Value](builder)
+                  }
+
+                  def encodeUnsafe(value: Map[Key, Value], writer: BsonBinaryWriter): Unit = {
+                    writer.writeStartArray()
+                    val it = deconstructor.deconstruct(value)
+                    while (it.hasNext) {
+                      val kv = it.next()
+                      writer.writeStartDocument()
+                      writer.writeName("_1")
+                      keyCodec.encodeUnsafe(deconstructor.getKey(kv), writer)
+                      writer.writeName("_2")
+                      valueCodec.encodeUnsafe(deconstructor.getValue(kv), writer)
+                      writer.writeEndDocument()
+                    }
+                    writer.writeEndArray()
+                  }
+                }
+              }
+            } else map.mapBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isRecord) {
+            val record = reflect.asRecord.get
+            if (record.recordBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding     = record.recordBinding.asInstanceOf[Binding.Record[A]]
+              val fields      = record.fields
+              val isRecursive = fields.exists(_.value.isInstanceOf[Reflect.Deferred[F, ?]])
+              val typeName    = record.typeName
+              var codecs      = if (isRecursive) recursiveRecordCache.get.get(typeName) else null
+              var offset      = 0L
+              if (codecs eq null) {
+                val len = fields.length
+                codecs = new Array[BsonBinaryCodec[?]](len)
+                if (isRecursive) recursiveRecordCache.get.put(typeName, codecs)
+                var idx = 0
+                while (idx < len) {
+                  val field = fields(idx)
+                  val codec = deriveCodec(field.value)
+                  codecs(idx) = codec
+                  offset = RegisterOffset.add(codec.valueOffset, offset)
+                  idx += 1
+                }
+              }
+              new BsonBinaryCodec[A]() {
+                private[this] val deconstructor = binding.deconstructor
+                private[this] val constructor   = binding.constructor
+                private[this] val usedRegisters = offset
+                private[this] val fieldCodecs   = codecs
+
+                def decodeUnsafe(reader: BsonBinaryReader): A = {
+                  val regs   = Registers(usedRegisters)
+                  var offset = 0L
+                  val len    = fieldCodecs.length
+                  var idx    = 0
+                  reader.readStartDocument()
+                  try {
+                    while (idx < len) {
+                      val codec     = fieldCodecs(idx)
+                      val fieldName = fields(idx).name
+                      reader.readName(fieldName)
+                      codec.valueType match {
+                        case BsonBinaryCodec.objectType =>
+                          regs.setObject(offset, codec.asInstanceOf[BsonBinaryCodec[AnyRef]].decodeUnsafe(reader))
+                        case BsonBinaryCodec.intType =>
+                          regs.setInt(offset, codec.asInstanceOf[BsonBinaryCodec[Int]].decodeUnsafe(reader))
+                        case BsonBinaryCodec.longType =>
+                          regs.setLong(offset, codec.asInstanceOf[BsonBinaryCodec[Long]].decodeUnsafe(reader))
+                        case BsonBinaryCodec.floatType =>
+                          regs.setFloat(offset, codec.asInstanceOf[BsonBinaryCodec[Float]].decodeUnsafe(reader))
+                        case BsonBinaryCodec.doubleType =>
+                          regs.setDouble(offset, codec.asInstanceOf[BsonBinaryCodec[Double]].decodeUnsafe(reader))
+                        case BsonBinaryCodec.booleanType =>
+                          regs.setBoolean(offset, codec.asInstanceOf[BsonBinaryCodec[Boolean]].decodeUnsafe(reader))
+                        case BsonBinaryCodec.byteType =>
+                          regs.setByte(offset, codec.asInstanceOf[BsonBinaryCodec[Byte]].decodeUnsafe(reader))
+                        case BsonBinaryCodec.charType =>
+                          regs.setChar(offset, codec.asInstanceOf[BsonBinaryCodec[Char]].decodeUnsafe(reader))
+                        case BsonBinaryCodec.shortType =>
+                          regs.setShort(offset, codec.asInstanceOf[BsonBinaryCodec[Short]].decodeUnsafe(reader))
+                        case _ => codec.asInstanceOf[BsonBinaryCodec[Unit]].decodeUnsafe(reader)
+                      }
+                      offset += codec.valueOffset
+                      idx += 1
+                    }
+                    reader.readEndDocument()
+                    constructor.construct(regs, 0)
+                  } catch {
+                    case error if NonFatal(error) => decodeError(new DynamicOptic.Node.Field(fields(idx).name), error)
+                  }
+                }
+
+                def encodeUnsafe(value: A, writer: BsonBinaryWriter): Unit = {
+                  val regs   = Registers(usedRegisters)
+                  var offset = 0L
+                  deconstructor.deconstruct(regs, offset, value)
+                  val len = fieldCodecs.length
+                  var idx = 0
+                  writer.writeStartDocument()
+                  while (idx < len) {
+                    val codec     = fieldCodecs(idx)
+                    val fieldName = fields(idx).name
+                    writer.writeName(fieldName)
+                    codec.valueType match {
+                      case BsonBinaryCodec.objectType =>
+                        codec.asInstanceOf[BsonBinaryCodec[AnyRef]].encodeUnsafe(regs.getObject(offset), writer)
+                      case BsonBinaryCodec.intType =>
+                        codec.asInstanceOf[BsonBinaryCodec[Int]].encodeUnsafe(regs.getInt(offset), writer)
+                      case BsonBinaryCodec.longType =>
+                        codec.asInstanceOf[BsonBinaryCodec[Long]].encodeUnsafe(regs.getLong(offset), writer)
+                      case BsonBinaryCodec.floatType =>
+                        codec.asInstanceOf[BsonBinaryCodec[Float]].encodeUnsafe(regs.getFloat(offset), writer)
+                      case BsonBinaryCodec.doubleType =>
+                        codec.asInstanceOf[BsonBinaryCodec[Double]].encodeUnsafe(regs.getDouble(offset), writer)
+                      case BsonBinaryCodec.booleanType =>
+                        codec.asInstanceOf[BsonBinaryCodec[Boolean]].encodeUnsafe(regs.getBoolean(offset), writer)
+                      case BsonBinaryCodec.byteType =>
+                        codec.asInstanceOf[BsonBinaryCodec[Byte]].encodeUnsafe(regs.getByte(offset), writer)
+                      case BsonBinaryCodec.charType =>
+                        codec.asInstanceOf[BsonBinaryCodec[Char]].encodeUnsafe(regs.getChar(offset), writer)
+                      case BsonBinaryCodec.shortType =>
+                        codec.asInstanceOf[BsonBinaryCodec[Short]].encodeUnsafe(regs.getShort(offset), writer)
+                      case _ => codec.asInstanceOf[BsonBinaryCodec[Unit]].encodeUnsafe((), writer)
+                    }
+                    offset += codec.valueOffset
+                    idx += 1
+                  }
+                  writer.writeEndDocument()
+                }
+              }
+            } else record.recordBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else if (reflect.isWrapper) {
+            val wrapper = reflect.asWrapperUnknown.get.wrapper
+            if (wrapper.wrapperBinding.isInstanceOf[Binding[?, ?]]) {
+              val binding = wrapper.wrapperBinding.asInstanceOf[Binding.Wrapper[A, Wrapped]]
+              val codec   = deriveCodec(wrapper.wrapped).asInstanceOf[BsonBinaryCodec[Wrapped]]
+              new BsonBinaryCodec[A](wrapper.wrapperPrimitiveType.fold(BsonBinaryCodec.objectType) {
+                case _: PrimitiveType.Boolean   => BsonBinaryCodec.booleanType
+                case _: PrimitiveType.Byte      => BsonBinaryCodec.byteType
+                case _: PrimitiveType.Char      => BsonBinaryCodec.charType
+                case _: PrimitiveType.Short     => BsonBinaryCodec.shortType
+                case _: PrimitiveType.Float     => BsonBinaryCodec.floatType
+                case _: PrimitiveType.Int       => BsonBinaryCodec.intType
+                case _: PrimitiveType.Double    => BsonBinaryCodec.doubleType
+                case _: PrimitiveType.Long      => BsonBinaryCodec.longType
+                case _: PrimitiveType.Unit.type => BsonBinaryCodec.unitType
+                case _                          => BsonBinaryCodec.objectType
+              }) {
+                private[this] val unwrap       = binding.unwrap
+                private[this] val wrap         = binding.wrap
+                private[this] val wrappedCodec = codec
+
+                def decodeUnsafe(reader: BsonBinaryReader): A = {
+                  val wrapped =
+                    try wrappedCodec.decodeUnsafe(reader)
+                    catch {
+                      case error if NonFatal(error) => decodeError(DynamicOptic.Node.Wrapped, error)
+                    }
+                  wrap(wrapped) match {
+                    case Right(x)  => x
+                    case Left(err) => decodeError(err)
+                  }
+                }
+
+                def encodeUnsafe(value: A, writer: BsonBinaryWriter): Unit =
+                  wrappedCodec.encodeUnsafe(unwrap(value), writer)
+              }
+            } else wrapper.wrapperBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          } else {
+            val dynamic = reflect.asDynamic.get
+            if (dynamic.dynamicBinding.isInstanceOf[Binding[?, ?]]) dynamicValueCodec
+            else dynamic.dynamicBinding.asInstanceOf[BindingInstance[TC, ?, A]].instance.force
+          }
+        }.asInstanceOf[BsonBinaryCodec[A]]
+
+        private[this] val dynamicValueCodec = new BsonBinaryCodec[DynamicValue]() {
+          private[this] val spanPrimitive = new DynamicOptic.Node.Case("Primitive")
+          private[this] val spanRecord    = new DynamicOptic.Node.Case("Record")
+          private[this] val spanVariant   = new DynamicOptic.Node.Case("Variant")
+          private[this] val spanSequence  = new DynamicOptic.Node.Case("Sequence")
+          private[this] val spanMap       = new DynamicOptic.Node.Case("Map")
+          private[this] val spanFields    = new DynamicOptic.Node.Field("fields")
+          private[this] val spanCaseName  = new DynamicOptic.Node.Field("caseName")
+          private[this] val spanValue     = new DynamicOptic.Node.Field("value")
+          private[this] val spanElements  = new DynamicOptic.Node.Field("elements")
+          private[this] val spanEntries   = new DynamicOptic.Node.Field("entries")
+          private[this] val span_1        = new DynamicOptic.Node.Field("_1")
+          private[this] val span_2        = new DynamicOptic.Node.Field("_2")
+
+          def decodeUnsafe(reader: BsonBinaryReader): DynamicValue = {
+            reader.readStartDocument()
+            reader.readName("_type")
+            val typeName = reader.readString()
+            reader.readName("value")
+            val result = typeName match {
+              case "Primitive" =>
+                try {
+                  reader.readStartDocument()
+                  reader.readName("_type")
+                  val primitiveType  = reader.readString()
+                  val primitiveValue = primitiveType match {
+                    case "Unit" =>
+                      reader.readEndDocument()
+                      PrimitiveValue.Unit
+                    case "Boolean" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Boolean(booleanCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "Byte" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Byte(byteCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "Short" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Short(shortCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "Int" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Int(intCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "Long" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Long(longCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "Float" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Float(floatCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "Double" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Double(doubleCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "Char" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Char(charCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "String" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.String(stringCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "BigInt" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.BigInt(bigIntCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "BigDecimal" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.BigDecimal(bigDecimalCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "DayOfWeek" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.DayOfWeek(dayOfWeekCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "Duration" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Duration(durationCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "Instant" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Instant(instantCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "LocalDate" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.LocalDate(localDateCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "LocalDateTime" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.LocalDateTime(localDateTimeCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "LocalTime" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.LocalTime(localTimeCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "Month" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Month(monthCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "MonthDay" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.MonthDay(monthDayCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "OffsetDateTime" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.OffsetDateTime(offsetDateTimeCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "OffsetTime" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.OffsetTime(offsetTimeCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "Period" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Period(periodCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "Year" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Year(yearCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "YearMonth" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.YearMonth(yearMonthCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "ZoneId" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.ZoneId(zoneIdCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "ZoneOffset" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.ZoneOffset(zoneOffsetCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "ZonedDateTime" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.ZonedDateTime(zonedDateTimeCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "Currency" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.Currency(currencyCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case "UUID" =>
+                      reader.readName("value")
+                      val v = new PrimitiveValue.UUID(uuidCodec.decodeUnsafe(reader))
+                      reader.readEndDocument()
+                      v
+                    case other =>
+                      decodeError(s"Unknown primitive type: $other")
+                  }
+                  new DynamicValue.Primitive(primitiveValue)
+                } catch {
+                  case error if NonFatal(error) => decodeError(spanPrimitive, error)
+                }
+              case "Record" =>
+                try {
+                  val builder = Vector.newBuilder[(String, DynamicValue)]
+                  reader.readStartArray()
+                  var count = 0
+                  while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                    reader.readStartDocument()
+                    reader.readName("name")
+                    val k =
+                      try reader.readString()
+                      catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(count), span_1, error)
+                      }
+                    reader.readName("value")
+                    val v =
+                      try decodeUnsafe(reader)
+                      catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(count), span_2, error)
+                      }
+                    reader.readEndDocument()
+                    builder.addOne((k, v))
+                    count += 1
+                  }
+                  reader.readEndArray()
+                  new DynamicValue.Record(builder.result())
+                } catch {
+                  case error if NonFatal(error) => decodeError(spanRecord, spanFields, error)
+                }
+              case "Variant" =>
+                reader.readStartDocument()
+                reader.readName("caseName")
+                val caseName =
+                  try reader.readString()
+                  catch {
+                    case error if NonFatal(error) => decodeError(spanVariant, spanCaseName, error)
+                  }
+                reader.readName("value")
+                val value =
+                  try decodeUnsafe(reader)
+                  catch {
+                    case error if NonFatal(error) => decodeError(spanVariant, spanValue, error)
+                  }
+                reader.readEndDocument()
+                new DynamicValue.Variant(caseName, value)
+              case "Sequence" =>
+                try {
+                  val builder = Vector.newBuilder[DynamicValue]
+                  reader.readStartArray()
+                  var count = 0
+                  while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                    try {
+                      builder.addOne(decodeUnsafe(reader))
+                      count += 1
+                    } catch {
+                      case error if NonFatal(error) => decodeError(new DynamicOptic.Node.AtIndex(count), error)
+                    }
+                  }
+                  reader.readEndArray()
+                  new DynamicValue.Sequence(builder.result())
+                } catch {
+                  case error if NonFatal(error) => decodeError(spanSequence, spanElements, error)
+                }
+              case "Map" =>
+                try {
+                  val builder = Vector.newBuilder[(DynamicValue, DynamicValue)]
+                  reader.readStartArray()
+                  var count = 0
+                  while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                    reader.readStartDocument()
+                    reader.readName("key")
+                    val k =
+                      try decodeUnsafe(reader)
+                      catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(count), span_1, error)
+                      }
+                    reader.readName("value")
+                    val v =
+                      try decodeUnsafe(reader)
+                      catch {
+                        case error if NonFatal(error) =>
+                          decodeError(new DynamicOptic.Node.AtIndex(count), span_2, error)
+                      }
+                    reader.readEndDocument()
+                    builder.addOne((k, v))
+                    count += 1
+                  }
+                  reader.readEndArray()
+                  new DynamicValue.Map(builder.result())
+                } catch {
+                  case error if NonFatal(error) => decodeError(spanMap, spanEntries, error)
+                }
+              case other => decodeError(s"Unknown DynamicValue type: $other")
+            }
+            reader.readEndDocument()
+            result
+          }
+
+          def encodeUnsafe(value: DynamicValue, writer: BsonBinaryWriter): Unit = value match {
+            case primitive: DynamicValue.Primitive =>
+              writer.writeStartDocument()
+              writer.writeName("_type")
+              writer.writeString("Primitive")
+              writer.writeName("value")
+              primitive.value match {
+                case _: PrimitiveValue.Unit.type =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Unit")
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Boolean =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Boolean")
+                  writer.writeName("value")
+                  booleanCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Byte =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Byte")
+                  writer.writeName("value")
+                  byteCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Short =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Short")
+                  writer.writeName("value")
+                  shortCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Int =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Int")
+                  writer.writeName("value")
+                  intCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Long =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Long")
+                  writer.writeName("value")
+                  longCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Float =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Float")
+                  writer.writeName("value")
+                  floatCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Double =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Double")
+                  writer.writeName("value")
+                  doubleCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Char =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Char")
+                  writer.writeName("value")
+                  charCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.String =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("String")
+                  writer.writeName("value")
+                  stringCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.BigInt =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("BigInt")
+                  writer.writeName("value")
+                  bigIntCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.BigDecimal =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("BigDecimal")
+                  writer.writeName("value")
+                  bigDecimalCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.DayOfWeek =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("DayOfWeek")
+                  writer.writeName("value")
+                  dayOfWeekCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Duration =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Duration")
+                  writer.writeName("value")
+                  durationCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Instant =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Instant")
+                  writer.writeName("value")
+                  instantCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.LocalDate =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("LocalDate")
+                  writer.writeName("value")
+                  localDateCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.LocalDateTime =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("LocalDateTime")
+                  writer.writeName("value")
+                  localDateTimeCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.LocalTime =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("LocalTime")
+                  writer.writeName("value")
+                  localTimeCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Month =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Month")
+                  writer.writeName("value")
+                  monthCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.MonthDay =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("MonthDay")
+                  writer.writeName("value")
+                  monthDayCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.OffsetDateTime =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("OffsetDateTime")
+                  writer.writeName("value")
+                  offsetDateTimeCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.OffsetTime =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("OffsetTime")
+                  writer.writeName("value")
+                  offsetTimeCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Period =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Period")
+                  writer.writeName("value")
+                  periodCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Year =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Year")
+                  writer.writeName("value")
+                  yearCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.YearMonth =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("YearMonth")
+                  writer.writeName("value")
+                  yearMonthCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.ZoneId =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("ZoneId")
+                  writer.writeName("value")
+                  zoneIdCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.ZoneOffset =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("ZoneOffset")
+                  writer.writeName("value")
+                  zoneOffsetCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.ZonedDateTime =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("ZonedDateTime")
+                  writer.writeName("value")
+                  zonedDateTimeCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.Currency =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("Currency")
+                  writer.writeName("value")
+                  currencyCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+                case v: PrimitiveValue.UUID =>
+                  writer.writeStartDocument()
+                  writer.writeName("_type")
+                  writer.writeString("UUID")
+                  writer.writeName("value")
+                  uuidCodec.encodeUnsafe(v.value, writer)
+                  writer.writeEndDocument()
+              }
+              writer.writeEndDocument()
+            case record: DynamicValue.Record =>
+              writer.writeStartDocument()
+              writer.writeName("_type")
+              writer.writeString("Record")
+              writer.writeName("value")
+              writer.writeStartArray()
+              val fields = record.fields
+              val it     = fields.iterator
+              while (it.hasNext) {
+                val kv = it.next()
+                writer.writeStartDocument()
+                writer.writeName("name")
+                writer.writeString(kv._1)
+                writer.writeName("value")
+                encodeUnsafe(kv._2, writer)
+                writer.writeEndDocument()
+              }
+              writer.writeEndArray()
+              writer.writeEndDocument()
+            case variant: DynamicValue.Variant =>
+              writer.writeStartDocument()
+              writer.writeName("_type")
+              writer.writeString("Variant")
+              writer.writeName("value")
+              writer.writeStartDocument()
+              writer.writeName("caseName")
+              writer.writeString(variant.caseName)
+              writer.writeName("value")
+              encodeUnsafe(variant.value, writer)
+              writer.writeEndDocument()
+              writer.writeEndDocument()
+            case sequence: DynamicValue.Sequence =>
+              writer.writeStartDocument()
+              writer.writeName("_type")
+              writer.writeString("Sequence")
+              writer.writeName("value")
+              writer.writeStartArray()
+              val elements = sequence.elements
+              val it       = elements.iterator
+              while (it.hasNext) {
+                encodeUnsafe(it.next(), writer)
+              }
+              writer.writeEndArray()
+              writer.writeEndDocument()
+            case map: DynamicValue.Map =>
+              writer.writeStartDocument()
+              writer.writeName("_type")
+              writer.writeString("Map")
+              writer.writeName("value")
+              writer.writeStartArray()
+              val entries = map.entries
+              val it      = entries.iterator
+              while (it.hasNext) {
+                val kv = it.next()
+                writer.writeStartDocument()
+                writer.writeName("key")
+                encodeUnsafe(kv._1, writer)
+                writer.writeName("value")
+                encodeUnsafe(kv._2, writer)
+                writer.writeEndDocument()
+              }
+              writer.writeEndArray()
+              writer.writeEndDocument()
+          }
+        }
+      }
+    )

--- a/schema-bson/src/test/scala/zio/blocks/schema/bson/BsonFormatSpec.scala
+++ b/schema-bson/src/test/scala/zio/blocks/schema/bson/BsonFormatSpec.scala
@@ -1,0 +1,606 @@
+package zio.blocks.schema.bson
+
+import zio.blocks.schema._
+import zio.blocks.schema.bson.BsonTestUtils._
+import zio.blocks.schema.binding.Binding
+import zio.test._
+import java.time._
+import java.util.{Currency, UUID}
+import scala.collection.immutable.ArraySeq
+
+object BsonFormatSpec extends ZIOSpecDefault {
+  def spec: Spec[TestEnvironment, Any] = suite("BsonFormatSpec")(
+    suite("primitives")(
+      test("Unit") {
+        roundTrip(())
+      },
+      test("Boolean true") {
+        roundTrip(true)
+      },
+      test("Boolean false") {
+        roundTrip(false)
+      },
+      test("Byte positive") {
+        roundTrip(1: Byte)
+      },
+      test("Byte min") {
+        roundTrip(Byte.MinValue)
+      },
+      test("Byte max") {
+        roundTrip(Byte.MaxValue)
+      },
+      test("Short positive") {
+        roundTrip(1: Short)
+      },
+      test("Short min") {
+        roundTrip(Short.MinValue)
+      },
+      test("Short max") {
+        roundTrip(Short.MaxValue)
+      },
+      test("Int positive") {
+        roundTrip(42)
+      },
+      test("Int min") {
+        roundTrip(Int.MinValue)
+      },
+      test("Int max") {
+        roundTrip(Int.MaxValue)
+      },
+      test("Long positive") {
+        roundTrip(42L)
+      },
+      test("Long min") {
+        roundTrip(Long.MinValue)
+      },
+      test("Long max") {
+        roundTrip(Long.MaxValue)
+      },
+      test("Float positive") {
+        roundTrip(42.0f)
+      },
+      test("Float min") {
+        roundTrip(Float.MinValue)
+      },
+      test("Float max") {
+        roundTrip(Float.MaxValue)
+      },
+      test("Double positive") {
+        roundTrip(42.0)
+      },
+      test("Double min") {
+        roundTrip(Double.MinValue)
+      },
+      test("Double max") {
+        roundTrip(Double.MaxValue)
+      },
+      test("Char") {
+        roundTrip('7')
+      },
+      test("Char min") {
+        roundTrip(Char.MinValue)
+      },
+      test("Char max") {
+        roundTrip(Char.MaxValue)
+      },
+      test("String") {
+        roundTrip("Hello")
+      },
+      test("String unicode") {
+        roundTrip("Hello World")
+      },
+      test("BigInt") {
+        roundTrip(BigInt("9" * 20))
+      },
+      test("BigDecimal") {
+        roundTrip(BigDecimal("9." + "9" * 20 + "E+12345"))
+      },
+      test("DayOfWeek") {
+        roundTrip(java.time.DayOfWeek.WEDNESDAY)
+      },
+      test("Duration") {
+        roundTrip(java.time.Duration.ofNanos(1234567890123456789L))
+      },
+      test("Instant") {
+        roundTrip(java.time.Instant.parse("2025-07-18T08:29:13.121409459Z"))
+      },
+      test("LocalDate") {
+        roundTrip(java.time.LocalDate.parse("2025-07-18"))
+      },
+      test("LocalDateTime") {
+        roundTrip(java.time.LocalDateTime.parse("2025-07-18T08:29:13.121409459"))
+      },
+      test("LocalTime") {
+        roundTrip(java.time.LocalTime.parse("08:29:13.121409459"))
+      },
+      test("Month") {
+        roundTrip(java.time.Month.of(12))
+      },
+      test("MonthDay") {
+        roundTrip(java.time.MonthDay.of(12, 31))
+      },
+      test("OffsetDateTime") {
+        roundTrip(java.time.OffsetDateTime.parse("2025-07-18T08:29:13.121409459-07:00"))
+      },
+      test("OffsetTime") {
+        roundTrip(java.time.OffsetTime.parse("08:29:13.121409459-07:00"))
+      },
+      test("Period") {
+        roundTrip(java.time.Period.of(1, 12, 31))
+      },
+      test("Year") {
+        roundTrip(java.time.Year.of(2025))
+      },
+      test("YearMonth") {
+        roundTrip(java.time.YearMonth.of(2025, 7))
+      },
+      test("ZoneId") {
+        roundTrip(java.time.ZoneId.of("UTC"))
+      },
+      test("ZoneOffset") {
+        roundTrip(java.time.ZoneOffset.ofTotalSeconds(3600))
+      },
+      test("ZonedDateTime") {
+        roundTrip(java.time.ZonedDateTime.parse("2025-07-18T08:29:13.121409459+02:00[Europe/Warsaw]"))
+      },
+      test("Currency") {
+        roundTrip(Currency.getInstance("USD"))
+      },
+      test("UUID") {
+        roundTrip(UUID.randomUUID())
+      }
+    ),
+    suite("records")(
+      test("simple record") {
+        roundTrip(Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV"))
+      },
+      test("nested record") {
+        roundTrip(
+          Record2(
+            Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV"),
+            Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV")
+          )
+        )
+      },
+      test("recursive record") {
+        roundTrip(Recursive(1, List(Recursive(2, List(Recursive(3, Nil))))))
+      },
+      test("record with unit and variant fields") {
+        roundTrip(Record4((), Some("VVV")))
+      },
+      test("record with None") {
+        roundTrip(Record4((), None))
+      }
+    ),
+    suite("sequences")(
+      test("Array[Unit]") {
+        implicit val arrayOfUnitSchema: Schema[Array[Unit]] = Schema.derived
+        roundTrip(Array[Unit]((), (), ()))
+      },
+      test("Array[Boolean]") {
+        implicit val arrayOfBooleanSchema: Schema[Array[Boolean]] = Schema.derived
+        roundTrip(Array[Boolean](true, false, true))
+      },
+      test("Array[Byte]") {
+        implicit val arrayOfByteSchema: Schema[Array[Byte]] = Schema.derived
+        roundTrip(Array[Byte](1: Byte, 2: Byte, 3: Byte))
+      },
+      test("Array[Short]") {
+        implicit val arrayOfShortSchema: Schema[Array[Short]] = Schema.derived
+        roundTrip(Array[Short](1: Short, 2: Short, 3: Short))
+      },
+      test("Array[Char]") {
+        implicit val arrayOfCharSchema: Schema[Array[Char]] = Schema.derived
+        roundTrip(Array('1', '2', '3'))
+      },
+      test("Array[Float]") {
+        implicit val arrayOfFloatSchema: Schema[Array[Float]] = Schema.derived
+        roundTrip(Array[Float](1.0f, 2.0f, 3.0f))
+      },
+      test("Array[Int]") {
+        implicit val arrayOfIntSchema: Schema[Array[Int]] = Schema.derived
+        roundTrip(Array[Int](1, 2, 3))
+      },
+      test("Array[Double]") {
+        implicit val arrayOfDoubleSchema: Schema[Array[Double]] = Schema.derived
+        roundTrip(Array[Double](1.0, 2.0, 3.0))
+      },
+      test("Array[Long]") {
+        implicit val arrayOfLongSchema: Schema[Array[Long]] = Schema.derived
+        roundTrip(Array[Long](1, 2, 3))
+      },
+      test("List[Int]") {
+        roundTrip((1 to 100).toList)
+      },
+      test("Set[Long]") {
+        roundTrip(Set(1L, 2L, 3L))
+      },
+      test("ArraySeq[Float]") {
+        implicit val arraySeqOfFloatSchema: Schema[ArraySeq[Float]] = Schema.derived
+        roundTrip(ArraySeq(1.0f, 2.0f, 3.0f))
+      },
+      test("Vector[Double]") {
+        roundTrip(Vector(1.0, 2.0, 3.0))
+      },
+      test("List[String]") {
+        roundTrip(List("1", "2", "3"))
+      },
+      test("List[BigInt]") {
+        roundTrip(List(BigInt(1), BigInt(2), BigInt(3)))
+      },
+      test("List[Record1]") {
+        roundTrip(
+          List(
+            Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV"),
+            Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV")
+          )
+        )
+      },
+      test("List[Recursive]") {
+        roundTrip(
+          List(
+            Recursive(1, List(Recursive(2, List(Recursive(3, Nil))))),
+            Recursive(4, List(Recursive(5, List(Recursive(6, Nil)))))
+          )
+        )
+      }
+    ),
+    suite("maps")(
+      test("Map[String, Unit]") {
+        roundTrip(Map("VVV" -> (), "WWW" -> ()))
+      },
+      test("Map[String, Boolean]") {
+        roundTrip(Map("VVV" -> true, "WWW" -> false))
+      },
+      test("Map[String, Byte]") {
+        roundTrip(Map("VVV" -> (1: Byte), "WWW" -> (2: Byte)))
+      },
+      test("Map[String, Short]") {
+        roundTrip(Map("VVV" -> (1: Short), "WWW" -> (2: Short)))
+      },
+      test("Map[String, Char]") {
+        roundTrip(Map("VVV" -> '1', "WWW" -> '2'))
+      },
+      test("Map[String, Int]") {
+        roundTrip(Map("VVV" -> 1, "WWW" -> 2))
+      },
+      test("Map[String, Long]") {
+        roundTrip(Map("VVV" -> 1L, "WWW" -> 2L))
+      },
+      test("Map[String, Float]") {
+        roundTrip(Map("VVV" -> 1.0f, "WWW" -> 2.0f))
+      },
+      test("Map[String, Double]") {
+        roundTrip(Map("VVV" -> 1.0, "WWW" -> 2.0))
+      },
+      test("Map[String, String]") {
+        roundTrip(Map("VVV" -> "1", "WWW" -> "2"))
+      },
+      test("Map[String, BigInt]") {
+        roundTrip(Map("VVV" -> BigInt(1), "WWW" -> BigInt(2)))
+      },
+      test("Map[String, Record1]") {
+        roundTrip(
+          Map(
+            "VVV" -> Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV"),
+            "WWW" -> Record1(true, 1: Byte, 2: Short, 3, 4L, 5.0f, 6.0, '7', "VVV")
+          )
+        )
+      },
+      test("Map[String, Recursive]") {
+        roundTrip(
+          Map(
+            "VVV" -> Recursive(1, List(Recursive(2, List(Recursive(3, Nil))))),
+            "WWW" -> Recursive(4, List(Recursive(5, List(Recursive(6, Nil)))))
+          )
+        )
+      },
+      test("Map[Int, Long] (non-string key)") {
+        roundTrip(Map(1 -> 1L, 2 -> 2L))
+      },
+      test("Map[Recursive, Int] (non-string key with recursive values)") {
+        roundTrip(
+          Map(
+            Recursive(1, List(Recursive(2, List(Recursive(3, Nil))))) -> 1,
+            Recursive(4, List(Recursive(5, List(Recursive(6, Nil))))) -> 2
+          )
+        )
+      },
+      test("nested maps") {
+        roundTrip(Map("VVV" -> Map(1 -> 1L, 2 -> 2L)))
+      }
+    ),
+    suite("variants")(
+      test("constant values Red") {
+        roundTrip[TrafficLight](TrafficLight.Red)
+      },
+      test("constant values Yellow") {
+        roundTrip[TrafficLight](TrafficLight.Yellow)
+      },
+      test("constant values Green") {
+        roundTrip[TrafficLight](TrafficLight.Green)
+      },
+      test("option Some") {
+        roundTrip(Option(42))
+      },
+      test("option None") {
+        roundTrip[Option[Int]](None)
+      },
+      test("either Right") {
+        roundTrip[Either[String, Int]](Right(42))
+      },
+      test("either Left") {
+        roundTrip[Either[String, Int]](Left("VVV"))
+      }
+    ),
+    suite("wrapper")(
+      test("UserId wrapper") {
+        roundTrip[UserId](UserId(1234567890123456789L))
+      },
+      test("Email wrapper") {
+        roundTrip[Email](Email("john@gmail.com"))
+      },
+      test("as a record field") {
+        roundTrip[Record3](Record3(UserId(1234567890123456789L), Email("backup@gmail.com")))
+      }
+    ),
+    suite("dynamic value")(
+      test("Primitive Unit") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Unit))
+      },
+      test("Primitive Boolean") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Boolean(true)))
+      },
+      test("Primitive Byte") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Byte(1: Byte)))
+      },
+      test("Primitive Short") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Short(1: Short)))
+      },
+      test("Primitive Int") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Int(1)))
+      },
+      test("Primitive Long") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Long(1L)))
+      },
+      test("Primitive Float") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Float(1.0f)))
+      },
+      test("Primitive Double") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Double(1.0)))
+      },
+      test("Primitive Char") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Char('1')))
+      },
+      test("Primitive String") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.String("VVV")))
+      },
+      test("Primitive BigInt") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.BigInt(123)))
+      },
+      test("Primitive BigDecimal") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.BigDecimal(123.45)))
+      },
+      test("Primitive DayOfWeek") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.DayOfWeek(DayOfWeek.MONDAY)))
+      },
+      test("Primitive Duration") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Duration(Duration.ofSeconds(60))))
+      },
+      test("Primitive Instant") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Instant(Instant.EPOCH)))
+      },
+      test("Primitive LocalDate") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.LocalDate(LocalDate.MAX)))
+      },
+      test("Primitive LocalDateTime") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.LocalDateTime(LocalDateTime.MAX)))
+      },
+      test("Primitive LocalTime") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.LocalTime(LocalTime.MAX)))
+      },
+      test("Primitive Month") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Month(Month.MAY)))
+      },
+      test("Primitive MonthDay") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.MonthDay(MonthDay.of(Month.MAY, 1))))
+      },
+      test("Primitive OffsetDateTime") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.OffsetDateTime(OffsetDateTime.MAX)))
+      },
+      test("Primitive OffsetTime") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.OffsetTime(OffsetTime.MAX)))
+      },
+      test("Primitive Period") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Period(Period.ofDays(1))))
+      },
+      test("Primitive Year") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Year(Year.of(2025))))
+      },
+      test("Primitive YearMonth") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.YearMonth(YearMonth.of(2025, 1))))
+      },
+      test("Primitive ZoneId") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.ZoneId(ZoneId.of("UTC"))))
+      },
+      test("Primitive ZoneOffset") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.ZoneOffset(ZoneOffset.MAX)))
+      },
+      test("Primitive ZonedDateTime") {
+        roundTrip[DynamicValue](
+          DynamicValue.Primitive(
+            PrimitiveValue.ZonedDateTime(ZonedDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
+          )
+        )
+      },
+      test("Primitive Currency") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.Currency(Currency.getInstance("USD"))))
+      },
+      test("Primitive UUID") {
+        roundTrip[DynamicValue](DynamicValue.Primitive(PrimitiveValue.UUID(UUID.randomUUID())))
+      },
+      test("Record") {
+        roundTrip[DynamicValue](
+          DynamicValue.Record(
+            Vector(
+              ("i", DynamicValue.Primitive(PrimitiveValue.Int(1))),
+              ("s", DynamicValue.Primitive(PrimitiveValue.String("VVV")))
+            )
+          )
+        )
+      },
+      test("Variant") {
+        roundTrip[DynamicValue](DynamicValue.Variant("Int", DynamicValue.Primitive(PrimitiveValue.Int(1))))
+      },
+      test("Sequence") {
+        roundTrip[DynamicValue](
+          DynamicValue.Sequence(
+            Vector(
+              DynamicValue.Primitive(PrimitiveValue.Int(1)),
+              DynamicValue.Primitive(PrimitiveValue.String("VVV"))
+            )
+          )
+        )
+      },
+      test("Map") {
+        roundTrip[DynamicValue](
+          DynamicValue.Map(
+            Vector(
+              (DynamicValue.Primitive(PrimitiveValue.Long(1L)), DynamicValue.Primitive(PrimitiveValue.Int(1))),
+              (DynamicValue.Primitive(PrimitiveValue.Long(2L)), DynamicValue.Primitive(PrimitiveValue.String("VVV")))
+            )
+          )
+        )
+      }
+    ),
+    suite("edge cases")(
+      test("empty string") {
+        roundTrip("")
+      },
+      test("empty list") {
+        roundTrip(List.empty[Int])
+      },
+      test("empty map") {
+        roundTrip(Map.empty[String, Int])
+      },
+      test("deeply nested record") {
+        roundTrip(Recursive(1, List(Recursive(2, List(Recursive(3, List(Recursive(4, List(Recursive(5, Nil))))))))))
+      },
+      test("large list") {
+        roundTrip((1 to 1000).toList)
+      },
+      test("special characters in string") {
+        roundTrip("Hello\nWorld\t!")
+      },
+      test("null character in string") {
+        roundTrip("Hello\u0000World")
+      }
+    )
+  )
+
+  case class Record1(
+    bl: Boolean,
+    b: Byte,
+    sh: Short,
+    i: Int,
+    l: Long,
+    f: Float,
+    d: Double,
+    c: Char,
+    s: String
+  )
+
+  object Record1 extends CompanionOptics[Record1] {
+    implicit val schema: Schema[Record1] = Schema.derived
+
+    val i: Lens[Record1, Int] = $(_.i)
+  }
+
+  case class Record2(
+    r1_1: Record1,
+    r1_2: Record1
+  )
+
+  object Record2 extends CompanionOptics[Record2] {
+    implicit val schema: Schema[Record2] = Schema.derived
+
+    val r1_1: Lens[Record2, Record1] = $(_.r1_1)
+    val r1_2: Lens[Record2, Record1] = $(_.r1_2)
+    val r1_1_i: Lens[Record2, Int]   = $(_.r1_1.i)
+    val r1_2_i: Lens[Record2, Int]   = $(_.r1_2.i)
+  }
+
+  case class Recursive(i: Int, ln: List[Recursive])
+
+  object Recursive extends CompanionOptics[Recursive] {
+    implicit val schema: Schema[Recursive]   = Schema.derived
+    val i: Lens[Recursive, Int]              = $(_.i)
+    val ln: Lens[Recursive, List[Recursive]] = $(_.ln)
+  }
+
+  sealed trait TrafficLight
+
+  object TrafficLight {
+    implicit val schema: Schema[TrafficLight] = Schema.derived
+
+    case object Red extends TrafficLight
+
+    case object Yellow extends TrafficLight
+
+    case object Green extends TrafficLight
+  }
+
+  implicit val eitherSchema: Schema[Either[String, Int]] = Schema.derived
+
+  case class UserId(value: Long)
+
+  object UserId {
+    implicit val schema: Schema[UserId] = Schema.derived.wrapTotal(x => new UserId(x), _.value)
+  }
+
+  case class Email(value: String)
+
+  object Email {
+    private[this] val EmailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$".r
+
+    implicit val schema: Schema[Email] = new Schema(
+      new Reflect.Wrapper[Binding, Email, String](
+        Schema[String].reflect,
+        TypeName(Namespace(Seq("zio", "blocks", "bson"), Seq("BsonFormatSpec")), "Email"),
+        None,
+        new Binding.Wrapper(
+          {
+            case x @ EmailRegex(_*) => new Right(new Email(x))
+            case _                  => new Left("Expected Email")
+          },
+          _.value
+        )
+      )
+    )
+  }
+
+  case class Record3(userId: UserId, email: Email)
+
+  object Record3 {
+    implicit val schema: Schema[Record3] = Schema.derived
+  }
+
+  case class Record4(hidden: Unit, optKey: Option[String])
+
+  object Record4 extends CompanionOptics[Record4] {
+    implicit val schema: Schema[Record4] = Schema.derived
+
+    val hidden: Lens[Record4, Unit]               = $(_.hidden)
+    val optKey: Lens[Record4, Option[String]]     = $(_.optKey)
+    val optKey_None: Optional[Record4, None.type] = $(_.optKey.when[None.type])
+  }
+
+  case class Dynamic(primitive: DynamicValue, map: DynamicValue)
+
+  object Dynamic extends CompanionOptics[Dynamic] {
+    implicit val schema: Schema[Dynamic] = Schema.derived
+
+    val primitive: Lens[Dynamic, DynamicValue] = $(_.primitive)
+    val map: Lens[Dynamic, DynamicValue]       = $(_.map)
+  }
+}

--- a/schema-bson/src/test/scala/zio/blocks/schema/bson/BsonTestUtils.scala
+++ b/schema-bson/src/test/scala/zio/blocks/schema/bson/BsonTestUtils.scala
@@ -1,0 +1,60 @@
+package zio.blocks.schema.bson
+
+import zio.blocks.schema.{Schema, SchemaError}
+import zio.test.Assertion._
+import zio.test._
+import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.immutable.ArraySeq
+
+object BsonTestUtils {
+  private[this] val codecs = new ConcurrentHashMap[Schema[?], BsonBinaryCodec[?]]()
+
+  private[this] def codec[A](schema: Schema[A]): BsonBinaryCodec[A] =
+    codecs.computeIfAbsent(schema, _.derive(BsonFormat.deriver)).asInstanceOf[BsonBinaryCodec[A]]
+
+  def roundTrip[A](value: A)(implicit schema: Schema[A]): TestResult =
+    roundTrip(value, codec(schema))
+
+  def roundTrip[A](value: A, codec: BsonBinaryCodec[A]): TestResult = {
+    val heapByteBuffer = ByteBuffer.allocate(maxBufSize)
+    codec.encode(value, heapByteBuffer)
+    val encodedBySchema1 = java.util.Arrays.copyOf(heapByteBuffer.array, heapByteBuffer.position)
+    val directByteBuffer = ByteBuffer.allocateDirect(maxBufSize)
+    codec.encode(value, directByteBuffer)
+    val encodedBySchema2 = {
+      val dup = directByteBuffer.duplicate()
+      val out = new Array[Byte](dup.position)
+      dup.position(0)
+      dup.get(out)
+      out
+    }
+    val output = new java.io.ByteArrayOutputStream(maxBufSize)
+    codec.encode(value, output)
+    output.close()
+    val encodedBySchema3 = output.toByteArray
+    val encodedBySchema4 = codec.encode(value)
+    assertTrue(encodedBySchema1.length > 0) &&
+    assert(ArraySeq.unsafeWrapArray(encodedBySchema1))(equalTo(ArraySeq.unsafeWrapArray(encodedBySchema2))) &&
+    assert(ArraySeq.unsafeWrapArray(encodedBySchema1))(equalTo(ArraySeq.unsafeWrapArray(encodedBySchema3))) &&
+    assert(ArraySeq.unsafeWrapArray(encodedBySchema1))(equalTo(ArraySeq.unsafeWrapArray(encodedBySchema4))) &&
+    assert(codec.decode(encodedBySchema1))(isRight(equalTo(value))) &&
+    assert(codec.decode(toInputStream(encodedBySchema1)))(isRight(equalTo(value))) &&
+    assert(codec.decode(toHeapByteBuffer(encodedBySchema1)))(isRight(equalTo(value)))
+  }
+
+  def decodeError[A](bytes: Array[Byte], error: String)(implicit schema: Schema[A]): TestResult =
+    decodeError(bytes, codec(schema), error)
+
+  def decodeError[A](bytes: Array[Byte], codec: BsonBinaryCodec[A], error: String): TestResult =
+    assert(codec.decode(bytes))(isLeft(hasError(error)))
+
+  private[this] def hasError(message: String) =
+    hasField[SchemaError, String]("getMessage", _.getMessage, containsString(message))
+
+  private[this] def toInputStream(bs: Array[Byte]): java.io.InputStream = new java.io.ByteArrayInputStream(bs)
+
+  private[this] def toHeapByteBuffer(bs: Array[Byte]): ByteBuffer = ByteBuffer.wrap(bs)
+
+  private[this] val maxBufSize = 65536
+}


### PR DESCRIPTION
## Summary

Port BSON support from ZIO Schema v1 to ZIO Schema 2 in a new top-level `schema-bson` project.

### Implementation includes:
- `BsonBinaryCodec` abstract class extending `BinaryCodec[A]`
- `BsonFormat` object with `Deriver[BsonBinaryCodec]`
- Support for all 30 primitive types (Unit, Boolean, Byte, Short, Int, Long, Float, Double, Char, String, BigInt, BigDecimal, all java.time types, Currency, UUID)
- Record, variant, sequence, map, dynamic value, and wrapper support
- Recursive type support via lazy initialization
- Comprehensive test suite with **135 tests**

### Deriver Methods Implemented:
- `derivePrimitive` - All primitive types
- `deriveRecord` - Case classes encoded as BSON documents
- `deriveVariant` - Sealed traits with discriminator field
- `deriveSequence` - Collections encoded as BSON arrays
- `deriveMap` - Maps encoded as BSON documents (string keys) or arrays (non-string keys)
- `deriveDynamic` - DynamicValue support
- `deriveWrapper` - Wrapper types with validation

### Dependencies:
- `org.mongodb:bson:5.2.0`

## Test plan
- [x] All 135 tests pass
- [x] Format check passes
- [x] Compiles against latest main

/claim #683