### PR TITLE
JSON Schema Generation Feature Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ object Person {
 }
 
 // Get everything for free:
-val jsonCodec = Schema[Person].derive(JsonFormat.deriver)      // JSON serialization
-val avroCodec = Schema[Person].derive(AvroFormat.deriver)      // Avro serialization
-val toonCodec = Schema[Person].derive(ToonFormat.deriver)      // TOON serialization
-val protobuf  = Schema[Person].derive(ProtobufFormat.deriver)  // Protobuf serialization (not implemented yet)
-val thrift    = Schema[Person].derive(ThriftFormat.deriver)    // Thrift serialization (not implemented yet)
+val jsonCodec   = Schema[Person].derive(JsonFormat.deriver)       // JSON serialization
+val avroCodec   = Schema[Person].derive(AvroFormat.deriver)       // Avro serialization
+val toonCodec   = Schema[Person].derive(ToonFormat.deriver)       // TOON serialization
+val jsonSchema  = Schema[Person].derive(JsonSchemaFormat.deriver) // JSON Schema generation
+val protobuf    = Schema[Person].derive(ProtobufFormat.deriver)   // Protobuf serialization (not implemented yet)
+val thrift      = Schema[Person].derive(ThriftFormat.deriver)     // Thrift serialization (not implemented yet)
 // ...
 ```
 
@@ -55,6 +56,7 @@ Here are the key features that make ZIO Blocks stand out:
    - **JSON** – Fast, type-safe JSON handling
    - **Avro** – Apache Avro binary format
    - **TOON** – Compact, LLM-optimized format
+   - **JSON Schema** – Generate JSON Schema for API documentation and validation
    - **Protobuf** – Protocol Buffers
    - **Thrift** – Apache Thrift
    - **BSON** – MongoDB's binary JSON format
@@ -76,6 +78,7 @@ Now you have access to the core ZIO Blocks schema library. You can also add addi
 libraryDependencies += "dev.zio" %% "zio-blocks-schema-json" % "0.0.1"
 libraryDependencies += "dev.zio" %% "zio-blocks-schema-avro" % "0.0.1"
 libraryDependencies += "dev.zio" %% "zio-blocks-schema-toon" % "0.0.1"
+libraryDependencies += "dev.zio" %% "zio-blocks-schema-json-schema" % "0.0.1"
 ```
 
 ## Example

--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,9 @@ lazy val root = project
     schema.js,
     schema.native,
     `schema-avro`,
+    `schema-json-schema`.jvm,
+    `schema-json-schema`.js,
+    `schema-json-schema`.native,
     `schema-toon`.jvm,
     `schema-toon`.js,
     `schema-toon`.native,
@@ -216,6 +219,23 @@ lazy val `schema-toon` = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-locales"         % "1.5.4" % Test,
       "io.github.cquiroz" %%% "locales-full-currencies-db" % "1.5.4" % Test
+    )
+  )
+
+lazy val `schema-json-schema` = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .crossType(CrossType.Pure)
+  .settings(stdSettings("zio-blocks-schema-json-schema"))
+  .settings(crossProjectSettings)
+  .settings(buildInfoSettings("zio.blocks.schema.jsonschema"))
+  .enablePlugins(BuildInfoPlugin)
+  .jvmSettings(mimaSettings(failOnProblem = false))
+  .jsSettings(jsSettings)
+  .nativeSettings(nativeSettings)
+  .dependsOn(schema)
+  .settings(
+    libraryDependencies ++= Seq(
+      "dev.zio" %%% "zio-test"     % "2.1.24" % Test,
+      "dev.zio" %%% "zio-test-sbt" % "2.1.24" % Test
     )
   )
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,11 +36,12 @@ object Person {
 }
 
 // Get everything for free:
-val jsonCodec = Schema[Person].derive(JsonFormat.deriver)      // JSON serialization
-val avroCodec = Schema[Person].derive(AvroFormat.deriver)      // Avro serialization
-val toonCodec = Schema[Person].derive(ToonFormat.deriver)      // TOON serialization
-val protobuf  = Schema[Person].derive(ProtobufFormat.deriver)  // Protobuf serialization (not implemented yet)
-val thrift    = Schema[Person].derive(ThriftFormat.deriver)    // Thrift serialization (not implemented yet)
+val jsonCodec   = Schema[Person].derive(JsonFormat.deriver)       // JSON serialization
+val avroCodec   = Schema[Person].derive(AvroFormat.deriver)       // Avro serialization
+val toonCodec   = Schema[Person].derive(ToonFormat.deriver)       // TOON serialization
+val jsonSchema  = Schema[Person].derive(JsonSchemaFormat.deriver) // JSON Schema generation
+val protobuf    = Schema[Person].derive(ProtobufFormat.deriver)   // Protobuf serialization (not implemented yet)
+val thrift      = Schema[Person].derive(ThriftFormat.deriver)     // Thrift serialization (not implemented yet)
 // ...
 ```
 
@@ -54,6 +55,7 @@ Here are the key features that make ZIO Blocks stand out:
    - **JSON** – Fast, type-safe JSON handling
    - **Avro** – Apache Avro binary format
    - **TOON** – Compact, LLM-optimized format
+   - **JSON Schema** – Generate JSON Schema for API documentation and validation
    - **Protobuf** – Protocol Buffers
    - **Thrift** – Apache Thrift
    - **BSON** – MongoDB's binary JSON format
@@ -75,6 +77,7 @@ Now you have access to the core ZIO Blocks schema library. You can also add addi
 libraryDependencies += "dev.zio" %% "zio-blocks-schema-json" % "@VERSION@"
 libraryDependencies += "dev.zio" %% "zio-blocks-schema-avro" % "@VERSION@"
 libraryDependencies += "dev.zio" %% "zio-blocks-schema-toon" % "@VERSION@"
+libraryDependencies += "dev.zio" %% "zio-blocks-schema-json-schema" % "@VERSION@"
 ```
 
 ## Example

--- a/schema-json-schema/src/main/scala/zio/blocks/schema/jsonschema/JsonSchema.scala
+++ b/schema-json-schema/src/main/scala/zio/blocks/schema/jsonschema/JsonSchema.scala
@@ -1,0 +1,203 @@
+package zio.blocks.schema.jsonschema
+
+import zio.blocks.schema._
+import zio.blocks.schema.jsonschema.JsonSchemaValue._
+
+/**
+ * Represents a JSON Schema for a Scala type A.
+ *
+ * JSON Schema is a vocabulary that allows you to annotate and validate JSON documents.
+ * This implementation supports JSON Schema Draft 2020-12.
+ *
+ * @see https://json-schema.org/
+ */
+final case class JsonSchema[A](schema: JsonSchemaValue.Obj) {
+
+  /**
+   * Returns the JSON Schema as a compact JSON string.
+   */
+  def toJson: String = schema.toJson
+
+  /**
+   * Returns the JSON Schema as a pretty-printed JSON string.
+   */
+  def toPrettyJson: String = schema.toPrettyJson
+
+  /**
+   * Adds a custom property to the schema.
+   */
+  def withProperty(key: String, value: JsonSchemaValue): JsonSchema[A] =
+    JsonSchema(schema + (key -> value))
+
+  /**
+   * Sets the title of the schema.
+   */
+  def withTitle(title: String): JsonSchema[A] =
+    withProperty("title", Str(title))
+
+  /**
+   * Sets the description of the schema.
+   */
+  def withDescription(description: String): JsonSchema[A] =
+    withProperty("description", Str(description))
+
+  /**
+   * Marks the schema as deprecated.
+   */
+  def deprecated: JsonSchema[A] =
+    withProperty("deprecated", Bool(true))
+
+  /**
+   * Adds examples to the schema.
+   */
+  def withExamples(examples: JsonSchemaValue*): JsonSchema[A] =
+    withProperty("examples", Arr(examples.toIndexedSeq))
+
+  /**
+   * Sets a default value for the schema.
+   */
+  def withDefault(default: JsonSchemaValue): JsonSchema[A] =
+    withProperty("default", default)
+}
+
+object JsonSchema {
+
+  /**
+   * Creates a JSON Schema that references a definition.
+   */
+  def ref(name: String): JsonSchemaValue.Obj =
+    Obj("$ref" -> Str(s"#/$$defs/$name"))
+
+  /**
+   * Creates a JSON Schema for a string type.
+   */
+  def string: JsonSchemaValue.Obj = Obj("type" -> Str("string"))
+
+  /**
+   * Creates a JSON Schema for an integer type.
+   */
+  def integer: JsonSchemaValue.Obj = Obj("type" -> Str("integer"))
+
+  /**
+   * Creates a JSON Schema for a number type.
+   */
+  def number: JsonSchemaValue.Obj = Obj("type" -> Str("number"))
+
+  /**
+   * Creates a JSON Schema for a boolean type.
+   */
+  def boolean: JsonSchemaValue.Obj = Obj("type" -> Str("boolean"))
+
+  /**
+   * Creates a JSON Schema for a null type.
+   */
+  def `null`: JsonSchemaValue.Obj = Obj("type" -> Str("null"))
+
+  /**
+   * Creates a JSON Schema for an array type.
+   */
+  def array(items: JsonSchemaValue.Obj): JsonSchemaValue.Obj =
+    Obj("type" -> Str("array"), "items" -> items)
+
+  /**
+   * Creates a JSON Schema for an object type with properties.
+   */
+  def `object`(
+    properties: IndexedSeq[(String, JsonSchemaValue.Obj)],
+    required: IndexedSeq[String],
+    additionalProperties: Option[JsonSchemaValue] = None
+  ): JsonSchemaValue.Obj = {
+    val base = Obj(
+      "type"       -> Str("object"),
+      "properties" -> Obj(properties.map { case (k, v) => k -> (v: JsonSchemaValue) }: _*)
+    )
+    val withRequired =
+      if (required.isEmpty) base
+      else base + ("required" -> Arr(required.map(Str(_))))
+    additionalProperties match {
+      case Some(ap) => withRequired + ("additionalProperties" -> ap)
+      case None     => withRequired
+    }
+  }
+
+  /**
+   * Creates a JSON Schema for a map type (object with additionalProperties).
+   */
+  def map(valueSchema: JsonSchemaValue.Obj): JsonSchemaValue.Obj =
+    Obj(
+      "type"                 -> Str("object"),
+      "additionalProperties" -> valueSchema
+    )
+
+  /**
+   * Creates a JSON Schema oneOf for variants/unions.
+   */
+  def oneOf(schemas: IndexedSeq[JsonSchemaValue.Obj]): JsonSchemaValue.Obj =
+    Obj("oneOf" -> Arr(schemas.map(s => s: JsonSchemaValue)))
+
+  /**
+   * Creates a JSON Schema anyOf.
+   */
+  def anyOf(schemas: IndexedSeq[JsonSchemaValue.Obj]): JsonSchemaValue.Obj =
+    Obj("anyOf" -> Arr(schemas.map(s => s: JsonSchemaValue)))
+
+  /**
+   * Creates a JSON Schema for an enum.
+   */
+  def enum(values: IndexedSeq[JsonSchemaValue]): JsonSchemaValue.Obj =
+    Obj("enum" -> Arr(values))
+
+  /**
+   * Creates a JSON Schema with a constant value.
+   */
+  def const(value: JsonSchemaValue): JsonSchemaValue.Obj =
+    Obj("const" -> value)
+
+  /**
+   * Adds string constraints to a schema.
+   */
+  def withStringConstraints(
+    base: JsonSchemaValue.Obj,
+    minLength: Option[Int] = None,
+    maxLength: Option[Int] = None,
+    pattern: Option[String] = None,
+    format: Option[String] = None
+  ): JsonSchemaValue.Obj = {
+    var result = base
+    minLength.foreach(v => result = result + ("minLength" -> Num(v)))
+    maxLength.foreach(v => result = result + ("maxLength" -> Num(v)))
+    pattern.foreach(v => result = result + ("pattern" -> Str(v)))
+    format.foreach(v => result = result + ("format" -> Str(v)))
+    result
+  }
+
+  /**
+   * Adds numeric constraints to a schema.
+   */
+  def withNumericConstraints(
+    base: JsonSchemaValue.Obj,
+    minimum: Option[BigDecimal] = None,
+    maximum: Option[BigDecimal] = None,
+    exclusiveMinimum: Option[BigDecimal] = None,
+    exclusiveMaximum: Option[BigDecimal] = None
+  ): JsonSchemaValue.Obj = {
+    var result = base
+    minimum.foreach(v => result = result + ("minimum" -> Num(v)))
+    maximum.foreach(v => result = result + ("maximum" -> Num(v)))
+    exclusiveMinimum.foreach(v => result = result + ("exclusiveMinimum" -> Num(v)))
+    exclusiveMaximum.foreach(v => result = result + ("exclusiveMaximum" -> Num(v)))
+    result
+  }
+
+  /**
+   * Adds a description to a schema.
+   */
+  def withDescription(base: JsonSchemaValue.Obj, description: String): JsonSchemaValue.Obj =
+    base + ("description" -> Str(description))
+
+  /**
+   * Adds a title to a schema.
+   */
+  def withTitle(base: JsonSchemaValue.Obj, title: String): JsonSchemaValue.Obj =
+    base + ("title" -> Str(title))
+}

--- a/schema-json-schema/src/main/scala/zio/blocks/schema/jsonschema/JsonSchemaFormat.scala
+++ b/schema-json-schema/src/main/scala/zio/blocks/schema/jsonschema/JsonSchemaFormat.scala
@@ -1,0 +1,258 @@
+package zio.blocks.schema.jsonschema
+
+import zio.blocks.schema._
+import zio.blocks.schema.binding._
+import zio.blocks.schema.derive._
+import zio.blocks.schema.jsonschema.JsonSchemaValue._
+
+/**
+ * JSON Schema format for deriving JSON Schema from ZIO Blocks Schema.
+ *
+ * This format generates JSON Schema Draft 2020-12 compliant schemas from
+ * any Scala type that has a ZIO Blocks Schema.
+ *
+ * {{{
+ * import zio.blocks.schema._
+ * import zio.blocks.schema.jsonschema._
+ *
+ * case class Person(name: String, age: Int)
+ * object Person {
+ *   implicit val schema: Schema[Person] = Schema.derived
+ * }
+ *
+ * val jsonSchema: JsonSchema[Person] = Schema[Person].derive(JsonSchemaFormat.deriver)
+ * println(jsonSchema.toPrettyJson)
+ * }}}
+ */
+object JsonSchemaFormat {
+
+  /**
+   * The deriver for generating JSON Schema from ZIO Blocks Schema.
+   */
+  val deriver: Deriver[JsonSchema] = new Deriver[JsonSchema] {
+
+    override def derivePrimitive[F[_, _], A](
+      primitiveType: PrimitiveType[A],
+      typeName: TypeName[A],
+      binding: Binding[BindingType.Primitive, A],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    ): Lazy[JsonSchema[A]] = Lazy {
+      val baseSchema = primitiveTypeToSchema(primitiveType)
+      val withDoc = addDocumentation(baseSchema, doc)
+      JsonSchema(withDoc)
+    }
+
+    override def deriveRecord[F[_, _], A](
+      fields: IndexedSeq[Term[F, A, ?]],
+      typeName: TypeName[A],
+      binding: Binding[BindingType.Record, A],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[JsonSchema[A]] = Lazy {
+      val properties = fields.map { field =>
+        val fieldSchema = instance(field.value).force.schema
+        val fieldName = getFieldName(field)
+        fieldName -> fieldSchema
+      }
+
+      val required = fields.collect {
+        case field if !isOptional(field) => getFieldName(field)
+      }
+
+      val baseSchema = JsonSchema.`object`(properties, required, Some(Bool(false)))
+      val withTitle = JsonSchema.withTitle(baseSchema, typeName.name)
+      val withDoc = addDocumentation(withTitle, doc)
+      JsonSchema(withDoc)
+    }
+
+    override def deriveVariant[F[_, _], A](
+      cases: IndexedSeq[Term[F, A, ?]],
+      typeName: TypeName[A],
+      binding: Binding[BindingType.Variant, A],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[JsonSchema[A]] = Lazy {
+      // Check if this is an enum (all cases are singletons/units)
+      val isEnum = cases.forall { c =>
+        c.value match {
+          case r: Reflect.Record[F, ?] @unchecked => r.fields.isEmpty
+          case _                                   => false
+        }
+      }
+
+      val baseSchema = if (isEnum) {
+        // For enums, use enum with string values
+        val enumValues = cases.map(c => Str(getCaseName(c)): JsonSchemaValue)
+        JsonSchema.enum(enumValues)
+      } else {
+        // For sealed traits with data, use oneOf with discriminator
+        val caseSchemas = cases.map { c =>
+          val caseSchema = instance(c.value).force.schema
+          val caseName = getCaseName(c)
+          // Wrap each case in an object with the case name as discriminator
+          Obj(
+            "type"       -> Str("object"),
+            "properties" -> Obj(caseName -> caseSchema),
+            "required"   -> Arr(IndexedSeq(Str(caseName)))
+          )
+        }
+        JsonSchema.oneOf(caseSchemas)
+      }
+
+      val withTitle = JsonSchema.withTitle(baseSchema, typeName.name)
+      val withDoc = addDocumentation(withTitle, doc)
+      JsonSchema(withDoc)
+    }
+
+    override def deriveSequence[F[_, _], C[_], A](
+      element: Reflect[F, A],
+      typeName: TypeName[C[A]],
+      binding: Binding[BindingType.Seq[C], C[A]],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[JsonSchema[C[A]]] = Lazy {
+      val elementReflect = element.asInstanceOf[Reflect[F, A]]
+      val elementSchema = deriveFromReflect(elementReflect).schema
+      val baseSchema = JsonSchema.array(elementSchema)
+      val withDoc = addDocumentation(baseSchema, doc)
+      JsonSchema(withDoc)
+    }
+
+    override def deriveMap[F[_, _], M[_, _], K, V](
+      key: Reflect[F, K],
+      value: Reflect[F, V],
+      typeName: TypeName[M[K, V]],
+      binding: Binding[BindingType.Map[M], M[K, V]],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[JsonSchema[M[K, V]]] = Lazy {
+      // JSON Schema only supports string keys for objects
+      val valueSchema = deriveFromReflect(value.asInstanceOf[Reflect[F, V]]).schema
+      val baseSchema = JsonSchema.map(valueSchema)
+      val withDoc = addDocumentation(baseSchema, doc)
+      JsonSchema(withDoc)
+    }
+
+    override def deriveDynamic[F[_, _]](
+      binding: Binding[BindingType.Dynamic, DynamicValue],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[JsonSchema[DynamicValue]] = Lazy {
+      // Dynamic values can be any JSON value
+      val baseSchema = Obj.empty // Empty schema allows any value
+      val withDoc = addDocumentation(baseSchema, doc)
+      JsonSchema(withDoc)
+    }
+
+    override def deriveWrapper[F[_, _], A, B](
+      wrapped: Reflect[F, B],
+      typeName: TypeName[A],
+      wrapperPrimitiveType: Option[PrimitiveType[A]],
+      binding: Binding[BindingType.Wrapper[A, B], A],
+      doc: Doc,
+      modifiers: Seq[Modifier.Reflect]
+    )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[JsonSchema[A]] = Lazy {
+      // For wrappers, use the wrapped type's schema but with the wrapper's name
+      val wrappedSchema = deriveFromReflect(wrapped.asInstanceOf[Reflect[F, B]]).schema
+      val withTitle = JsonSchema.withTitle(wrappedSchema, typeName.name)
+      val withDoc = addDocumentation(withTitle, doc)
+      JsonSchema(withDoc)
+    }
+
+    private def deriveFromReflect[F[_, _], A](reflect: Reflect[F, A])(implicit
+      F: HasBinding[F],
+      D: HasInstance[F]
+    ): JsonSchema[A] = reflect match {
+      case p: Reflect.Primitive[F, A] @unchecked =>
+        derivePrimitive(p.primitiveType, p.typeName, p.binding.asInstanceOf[Binding[BindingType.Primitive, A]], p.doc, p.modifiers).force
+
+      case r: Reflect.Record[F, A] @unchecked =>
+        deriveRecord(r.fields, r.typeName, r.binding.asInstanceOf[Binding[BindingType.Record, A]], r.doc, r.modifiers).force
+
+      case v: Reflect.Variant[F, A] @unchecked =>
+        deriveVariant(v.cases, v.typeName, v.binding.asInstanceOf[Binding[BindingType.Variant, A]], v.doc, v.modifiers).force
+
+      case s: Reflect.Sequence[F, c, a] @unchecked =>
+        deriveSequence(s.element, s.typeName, s.binding.asInstanceOf[Binding[BindingType.Seq[c], c[a]]], s.doc, s.modifiers).force.asInstanceOf[JsonSchema[A]]
+
+      case m: Reflect.Map[F, map, k, v] @unchecked =>
+        deriveMap(m.key, m.value, m.typeName, m.binding.asInstanceOf[Binding[BindingType.Map[map], map[k, v]]], m.doc, m.modifiers).force.asInstanceOf[JsonSchema[A]]
+
+      case d: Reflect.Dynamic[F] @unchecked =>
+        deriveDynamic(d.binding.asInstanceOf[Binding[BindingType.Dynamic, DynamicValue]], d.doc, d.modifiers).force.asInstanceOf[JsonSchema[A]]
+
+      case w: Reflect.Wrapper[F, A, b] @unchecked =>
+        deriveWrapper(w.wrapped, w.typeName, w.wrapperPrimitiveType, w.binding.asInstanceOf[Binding[BindingType.Wrapper[A, b], A]], w.doc, w.modifiers).force
+
+      case deferred: Reflect.Deferred[F, A] @unchecked =>
+        deriveFromReflect(deferred.value)
+    }
+
+    private def primitiveTypeToSchema[A](primitiveType: PrimitiveType[A]): Obj = primitiveType match {
+      case _: PrimitiveType.Unit.type    => JsonSchema.`null`
+      case _: PrimitiveType.Boolean.type => JsonSchema.boolean
+      case _: PrimitiveType.Byte.type    => JsonSchema.withNumericConstraints(JsonSchema.integer, minimum = Some(-128), maximum = Some(127))
+      case _: PrimitiveType.Short.type   => JsonSchema.withNumericConstraints(JsonSchema.integer, minimum = Some(-32768), maximum = Some(32767))
+      case _: PrimitiveType.Int.type     => JsonSchema.integer
+      case _: PrimitiveType.Long.type    => JsonSchema.integer
+      case _: PrimitiveType.Float.type   => JsonSchema.number
+      case _: PrimitiveType.Double.type  => JsonSchema.number
+      case _: PrimitiveType.Char.type    => JsonSchema.withStringConstraints(JsonSchema.string, minLength = Some(1), maxLength = Some(1))
+      case _: PrimitiveType.String.type  => JsonSchema.string
+      case _: PrimitiveType.BigInt.type  => JsonSchema.integer
+      case _: PrimitiveType.BigDecimal.type => JsonSchema.number
+      case _: PrimitiveType.Binary.type  => JsonSchema.withStringConstraints(JsonSchema.string, format = Some("byte")) // base64 encoded
+      case _: PrimitiveType.UUID.type    => JsonSchema.withStringConstraints(JsonSchema.string, format = Some("uuid"))
+      case _: PrimitiveType.Currency.type => JsonSchema.string
+      case _: PrimitiveType.DayOfWeek.type => JsonSchema.enum(IndexedSeq(
+        Str("MONDAY"), Str("TUESDAY"), Str("WEDNESDAY"), Str("THURSDAY"),
+        Str("FRIDAY"), Str("SATURDAY"), Str("SUNDAY")
+      ))
+      case _: PrimitiveType.Duration.type => JsonSchema.withStringConstraints(JsonSchema.string, format = Some("duration"))
+      case _: PrimitiveType.Instant.type => JsonSchema.withStringConstraints(JsonSchema.string, format = Some("date-time"))
+      case _: PrimitiveType.LocalDate.type => JsonSchema.withStringConstraints(JsonSchema.string, format = Some("date"))
+      case _: PrimitiveType.LocalDateTime.type => JsonSchema.withStringConstraints(JsonSchema.string, format = Some("date-time"))
+      case _: PrimitiveType.LocalTime.type => JsonSchema.withStringConstraints(JsonSchema.string, format = Some("time"))
+      case _: PrimitiveType.Month.type => JsonSchema.enum(IndexedSeq(
+        Str("JANUARY"), Str("FEBRUARY"), Str("MARCH"), Str("APRIL"), Str("MAY"), Str("JUNE"),
+        Str("JULY"), Str("AUGUST"), Str("SEPTEMBER"), Str("OCTOBER"), Str("NOVEMBER"), Str("DECEMBER")
+      ))
+      case _: PrimitiveType.MonthDay.type => JsonSchema.string
+      case _: PrimitiveType.OffsetDateTime.type => JsonSchema.withStringConstraints(JsonSchema.string, format = Some("date-time"))
+      case _: PrimitiveType.OffsetTime.type => JsonSchema.withStringConstraints(JsonSchema.string, format = Some("time"))
+      case _: PrimitiveType.Period.type => JsonSchema.string
+      case _: PrimitiveType.Year.type => JsonSchema.integer
+      case _: PrimitiveType.YearMonth.type => JsonSchema.string
+      case _: PrimitiveType.ZonedDateTime.type => JsonSchema.withStringConstraints(JsonSchema.string, format = Some("date-time"))
+      case _: PrimitiveType.ZoneId.type => JsonSchema.string
+      case _: PrimitiveType.ZoneOffset.type => JsonSchema.string
+    }
+
+    private def addDocumentation(schema: Obj, doc: Doc): Obj = doc match {
+      case Doc.Empty => schema
+      case Doc.Text(value) => schema + ("description" -> Str(value))
+      case Doc.Concat(leaves) =>
+        val text = leaves.collect { case Doc.Text(v) => v }.mkString(" ")
+        if (text.isEmpty) schema
+        else schema + ("description" -> Str(text))
+    }
+
+    private def getFieldName[F[_, _], A, B](field: Term[F, A, B]): String =
+      field.modifiers.collectFirst {
+        case Modifier.rename(name) => name
+      }.getOrElse(field.name)
+
+    private def getCaseName[F[_, _], A, B](c: Term[F, A, B]): String =
+      c.modifiers.collectFirst {
+        case Modifier.rename(name) => name
+      }.getOrElse(c.name)
+
+    private def isOptional[F[_, _], A, B](field: Term[F, A, B]): Boolean =
+      field.value match {
+        case v: Reflect.Variant[F, B] @unchecked =>
+          v.typeName.namespace.packages == Seq("scala") && v.typeName.name == "Option"
+        case _ => false
+      }
+  }
+}

--- a/schema-json-schema/src/main/scala/zio/blocks/schema/jsonschema/JsonSchemaValue.scala
+++ b/schema-json-schema/src/main/scala/zio/blocks/schema/jsonschema/JsonSchemaValue.scala
@@ -1,0 +1,88 @@
+package zio.blocks.schema.jsonschema
+
+/**
+ * Represents a JSON Schema value that can be serialized to JSON.
+ * This is a simplified representation of JSON Schema Draft 2020-12.
+ */
+sealed trait JsonSchemaValue {
+  def toJson: String = JsonSchemaValue.toJson(this)
+
+  def toPrettyJson: String = JsonSchemaValue.toPrettyJson(this, 0)
+}
+
+object JsonSchemaValue {
+  case object Null extends JsonSchemaValue
+
+  case class Bool(value: Boolean) extends JsonSchemaValue
+
+  case class Num(value: BigDecimal) extends JsonSchemaValue
+
+  case class Str(value: String) extends JsonSchemaValue
+
+  case class Arr(values: IndexedSeq[JsonSchemaValue]) extends JsonSchemaValue
+
+  case class Obj(fields: IndexedSeq[(String, JsonSchemaValue)]) extends JsonSchemaValue {
+    def ++(other: Obj): Obj = Obj(fields ++ other.fields)
+
+    def +(field: (String, JsonSchemaValue)): Obj = Obj(fields :+ field)
+  }
+
+  object Obj {
+    val empty: Obj = Obj(IndexedSeq.empty)
+
+    def apply(fields: (String, JsonSchemaValue)*): Obj = new Obj(fields.toIndexedSeq)
+  }
+
+  private def escapeString(s: String): String = {
+    val sb = new StringBuilder()
+    sb.append('"')
+    var i = 0
+    while (i < s.length) {
+      val c = s.charAt(i)
+      c match {
+        case '"'  => sb.append("\\\"")
+        case '\\' => sb.append("\\\\")
+        case '\b' => sb.append("\\b")
+        case '\f' => sb.append("\\f")
+        case '\n' => sb.append("\\n")
+        case '\r' => sb.append("\\r")
+        case '\t' => sb.append("\\t")
+        case _ =>
+          if (c < 32) sb.append(f"\\u${c.toInt}%04x")
+          else sb.append(c)
+      }
+      i += 1
+    }
+    sb.append('"')
+    sb.toString
+  }
+
+  def toJson(value: JsonSchemaValue): String = value match {
+    case Null       => "null"
+    case Bool(v)    => v.toString
+    case Num(v)     => v.toString
+    case Str(v)     => escapeString(v)
+    case Arr(vs)    => vs.map(toJson).mkString("[", ",", "]")
+    case Obj(fields) =>
+      fields.map { case (k, v) => s"${escapeString(k)}:${toJson(v)}" }.mkString("{", ",", "}")
+  }
+
+  def toPrettyJson(value: JsonSchemaValue, indent: Int): String = {
+    val pad = "  " * indent
+    val padInner = "  " * (indent + 1)
+    value match {
+      case Null       => "null"
+      case Bool(v)    => v.toString
+      case Num(v)     => v.toString
+      case Str(v)     => escapeString(v)
+      case Arr(vs) if vs.isEmpty => "[]"
+      case Arr(vs)    =>
+        vs.map(v => padInner + toPrettyJson(v, indent + 1)).mkString("[\n", ",\n", s"\n$pad]")
+      case Obj(fields) if fields.isEmpty => "{}"
+      case Obj(fields) =>
+        fields.map { case (k, v) =>
+          s"$padInner${escapeString(k)}: ${toPrettyJson(v, indent + 1)}"
+        }.mkString("{\n", ",\n", s"\n$pad}")
+    }
+  }
+}

--- a/schema-json-schema/src/main/scala/zio/blocks/schema/jsonschema/package.scala
+++ b/schema-json-schema/src/main/scala/zio/blocks/schema/jsonschema/package.scala
@@ -1,0 +1,15 @@
+package zio.blocks.schema
+
+package object jsonschema {
+
+  /**
+   * Extension methods for Schema to easily derive JSON Schema.
+   */
+  implicit class SchemaJsonSchemaOps[A](private val schema: Schema[A]) extends AnyVal {
+
+    /**
+     * Derives a JSON Schema from this Schema.
+     */
+    def toJsonSchema: JsonSchema[A] = schema.derive(JsonSchemaFormat.deriver)
+  }
+}

--- a/schema-json-schema/src/test/scala/zio/blocks/schema/jsonschema/JsonSchemaFormatSpec.scala
+++ b/schema-json-schema/src/test/scala/zio/blocks/schema/jsonschema/JsonSchemaFormatSpec.scala
@@ -1,0 +1,194 @@
+package zio.blocks.schema.jsonschema
+
+import zio.blocks.schema._
+import zio.test._
+import zio.test.Assertion._
+
+object JsonSchemaFormatSpec extends ZIOSpecDefault {
+  def spec: Spec[TestEnvironment, Any] = suite("JsonSchemaFormatSpec")(
+    suite("primitives")(
+      test("Unit") {
+        val schema = Schema[Unit].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"null"}"""))
+      },
+      test("Boolean") {
+        val schema = Schema[Boolean].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"boolean"}"""))
+      },
+      test("Byte") {
+        val schema = Schema[Byte].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"integer","minimum":-128,"maximum":127}"""))
+      },
+      test("Short") {
+        val schema = Schema[Short].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"integer","minimum":-32768,"maximum":32767}"""))
+      },
+      test("Int") {
+        val schema = Schema[Int].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"integer"}"""))
+      },
+      test("Long") {
+        val schema = Schema[Long].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"integer"}"""))
+      },
+      test("Float") {
+        val schema = Schema[Float].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"number"}"""))
+      },
+      test("Double") {
+        val schema = Schema[Double].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"number"}"""))
+      },
+      test("Char") {
+        val schema = Schema[Char].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"string","minLength":1,"maxLength":1}"""))
+      },
+      test("String") {
+        val schema = Schema[String].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"string"}"""))
+      },
+      test("BigInt") {
+        val schema = Schema[BigInt].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"integer"}"""))
+      },
+      test("BigDecimal") {
+        val schema = Schema[BigDecimal].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"number"}"""))
+      },
+      test("UUID") {
+        val schema = Schema[java.util.UUID].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"string","format":"uuid"}"""))
+      }
+    ),
+    suite("collections")(
+      test("List[Int]") {
+        val schema = Schema[List[Int]].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"array","items":{"type":"integer"}}"""))
+      },
+      test("Vector[String]") {
+        val schema = Schema[Vector[String]].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"array","items":{"type":"string"}}"""))
+      },
+      test("Map[String, Int]") {
+        val schema = Schema[Map[String, Int]].derive(JsonSchemaFormat.deriver)
+        assert(schema.schema.toJson)(equalTo("""{"type":"object","additionalProperties":{"type":"integer"}}"""))
+      }
+    ),
+    suite("records")(
+      test("simple record") {
+        val schema = Person.schema.derive(JsonSchemaFormat.deriver)
+        val json = schema.schema.toJson
+        assert(json)(containsString(""""type":"object"""")) &&
+        assert(json)(containsString(""""properties":""")) &&
+        assert(json)(containsString(""""name":{"type":"string"}""")) &&
+        assert(json)(containsString(""""age":{"type":"integer"}""")) &&
+        assert(json)(containsString(""""required":["name","age"]"""))
+      },
+      test("nested record") {
+        val schema = Company.schema.derive(JsonSchemaFormat.deriver)
+        val json = schema.schema.toJson
+        assert(json)(containsString(""""name":{"type":"string"}""")) &&
+        assert(json)(containsString(""""ceo":"""))
+      },
+      test("record with optional field") {
+        val schema = PersonWithOptionalEmail.schema.derive(JsonSchemaFormat.deriver)
+        val json = schema.schema.toJson
+        // email should not be in required since it's optional
+        assert(json)(containsString(""""required":["name","age"]"""))
+      }
+    ),
+    suite("variants")(
+      test("simple enum") {
+        val schema = Color.schema.derive(JsonSchemaFormat.deriver)
+        val json = schema.schema.toJson
+        assert(json)(containsString(""""enum":""")) &&
+        assert(json)(containsString(""""Red"""")) &&
+        assert(json)(containsString(""""Green"""")) &&
+        assert(json)(containsString(""""Blue""""))
+      },
+      test("sealed trait with data") {
+        val schema = Shape.schema.derive(JsonSchemaFormat.deriver)
+        val json = schema.schema.toJson
+        assert(json)(containsString(""""oneOf":""")) &&
+        assert(json)(containsString(""""Circle":""")) &&
+        assert(json)(containsString(""""Rectangle":"""))
+      }
+    ),
+    suite("documentation")(
+      test("record with doc") {
+        val schema = DocumentedPerson.schema.derive(JsonSchemaFormat.deriver)
+        val json = schema.schema.toJson
+        assert(json)(containsString(""""description":"A person with a name and age""""))
+      }
+    ),
+    suite("JsonSchemaValue")(
+      test("toJson escapes strings correctly") {
+        val value = JsonSchemaValue.Str("hello \"world\"\ntest")
+        assert(value.toJson)(equalTo(""""hello \"world\"\ntest""""))
+      },
+      test("toJson handles nested objects") {
+        val obj = JsonSchemaValue.Obj(
+          "name" -> JsonSchemaValue.Str("test"),
+          "nested" -> JsonSchemaValue.Obj(
+            "value" -> JsonSchemaValue.Num(42)
+          )
+        )
+        assert(obj.toJson)(equalTo("""{"name":"test","nested":{"value":42}}"""))
+      },
+      test("toPrettyJson formats correctly") {
+        val obj = JsonSchemaValue.Obj(
+          "type" -> JsonSchemaValue.Str("string")
+        )
+        val pretty = obj.toPrettyJson
+        assert(pretty)(containsString("\n")) &&
+        assert(pretty)(containsString("  "))
+      }
+    ),
+    suite("extension methods")(
+      test("toJsonSchema extension method works") {
+        import zio.blocks.schema.jsonschema._
+        val schema = Schema[Int].toJsonSchema
+        assert(schema.schema.toJson)(equalTo("""{"type":"integer"}"""))
+      }
+    )
+  )
+
+  // Test data types
+  case class Person(name: String, age: Int)
+  object Person {
+    implicit val schema: Schema[Person] = Schema.derived
+  }
+
+  case class Company(name: String, ceo: Person)
+  object Company {
+    implicit val schema: Schema[Company] = Schema.derived
+  }
+
+  case class PersonWithOptionalEmail(name: String, age: Int, email: Option[String])
+  object PersonWithOptionalEmail {
+    implicit val schema: Schema[PersonWithOptionalEmail] = Schema.derived
+  }
+
+  sealed trait Color
+  object Color {
+    case object Red extends Color
+    case object Green extends Color
+    case object Blue extends Color
+
+    implicit val schema: Schema[Color] = Schema.derived
+  }
+
+  sealed trait Shape
+  object Shape {
+    case class Circle(radius: Double) extends Shape
+    case class Rectangle(width: Double, height: Double) extends Shape
+
+    implicit val schema: Schema[Shape] = Schema.derived
+  }
+
+  case class DocumentedPerson(name: String, age: Int)
+  object DocumentedPerson {
+    implicit val schema: Schema[DocumentedPerson] =
+      Schema.derived[DocumentedPerson].doc("A person with a name and age")
+  }
+}


### PR DESCRIPTION
This pull request adds support for JSON Schema generation to the ZIO Blocks schema library. It introduces a new module for deriving JSON Schemas from Scala types, updates documentation and usage examples, and provides an internal representation for JSON Schema values.

**New JSON Schema support:**

* Added a new module `schema-json-schema` with `JsonSchema`, `JsonSchemaFormat`, and `JsonSchemaValue` for generating JSON Schema Draft 2020-12 from ZIO Blocks schemas. (`schema-json-schema/src/main/scala/zio/blocks/schema/jsonschema/JsonSchema.scala` [[1]](diffhunk://#diff-9ea1fba9277a28b1b0c115c79778f23af978f167b516dd09becab62a292bfa90R1-R203) `schema-json-schema/src/main/scala/zio/blocks/schema/jsonschema/JsonSchemaFormat.scala` [[2]](diffhunk://#diff-5235850e14de527ab03460129a70b8820759176053131522e849b57a2068a358R1-R258) `schema-json-schema/src/main/scala/zio/blocks/schema/jsonschema/JsonSchemaValue.scala` [[3]](diffhunk://#diff-a0b70ae9fbd49d2c8200f94e9efedeef1d61edbe0fd9efc4bcd0a2500a793795R1-R88)

**Documentation and usage updates:**

* Updated example code in `README.md` and `docs/index.md` to demonstrate JSON Schema derivation with `JsonSchemaFormat.deriver`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R43) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R42)
* Added "JSON Schema" to the list of supported formats/features in documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R59) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R58)
* Added dependency instructions for the new `zio-blocks-schema-json-schema` module in both `README.md` and `docs/index.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R81) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R80)