### PR TITLE
Add JsonPatch type for diffing and patching JSON values (#685)

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/json/Json.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/Json.scala
@@ -1,0 +1,105 @@
+package zio.blocks.schema.json
+
+/**
+ * A JSON value represented as an algebraic data type.
+ *
+ * This type represents the complete JSON data model:
+ *   - `Json.Null` - JSON null value
+ *   - `Json.Bool` - JSON boolean (true/false)
+ *   - `Json.Num` - JSON number (stored as string for precision)
+ *   - `Json.Str` - JSON string
+ *   - `Json.Arr` - JSON array
+ *   - `Json.Obj` - JSON object
+ *
+ * Numbers are stored as strings to preserve exact precision and avoid
+ * floating-point representation errors. Use `numValue` for numeric operations.
+ * Objects preserve insertion order using `Vector[(String, Json)]`.
+ */
+sealed trait Json {
+  def typeIndex: Int
+
+  def isNull: Boolean    = this.isInstanceOf[Json.Null.type]
+  def isBoolean: Boolean = this.isInstanceOf[Json.Bool]
+  def isNumber: Boolean  = this.isInstanceOf[Json.Num]
+  def isString: Boolean  = this.isInstanceOf[Json.Str]
+  def isArray: Boolean   = this.isInstanceOf[Json.Arr]
+  def isObject: Boolean  = this.isInstanceOf[Json.Obj]
+}
+
+object Json {
+
+  case object Null extends Json {
+    def typeIndex: Int = 0
+  }
+
+  final case class Bool(value: Boolean) extends Json {
+    def typeIndex: Int = 1
+  }
+
+  final case class Num(value: String) extends Json {
+    def typeIndex: Int            = 2
+    lazy val numValue: BigDecimal = BigDecimal(value)
+  }
+
+  object Num {
+    def apply(value: Int): Num        = Num(value.toString)
+    def apply(value: Long): Num       = Num(value.toString)
+    def apply(value: Double): Num     = Num(value.toString)
+    def apply(value: BigDecimal): Num = Num(value.toString)
+    def apply(value: BigInt): Num     = Num(value.toString)
+  }
+
+  final case class Str(value: String) extends Json {
+    def typeIndex: Int = 3
+  }
+
+  final case class Arr(elements: Vector[Json]) extends Json {
+    def typeIndex: Int   = 4
+    def isEmpty: Boolean = elements.isEmpty
+    def length: Int      = elements.length
+  }
+
+  object Arr {
+    val empty: Arr                  = Arr(Vector.empty)
+    def apply(elements: Json*): Arr = Arr(elements.toVector)
+  }
+
+  final case class Obj(fields: Vector[(String, Json)]) extends Json {
+    def typeIndex: Int   = 5
+    def isEmpty: Boolean = fields.isEmpty
+    def size: Int        = fields.length
+
+    def get(key: String): Option[Json] = {
+      var idx = 0
+      while (idx < fields.length) {
+        val (k, v) = fields(idx)
+        if (k == key) return Some(v)
+        idx += 1
+      }
+      None
+    }
+
+    def getOrElse(key: String, default: => Json): Json = get(key).getOrElse(default)
+    def contains(key: String): Boolean                 = get(key).isDefined
+    def keys: Vector[String]                           = fields.map(_._1)
+    def values: Vector[Json]                           = fields.map(_._2)
+    def toMap: Map[String, Json]                       = fields.toMap
+  }
+
+  object Obj {
+    val empty: Obj                          = Obj(Vector.empty)
+    def apply(fields: (String, Json)*): Obj = Obj(fields.toVector)
+  }
+
+  val True: Json  = Bool(true)
+  val False: Json = Bool(false)
+
+  def obj(fields: (String, Json)*): Obj = Obj(fields.toVector)
+  def arr(elements: Json*): Arr         = Arr(elements.toVector)
+  def str(value: String): Str           = Str(value)
+  def num(value: Int): Num              = Num(value.toString)
+  def num(value: Long): Num             = Num(value.toString)
+  def num(value: Double): Num           = Num(value.toString)
+  def num(value: BigDecimal): Num       = Num(value.toString)
+  def bool(value: Boolean): Bool        = Bool(value)
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonDiffer.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonDiffer.scala
@@ -1,0 +1,226 @@
+package zio.blocks.schema.json
+
+import zio.blocks.schema.DynamicOptic
+
+// Computes minimal patches between two Json values using LCS algorithms.
+private[json] object JsonDiffer {
+
+  def diff(oldJson: Json, newJson: Json): JsonPatch =
+    if (oldJson == newJson) JsonPatch.empty
+    else
+      (oldJson, newJson) match {
+        case (Json.Num(oldS), Json.Num(newS))           => diffNumber(oldS, newS)
+        case (Json.Str(oldS), Json.Str(newS))           => diffString(oldS, newS)
+        case (Json.Arr(oldElems), Json.Arr(newElems))   => diffArray(oldElems, newElems)
+        case (Json.Obj(oldFields), Json.Obj(newFields)) => diffObject(oldFields, newFields)
+        case _                                          => JsonPatch.root(JsonPatch.Op.Set(newJson))
+      }
+
+  // Use Set instead of NumberDelta to preserve exact string representation
+  // BigDecimal.toString can produce different representations (e.g., "0" vs "0.0")
+  private def diffNumber(oldS: String, newS: String): JsonPatch =
+    JsonPatch.root(JsonPatch.Op.Set(Json.Num(newS)))
+
+  private def diffString(oldStr: String, newStr: String): JsonPatch =
+    if (oldStr == newStr) JsonPatch.empty
+    else {
+      val edits    = computeStringEdits(oldStr, newStr)
+      val editSize = edits.foldLeft(0) {
+        case (acc, JsonPatch.StringOp.Insert(_, text))    => acc + text.length
+        case (acc, JsonPatch.StringOp.Delete(_, _))       => acc + 1
+        case (acc, JsonPatch.StringOp.Append(text))       => acc + text.length
+        case (acc, JsonPatch.StringOp.Modify(_, _, text)) => acc + text.length
+      }
+      if (edits.nonEmpty && editSize < newStr.length)
+        JsonPatch.root(JsonPatch.Op.PrimitiveDelta(JsonPatch.PrimitiveOp.StringEdit(edits)))
+      else
+        JsonPatch.root(JsonPatch.Op.Set(Json.Str(newStr)))
+    }
+
+  private def computeStringEdits(oldStr: String, newStr: String): Vector[JsonPatch.StringOp] = {
+    if (oldStr == newStr) return Vector.empty
+    if (oldStr.isEmpty) return Vector(JsonPatch.StringOp.Insert(0, newStr))
+    if (newStr.isEmpty) return Vector(JsonPatch.StringOp.Delete(0, oldStr.length))
+
+    val lcs    = longestCommonSubsequence(oldStr, newStr)
+    val edits  = Vector.newBuilder[JsonPatch.StringOp]
+    var oldIdx = 0
+    var newIdx = 0
+    var lcsIdx = 0
+    var cursor = 0
+
+    while (lcsIdx < lcs.length) {
+      val targetChar  = lcs.charAt(lcsIdx)
+      val deleteStart = oldIdx
+      while (oldIdx < oldStr.length && oldStr.charAt(oldIdx) != targetChar) oldIdx += 1
+      val deleteLen = oldIdx - deleteStart
+      if (deleteLen > 0) edits += JsonPatch.StringOp.Delete(cursor, deleteLen)
+
+      val insertStart = newIdx
+      while (newIdx < newStr.length && newStr.charAt(newIdx) != targetChar) newIdx += 1
+      if (newIdx > insertStart) {
+        val text = newStr.substring(insertStart, newIdx)
+        edits += JsonPatch.StringOp.Insert(cursor, text)
+        cursor += text.length
+      }
+
+      oldIdx += 1
+      newIdx += 1
+      cursor += 1
+      lcsIdx += 1
+    }
+
+    if (oldIdx < oldStr.length) edits += JsonPatch.StringOp.Delete(cursor, oldStr.length - oldIdx)
+    if (newIdx < newStr.length) {
+      val text = newStr.substring(newIdx)
+      if (text.nonEmpty) edits += JsonPatch.StringOp.Insert(cursor, text)
+    }
+    edits.result()
+  }
+
+  private def longestCommonSubsequence(s1: String, s2: String): String = {
+    val m  = s1.length
+    val n  = s2.length
+    val dp = Array.ofDim[Int](m + 1, n + 1)
+
+    var i = 1
+    while (i <= m) {
+      var j = 1
+      while (j <= n) {
+        dp(i)(j) = if (s1(i - 1) == s2(j - 1)) dp(i - 1)(j - 1) + 1 else Math.max(dp(i - 1)(j), dp(i)(j - 1))
+        j += 1
+      }
+      i += 1
+    }
+
+    val result = new StringBuilder
+    i = m
+    var j = n
+    while (i > 0 && j > 0) {
+      if (s1(i - 1) == s2(j - 1)) {
+        result.insert(0, s1(i - 1))
+        i -= 1
+        j -= 1
+      } else if (dp(i - 1)(j) > dp(i)(j - 1)) i -= 1
+      else j -= 1
+    }
+    result.toString
+  }
+
+  private def diffArray(oldElems: Vector[Json], newElems: Vector[Json]): JsonPatch =
+    if (oldElems == newElems) JsonPatch.empty
+    else if (oldElems.isEmpty) JsonPatch.root(JsonPatch.Op.ArrayEdit(Vector(JsonPatch.ArrayOp.Append(newElems))))
+    else if (newElems.isEmpty)
+      JsonPatch.root(JsonPatch.Op.ArrayEdit(Vector(JsonPatch.ArrayOp.Delete(0, oldElems.length))))
+    else {
+      val arrayOps = computeArrayOps(oldElems, newElems)
+      if (arrayOps.isEmpty) JsonPatch.empty else JsonPatch.root(JsonPatch.Op.ArrayEdit(arrayOps))
+    }
+
+  private def computeArrayOps(oldElems: Vector[Json], newElems: Vector[Json]): Vector[JsonPatch.ArrayOp] = {
+    val ops       = Vector.newBuilder[JsonPatch.ArrayOp]
+    val matches   = longestCommonSubsequenceIndices(oldElems, newElems)
+    var oldIdx    = 0
+    var newIdx    = 0
+    var cursor    = 0
+    var curLength = oldElems.length
+
+    def emitDelete(count: Int): Unit =
+      if (count > 0) {
+        ops += JsonPatch.ArrayOp.Delete(cursor, count)
+        curLength -= count
+      }
+
+    def emitInsert(values: Vector[Json]): Unit =
+      if (values.nonEmpty) {
+        if (cursor == curLength) ops += JsonPatch.ArrayOp.Append(values)
+        else ops += JsonPatch.ArrayOp.Insert(cursor, values)
+        cursor += values.length
+        curLength += values.length
+      }
+
+    matches.foreach { case (matchOld, matchNew) =>
+      emitDelete(matchOld - oldIdx)
+      emitInsert(newElems.slice(newIdx, matchNew))
+      oldIdx = matchOld + 1
+      newIdx = matchNew + 1
+      cursor += 1
+    }
+
+    emitDelete(oldElems.length - oldIdx)
+    emitInsert(newElems.slice(newIdx, newElems.length))
+    ops.result()
+  }
+
+  private def longestCommonSubsequenceIndices(
+    oldElems: Vector[Json],
+    newElems: Vector[Json]
+  ): Vector[(Int, Int)] = {
+    val m  = oldElems.length
+    val n  = newElems.length
+    val dp = Array.ofDim[Int](m + 1, n + 1)
+
+    var i = 1
+    while (i <= m) {
+      var j = 1
+      while (j <= n) {
+        dp(i)(j) =
+          if (oldElems(i - 1) == newElems(j - 1)) dp(i - 1)(j - 1) + 1 else Math.max(dp(i - 1)(j), dp(i)(j - 1))
+        j += 1
+      }
+      i += 1
+    }
+
+    val builder = Vector.newBuilder[(Int, Int)]
+    i = m
+    var j = n
+    while (i > 0 && j > 0) {
+      if (oldElems(i - 1) == newElems(j - 1)) {
+        builder += ((i - 1, j - 1))
+        i -= 1
+        j -= 1
+      } else if (dp(i - 1)(j) >= dp(i)(j - 1)) i -= 1
+      else j -= 1
+    }
+    builder.result().reverse
+  }
+
+  private def diffObject(
+    oldFields: Vector[(String, Json)],
+    newFields: Vector[(String, Json)]
+  ): JsonPatch = {
+    val oldMap = oldFields.toMap
+    val newMap = newFields.toMap
+    val ops    = Vector.newBuilder[JsonPatch.JsonPatchOp]
+
+    for ((fieldName, newValue) <- newFields) {
+      oldMap.get(fieldName) match {
+        case Some(oldValue) if oldValue != newValue =>
+          val fieldPatch = diff(oldValue, newValue)
+          if (!fieldPatch.isEmpty) {
+            for (op <- fieldPatch.ops) {
+              ops += JsonPatch.JsonPatchOp(
+                new DynamicOptic(DynamicOptic.Node.Field(fieldName) +: op.path.nodes),
+                op.op
+              )
+            }
+          }
+        case None =>
+          ops += JsonPatch.JsonPatchOp(
+            DynamicOptic.root,
+            JsonPatch.Op.ObjectEdit(Vector(JsonPatch.ObjectOp.Add(fieldName, newValue)))
+          )
+        case _ =>
+      }
+    }
+
+    for ((fieldName, _) <- oldFields if !newMap.contains(fieldName)) {
+      ops += JsonPatch.JsonPatchOp(
+        DynamicOptic.root,
+        JsonPatch.Op.ObjectEdit(Vector(JsonPatch.ObjectOp.Remove(fieldName)))
+      )
+    }
+
+    JsonPatch(ops.result())
+  }
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonError.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonError.scala
@@ -1,0 +1,40 @@
+package zio.blocks.schema.json
+
+final case class JsonError(message: String, path: Vector[String] = Vector.empty) {
+  def prependPath(segment: String): JsonError = copy(path = segment +: path)
+  def prependField(field: String): JsonError  = prependPath(s".$field")
+  def prependIndex(index: Int): JsonError     = prependPath(s"[$index]")
+
+  override def toString: String =
+    if (path.isEmpty) message
+    else s"$message at ${path.mkString}"
+}
+
+object JsonError {
+  def typeMismatch(expected: String, actual: String): JsonError =
+    JsonError(s"Type mismatch: expected $expected, got $actual")
+
+  def missingField(field: String): JsonError =
+    JsonError(s"Missing field: $field")
+
+  def indexOutOfBounds(index: Int, length: Int): JsonError =
+    JsonError(s"Index $index out of bounds (length: $length)")
+
+  def keyNotFound(key: String): JsonError =
+    JsonError(s"Key not found: $key")
+
+  def fieldExists(field: String): JsonError =
+    JsonError(s"Field already exists: $field")
+
+  def invalidRange(start: Int, end: Int, length: Int): JsonError =
+    JsonError(s"Invalid range [$start, $end) for length $length")
+
+  def stringIndexOutOfBounds(index: Int, length: Int): JsonError =
+    JsonError(s"String index $index out of bounds (length: $length)")
+
+  def unsupportedOperation(message: String): JsonError =
+    JsonError(s"Unsupported operation: $message")
+
+  def incompatibleDynamicPatch(message: String): JsonError =
+    JsonError(s"Incompatible DynamicPatch: $message")
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonPatch.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonPatch.scala
@@ -1,0 +1,627 @@
+package zio.blocks.schema.json
+
+import zio.blocks.schema.DynamicOptic
+import zio.blocks.schema.DynamicValue
+import zio.blocks.schema.PrimitiveValue
+import zio.blocks.schema.patch.DynamicPatch
+
+/**
+ * A patch that operates on [[Json]] values.
+ *
+ * `JsonPatch` is the JSON-specific counterpart to
+ * [[zio.blocks.schema.patch.DynamicPatch]]. It represents a sequence of
+ * operations that transform one JSON value into another. Patches are
+ * serializable and composable using the `++` operator.
+ *
+ * ==Relationship to DynamicPatch==
+ *
+ * This type mirrors [[zio.blocks.schema.patch.DynamicPatch]] but is specialized
+ * for JSON's simpler data model:
+ *   - JSON has 4 leaf types (string, number, boolean, null) vs 30+
+ *     PrimitiveValues
+ *   - JSON objects have string keys only (no arbitrary-keyed maps)
+ *   - JSON has no native Variant type
+ *
+ * Bidirectional conversion is supported via `toDynamicPatch` and
+ * `fromDynamicPatch`.
+ *
+ * ==Algebraic Laws==
+ *
+ * '''L1. Left Identity''': `(JsonPatch.empty ++ p)(j, mode) == p(j, mode)`
+ *
+ * '''L2. Right Identity''': `(p ++ JsonPatch.empty)(j, mode) == p(j, mode)`
+ *
+ * '''L3. Associativity''':
+ * `((p1 ++ p2) ++ p3)(j, mode) == (p1 ++ (p2 ++ p3))(j, mode)`
+ *
+ * '''L4. Roundtrip''': `JsonPatch.diff(a, b)(a, Strict) == Right(b)`
+ *
+ * '''L5. Identity Diff''': `JsonPatch.diff(j, j).isEmpty == true`
+ *
+ * '''L6. Diff Composition''':
+ * `(JsonPatch.diff(a, b) ++ JsonPatch.diff(b, c))(a, Strict) == Right(c)`
+ *
+ * '''L7. Lenient Subsumes Strict''': If `p(j, Strict) == Right(r)` then
+ * `p(j, Lenient) == Right(r)`
+ *
+ * @param ops
+ *   The sequence of patch operations
+ * @see
+ *   [[zio.blocks.schema.patch.DynamicPatch]] for the underlying implementation
+ * @see
+ *   [[JsonPatchMode]] for patch application modes
+ */
+final case class JsonPatch(ops: Vector[JsonPatch.JsonPatchOp]) {
+  import JsonPatch._
+
+  def apply(json: Json, mode: JsonPatchMode = JsonPatchMode.Strict): Either[JsonError, Json] = {
+    var current: Json                  = json
+    var idx                            = 0
+    var error: Either[JsonError, Unit] = Right(())
+
+    while (idx < ops.length && error.isRight) {
+      val op = ops(idx)
+      applyOp(current, op.path.nodes, op.op, mode) match {
+        case Right(updated) => current = updated
+        case Left(err)      =>
+          mode match {
+            case JsonPatchMode.Strict  => error = Left(err)
+            case JsonPatchMode.Lenient => ()
+            case JsonPatchMode.Clobber => ()
+          }
+      }
+      idx += 1
+    }
+    error.map(_ => current)
+  }
+
+  def ++(that: JsonPatch): JsonPatch = JsonPatch(ops ++ that.ops)
+
+  def isEmpty: Boolean = ops.isEmpty
+
+  def toDynamicPatch: DynamicPatch = {
+    val dynamicOps = ops.map { op =>
+      DynamicPatch.DynamicPatchOp(op.path, opToDynamicOperation(op.op))
+    }
+    DynamicPatch(dynamicOps)
+  }
+
+  private def opToDynamicOperation(op: Op): DynamicPatch.Operation = op match {
+    case Op.Set(value)             => DynamicPatch.Operation.Set(jsonToDynamicValue(value))
+    case Op.PrimitiveDelta(primOp) =>
+      val dynamicPrimOp = primOp match {
+        case PrimitiveOp.NumberDelta(delta)    => DynamicPatch.PrimitiveOp.BigDecimalDelta(delta)
+        case PrimitiveOp.StringEdit(stringOps) =>
+          DynamicPatch.PrimitiveOp.StringEdit(stringOps.map {
+            case StringOp.Insert(idx, text)      => DynamicPatch.StringOp.Insert(idx, text)
+            case StringOp.Delete(idx, len)       => DynamicPatch.StringOp.Delete(idx, len)
+            case StringOp.Append(text)           => DynamicPatch.StringOp.Append(text)
+            case StringOp.Modify(idx, len, text) => DynamicPatch.StringOp.Modify(idx, len, text)
+          })
+      }
+      DynamicPatch.Operation.PrimitiveDelta(dynamicPrimOp)
+    case Op.ArrayEdit(arrayOps) =>
+      DynamicPatch.Operation.SequenceEdit(arrayOps.map {
+        case ArrayOp.Insert(idx, values)   => DynamicPatch.SeqOp.Insert(idx, values.map(jsonToDynamicValue))
+        case ArrayOp.Append(values)        => DynamicPatch.SeqOp.Append(values.map(jsonToDynamicValue))
+        case ArrayOp.Delete(idx, count)    => DynamicPatch.SeqOp.Delete(idx, count)
+        case ArrayOp.Modify(idx, nestedOp) => DynamicPatch.SeqOp.Modify(idx, opToDynamicOperation(nestedOp))
+      })
+    case Op.ObjectEdit(objectOps) =>
+      DynamicPatch.Operation.MapEdit(objectOps.map {
+        case ObjectOp.Add(key, value) =>
+          DynamicPatch.MapOp.Add(DynamicValue.Primitive(PrimitiveValue.String(key)), jsonToDynamicValue(value))
+        case ObjectOp.Remove(key) =>
+          DynamicPatch.MapOp.Remove(DynamicValue.Primitive(PrimitiveValue.String(key)))
+        case ObjectOp.Modify(key, patch) =>
+          DynamicPatch.MapOp.Modify(DynamicValue.Primitive(PrimitiveValue.String(key)), patch.toDynamicPatch)
+      })
+    case Op.Nested(nestedPatch) => DynamicPatch.Operation.Patch(nestedPatch.toDynamicPatch)
+  }
+
+  private def jsonToDynamicValue(json: Json): DynamicValue = json match {
+    case Json.Null        => DynamicValue.Primitive(PrimitiveValue.Unit)
+    case Json.Bool(b)     => DynamicValue.Primitive(PrimitiveValue.Boolean(b))
+    case Json.Num(s)      => DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal(s)))
+    case Json.Str(s)      => DynamicValue.Primitive(PrimitiveValue.String(s))
+    case Json.Arr(elems)  => DynamicValue.Sequence(elems.map(jsonToDynamicValue))
+    case Json.Obj(fields) =>
+      DynamicValue.Map(fields.map { case (k, v) =>
+        (DynamicValue.Primitive(PrimitiveValue.String(k)), jsonToDynamicValue(v))
+      })
+  }
+}
+
+object JsonPatch {
+
+  val empty: JsonPatch = JsonPatch(Vector.empty)
+
+  def root(op: Op): JsonPatch = JsonPatch(Vector(JsonPatchOp(DynamicOptic.root, op)))
+
+  def apply(path: DynamicOptic, op: Op): JsonPatch = JsonPatch(Vector(JsonPatchOp(path, op)))
+
+  def diff(oldJson: Json, newJson: Json): JsonPatch = JsonDiffer.diff(oldJson, newJson)
+
+  def fromDynamicPatch(patch: DynamicPatch): Either[JsonError, JsonPatch] = {
+    val builder                  = Vector.newBuilder[JsonPatchOp]
+    var error: Option[JsonError] = None
+
+    patch.ops.foreach { dynamicOp =>
+      if (error.isEmpty) {
+        dynamicOperationToOp(dynamicOp.operation) match {
+          case Right(op) => builder += JsonPatchOp(dynamicOp.path, op)
+          case Left(err) => error = Some(err)
+        }
+      }
+    }
+    error.toLeft(JsonPatch(builder.result()))
+  }
+
+  private def dynamicOperationToOp(operation: DynamicPatch.Operation): Either[JsonError, Op] =
+    operation match {
+      case DynamicPatch.Operation.Set(value)             => dynamicValueToJson(value).map(Op.Set.apply)
+      case DynamicPatch.Operation.PrimitiveDelta(primOp) =>
+        dynamicPrimitiveOpToJsonPrimitiveOp(primOp).map(Op.PrimitiveDelta.apply)
+      case DynamicPatch.Operation.SequenceEdit(seqOps) => convertSeqOps(seqOps).map(Op.ArrayEdit.apply)
+      case DynamicPatch.Operation.MapEdit(mapOps)      => convertMapOps(mapOps).map(Op.ObjectEdit.apply)
+      case DynamicPatch.Operation.Patch(nestedPatch)   => fromDynamicPatch(nestedPatch).map(Op.Nested.apply)
+    }
+
+  private def dynamicPrimitiveOpToJsonPrimitiveOp(op: DynamicPatch.PrimitiveOp): Either[JsonError, PrimitiveOp] =
+    op match {
+      case DynamicPatch.PrimitiveOp.IntDelta(delta)        => Right(PrimitiveOp.NumberDelta(BigDecimal(delta)))
+      case DynamicPatch.PrimitiveOp.LongDelta(delta)       => Right(PrimitiveOp.NumberDelta(BigDecimal(delta)))
+      case DynamicPatch.PrimitiveOp.DoubleDelta(delta)     => Right(PrimitiveOp.NumberDelta(BigDecimal(delta)))
+      case DynamicPatch.PrimitiveOp.FloatDelta(delta)      => Right(PrimitiveOp.NumberDelta(BigDecimal(delta.toDouble)))
+      case DynamicPatch.PrimitiveOp.ShortDelta(delta)      => Right(PrimitiveOp.NumberDelta(BigDecimal(delta.toInt)))
+      case DynamicPatch.PrimitiveOp.ByteDelta(delta)       => Right(PrimitiveOp.NumberDelta(BigDecimal(delta.toInt)))
+      case DynamicPatch.PrimitiveOp.BigIntDelta(delta)     => Right(PrimitiveOp.NumberDelta(BigDecimal(delta)))
+      case DynamicPatch.PrimitiveOp.BigDecimalDelta(delta) => Right(PrimitiveOp.NumberDelta(delta))
+      case DynamicPatch.PrimitiveOp.StringEdit(strOps)     =>
+        Right(PrimitiveOp.StringEdit(strOps.map {
+          case DynamicPatch.StringOp.Insert(idx, text)      => StringOp.Insert(idx, text)
+          case DynamicPatch.StringOp.Delete(idx, len)       => StringOp.Delete(idx, len)
+          case DynamicPatch.StringOp.Append(text)           => StringOp.Append(text)
+          case DynamicPatch.StringOp.Modify(idx, len, text) => StringOp.Modify(idx, len, text)
+        }))
+      case _ =>
+        Left(JsonError.incompatibleDynamicPatch(s"Unsupported primitive operation: ${op.getClass.getSimpleName}"))
+    }
+
+  private def convertSeqOps(seqOps: Vector[DynamicPatch.SeqOp]): Either[JsonError, Vector[ArrayOp]] = {
+    val builder                  = Vector.newBuilder[ArrayOp]
+    var error: Option[JsonError] = None
+
+    seqOps.foreach { seqOp =>
+      if (error.isEmpty) seqOp match {
+        case DynamicPatch.SeqOp.Insert(idx, values) =>
+          val converted = values.map(dynamicValueToJson)
+          converted.collectFirst { case Left(e) => e } match {
+            case Some(e) => error = Some(e)
+            case None    => builder += ArrayOp.Insert(idx, converted.collect { case Right(j) => j })
+          }
+        case DynamicPatch.SeqOp.Append(values) =>
+          val converted = values.map(dynamicValueToJson)
+          converted.collectFirst { case Left(e) => e } match {
+            case Some(e) => error = Some(e)
+            case None    => builder += ArrayOp.Append(converted.collect { case Right(j) => j })
+          }
+        case DynamicPatch.SeqOp.Delete(idx, count)    => builder += ArrayOp.Delete(idx, count)
+        case DynamicPatch.SeqOp.Modify(idx, nestedOp) =>
+          dynamicOperationToOp(nestedOp) match {
+            case Right(op) => builder += ArrayOp.Modify(idx, op)
+            case Left(err) => error = Some(err)
+          }
+      }
+    }
+    error.toLeft(builder.result())
+  }
+
+  private def convertMapOps(mapOps: Vector[DynamicPatch.MapOp]): Either[JsonError, Vector[ObjectOp]] = {
+    val builder                  = Vector.newBuilder[ObjectOp]
+    var error: Option[JsonError] = None
+
+    mapOps.foreach { mapOp =>
+      if (error.isEmpty) mapOp match {
+        case DynamicPatch.MapOp.Add(key, value) =>
+          getStringKey(key) match {
+            case Some(k) =>
+              dynamicValueToJson(value) match {
+                case Right(v) => builder += ObjectOp.Add(k, v)
+                case Left(e)  => error = Some(e)
+              }
+            case None => error = Some(JsonError.incompatibleDynamicPatch("Map key must be a string"))
+          }
+        case DynamicPatch.MapOp.Remove(key) =>
+          getStringKey(key) match {
+            case Some(k) => builder += ObjectOp.Remove(k)
+            case None    => error = Some(JsonError.incompatibleDynamicPatch("Map key must be a string"))
+          }
+        case DynamicPatch.MapOp.Modify(key, nestedPatch) =>
+          getStringKey(key) match {
+            case Some(k) =>
+              fromDynamicPatch(nestedPatch) match {
+                case Right(p) => builder += ObjectOp.Modify(k, p)
+                case Left(e)  => error = Some(e)
+              }
+            case None => error = Some(JsonError.incompatibleDynamicPatch("Map key must be a string"))
+          }
+      }
+    }
+    error.toLeft(builder.result())
+  }
+
+  private def getStringKey(key: DynamicValue): Option[String] = key match {
+    case DynamicValue.Primitive(PrimitiveValue.String(s)) => Some(s)
+    case _                                                => None
+  }
+
+  private def dynamicValueToJson(value: DynamicValue): Either[JsonError, Json] = value match {
+    case DynamicValue.Primitive(pv)   => primitiveValueToJson(pv)
+    case DynamicValue.Sequence(elems) =>
+      val converted = elems.map(dynamicValueToJson)
+      converted.collectFirst { case Left(e) => e }.toLeft(Json.Arr(converted.collect { case Right(j) => j }))
+    case DynamicValue.Map(entries) =>
+      val builder                  = Vector.newBuilder[(String, Json)]
+      var error: Option[JsonError] = None
+      entries.foreach { case (k, v) =>
+        if (error.isEmpty) getStringKey(k) match {
+          case Some(key) =>
+            dynamicValueToJson(v) match {
+              case Right(json) => builder += (key -> json)
+              case Left(e)     => error = Some(e)
+            }
+          case None => error = Some(JsonError.incompatibleDynamicPatch("Map key must be a string"))
+        }
+      }
+      error.toLeft(Json.Obj(builder.result()))
+    case DynamicValue.Record(fields) =>
+      val builder                  = Vector.newBuilder[(String, Json)]
+      var error: Option[JsonError] = None
+      fields.foreach { case (name, v) =>
+        if (error.isEmpty) dynamicValueToJson(v) match {
+          case Right(json) => builder += (name -> json)
+          case Left(e)     => error = Some(e)
+        }
+      }
+      error.toLeft(Json.Obj(builder.result()))
+    case DynamicValue.Variant(_, _) =>
+      Left(JsonError.incompatibleDynamicPatch("Variant types are not supported in JSON"))
+  }
+
+  private def primitiveValueToJson(pv: PrimitiveValue): Either[JsonError, Json] = pv match {
+    case PrimitiveValue.Unit           => Right(Json.Null)
+    case PrimitiveValue.Boolean(b)     => Right(Json.Bool(b))
+    case PrimitiveValue.String(s)      => Right(Json.Str(s))
+    case PrimitiveValue.Int(i)         => Right(Json.Num(i.toString))
+    case PrimitiveValue.Long(l)        => Right(Json.Num(l.toString))
+    case PrimitiveValue.Float(f)       => Right(Json.Num(f.toString))
+    case PrimitiveValue.Double(d)      => Right(Json.Num(d.toString))
+    case PrimitiveValue.Short(s)       => Right(Json.Num(s.toString))
+    case PrimitiveValue.Byte(b)        => Right(Json.Num(b.toString))
+    case PrimitiveValue.Char(c)        => Right(Json.Str(c.toString))
+    case PrimitiveValue.BigInt(bi)     => Right(Json.Num(bi.toString))
+    case PrimitiveValue.BigDecimal(bd) => Right(Json.Num(bd.toString))
+    case _                             => Left(JsonError.incompatibleDynamicPatch(s"Unsupported primitive type: ${pv.getClass.getSimpleName}"))
+  }
+
+  private def applyOp(
+    json: Json,
+    path: IndexedSeq[DynamicOptic.Node],
+    operation: Op,
+    mode: JsonPatchMode
+  ): Either[JsonError, Json] =
+    if (path.isEmpty) applyOperation(json, operation, mode)
+    else navigateAndApply(json, path, 0, operation, mode)
+
+  private def navigateAndApply(
+    json: Json,
+    path: IndexedSeq[DynamicOptic.Node],
+    pathIdx: Int,
+    operation: Op,
+    mode: JsonPatchMode
+  ): Either[JsonError, Json] = {
+    val node   = path(pathIdx)
+    val isLast = pathIdx == path.length - 1
+
+    node match {
+      case DynamicOptic.Node.Field(name) =>
+        json match {
+          case obj: Json.Obj =>
+            val fieldIdx = obj.fields.indexWhere(_._1 == name)
+            if (fieldIdx < 0) Left(JsonError.missingField(name))
+            else {
+              val (fieldName, fieldValue) = obj.fields(fieldIdx)
+              val result                  =
+                if (isLast) applyOperation(fieldValue, operation, mode)
+                else navigateAndApply(fieldValue, path, pathIdx + 1, operation, mode)
+              result.map(newValue => Json.Obj(obj.fields.updated(fieldIdx, (fieldName, newValue))))
+            }
+          case _ => Left(JsonError.typeMismatch("Object", json.getClass.getSimpleName))
+        }
+
+      case DynamicOptic.Node.AtIndex(index) =>
+        json match {
+          case arr: Json.Arr =>
+            if (index < 0 || index >= arr.elements.length) Left(JsonError.indexOutOfBounds(index, arr.elements.length))
+            else {
+              val element = arr.elements(index)
+              val result  =
+                if (isLast) applyOperation(element, operation, mode)
+                else navigateAndApply(element, path, pathIdx + 1, operation, mode)
+              result.map(newElement => Json.Arr(arr.elements.updated(index, newElement)))
+            }
+          case _ => Left(JsonError.typeMismatch("Array", json.getClass.getSimpleName))
+        }
+
+      case DynamicOptic.Node.AtMapKey(key) =>
+        getStringKey(key) match {
+          case Some(keyStr) =>
+            json match {
+              case obj: Json.Obj =>
+                val fieldIdx = obj.fields.indexWhere(_._1 == keyStr)
+                if (fieldIdx < 0) Left(JsonError.keyNotFound(keyStr))
+                else {
+                  val (k, v) = obj.fields(fieldIdx)
+                  val result =
+                    if (isLast) applyOperation(v, operation, mode)
+                    else navigateAndApply(v, path, pathIdx + 1, operation, mode)
+                  result.map(newValue => Json.Obj(obj.fields.updated(fieldIdx, (k, newValue))))
+                }
+              case _ => Left(JsonError.typeMismatch("Object", json.getClass.getSimpleName))
+            }
+          case None => Left(JsonError.incompatibleDynamicPatch("Map key must be a string"))
+        }
+
+      case DynamicOptic.Node.Elements =>
+        json match {
+          case arr: Json.Arr =>
+            if (arr.elements.isEmpty) {
+              if (mode == JsonPatchMode.Strict) Left(JsonError("Cannot apply operation to empty array"))
+              else Right(json)
+            } else if (isLast) applyToAllElements(arr.elements, operation, mode).map(Json.Arr(_))
+            else navigateAllElements(arr.elements, path, pathIdx + 1, operation, mode).map(Json.Arr(_))
+          case _ => Left(JsonError.typeMismatch("Array", json.getClass.getSimpleName))
+        }
+
+      case DynamicOptic.Node.Wrapped =>
+        if (isLast) applyOperation(json, operation, mode)
+        else navigateAndApply(json, path, pathIdx + 1, operation, mode)
+
+      case _ => Left(JsonError.unsupportedOperation(s"Path node type not supported: ${node.getClass.getSimpleName}"))
+    }
+  }
+
+  private def applyToAllElements(
+    elements: Vector[Json],
+    operation: Op,
+    mode: JsonPatchMode
+  ): Either[JsonError, Vector[Json]] = {
+    val results                  = new Array[Json](elements.length)
+    var idx                      = 0
+    var error: Option[JsonError] = None
+
+    while (idx < elements.length && error.isEmpty) {
+      applyOperation(elements(idx), operation, mode) match {
+        case Right(updated) => results(idx) = updated
+        case Left(err)      =>
+          if (mode == JsonPatchMode.Strict) error = Some(err.prependIndex(idx))
+          else results(idx) = elements(idx)
+      }
+      idx += 1
+    }
+    error.toLeft(results.toVector)
+  }
+
+  private def navigateAllElements(
+    elements: Vector[Json],
+    path: IndexedSeq[DynamicOptic.Node],
+    pathIdx: Int,
+    operation: Op,
+    mode: JsonPatchMode
+  ): Either[JsonError, Vector[Json]] = {
+    val results                  = new Array[Json](elements.length)
+    var idx                      = 0
+    var error: Option[JsonError] = None
+
+    while (idx < elements.length && error.isEmpty) {
+      navigateAndApply(elements(idx), path, pathIdx, operation, mode) match {
+        case Right(updated) => results(idx) = updated
+        case Left(err)      =>
+          if (mode == JsonPatchMode.Strict) error = Some(err.prependIndex(idx))
+          else results(idx) = elements(idx)
+      }
+      idx += 1
+    }
+    error.toLeft(results.toVector)
+  }
+
+  private def applyOperation(json: Json, operation: Op, mode: JsonPatchMode): Either[JsonError, Json] =
+    operation match {
+      case Op.Set(newValue)          => Right(newValue)
+      case Op.PrimitiveDelta(primOp) => applyPrimitiveDelta(json, primOp)
+      case Op.ArrayEdit(arrayOps)    => applyArrayEdit(json, arrayOps, mode)
+      case Op.ObjectEdit(objectOps)  => applyObjectEdit(json, objectOps, mode)
+      case Op.Nested(nestedPatch)    => nestedPatch.apply(json, mode)
+    }
+
+  private def applyPrimitiveDelta(json: Json, op: PrimitiveOp): Either[JsonError, Json] =
+    (json, op) match {
+      case (Json.Num(s), PrimitiveOp.NumberDelta(delta)) => Right(Json.Num((BigDecimal(s) + delta).toString))
+      case (Json.Str(s), PrimitiveOp.StringEdit(strOps)) => applyStringEdits(s, strOps).map(Json.Str.apply)
+      case _                                             => Left(JsonError.typeMismatch(s"${op.getClass.getSimpleName} target", json.getClass.getSimpleName))
+    }
+
+  private def applyStringEdits(str: String, ops: Vector[StringOp]): Either[JsonError, String] = {
+    var result                   = str
+    var idx                      = 0
+    var error: Option[JsonError] = None
+
+    while (idx < ops.length && error.isEmpty) {
+      ops(idx) match {
+        case StringOp.Insert(index, text) =>
+          if (index < 0 || index > result.length) error = Some(JsonError.stringIndexOutOfBounds(index, result.length))
+          else result = result.substring(0, index) + text + result.substring(index)
+        case StringOp.Delete(index, length) =>
+          if (index < 0 || index + length > result.length)
+            error = Some(JsonError.invalidRange(index, index + length, result.length))
+          else result = result.substring(0, index) + result.substring(index + length)
+        case StringOp.Append(text)                => result = result + text
+        case StringOp.Modify(index, length, text) =>
+          if (index < 0 || index + length > result.length)
+            error = Some(JsonError.invalidRange(index, index + length, result.length))
+          else result = result.substring(0, index) + text + result.substring(index + length)
+      }
+      idx += 1
+    }
+    error.toLeft(result)
+  }
+
+  private def applyArrayEdit(json: Json, ops: Vector[ArrayOp], mode: JsonPatchMode): Either[JsonError, Json] =
+    json match {
+      case arr: Json.Arr => applyArrayOps(arr.elements, ops, mode).map(Json.Arr(_))
+      case _             => Left(JsonError.typeMismatch("Array", json.getClass.getSimpleName))
+    }
+
+  private def applyArrayOps(
+    elements: Vector[Json],
+    ops: Vector[ArrayOp],
+    mode: JsonPatchMode
+  ): Either[JsonError, Vector[Json]] = {
+    var result                   = elements
+    var idx                      = 0
+    var error: Option[JsonError] = None
+
+    while (idx < ops.length && error.isEmpty) {
+      applyArrayOp(result, ops(idx), mode) match {
+        case Right(updated) => result = updated
+        case Left(err)      => if (mode == JsonPatchMode.Strict) error = Some(err)
+      }
+      idx += 1
+    }
+    error.toLeft(result)
+  }
+
+  private def applyArrayOp(
+    elements: Vector[Json],
+    op: ArrayOp,
+    mode: JsonPatchMode
+  ): Either[JsonError, Vector[Json]] =
+    op match {
+      case ArrayOp.Append(values)        => Right(elements ++ values)
+      case ArrayOp.Insert(index, values) =>
+        if (index < 0 || index > elements.length) {
+          if (mode == JsonPatchMode.Clobber) {
+            val clampedIndex    = Math.max(0, Math.min(index, elements.length))
+            val (before, after) = elements.splitAt(clampedIndex)
+            Right(before ++ values ++ after)
+          } else Left(JsonError.indexOutOfBounds(index, elements.length))
+        } else {
+          val (before, after) = elements.splitAt(index)
+          Right(before ++ values ++ after)
+        }
+      case ArrayOp.Delete(index, count) =>
+        if (index < 0 || index + count > elements.length) {
+          if (mode == JsonPatchMode.Clobber) {
+            val clampedIndex = Math.max(0, Math.min(index, elements.length))
+            val clampedEnd   = Math.max(0, Math.min(index + count, elements.length))
+            Right(elements.take(clampedIndex) ++ elements.drop(clampedEnd))
+          } else Left(JsonError.invalidRange(index, index + count, elements.length))
+        } else Right(elements.take(index) ++ elements.drop(index + count))
+      case ArrayOp.Modify(index, nestedOp) =>
+        if (index < 0 || index >= elements.length) Left(JsonError.indexOutOfBounds(index, elements.length))
+        else applyOperation(elements(index), nestedOp, mode).map(newElement => elements.updated(index, newElement))
+    }
+
+  private def applyObjectEdit(json: Json, ops: Vector[ObjectOp], mode: JsonPatchMode): Either[JsonError, Json] =
+    json match {
+      case obj: Json.Obj => applyObjectOps(obj.fields, ops, mode).map(Json.Obj(_))
+      case _             => Left(JsonError.typeMismatch("Object", json.getClass.getSimpleName))
+    }
+
+  private def applyObjectOps(
+    fields: Vector[(String, Json)],
+    ops: Vector[ObjectOp],
+    mode: JsonPatchMode
+  ): Either[JsonError, Vector[(String, Json)]] = {
+    var result                   = fields
+    var idx                      = 0
+    var error: Option[JsonError] = None
+
+    while (idx < ops.length && error.isEmpty) {
+      applyObjectOp(result, ops(idx), mode) match {
+        case Right(updated) => result = updated
+        case Left(err)      => if (mode == JsonPatchMode.Strict) error = Some(err)
+      }
+      idx += 1
+    }
+    error.toLeft(result)
+  }
+
+  private def applyObjectOp(
+    fields: Vector[(String, Json)],
+    op: ObjectOp,
+    mode: JsonPatchMode
+  ): Either[JsonError, Vector[(String, Json)]] =
+    op match {
+      case ObjectOp.Add(key, value) =>
+        val existingIdx = fields.indexWhere(_._1 == key)
+        if (existingIdx >= 0) {
+          if (mode == JsonPatchMode.Clobber) Right(fields.updated(existingIdx, (key, value)))
+          else Left(JsonError.fieldExists(key))
+        } else Right(fields :+ (key, value))
+      case ObjectOp.Remove(key) =>
+        val existingIdx = fields.indexWhere(_._1 == key)
+        if (existingIdx < 0) {
+          if (mode == JsonPatchMode.Clobber) Right(fields)
+          else Left(JsonError.keyNotFound(key))
+        } else Right(fields.take(existingIdx) ++ fields.drop(existingIdx + 1))
+      case ObjectOp.Modify(key, nestedPatch) =>
+        val existingIdx = fields.indexWhere(_._1 == key)
+        if (existingIdx < 0) Left(JsonError.keyNotFound(key))
+        else {
+          val (k, v) = fields(existingIdx)
+          nestedPatch.apply(v, mode).map(newValue => fields.updated(existingIdx, (k, newValue)))
+        }
+    }
+
+  final case class JsonPatchOp(path: DynamicOptic, op: Op)
+
+  sealed trait Op
+  object Op {
+    final case class Set(value: Json)                  extends Op
+    final case class PrimitiveDelta(op: PrimitiveOp)   extends Op
+    final case class ArrayEdit(ops: Vector[ArrayOp])   extends Op
+    final case class ObjectEdit(ops: Vector[ObjectOp]) extends Op
+    final case class Nested(patch: JsonPatch)          extends Op
+  }
+
+  sealed trait PrimitiveOp
+  object PrimitiveOp {
+    final case class NumberDelta(delta: BigDecimal)    extends PrimitiveOp
+    final case class StringEdit(ops: Vector[StringOp]) extends PrimitiveOp
+  }
+
+  sealed trait StringOp
+  object StringOp {
+    final case class Insert(index: Int, text: String)              extends StringOp
+    final case class Delete(index: Int, length: Int)               extends StringOp
+    final case class Append(text: String)                          extends StringOp
+    final case class Modify(index: Int, length: Int, text: String) extends StringOp
+  }
+
+  sealed trait ArrayOp
+  object ArrayOp {
+    final case class Insert(index: Int, values: Vector[Json]) extends ArrayOp
+    final case class Append(values: Vector[Json])             extends ArrayOp
+    final case class Delete(index: Int, count: Int)           extends ArrayOp
+    final case class Modify(index: Int, op: Op)               extends ArrayOp
+  }
+
+  sealed trait ObjectOp
+  object ObjectOp {
+    final case class Add(key: String, value: Json)         extends ObjectOp
+    final case class Remove(key: String)                   extends ObjectOp
+    final case class Modify(key: String, patch: JsonPatch) extends ObjectOp
+  }
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonPatchMode.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonPatchMode.scala
@@ -1,0 +1,15 @@
+package zio.blocks.schema.json
+
+sealed trait JsonPatchMode
+
+object JsonPatchMode {
+
+  // Fail on precondition violations.
+  case object Strict extends JsonPatchMode
+
+  // Skip operations that fail preconditions.
+  case object Lenient extends JsonPatchMode
+
+  // Replace/overwrite on conflicts.
+  case object Clobber extends JsonPatchMode
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonPatchSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonPatchSpec.scala
@@ -1,0 +1,287 @@
+package zio.blocks.schema.json
+
+import zio.blocks.schema.DynamicOptic
+import zio.blocks.schema.SchemaBaseSpec
+import zio.test._
+
+object JsonPatchSpec extends SchemaBaseSpec {
+
+  val genJsonNull: Gen[Any, Json] = Gen.const(Json.Null)
+  val genJsonBool: Gen[Any, Json] = Gen.boolean.map(Json.Bool)
+  val genJsonNum: Gen[Any, Json]  = Gen.oneOf(
+    Gen.int.map(i => Json.Num(i.toString)),
+    Gen.long.map(l => Json.Num(l.toString)),
+    Gen.double.map(d => Json.Num(d.toString))
+  )
+  val genJsonStr: Gen[Any, Json]       = Gen.alphaNumericStringBounded(0, 20).map(Json.Str)
+  val genJsonPrimitive: Gen[Any, Json] = Gen.oneOf(genJsonNull, genJsonBool, genJsonNum, genJsonStr)
+
+  def genJsonArr(depth: Int): Gen[Any, Json] =
+    if (depth <= 0) genJsonPrimitive
+    else Gen.listOfBounded(0, 3)(genJson(depth - 1)).map(ls => Json.Arr(ls.toVector))
+
+  def genJsonObj(depth: Int): Gen[Any, Json] =
+    if (depth <= 0) genJsonPrimitive
+    else
+      Gen
+        .listOfBounded(0, 3) {
+          for {
+            key   <- Gen.alphaNumericStringBounded(1, 10)
+            value <- genJson(depth - 1)
+          } yield (key, value)
+        }
+        .map(fields => Json.Obj(fields.toVector))
+
+  def genJson(depth: Int): Gen[Any, Json] =
+    if (depth <= 0) genJsonPrimitive
+    else Gen.oneOf(genJsonPrimitive, genJsonArr(depth), genJsonObj(depth))
+
+  val genJsonValue: Gen[Any, Json] = genJson(2)
+
+  def spec = suite("JsonPatchSpec")(
+    suite("Monoid Laws")(
+      test("left identity: (empty ++ p)(j) == p(j)") {
+        check(genJsonValue, genJsonValue) { (old, new_) =>
+          val patch    = JsonPatch.diff(old, new_)
+          val composed = JsonPatch.empty ++ patch
+          val result1  = composed(old, JsonPatchMode.Strict)
+          val result2  = patch(old, JsonPatchMode.Strict)
+          assertTrue(result1 == result2)
+        }
+      },
+      test("right identity: (p ++ empty)(j) == p(j)") {
+        check(genJsonValue, genJsonValue) { (old, new_) =>
+          val patch    = JsonPatch.diff(old, new_)
+          val composed = patch ++ JsonPatch.empty
+          val result1  = composed(old, JsonPatchMode.Strict)
+          val result2  = patch(old, JsonPatchMode.Strict)
+          assertTrue(result1 == result2)
+        }
+      },
+      test("associativity: ((p1 ++ p2) ++ p3)(j) == (p1 ++ (p2 ++ p3))(j)") {
+        check(genJsonValue, genJsonValue, genJsonValue, genJsonValue) { (v0, v1, v2, v3) =>
+          val p1      = JsonPatch.diff(v0, v1)
+          val p2      = JsonPatch.diff(v1, v2)
+          val p3      = JsonPatch.diff(v2, v3)
+          val left    = (p1 ++ p2) ++ p3
+          val right   = p1 ++ (p2 ++ p3)
+          val result1 = left(v0, JsonPatchMode.Strict)
+          val result2 = right(v0, JsonPatchMode.Strict)
+          assertTrue(result1 == result2)
+        }
+      }
+    ),
+    suite("Diff/Apply Laws")(
+      test("roundtrip: diff(a, b)(a) == Right(b)") {
+        check(genJsonValue, genJsonValue) { (source, target) =>
+          val patch  = JsonPatch.diff(source, target)
+          val result = patch(source, JsonPatchMode.Strict)
+          assertTrue(result == Right(target))
+        }
+      },
+      test("identity diff: diff(j, j).isEmpty") {
+        check(genJsonValue) { json =>
+          val patch = JsonPatch.diff(json, json)
+          assertTrue(patch.isEmpty)
+        }
+      },
+      test("diff composition: (diff(a, b) ++ diff(b, c))(a) == Right(c)") {
+        check(genJsonValue, genJsonValue, genJsonValue) { (a, b, c) =>
+          val p1       = JsonPatch.diff(a, b)
+          val p2       = JsonPatch.diff(b, c)
+          val composed = p1 ++ p2
+          val result   = composed(a, JsonPatchMode.Strict)
+          assertTrue(result == Right(c))
+        }
+      }
+    ),
+    suite("PatchMode Laws")(
+      test("lenient subsumes strict") {
+        check(genJsonValue, genJsonValue) { (source, target) =>
+          val patch        = JsonPatch.diff(source, target)
+          val strictResult = patch(source, JsonPatchMode.Strict)
+          strictResult match {
+            case Right(r) =>
+              val lenientResult = patch(source, JsonPatchMode.Lenient)
+              assertTrue(lenientResult == Right(r))
+            case Left(_) => assertTrue(true)
+          }
+        }
+      }
+    ),
+    suite("Operation Types")(
+      test("Op.Set replaces value") {
+        val json   = Json.Num(10)
+        val patch  = JsonPatch.root(JsonPatch.Op.Set(Json.Num(42)))
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result == Right(Json.Num(42)))
+      },
+      test("Op.PrimitiveDelta - NumberDelta") {
+        val json   = Json.Num(10)
+        val patch  = JsonPatch.root(JsonPatch.Op.PrimitiveDelta(JsonPatch.PrimitiveOp.NumberDelta(BigDecimal(5))))
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result == Right(Json.Num("15")))
+      },
+      test("Op.PrimitiveDelta - StringEdit") {
+        val json  = Json.Str("hello")
+        val patch = JsonPatch.root(
+          JsonPatch.Op.PrimitiveDelta(JsonPatch.PrimitiveOp.StringEdit(Vector(JsonPatch.StringOp.Append(" world"))))
+        )
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result == Right(Json.Str("hello world")))
+      },
+      test("Op.ArrayEdit - Insert") {
+        val json  = Json.Arr(Vector(Json.Num(1), Json.Num(2)))
+        val patch = JsonPatch.root(
+          JsonPatch.Op.ArrayEdit(Vector(JsonPatch.ArrayOp.Insert(1, Vector(Json.Num(10)))))
+        )
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result == Right(Json.Arr(Vector(Json.Num(1), Json.Num(10), Json.Num(2)))))
+      },
+      test("Op.ObjectEdit - Add") {
+        val json  = Json.Obj(Vector("a" -> Json.Num(1)))
+        val patch = JsonPatch.root(
+          JsonPatch.Op.ObjectEdit(Vector(JsonPatch.ObjectOp.Add("b", Json.Num(2))))
+        )
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result == Right(Json.Obj(Vector("a" -> Json.Num(1), "b" -> Json.Num(2)))))
+      }
+    ),
+    suite("ArrayOp Variants")(
+      test("Append") {
+        val json   = Json.Arr(Vector(Json.Num(1)))
+        val patch  = JsonPatch.root(JsonPatch.Op.ArrayEdit(Vector(JsonPatch.ArrayOp.Append(Vector(Json.Num(2))))))
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result == Right(Json.Arr(Vector(Json.Num(1), Json.Num(2)))))
+      },
+      test("Delete") {
+        val json   = Json.Arr(Vector(Json.Num(1), Json.Num(2), Json.Num(3)))
+        val patch  = JsonPatch.root(JsonPatch.Op.ArrayEdit(Vector(JsonPatch.ArrayOp.Delete(1, 1))))
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result == Right(Json.Arr(Vector(Json.Num(1), Json.Num(3)))))
+      },
+      test("Modify") {
+        val json  = Json.Arr(Vector(Json.Num(1), Json.Num(2)))
+        val patch = JsonPatch.root(
+          JsonPatch.Op.ArrayEdit(Vector(JsonPatch.ArrayOp.Modify(1, JsonPatch.Op.Set(Json.Num(20)))))
+        )
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result == Right(Json.Arr(Vector(Json.Num(1), Json.Num(20)))))
+      }
+    ),
+    suite("ObjectOp Variants")(
+      test("Add") {
+        val json   = Json.Obj(Vector("a" -> Json.Num(1)))
+        val patch  = JsonPatch.root(JsonPatch.Op.ObjectEdit(Vector(JsonPatch.ObjectOp.Add("b", Json.Num(2)))))
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result == Right(Json.Obj(Vector("a" -> Json.Num(1), "b" -> Json.Num(2)))))
+      },
+      test("Remove") {
+        val json   = Json.Obj(Vector("a" -> Json.Num(1), "b" -> Json.Num(2)))
+        val patch  = JsonPatch.root(JsonPatch.Op.ObjectEdit(Vector(JsonPatch.ObjectOp.Remove("a"))))
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result == Right(Json.Obj(Vector("b" -> Json.Num(2)))))
+      }
+    ),
+    suite("StringOp Variants")(
+      test("Insert") {
+        val json  = Json.Str("hello")
+        val patch = JsonPatch.root(
+          JsonPatch.Op.PrimitiveDelta(JsonPatch.PrimitiveOp.StringEdit(Vector(JsonPatch.StringOp.Insert(5, " world"))))
+        )
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result == Right(Json.Str("hello world")))
+      },
+      test("Delete") {
+        val json  = Json.Str("hello world")
+        val patch = JsonPatch.root(
+          JsonPatch.Op.PrimitiveDelta(JsonPatch.PrimitiveOp.StringEdit(Vector(JsonPatch.StringOp.Delete(5, 6))))
+        )
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result == Right(Json.Str("hello")))
+      },
+      test("Modify") {
+        val json  = Json.Str("hello")
+        val patch = JsonPatch.root(
+          JsonPatch.Op.PrimitiveDelta(JsonPatch.PrimitiveOp.StringEdit(Vector(JsonPatch.StringOp.Modify(0, 5, "hi"))))
+        )
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result == Right(Json.Str("hi")))
+      }
+    ),
+    suite("PatchMode Behaviors")(
+      test("Strict fails on missing field") {
+        val json   = Json.Obj(Vector("a" -> Json.Num(1)))
+        val patch  = JsonPatch(DynamicOptic.root.field("nonexistent"), JsonPatch.Op.Set(Json.Num(42)))
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result.isLeft)
+      },
+      test("Lenient skips on missing field") {
+        val json   = Json.Obj(Vector("a" -> Json.Num(1)))
+        val patch  = JsonPatch(DynamicOptic.root.field("nonexistent"), JsonPatch.Op.Set(Json.Num(42)))
+        val result = patch(json, JsonPatchMode.Lenient)
+        assertTrue(result == Right(json))
+      },
+      test("Clobber overwrites existing on Add") {
+        val json          = Json.Obj(Vector("a" -> Json.Num(1)))
+        val patch         = JsonPatch.root(JsonPatch.Op.ObjectEdit(Vector(JsonPatch.ObjectOp.Add("a", Json.Num(100)))))
+        val strictResult  = patch(json, JsonPatchMode.Strict)
+        val clobberResult = patch(json, JsonPatchMode.Clobber)
+        assertTrue(strictResult.isLeft && clobberResult == Right(Json.Obj(Vector("a" -> Json.Num(100)))))
+      }
+    ),
+    suite("Edge Cases")(
+      test("Empty array roundtrip") {
+        val source = Json.Arr.empty
+        val target = Json.Arr(Vector(Json.Num(1), Json.Num(2)))
+        val patch  = JsonPatch.diff(source, target)
+        val result = patch(source, JsonPatchMode.Strict)
+        assertTrue(result == Right(target))
+      },
+      test("Empty object roundtrip") {
+        val source = Json.Obj.empty
+        val target = Json.Obj(Vector("a" -> Json.Num(1)))
+        val patch  = JsonPatch.diff(source, target)
+        val result = patch(source, JsonPatchMode.Strict)
+        assertTrue(result == Right(target))
+      },
+      test("Empty string roundtrip") {
+        val source = Json.Str("")
+        val target = Json.Str("hello")
+        val patch  = JsonPatch.diff(source, target)
+        val result = patch(source, JsonPatchMode.Strict)
+        assertTrue(result == Right(target))
+      },
+      test("Nested structures roundtrip") {
+        val source = Json.Obj(Vector("user" -> Json.Obj(Vector("name" -> Json.Str("Alice")))))
+        val target = Json.Obj(Vector("user" -> Json.Obj(Vector("name" -> Json.Str("Bob")))))
+        val patch  = JsonPatch.diff(source, target)
+        val result = patch(source, JsonPatchMode.Strict)
+        assertTrue(result == Right(target))
+      }
+    ),
+    suite("Error Cases")(
+      test("Type mismatch - number delta on string") {
+        val json   = Json.Str("hello")
+        val patch  = JsonPatch.root(JsonPatch.Op.PrimitiveDelta(JsonPatch.PrimitiveOp.NumberDelta(BigDecimal(5))))
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result.isLeft)
+      },
+      test("Array index out of bounds") {
+        val json   = Json.Arr(Vector(Json.Num(1), Json.Num(2)))
+        val patch  = JsonPatch(DynamicOptic.root.at(10), JsonPatch.Op.Set(Json.Num(42)))
+        val result = patch(json, JsonPatchMode.Strict)
+        assertTrue(result.isLeft)
+      }
+    ),
+    suite("Empty Patch Identity")(
+      test("Empty patch returns unchanged value") {
+        check(genJsonValue) { json =>
+          val empty  = JsonPatch.empty
+          val result = empty(json, JsonPatchMode.Strict)
+          assertTrue(result == Right(json))
+        }
+      }
+    )
+  )
+}


### PR DESCRIPTION
This PR implements JsonPatch for issue #685

## What it does

JsonPatch lets you compute the difference between two JSON values and apply that diff to transform one into the other. It follows the same patterns as DynamicPatch but is simpler since JSON only has 4 primitive types and string-only object keys.

## Files added

- Basic JSON type with Null, Bool, Num, Str, Arr, Obj
- Error types for patch failures
- Three patch modes: Strict, Lenient, Clobber
- Main implementation with diff and apply methods
- LCS algorithm for efficient string and array diffs
- Property tests for all algebraic laws

## How it works

val source = Json.Obj(Vector("name" -> Json.Str("Alice")))
val target = Json.Obj(Vector("name" -> Json.Str("Bob")))

val patch = JsonPatch.diff(source, target)
patch(source, JsonPatchMode.Strict) // Right(target)

## Laws verified

All seven algebraic laws from the issue are tested:
- Monoid laws (identity and associativity)
- Roundtrip: diff(a, b) applied to a gives b
- Identity: diff(x, x) is empty
- Composition: patches can be combined
- Mode subsumption: Strict success means Lenient success

Closes #685