### PR TITLE
Add benchmarks for TOON

### DIFF
--- a/benchmarks/src/main/scala/zio/blocks/schema/toon/ToonListOfRecordsBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/blocks/schema/toon/ToonListOfRecordsBenchmark.scala
@@ -1,0 +1,53 @@
+package zio.blocks.schema.toon
+
+import org.openjdk.jmh.annotations._
+import io.toonformat.toon4s._
+import io.toonformat.toon4s.codec.{Decoder, Encoder}
+import zio.blocks.BaseBenchmark
+import zio.blocks.schema.Schema
+import zio.blocks.schema.toon.ToonListOfRecordsDomain.{Person, zioBlocksCodec}
+import java.nio.charset.StandardCharsets.UTF_8
+import scala.compiletime.uninitialized
+
+class ToonListOfRecordsBenchmark extends BaseBenchmark {
+  @Param(Array("1", "10", "100", "1000", "10000", "100000"))
+  var size: Int                         = 100
+  var listOfRecords: List[Person]       = uninitialized
+  var encodedListOfRecords: Array[Byte] = uninitialized
+
+  @Setup
+  def setup(): Unit = {
+    listOfRecords = (1 to size).map(_ => Person(12345678901L, "John", 30, "123 Main St", List(5, 7, 9))).toList
+    encodedListOfRecords = zioBlocksCodec.encode(listOfRecords)
+  }
+
+  @Benchmark
+  def readingToon4s: List[Person] =
+    ToonTyped.decodeAs[List[Person]](new String(encodedListOfRecords, UTF_8)) match {
+      case Right(value) => value
+      case Left(error)  => throw error
+    }
+
+  @Benchmark
+  def readingZioBlocks: List[Person] = zioBlocksCodec.decode(encodedListOfRecords) match {
+    case Right(value) => value
+    case Left(error)  => throw error
+  }
+
+  @Benchmark
+  def writingToon4s: Array[Byte] = Toon.encode(listOfRecords) match {
+    case Right(str)  => str.getBytes(UTF_8)
+    case Left(error) => throw error
+  }
+
+  @Benchmark
+  def writingZioBlocks: Array[Byte] = zioBlocksCodec.encode(listOfRecords)
+}
+
+object ToonListOfRecordsDomain {
+  case class Person(id: Long, name: String, age: Int, address: String, childrenAges: List[Int]) derives Encoder, Decoder
+
+  val zioBlocksCodec: ToonBinaryCodec[List[Person]] = Schema.derived.derive(ToonFormat.deriver)
+
+  implicit val zioJsonCodec: zio.json.JsonCodec[Person] = zio.json.DeriveJsonCodec.gen
+}

--- a/benchmarks/src/test/scala/zio/blocks/schema/toon/ToonListOfRecordsBenchmarkSpec.scala
+++ b/benchmarks/src/test/scala/zio/blocks/schema/toon/ToonListOfRecordsBenchmarkSpec.scala
@@ -1,0 +1,25 @@
+package zio.blocks.schema.toon
+
+import zio.blocks.schema.SchemaBaseSpec
+import zio.test.*
+import zio.test.Assertion.*
+
+object ToonListOfRecordsBenchmarkSpec extends SchemaBaseSpec {
+  def spec: Spec[TestEnvironment, Any] = suite("ToonListOfRecordsBenchmarkSpec")(
+    test("reading") {
+      val benchmark = new ToonListOfRecordsBenchmark
+      benchmark.setup()
+      val toon4sOutput    = benchmark.readingToon4s
+      val zioBlocksOutput = benchmark.readingZioBlocks
+      assert(toon4sOutput)(equalTo(zioBlocksOutput))
+    },
+    test("writing") {
+      val benchmark = new ToonListOfRecordsBenchmark
+      benchmark.setup()
+      val toon4sOutput    = benchmark.writingToon4s
+      val zioBlocksOutput = benchmark.writingZioBlocks
+      // println(s"zioBlocksOutput: " + new String(zioBlocksOutput, "UTF-8"))
+      assert(new String(toon4sOutput))(equalTo(new String(zioBlocksOutput)))
+    }
+  )
+}

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val schema = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     compileOrder := CompileOrder.JavaThenScala,
     libraryDependencies ++= Seq(
-      "dev.zio" %%% "zio-prelude"  % "1.0.0-RC45" % Test,
+      "dev.zio" %%% "zio-prelude"  % "1.0.0-RC41" % Test,
       "dev.zio" %%% "zio-test"     % "2.1.24"     % Test,
       "dev.zio" %%% "zio-test-sbt" % "2.1.24"     % Test
     ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
@@ -249,9 +249,11 @@ lazy val benchmarks = project
   .dependsOn(schema.jvm % "compile->compile;test->test")
   .dependsOn(chunk.jvm)
   .dependsOn(`schema-avro`)
+  .dependsOn(`schema-toon`.jvm)
   .enablePlugins(JmhPlugin)
   .settings(
     libraryDependencies ++= Seq(
+      "com.vitthalmirji"                      %% "toon4s-core"           % "0.5.0",
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.38.8",
       "com.sksamuel.avro4s"                   %% "avro4s-core"           % "5.0.14",
       "dev.zio"                               %% "zio-json"              % "0.7.45",


### PR DESCRIPTION
Commands to assembly and run benchmarks:
```sh
sbt -java-home /usr/lib/jvm/jdk-11 ++3.7.4 clean benchmarks/assembly
/usr/lib/jvm/jdk-25/bin/java -jar /home/andriy/Projects/com/github/plokhotnyuk/zio-blocks/benchmarks/target/scala-3.7.4/benchmarks.jar -prof gc "ToonLists*"
```
Results of toon4s vs. zioBlocks comparison using Scala 3 on JDK 25:
```txt
Benchmark                                                       (size)   Mode  Cnt          Score       Error   Units
ToonListOfRecordsBenchmark.readingToon4s                             1  thrpt    5     697987.809 ±  1933.433   ops/s
ToonListOfRecordsBenchmark.readingToon4s:gc.alloc.rate               1  thrpt    5       6388.025 ±    17.417  MB/sec
ToonListOfRecordsBenchmark.readingToon4s:gc.alloc.rate.norm          1  thrpt    5       9600.008 ±     0.001    B/op
ToonListOfRecordsBenchmark.readingToon4s:gc.count                    1  thrpt    5         20.000              counts
ToonListOfRecordsBenchmark.readingToon4s:gc.time                     1  thrpt    5         21.000                  ms
ToonListOfRecordsBenchmark.readingToon4s                            10  thrpt    5      77807.152 ±   162.160   ops/s
ToonListOfRecordsBenchmark.readingToon4s:gc.alloc.rate              10  thrpt    5       6274.475 ±    14.911  MB/sec
ToonListOfRecordsBenchmark.readingToon4s:gc.alloc.rate.norm         10  thrpt    5      84576.076 ±     0.001    B/op
ToonListOfRecordsBenchmark.readingToon4s:gc.count                   10  thrpt    5         21.000              counts
ToonListOfRecordsBenchmark.readingToon4s:gc.time                    10  thrpt    5         19.000                  ms
ToonListOfRecordsBenchmark.readingToon4s                           100  thrpt    5       7606.893 ±    70.349   ops/s
ToonListOfRecordsBenchmark.readingToon4s:gc.alloc.rate             100  thrpt    5       5895.292 ±    56.252  MB/sec
ToonListOfRecordsBenchmark.readingToon4s:gc.alloc.rate.norm        100  thrpt    5     812795.200 ±   183.518    B/op
ToonListOfRecordsBenchmark.readingToon4s:gc.count                  100  thrpt    5         19.000              counts
ToonListOfRecordsBenchmark.readingToon4s:gc.time                   100  thrpt    5         19.000                  ms
ToonListOfRecordsBenchmark.readingToon4s                          1000  thrpt    5        775.904 ±    10.998   ops/s
ToonListOfRecordsBenchmark.readingToon4s:gc.alloc.rate            1000  thrpt    5       5967.837 ±    84.350  MB/sec
ToonListOfRecordsBenchmark.readingToon4s:gc.alloc.rate.norm       1000  thrpt    5    8068968.674 ±   653.062    B/op
ToonListOfRecordsBenchmark.readingToon4s:gc.count                 1000  thrpt    5         20.000              counts
ToonListOfRecordsBenchmark.readingToon4s:gc.time                  1000  thrpt    5         23.000                  ms
ToonListOfRecordsBenchmark.readingToon4s                         10000  thrpt    5         59.499 ±     0.670   ops/s
ToonListOfRecordsBenchmark.readingToon4s:gc.alloc.rate           10000  thrpt    5       4675.066 ±    52.410  MB/sec
ToonListOfRecordsBenchmark.readingToon4s:gc.alloc.rate.norm      10000  thrpt    5   82416650.133 ±     0.001    B/op
ToonListOfRecordsBenchmark.readingToon4s:gc.count                10000  thrpt    5         16.000              counts
ToonListOfRecordsBenchmark.readingToon4s:gc.time                 10000  thrpt    5         34.000                  ms
ToonListOfRecordsBenchmark.readingToon4s                        100000  thrpt    5          5.546 ±     0.731   ops/s
ToonListOfRecordsBenchmark.readingToon4s:gc.alloc.rate          100000  thrpt    5       4306.978 ±   568.028  MB/sec
ToonListOfRecordsBenchmark.readingToon4s:gc.alloc.rate.norm     100000  thrpt    5  814611109.333 ±     0.001    B/op
ToonListOfRecordsBenchmark.readingToon4s:gc.count               100000  thrpt    5         15.000              counts
ToonListOfRecordsBenchmark.readingToon4s:gc.time                100000  thrpt    5        292.000                  ms
ToonListOfRecordsBenchmark.readingZioBlocks                          1  thrpt    5    1857747.043 ± 10357.322   ops/s
ToonListOfRecordsBenchmark.readingZioBlocks:gc.alloc.rate            1  thrpt    5       6717.169 ±    37.788  MB/sec
ToonListOfRecordsBenchmark.readingZioBlocks:gc.alloc.rate.norm       1  thrpt    5       3792.004 ±     0.001    B/op
ToonListOfRecordsBenchmark.readingZioBlocks:gc.count                 1  thrpt    5         22.000              counts
ToonListOfRecordsBenchmark.readingZioBlocks:gc.time                  1  thrpt    5         22.000                  ms
ToonListOfRecordsBenchmark.readingZioBlocks                         10  thrpt    5     197625.264 ±  3850.667   ops/s
ToonListOfRecordsBenchmark.readingZioBlocks:gc.alloc.rate           10  thrpt    5       7008.915 ±   134.576  MB/sec
ToonListOfRecordsBenchmark.readingZioBlocks:gc.alloc.rate.norm      10  thrpt    5      37200.034 ±     0.002    B/op
ToonListOfRecordsBenchmark.readingZioBlocks:gc.count                10  thrpt    5         23.000              counts
ToonListOfRecordsBenchmark.readingZioBlocks:gc.time                 10  thrpt    5         23.000                  ms
ToonListOfRecordsBenchmark.readingZioBlocks                        100  thrpt    5      20144.920 ±   182.749   ops/s
ToonListOfRecordsBenchmark.readingZioBlocks:gc.alloc.rate          100  thrpt    5       7076.110 ±    63.977  MB/sec
ToonListOfRecordsBenchmark.readingZioBlocks:gc.alloc.rate.norm     100  thrpt    5     368369.969 ±    14.121    B/op
ToonListOfRecordsBenchmark.readingZioBlocks:gc.count               100  thrpt    5         23.000              counts
ToonListOfRecordsBenchmark.readingZioBlocks:gc.time                100  thrpt    5         25.000                  ms
ToonListOfRecordsBenchmark.readingZioBlocks                       1000  thrpt    5       1887.194 ±    17.906   ops/s
ToonListOfRecordsBenchmark.readingZioBlocks:gc.alloc.rate         1000  thrpt    5       6640.209 ±    66.413  MB/sec
ToonListOfRecordsBenchmark.readingZioBlocks:gc.alloc.rate.norm    1000  thrpt    5    3690347.473 ±     0.152    B/op
ToonListOfRecordsBenchmark.readingZioBlocks:gc.count              1000  thrpt    5         21.000              counts
ToonListOfRecordsBenchmark.readingZioBlocks:gc.time               1000  thrpt    5         25.000                  ms
ToonListOfRecordsBenchmark.readingZioBlocks                      10000  thrpt    5        197.126 ±     2.296   ops/s
ToonListOfRecordsBenchmark.readingZioBlocks:gc.alloc.rate        10000  thrpt    5       6953.426 ±    82.704  MB/sec
ToonListOfRecordsBenchmark.readingZioBlocks:gc.alloc.rate.norm   10000  thrpt    5   37004361.523 ±     1.964    B/op
ToonListOfRecordsBenchmark.readingZioBlocks:gc.count             10000  thrpt    5         23.000              counts
ToonListOfRecordsBenchmark.readingZioBlocks:gc.time              10000  thrpt    5         77.000                  ms
ToonListOfRecordsBenchmark.readingZioBlocks                     100000  thrpt    5         17.534 ±     1.648   ops/s
ToonListOfRecordsBenchmark.readingZioBlocks:gc.alloc.rate       100000  thrpt    5       5990.799 ±   564.769  MB/sec
ToonListOfRecordsBenchmark.readingZioBlocks:gc.alloc.rate.norm  100000  thrpt    5  358383742.933 ±    36.737    B/op
ToonListOfRecordsBenchmark.readingZioBlocks:gc.count            100000  thrpt    5         20.000              counts
ToonListOfRecordsBenchmark.readingZioBlocks:gc.time             100000  thrpt    5        419.000                  ms
ToonListOfRecordsBenchmark.writingToon4s                             1  thrpt    5     960671.613 ±  4907.170   ops/s
ToonListOfRecordsBenchmark.writingToon4s:gc.alloc.rate               1  thrpt    5       6176.307 ±    30.946  MB/sec
ToonListOfRecordsBenchmark.writingToon4s:gc.alloc.rate.norm          1  thrpt    5       6744.006 ±     0.001    B/op
ToonListOfRecordsBenchmark.writingToon4s:gc.count                    1  thrpt    5         20.000              counts
ToonListOfRecordsBenchmark.writingToon4s:gc.time                     1  thrpt    5         22.000                  ms
ToonListOfRecordsBenchmark.writingToon4s                            10  thrpt    5     122852.201 ±   459.153   ops/s
ToonListOfRecordsBenchmark.writingToon4s:gc.alloc.rate              10  thrpt    5       6019.209 ±    21.390  MB/sec
ToonListOfRecordsBenchmark.writingToon4s:gc.alloc.rate.norm         10  thrpt    5      51384.048 ±     0.001    B/op
ToonListOfRecordsBenchmark.writingToon4s:gc.count                   10  thrpt    5         19.000              counts
ToonListOfRecordsBenchmark.writingToon4s:gc.time                    10  thrpt    5         18.000                  ms
ToonListOfRecordsBenchmark.writingToon4s                           100  thrpt    5      12692.253 ±   138.987   ops/s
ToonListOfRecordsBenchmark.writingToon4s:gc.alloc.rate             100  thrpt    5       6329.890 ±    70.070  MB/sec
ToonListOfRecordsBenchmark.writingToon4s:gc.alloc.rate.norm        100  thrpt    5     523033.170 ±    76.897    B/op
ToonListOfRecordsBenchmark.writingToon4s:gc.count                  100  thrpt    5         20.000              counts
ToonListOfRecordsBenchmark.writingToon4s:gc.time                   100  thrpt    5         19.000                  ms
ToonListOfRecordsBenchmark.writingToon4s                          1000  thrpt    5       1296.098 ±     4.540   ops/s
ToonListOfRecordsBenchmark.writingToon4s:gc.alloc.rate            1000  thrpt    5       6434.933 ±    23.076  MB/sec
ToonListOfRecordsBenchmark.writingToon4s:gc.alloc.rate.norm       1000  thrpt    5    5208412.561 ±     0.195    B/op
ToonListOfRecordsBenchmark.writingToon4s:gc.count                 1000  thrpt    5         21.000              counts
ToonListOfRecordsBenchmark.writingToon4s:gc.time                  1000  thrpt    5         22.000                  ms
ToonListOfRecordsBenchmark.writingToon4s                         10000  thrpt    5        128.419 ±     0.470   ops/s
ToonListOfRecordsBenchmark.writingToon4s:gc.alloc.rate           10000  thrpt    5       6154.185 ±    22.312  MB/sec
ToonListOfRecordsBenchmark.writingToon4s:gc.alloc.rate.norm      10000  thrpt    5   50275670.251 ±     5.233    B/op
ToonListOfRecordsBenchmark.writingToon4s:gc.count                10000  thrpt    5         20.000              counts
ToonListOfRecordsBenchmark.writingToon4s:gc.time                 10000  thrpt    5         28.000                  ms
ToonListOfRecordsBenchmark.writingToon4s                        100000  thrpt    5         12.094 ±     0.211   ops/s
ToonListOfRecordsBenchmark.writingToon4s:gc.alloc.rate          100000  thrpt    5       6115.798 ±   107.613  MB/sec
ToonListOfRecordsBenchmark.writingToon4s:gc.alloc.rate.norm     100000  thrpt    5  530482372.923 ±     0.001    B/op
ToonListOfRecordsBenchmark.writingToon4s:gc.count               100000  thrpt    5         22.000              counts
ToonListOfRecordsBenchmark.writingToon4s:gc.time                100000  thrpt    5        184.000                  ms
ToonListOfRecordsBenchmark.writingZioBlocks                          1  thrpt    5    2861996.868 ± 25398.375   ops/s
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate            1  thrpt    5       5523.324 ±    49.138  MB/sec
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate.norm       1  thrpt    5       2024.002 ±     0.001    B/op
ToonListOfRecordsBenchmark.writingZioBlocks:gc.count                 1  thrpt    5         18.000              counts
ToonListOfRecordsBenchmark.writingZioBlocks:gc.time                  1  thrpt    5         18.000                  ms
ToonListOfRecordsBenchmark.writingZioBlocks                         10  thrpt    5     273847.850 ±  7599.422   ops/s
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate           10  thrpt    5       5123.479 ±   142.172  MB/sec
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate.norm      10  thrpt    5      19624.022 ±     0.001    B/op
ToonListOfRecordsBenchmark.writingZioBlocks:gc.count                10  thrpt    5         17.000              counts
ToonListOfRecordsBenchmark.writingZioBlocks:gc.time                 10  thrpt    5         18.000                  ms
ToonListOfRecordsBenchmark.writingZioBlocks                        100  thrpt    5      28723.082 ±   186.041   ops/s
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate          100  thrpt    5       5356.559 ±    34.166  MB/sec
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate.norm     100  thrpt    5     195576.206 ±     0.001    B/op
ToonListOfRecordsBenchmark.writingZioBlocks:gc.count               100  thrpt    5         17.000              counts
ToonListOfRecordsBenchmark.writingZioBlocks:gc.time                100  thrpt    5         17.000                  ms
ToonListOfRecordsBenchmark.writingZioBlocks                       1000  thrpt    5       2761.338 ±    29.719   ops/s
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate         1000  thrpt    5       5147.327 ±    54.757  MB/sec
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate.norm    1000  thrpt    5    1955074.131 ±     0.022    B/op
ToonListOfRecordsBenchmark.writingZioBlocks:gc.count              1000  thrpt    5         17.000              counts
ToonListOfRecordsBenchmark.writingZioBlocks:gc.time               1000  thrpt    5         18.000                  ms
ToonListOfRecordsBenchmark.writingZioBlocks                      10000  thrpt    5        287.384 ±     0.535   ops/s
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate        10000  thrpt    5       5355.912 ±    10.477  MB/sec
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate.norm   10000  thrpt    5   19550092.444 ±     0.001    B/op
ToonListOfRecordsBenchmark.writingZioBlocks:gc.count             10000  thrpt    5         17.000              counts
ToonListOfRecordsBenchmark.writingZioBlocks:gc.time              10000  thrpt    5         17.000                  ms
ToonListOfRecordsBenchmark.writingZioBlocks                     100000  thrpt    5         26.007 ±     0.961   ops/s
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate       100000  thrpt    5       4846.701 ±   180.188  MB/sec
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate.norm  100000  thrpt    5  195500315.752 ±    14.444    B/op
ToonListOfRecordsBenchmark.writingZioBlocks:gc.count            100000  thrpt    5         16.000              counts
ToonListOfRecordsBenchmark.writingZioBlocks:gc.time             100000  thrpt    5         36.000                  ms
```