### PR TITLE
More efficient serialization with TOON codecs

### DIFF
--- a/schema-toon/src/main/scala/zio/blocks/schema/toon/ToonBinaryCodec.scala
+++ b/schema-toon/src/main/scala/zio/blocks/schema/toon/ToonBinaryCodec.scala
@@ -378,7 +378,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: Unit, out: ToonWriter): Unit = out.writeNull()
   }
-
   val booleanCodec: ToonBinaryCodec[Boolean] = new ToonBinaryCodec[Boolean](ToonBinaryCodec.booleanType) {
     override def isPrimitive: Boolean = true
 
@@ -393,7 +392,6 @@ object ToonBinaryCodec {
 
     override def encodeKey(x: Boolean, out: ToonWriter): Unit = out.writeBoolean(x)
   }
-
   val byteCodec: ToonBinaryCodec[Byte] = new ToonBinaryCodec[Byte](ToonBinaryCodec.byteType) {
     override def isPrimitive: Boolean = true
 
@@ -408,7 +406,6 @@ object ToonBinaryCodec {
 
     override def encodeKey(x: Byte, out: ToonWriter): Unit = out.writeInt(x.toInt)
   }
-
   val shortCodec: ToonBinaryCodec[Short] = new ToonBinaryCodec[Short](ToonBinaryCodec.shortType) {
     override def isPrimitive: Boolean = true
 
@@ -423,7 +420,6 @@ object ToonBinaryCodec {
 
     override def encodeKey(x: Short, out: ToonWriter): Unit = out.writeInt(x.toInt)
   }
-
   val intCodec: ToonBinaryCodec[Int] = new ToonBinaryCodec[Int](ToonBinaryCodec.intType) {
     override def isPrimitive: Boolean = true
 
@@ -438,7 +434,6 @@ object ToonBinaryCodec {
 
     override def encodeKey(x: Int, out: ToonWriter): Unit = out.writeInt(x)
   }
-
   val longCodec: ToonBinaryCodec[Long] = new ToonBinaryCodec[Long](ToonBinaryCodec.longType) {
     override def isPrimitive: Boolean = true
 
@@ -453,7 +448,6 @@ object ToonBinaryCodec {
 
     override def encodeKey(x: Long, out: ToonWriter): Unit = out.writeLong(x)
   }
-
   val floatCodec: ToonBinaryCodec[Float] = new ToonBinaryCodec[Float](ToonBinaryCodec.floatType) {
     override def isPrimitive: Boolean = true
 
@@ -468,7 +462,6 @@ object ToonBinaryCodec {
 
     override def encodeKey(x: Float, out: ToonWriter): Unit = out.writeFloat(x)
   }
-
   val doubleCodec: ToonBinaryCodec[Double] = new ToonBinaryCodec[Double](ToonBinaryCodec.doubleType) {
     override def isPrimitive: Boolean = true
 
@@ -483,7 +476,6 @@ object ToonBinaryCodec {
 
     override def encodeKey(x: Double, out: ToonWriter): Unit = out.writeDouble(x)
   }
-
   val charCodec: ToonBinaryCodec[Char] = new ToonBinaryCodec[Char](ToonBinaryCodec.charType) {
     override def isPrimitive: Boolean = true
 
@@ -504,7 +496,6 @@ object ToonBinaryCodec {
 
     override def encodeKey(x: Char, out: ToonWriter): Unit = out.writeChar(x)
   }
-
   val stringCodec: ToonBinaryCodec[String] = new ToonBinaryCodec[String]() {
     override def isPrimitive: Boolean = true
 
@@ -519,7 +510,6 @@ object ToonBinaryCodec {
 
     override def encodeKey(x: String, out: ToonWriter): Unit = out.writeString(x)
   }
-
   val bigIntCodec: ToonBinaryCodec[BigInt] = new ToonBinaryCodec[BigInt]() {
     override def isPrimitive: Boolean = true
 
@@ -534,7 +524,6 @@ object ToonBinaryCodec {
 
     override def encodeKey(x: BigInt, out: ToonWriter): Unit = out.writeBigInt(x)
   }
-
   val bigDecimalCodec: ToonBinaryCodec[BigDecimal] = new ToonBinaryCodec[BigDecimal]() {
     override def isPrimitive: Boolean = true
 
@@ -549,7 +538,6 @@ object ToonBinaryCodec {
 
     override def encodeKey(x: BigDecimal, out: ToonWriter): Unit = out.writeBigDecimal(x)
   }
-
   val dayOfWeekCodec: ToonBinaryCodec[DayOfWeek] = new ToonBinaryCodec[java.time.DayOfWeek]() {
     override def isPrimitive: Boolean = true
 
@@ -562,7 +550,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.DayOfWeek, out: ToonWriter): Unit = out.writeString(x.name)
   }
-
   val durationCodec: ToonBinaryCodec[Duration] = new ToonBinaryCodec[java.time.Duration]() {
     override def isPrimitive: Boolean = true
 
@@ -575,7 +562,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.Duration, out: ToonWriter): Unit = out.writeString(x.toString)
   }
-
   val instantCodec: ToonBinaryCodec[Instant] = new ToonBinaryCodec[java.time.Instant]() {
     override def isPrimitive: Boolean = true
 
@@ -588,7 +574,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.Instant, out: ToonWriter): Unit = out.writeString(x.toString)
   }
-
   val localDateCodec: ToonBinaryCodec[LocalDate] = new ToonBinaryCodec[java.time.LocalDate]() {
     override def isPrimitive: Boolean = true
 
@@ -601,7 +586,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.LocalDate, out: ToonWriter): Unit = out.writeString(x.toString)
   }
-
   val localDateTimeCodec: ToonBinaryCodec[LocalDateTime] = new ToonBinaryCodec[java.time.LocalDateTime]() {
     override def isPrimitive: Boolean = true
 
@@ -614,7 +598,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.LocalDateTime, out: ToonWriter): Unit = out.writeString(x.toString)
   }
-
   val localTimeCodec: ToonBinaryCodec[LocalTime] = new ToonBinaryCodec[java.time.LocalTime]() {
     override def isPrimitive: Boolean = true
 
@@ -627,7 +610,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.LocalTime, out: ToonWriter): Unit = out.writeString(x.toString)
   }
-
   val monthCodec: ToonBinaryCodec[Month] = new ToonBinaryCodec[java.time.Month]() {
     override def isPrimitive: Boolean = true
 
@@ -640,7 +622,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.Month, out: ToonWriter): Unit = out.writeString(x.name)
   }
-
   val monthDayCodec: ToonBinaryCodec[MonthDay] = new ToonBinaryCodec[java.time.MonthDay]() {
     override def isPrimitive: Boolean = true
 
@@ -653,7 +634,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.MonthDay, out: ToonWriter): Unit = out.writeString(x.toString)
   }
-
   val offsetDateTimeCodec: ToonBinaryCodec[OffsetDateTime] = new ToonBinaryCodec[java.time.OffsetDateTime]() {
     override def isPrimitive: Boolean = true
 
@@ -666,7 +646,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.OffsetDateTime, out: ToonWriter): Unit = out.writeString(x.toString)
   }
-
   val offsetTimeCodec: ToonBinaryCodec[OffsetTime] = new ToonBinaryCodec[java.time.OffsetTime]() {
     override def isPrimitive: Boolean = true
 
@@ -679,7 +658,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.OffsetTime, out: ToonWriter): Unit = out.writeString(x.toString)
   }
-
   val periodCodec: ToonBinaryCodec[Period] = new ToonBinaryCodec[java.time.Period]() {
     override def isPrimitive: Boolean = true
 
@@ -692,7 +670,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.Period, out: ToonWriter): Unit = out.writeString(x.toString)
   }
-
   val yearCodec: ToonBinaryCodec[Year] = new ToonBinaryCodec[java.time.Year]() {
     override def isPrimitive: Boolean = true
 
@@ -709,7 +686,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.Year, out: ToonWriter): Unit = out.writeInt(x.getValue)
   }
-
   val yearMonthCodec: ToonBinaryCodec[YearMonth] = new ToonBinaryCodec[java.time.YearMonth]() {
     override def isPrimitive: Boolean = true
 
@@ -726,7 +702,6 @@ object ToonBinaryCodec {
       s
     }
   }
-
   val zoneIdCodec: ToonBinaryCodec[ZoneId] = new ToonBinaryCodec[java.time.ZoneId]() {
     override def isPrimitive: Boolean = true
 
@@ -739,7 +714,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.ZoneId, out: ToonWriter): Unit = out.writeString(x.getId)
   }
-
   val zoneOffsetCodec: ToonBinaryCodec[ZoneOffset] = new ToonBinaryCodec[java.time.ZoneOffset]() {
     override def isPrimitive: Boolean = true
 
@@ -752,7 +726,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.ZoneOffset, out: ToonWriter): Unit = out.writeString(x.getId)
   }
-
   val zonedDateTimeCodec: ToonBinaryCodec[ZonedDateTime] = new ToonBinaryCodec[java.time.ZonedDateTime]() {
     override def isPrimitive: Boolean = true
 
@@ -765,7 +738,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.time.ZonedDateTime, out: ToonWriter): Unit = out.writeString(x.toString)
   }
-
   val currencyCodec: ToonBinaryCodec[Currency] = new ToonBinaryCodec[java.util.Currency]() {
     override def isPrimitive: Boolean = true
 
@@ -778,7 +750,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.util.Currency, out: ToonWriter): Unit = out.writeString(x.getCurrencyCode)
   }
-
   val uuidCodec: ToonBinaryCodec[UUID] = new ToonBinaryCodec[java.util.UUID]() {
     override def isPrimitive: Boolean = true
 
@@ -791,7 +762,6 @@ object ToonBinaryCodec {
 
     def encodeValue(x: java.util.UUID, out: ToonWriter): Unit = out.writeString(x.toString)
   }
-
   val dynamicValueCodec: ToonBinaryCodec[DynamicValue] = new ToonBinaryCodec[DynamicValue]() {
     private[this] val falseValue = DynamicValue.Primitive(PrimitiveValue.Boolean(false))
     private[this] val trueValue  = DynamicValue.Primitive(PrimitiveValue.Boolean(true))
@@ -908,16 +878,13 @@ object ToonBinaryCodec {
           in.consumeListItemMarker()
           builder += decodeValue(in, unitValue)
           count += 1
-        } else if (in.hasMoreLines && in.getDepth >= startDepth) {
-          count = length
-        }
+        } else if (in.hasMoreLines && in.getDepth >= startDepth) count = length
       }
     }
 
     def decodeValue(in: ToonReader, default: DynamicValue): DynamicValue = {
       in.skipBlankLines()
       if (!in.hasMoreLines) return DynamicValue.Record(Vector.empty)
-
       val content = in.peekTrimmedContent
       if (content.isEmpty) {
         val currentDepth = in.getDepth
@@ -928,16 +895,19 @@ object ToonBinaryCodec {
         }
         return DynamicValue.Record(Vector.empty)
       }
-
       if (content.startsWith("[")) {
         return decodeRootArray(in)
       }
-
       val inferred = in.inferType(content)
       inferred match {
-        case null       => in.advanceLine(); unitValue
-        case b: Boolean => in.advanceLine(); if (b) trueValue else falseValue
-        case l: Long    =>
+        case null =>
+          in.advanceLine()
+          unitValue
+        case b: Boolean =>
+          in.advanceLine()
+          if (b) trueValue
+          else falseValue
+        case l: Long =>
           in.advanceLine()
           val intVal = l.toInt
           if (l == intVal) DynamicValue.Primitive(PrimitiveValue.Int(intVal))
@@ -949,7 +919,7 @@ object ToonBinaryCodec {
           in.advanceLine()
           DynamicValue.Primitive(PrimitiveValue.BigInt(bi))
         case s: String =>
-          if (content.contains(":")) decodeRecordFields(in)
+          if (content.indexOf(':') >= 0) decodeRecordFields(in)
           else { in.advanceLine(); DynamicValue.Primitive(PrimitiveValue.String(s)) }
         case _ =>
           in.advanceLine()
@@ -965,8 +935,7 @@ object ToonBinaryCodec {
         val (rawKey, wasQuoted) = in.readKeyWithQuoteInfo()
         val bracketStart        = rawKey.indexOf('[')
         val hasArrayNotation    = bracketStart >= 0 && rawKey.indexOf(']', bracketStart) > bracketStart
-
-        val (fieldName, value) = if (wasQuoted && bracketStart > 0) {
+        val (fieldName, value)  = if (wasQuoted && bracketStart > 0) {
           val quotedPart = rawKey.substring(0, bracketStart)
           val name       =
             if (quotedPart.startsWith("\"") && quotedPart.endsWith("\""))
@@ -1022,7 +991,7 @@ object ToonBinaryCodec {
       }
 
     private def expandDottedKey(key: String, value: DynamicValue): (String, DynamicValue) =
-      if (!key.contains('.')) (key, value)
+      if (key.indexOf('.') < 0) (key, value)
       else {
         val segments = key.split('.').toList
         if (segments.forall(ToonWriter.isIdentifierSegment)) {
@@ -1074,35 +1043,27 @@ object ToonBinaryCodec {
       val content      = in.peekTrimmedContent
       val bracketStart = content.indexOf('[')
       val bracketEnd   = content.indexOf(']', bracketStart)
-
       if (bracketStart < 0 || bracketEnd < 0) {
         in.decodeError("Expected array header with []")
       }
-
-      val bracketContent  = content.substring(bracketStart + 1, bracketEnd)
-      val (length, delim) = parseLengthAndDelimiter(bracketContent)
-
+      val bracketContent        = content.substring(bracketStart + 1, bracketEnd)
+      val (length, delim)       = parseLengthAndDelimiter(bracketContent)
       var afterBracket          = bracketEnd + 1
       var fields: Array[String] = null
-
       if (afterBracket < content.length && content.charAt(afterBracket) == '{') {
         val braceEnd = content.indexOf('}', afterBracket)
         if (braceEnd < 0) in.decodeError("Expected closing } in field list")
         fields = parseFieldNames(content.substring(afterBracket + 1, braceEnd), delim)
         afterBracket = braceEnd + 1
       }
-
       if (afterBracket >= content.length || content.charAt(afterBracket) != ':') {
         in.decodeError("Expected : after array header")
       }
-
       val inlineContent = content.substring(afterBracket + 1).trim
       in.advanceLine()
       in.setActiveDelimiter(delim)
-
       val builder    = new VectorBuilder[DynamicValue]
       val startDepth = in.getDepth
-
       if (fields != null && fields.nonEmpty) {
         in.skipBlankLinesInArray(true)
         decodeTabularRows(in, fields, length, startDepth, builder)
@@ -1112,7 +1073,6 @@ object ToonBinaryCodec {
         in.skipBlankLinesInArray(true)
         decodeListItems(in, length, startDepth, builder)
       }
-
       DynamicValue.Sequence(builder.result())
     }
 
@@ -1135,23 +1095,19 @@ object ToonBinaryCodec {
     }
 
     private def decodeArrayFieldValue(in: ToonReader, rawKey: String): DynamicValue.Sequence = {
-      val bracketStart   = rawKey.indexOf('[')
-      val bracketEnd     = rawKey.indexOf(']', bracketStart)
-      val bracketContent = rawKey.substring(bracketStart + 1, bracketEnd)
-
-      val (length, delim) = parseLengthAndDelimiter(bracketContent)
-
+      val bracketStart          = rawKey.indexOf('[')
+      val bracketEnd            = rawKey.indexOf(']', bracketStart)
+      val bracketContent        = rawKey.substring(bracketStart + 1, bracketEnd)
+      val (length, delim)       = parseLengthAndDelimiter(bracketContent)
       var fields: Array[String] = null
       val braceStart            = rawKey.indexOf('{', bracketEnd)
       val braceEnd              = rawKey.indexOf('}', braceStart)
       if (braceStart > 0 && braceEnd > braceStart) {
         fields = parseFieldNames(rawKey.substring(braceStart + 1, braceEnd), delim)
       }
-
       val builder    = new VectorBuilder[DynamicValue]
       val startDepth = in.getDepth
       in.setActiveDelimiter(delim)
-
       if (fields != null && fields.nonEmpty) {
         in.advanceLine()
         in.skipBlankLinesInArray(true)
@@ -1168,7 +1124,6 @@ object ToonBinaryCodec {
           decodeListItems(in, length, startDepth, builder)
         }
       }
-
       DynamicValue.Sequence(builder.result())
     }
 
@@ -1177,7 +1132,7 @@ object ToonBinaryCodec {
       case record: DynamicValue.Record       =>
         out.keyFolding match {
           case KeyFolding.Safe =>
-            val rootLiteralDottedKeys = record.fields.map(_._1).filter(_.contains('.')).toSet
+            val rootLiteralDottedKeys = record.fields.map(_._1).filter(_.indexOf('.') >= 0).toSet
             encodeRecordWithFolding(record, out, out.flattenDepth, "", rootLiteralDottedKeys)
           case KeyFolding.Off =>
             val fields = record.fields
@@ -1334,28 +1289,28 @@ object ToonBinaryCodec {
     ): Unit = {
       val fields       = record.fields
       val topLevelKeys = fields.map(_._1).toSet
-
-      val it = fields.iterator
+      val it           = fields.iterator
       while (it.hasNext) {
         val (key, value) = it.next()
         if (remainingDepth > 1 && ToonWriter.isIdentifierSegment(key)) {
           val (foldedKey, leafValue, depth) = collectFoldableChain(key, value, remainingDepth)
-
-          val firstSegment     = foldedKey.takeWhile(_ != '.')
-          val siblingCollision = foldedKey.contains('.') && topLevelKeys.exists { otherKey =>
-            otherKey != key && otherKey.startsWith(firstSegment + ".")
+          val firstSegment                  = foldedKey.split('.')(0)
+          val siblingCollision              = foldedKey.indexOf('.') >= 0 && topLevelKeys.exists {
+            val prefix = firstSegment + '.'
+            otherKey => otherKey != key && otherKey.startsWith(prefix)
           }
-
-          val fullFoldedPath    = if (ancestorPath.isEmpty) foldedKey else ancestorPath + "." + foldedKey
-          val ancestorCollision = rootLiteralDottedKeys.exists { literalKey =>
-            literalKey.startsWith(fullFoldedPath + ".") || literalKey == fullFoldedPath ||
-            fullFoldedPath.startsWith(literalKey + ".")
+          val fullFoldedPath =
+            if (ancestorPath.isEmpty) foldedKey
+            else ancestorPath + '.' + foldedKey
+          val ancestorCollision = rootLiteralDottedKeys.exists {
+            val prefix1 = fullFoldedPath + '.'
+            val prefix2 = fullFoldedPath + '.'
+            literalKey =>
+              literalKey.startsWith(prefix1) || literalKey == fullFoldedPath || fullFoldedPath.startsWith(prefix2)
           }
-
           if (siblingCollision || ancestorCollision || depth == 1) {
             writeFieldWithNesting(key, value, out, remainingDepth, ancestorPath, rootLiteralDottedKeys)
           } else {
-            val newAncestorPath = if (ancestorPath.isEmpty) foldedKey else ancestorPath + "." + foldedKey
             leafValue match {
               case nestedRecord: DynamicValue.Record if nestedRecord.fields.nonEmpty =>
                 out.writeKeyOnly(foldedKey)
@@ -1364,7 +1319,7 @@ object ToonBinaryCodec {
                   nestedRecord,
                   out,
                   remainingDepth - depth,
-                  newAncestorPath,
+                  fullFoldedPath,
                   rootLiteralDottedKeys
                 )
                 out.decrementDepth()
@@ -1378,7 +1333,7 @@ object ToonBinaryCodec {
                   variant.value,
                   out,
                   remainingDepth - depth,
-                  newAncestorPath,
+                  fullFoldedPath,
                   rootLiteralDottedKeys
                 )
                 out.decrementDepth()
@@ -1396,7 +1351,7 @@ object ToonBinaryCodec {
                         v,
                         out,
                         remainingDepth - depth,
-                        newAncestorPath,
+                        fullFoldedPath,
                         rootLiteralDottedKeys
                       )
                     case _ =>
@@ -1419,9 +1374,7 @@ object ToonBinaryCodec {
                 out.newLine()
             }
           }
-        } else {
-          writeFieldWithNesting(key, value, out, remainingDepth, ancestorPath, rootLiteralDottedKeys)
-        }
+        } else writeFieldWithNesting(key, value, out, remainingDepth, ancestorPath, rootLiteralDottedKeys)
       }
     }
 
@@ -1433,7 +1386,9 @@ object ToonBinaryCodec {
       ancestorPath: String,
       rootLiteralDottedKeys: Set[String]
     ): Unit = {
-      val newAncestorPath = if (ancestorPath.isEmpty) key else ancestorPath + "." + key
+      val newAncestorPath =
+        if (ancestorPath.isEmpty) key
+        else ancestorPath + '.' + key
       value match {
         case nestedRecord: DynamicValue.Record if nestedRecord.fields.nonEmpty =>
           out.writeKeyOnly(key)
@@ -1498,7 +1453,7 @@ object ToonBinaryCodec {
             val (nestedKey, nestedValue) = record.fields.head
             if (ToonWriter.isIdentifierSegment(nestedKey)) {
               val (restKey, leafValue, depth) = collectFoldableChain(nestedKey, nestedValue, maxDepth - 1)
-              (key + "." + restKey, leafValue, depth + 1)
+              (key + '.' + restKey, leafValue, depth + 1)
             } else {
               (key, value, 1)
             }

--- a/schema-toon/src/main/scala/zio/blocks/schema/toon/ToonReader.scala
+++ b/schema-toon/src/main/scala/zio/blocks/schema/toon/ToonReader.scala
@@ -555,7 +555,7 @@ final class ToonReader private[toon] (
   }
 
   private def parseNumber(s: String): Any =
-    if (s.contains(".") || s.contains("e") || s.contains("E")) {
+    if (s.indexOf('.') >= 0 || s.indexOf('e') >= 0 || s.indexOf('E') >= 0) {
       val d = s.toDouble
       if (d == d.toLong && d >= Long.MinValue && d <= Long.MaxValue) d.toLong
       else d

--- a/schema-toon/src/main/scala/zio/blocks/schema/toon/ToonWriter.scala
+++ b/schema-toon/src/main/scala/zio/blocks/schema/toon/ToonWriter.scala
@@ -2,7 +2,7 @@ package zio.blocks.schema.toon
 
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets.UTF_8
-import scala.annotation.switch
+import scala.annotation.{switch, tailrec}
 
 /**
  * A writer for iterative serialization of TOON keys and values.
@@ -84,49 +84,44 @@ final class ToonWriter private (
 
   def writeNull(): Unit = writeRaw(nullBytes)
 
-  def writeBoolean(x: Boolean): Unit =
-    if (x) writeRaw(trueBytes) else writeRaw(falseBytes)
+  def writeBoolean(x: Boolean): Unit = writeRaw {
+    if (x) trueBytes
+    else falseBytes
+  }
 
-  def writeInt(x: Int): Unit = writeRaw(x.toString.getBytes(UTF_8))
+  def writeInt(x: Int): Unit = writeRaw(java.lang.Integer.toString(x).getBytes(UTF_8))
 
-  def writeLong(x: Long): Unit = writeRaw(x.toString.getBytes(UTF_8))
+  def writeLong(x: Long): Unit = writeRaw(java.lang.Long.toString(x).getBytes(UTF_8))
 
   def writeFloat(x: Float): Unit =
     if (x.isNaN || x.isInfinite) writeNull()
     else if (x == 0.0f) writeByte('0')
-    else {
-      val str = java.lang.Float.toString(x)
-      writeDecimalString(str)
-    }
+    else writeDecimalString(java.lang.Float.toString(x))
 
   def writeDouble(x: Double): Unit =
     if (x.isNaN || x.isInfinite) writeNull()
     else if (x == 0.0 || x == -0.0) writeByte('0')
-    else {
-      val str = java.lang.Double.toString(x)
-      writeDecimalString(str)
-    }
+    else writeDecimalString(java.lang.Double.toString(x))
 
-  def writeBigDecimal(x: BigDecimal): Unit = {
-    val str = x.underlying.toString
-    writeDecimalString(str)
-  }
+  def writeBigDecimal(x: BigDecimal): Unit = writeDecimalString(x.underlying.toString)
 
   def writeBigInt(x: BigInt): Unit = writeRaw(x.toString.getBytes(UTF_8))
 
   def writeChar(c: Char): Unit = writeString(c.toString)
 
-  def writeString(s: String): Unit =
-    if (needsQuoting(s, if (inlineContext) activeDelimiter else null)) writeQuotedString(s)
-    else writeRaw(s.getBytes(UTF_8))
+  def writeString(s: String): Unit = writeString(
+    s,
+    if (inlineContext) activeDelimiter
+    else null
+  )
 
   def writeString(s: String, delimiterOverride: Delimiter): Unit =
     if (needsQuoting(s, delimiterOverride)) writeQuotedString(s)
-    else writeRaw(s.getBytes(UTF_8))
+    else writeUnquotedString(s)
 
   def writeKey(key: String): Unit = {
     ensureIndent()
-    if (isValidUnquotedKey(key)) writeRaw(key.getBytes(UTF_8))
+    if (isValidUnquotedKey(key)) writeUnquotedString(key)
     else writeQuotedString(key)
     writeByte(':')
     writeByte(' ')
@@ -134,7 +129,7 @@ final class ToonWriter private (
 
   def writeKeyOnly(key: String): Unit = {
     ensureIndent()
-    if (isValidUnquotedKey(key)) writeRaw(key.getBytes(UTF_8))
+    if (isValidUnquotedKey(key)) writeUnquotedString(key)
     else writeQuotedString(key)
     writeByte(':')
     newLine()
@@ -150,11 +145,11 @@ final class ToonWriter private (
   def writeArrayHeader(key: String, length: Int, fields: Array[String], delim: Delimiter): Unit = {
     ensureIndent()
     if (key != null) {
-      if (isValidUnquotedKey(key)) writeRaw(key.getBytes(UTF_8))
+      if (isValidUnquotedKey(key)) writeUnquotedString(key)
       else writeQuotedString(key)
     }
     writeByte('[')
-    writeRaw(length.toString.getBytes(UTF_8))
+    writeInt(length)
     if (delim != Delimiter.Comma) writeByte(delim.char)
     writeByte(']')
     if (fields != null && fields.length > 0) {
@@ -163,7 +158,7 @@ final class ToonWriter private (
       while (i < fields.length) {
         if (i > 0) writeByte(delim.char)
         val field = fields(i)
-        if (isValidUnquotedKey(field)) writeRaw(field.getBytes(UTF_8))
+        if (isValidUnquotedKey(field)) writeUnquotedString(field)
         else writeQuotedString(field)
         i += 1
       }
@@ -183,7 +178,7 @@ final class ToonWriter private (
   def writeTabularHeader(length: Int, fields: Vector[String]): Unit = {
     ensureIndent()
     writeByte('[')
-    writeRaw(length.toString.getBytes(UTF_8))
+    writeInt(length)
     if (delimiter != Delimiter.Comma) writeByte(delimiter.char)
     writeByte(']')
     writeByte('{')
@@ -191,7 +186,7 @@ final class ToonWriter private (
     while (i < fields.length) {
       if (i > 0) writeByte(delimiter.char)
       val field = fields(i)
-      if (isValidUnquotedKey(field)) writeRaw(field.getBytes(UTF_8))
+      if (isValidUnquotedKey(field)) writeUnquotedString(field)
       else writeQuotedString(field)
       i += 1
     }
@@ -221,83 +216,156 @@ final class ToonWriter private (
 
   private[toon] def ensureIndent(): Unit =
     if (lineStart) {
-      var i      = 0
-      val spaces = depth * indentSize
-      while (i < spaces) {
-        writeByte(' ')
-        i += 1
-      }
+      val newLen = depth * indentSize + count
+      if (newLen > buf.length) buf = java.util.Arrays.copyOf(buf, Math.max(buf.length << 1, newLen))
+      java.util.Arrays.fill(buf, count, newLen, ' ': Byte)
+      count = newLen
       lineStart = false
     }
 
   private def writeDecimalString(str: String): Unit = {
     val eIdx   = str.indexOf('E')
-    val result = if (eIdx < 0) {
-      val e2Idx = str.indexOf('e')
-      if (e2Idx < 0) stripTrailingZeros(str)
-      else expandScientific(str, e2Idx)
-    } else expandScientific(str, eIdx)
+    val result =
+      if (eIdx < 0) {
+        val e2Idx = str.indexOf('e')
+        if (e2Idx < 0) stripTrailingZeros(str)
+        else expandScientific(str, e2Idx)
+      } else expandScientific(str, eIdx)
     writeRaw(result.getBytes(UTF_8))
   }
 
-  private def expandScientific(str: String, eIdx: Int): String = {
+  private def expandScientific(str: String, eIdx: Int): String = stripTrailingZeros {
     val mantissa = str.substring(0, eIdx)
     val exp      = str.substring(eIdx + 1).toInt
-
-    val negative            = mantissa.startsWith("-")
-    val mant                = if (negative) mantissa.substring(1) else mantissa
-    val dotIdx              = mant.indexOf('.')
-    val (intPart, fracPart) =
-      if (dotIdx < 0) (mant, "")
-      else (mant.substring(0, dotIdx), mant.substring(dotIdx + 1))
-    val digits   = intPart + fracPart
-    val pointPos = intPart.length + exp
-
-    val plain =
-      if (pointPos <= 0) {
-        "0." + ("0" * -pointPos) + digits
-      } else if (pointPos >= digits.length) {
-        digits + ("0" * (pointPos - digits.length))
-      } else {
-        digits.substring(0, pointPos) + "." + digits.substring(pointPos)
+    val mant     = mantissa.split('.')
+    val digits   = mant(0) + mant(1)
+    val pointPos = mant(0).length + exp
+    if (pointPos <= 0) {
+      val sb = new java.lang.StringBuilder(digits.length - pointPos + 2)
+      sb.append('0').append('.')
+      var i = -pointPos
+      while (i > 0) {
+        sb.append('0')
+        i -= 1
       }
-
-    val stripped = stripTrailingZeros(plain)
-    if (negative) "-" + stripped else stripped
+      sb.append(digits).toString
+    } else if (pointPos >= digits.length) {
+      val sb = new java.lang.StringBuilder(pointPos)
+      sb.append(digits)
+      var i = pointPos - digits.length
+      while (i > 0) {
+        sb.append('0')
+        i -= 1
+      }
+      sb.toString
+    } else digits.substring(0, pointPos) + '.' + digits.substring(pointPos)
   }
 
   private def writeQuotedString(s: String): Unit = {
     writeByte('"')
-    var i = 0
-    while (i < s.length) {
-      val c = s.charAt(i)
-      (c: @switch) match {
-        case '"' =>
-          writeByte('\\')
-          writeByte('"')
-        case '\\' =>
-          writeByte('\\')
-          writeByte('\\')
-        case '\n' =>
-          writeByte('\\')
-          writeByte('n')
-        case '\r' =>
-          writeByte('\\')
-          writeByte('r')
-        case '\t' =>
-          writeByte('\\')
-          writeByte('t')
-        case _ =>
-          if (c < 0x80) writeByte(c.toByte)
-          else if (Character.isHighSurrogate(c) && i + 1 < s.length && Character.isLowSurrogate(s.charAt(i + 1))) {
-            writeRaw(s.substring(i, i + 2).getBytes(UTF_8))
-            i += 1
-          } else writeRaw(Character.toString(c).getBytes(UTF_8))
-      }
-      i += 1
-    }
+    count = writeEscapedStringAsUtf8Bytes(s, 0, s.length, count, buf.length - 4)
     writeByte('"')
   }
+
+  @tailrec
+  private def writeEscapedStringAsUtf8Bytes(s: String, from: Int, to: Int, pos: Int, posLim: Int): Int =
+    if (from >= to) pos
+    else if (pos >= posLim) {
+      buf = java.util.Arrays.copyOf(buf, Math.max(buf.length << 1, count + (to - from) * 3))
+      writeEscapedStringAsUtf8Bytes(s, from, to, pos, buf.length - 4)
+    } else {
+      val ch1 = s.charAt(from).toInt
+      if (ch1 < 0x80) {
+        (ch1: @switch) match {
+          case '"' =>
+            buf(pos) = '\\'
+            buf(pos + 1) = '"'
+            writeEscapedStringAsUtf8Bytes(s, from + 1, to, pos + 2, posLim)
+          case '\\' =>
+            buf(pos) = '\\'
+            buf(pos + 1) = '\\'
+            writeEscapedStringAsUtf8Bytes(s, from + 1, to, pos + 2, posLim)
+          case '\n' =>
+            buf(pos) = '\\'
+            buf(pos + 1) = 'n'
+            writeEscapedStringAsUtf8Bytes(s, from + 1, to, pos + 2, posLim)
+          case '\r' =>
+            buf(pos) = '\\'
+            buf(pos + 1) = 'r'
+            writeEscapedStringAsUtf8Bytes(s, from + 1, to, pos + 2, posLim)
+          case '\t' =>
+            buf(pos) = '\\'
+            buf(pos + 1) = 't'
+            writeEscapedStringAsUtf8Bytes(s, from + 1, to, pos + 2, posLim)
+          case _ =>
+            buf(pos) = ch1.toByte
+            writeEscapedStringAsUtf8Bytes(s, from + 1, to, pos + 1, posLim)
+        }
+      } else if (ch1 < 0x800) { // 00000bbbbbaaaaaa (UTF-16 char) -> 110bbbbb 10aaaaaa (UTF-8 bytes)
+        buf(pos) = (ch1 >> 6 | 0xc0).toByte
+        buf(pos + 1) = (ch1 & 0x3f | 0x80).toByte
+        writeEscapedStringAsUtf8Bytes(s, from + 1, to, pos + 2, posLim)
+      } else if ((ch1 & 0xf800) != 0xd800) { // ccccbbbbbbaaaaaa (UTF-16 char) -> 1110cccc 10bbbbbb 10aaaaaa (UTF-8 bytes)
+        buf(pos) = (ch1 >> 12 | 0xe0).toByte
+        buf(pos + 1) = (ch1 >> 6 & 0x3f | 0x80).toByte
+        buf(pos + 2) = (ch1 & 0x3f | 0x80).toByte
+        writeEscapedStringAsUtf8Bytes(s, from + 1, to, pos + 3, posLim)
+      } else { // 110110uuuuccccbb 110111bbbbaaaaaa (UTF-16 chars) -> 11110ddd 10ddcccc 10bbbbbb 10aaaaaa (UTF-8 bytes), where ddddd = uuuu + 1
+        var ch2 = 0
+        if (
+          ch1 >= 0xdc00 || from + 1 >= to || {
+            ch2 = s.charAt(from + 1).toInt
+            (ch2 & 0xfc00) != 0xdc00
+          }
+        ) encodeError("Illegal surrogate pair")
+        val cp = (ch1 << 10) + (ch2 - 56613888) // -56613888 == 0x10000 - (0xD800 << 10) - 0xDC00
+        buf(pos) = (cp >> 18 | 0xf0).toByte
+        buf(pos + 1) = (cp >> 12 & 0x3f | 0x80).toByte
+        buf(pos + 2) = (cp >> 6 & 0x3f | 0x80).toByte
+        buf(pos + 3) = (cp & 0x3f | 0x80).toByte
+        writeEscapedStringAsUtf8Bytes(s, from + 2, to, pos + 4, posLim)
+      }
+    }
+
+  private def writeUnquotedString(s: String): Unit =
+    count = writeStringAsUtf8Bytes(s, 0, s.length, count, buf.length - 4)
+
+  @tailrec
+  private def writeStringAsUtf8Bytes(s: String, from: Int, to: Int, pos: Int, posLim: Int): Int =
+    if (from >= to) pos
+    else if (pos >= posLim) {
+      buf = java.util.Arrays.copyOf(buf, Math.max(buf.length << 1, count + (to - from) * 3))
+      writeStringAsUtf8Bytes(s, from, to, pos, buf.length - 4)
+    } else {
+      val ch1 = s.charAt(from).toInt
+      if (ch1 < 0x80) {
+        buf(pos) = ch1.toByte
+        writeStringAsUtf8Bytes(s, from + 1, to, pos + 1, posLim)
+      } else if (ch1 < 0x800) { // 00000bbbbbaaaaaa (UTF-16 char) -> 110bbbbb 10aaaaaa (UTF-8 bytes)
+        buf(pos) = (ch1 >> 6 | 0xc0).toByte
+        buf(pos + 1) = (ch1 & 0x3f | 0x80).toByte
+        writeStringAsUtf8Bytes(s, from + 1, to, pos + 2, posLim)
+      } else if ((ch1 & 0xf800) != 0xd800) { // ccccbbbbbbaaaaaa (UTF-16 char) -> 1110cccc 10bbbbbb 10aaaaaa (UTF-8 bytes)
+        buf(pos) = (ch1 >> 12 | 0xe0).toByte
+        buf(pos + 1) = (ch1 >> 6 & 0x3f | 0x80).toByte
+        buf(pos + 2) = (ch1 & 0x3f | 0x80).toByte
+        writeStringAsUtf8Bytes(s, from + 1, to, pos + 3, posLim)
+      } else { // 110110uuuuccccbb 110111bbbbaaaaaa (UTF-16 chars) -> 11110ddd 10ddcccc 10bbbbbb 10aaaaaa (UTF-8 bytes), where ddddd = uuuu + 1
+        var ch2 = 0
+        if (
+          ch1 >= 0xdc00 || from + 1 >= to || {
+            ch2 = s.charAt(from + 1).toInt
+            (ch2 & 0xfc00) != 0xdc00
+          }
+        ) encodeError("Illegal surrogate pair")
+        val cp = (ch1 << 10) + (ch2 - 56613888) // -56613888 == 0x10000 - (0xD800 << 10) - 0xDC00
+        buf(pos) = (cp >> 18 | 0xf0).toByte
+        buf(pos + 1) = (cp >> 12 & 0x3f | 0x80).toByte
+        buf(pos + 2) = (cp >> 6 & 0x3f | 0x80).toByte
+        buf(pos + 3) = (cp & 0x3f | 0x80).toByte
+        writeStringAsUtf8Bytes(s, from + 2, to, pos + 4, posLim)
+      }
+    }
 
   private def writeByte(b: Int): Unit = {
     if (count >= buf.length) buf = java.util.Arrays.copyOf(buf, buf.length << 1)
@@ -319,17 +387,19 @@ object ToonWriter {
   private val trueBytes  = "true".getBytes(UTF_8)
   private val falseBytes = "false".getBytes(UTF_8)
 
-  private val validKeyPattern          = "^[A-Za-z_][A-Za-z0-9_.]*$".r.pattern
-  private val identifierSegmentPattern = "^[A-Za-z_][A-Za-z0-9_]*$".r.pattern
-  private val numericPattern           = "^-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$".r.pattern
-  private val leadingZeroPattern       = "^0\\d+$".r.pattern
-
-  /**
-   * Checks if a key segment is a valid IdentifierSegment per TOON spec.
-   * Pattern: ^[A-Za-z_][A-Za-z0-9_]*$ (no dots, no hyphens, no special chars)
-   */
-  private[toon] def isIdentifierSegment(key: String): Boolean =
-    key.nonEmpty && identifierSegmentPattern.matcher(key).matches()
+  private[toon] def isIdentifierSegment(key: String): Boolean = {
+    val len = key.length
+    var i   = 0
+    while (i < len) {
+      val c = key.charAt(i)
+      val a = c | 0x20
+      if (!(a >= 'a' && a <= 'z' || c == '_' || i > 0 && (c >= '0' && c <= '9'))) {
+        return false
+      }
+      i += 1
+    }
+    i != 0
+  }
 
   private val pool: ThreadLocal[ToonWriter] = new ThreadLocal[ToonWriter] {
     override def initialValue(): ToonWriter =
@@ -376,23 +446,68 @@ object ToonWriter {
       config.discriminatorField
     )
 
-  private def isValidUnquotedKey(key: String): Boolean =
-    key.nonEmpty && validKeyPattern.matcher(key).matches()
+  private def isValidUnquotedKey(key: String): Boolean = {
+    val len = key.length
+    var i   = 0
+    while (i < len) {
+      val c = key.charAt(i)
+      val a = c | 0x20
+      if (!(a >= 'a' && a <= 'z' || c == '_' || i > 0 && (c >= '0' && c <= '9' || c == '.'))) {
+        return false
+      }
+      i += 1
+    }
+    i != 0
+  }
 
   private def needsQuoting(s: String, delimiter: Delimiter): Boolean = {
     if (s.isEmpty) return true
-    if (s.charAt(0) == ' ' || s.charAt(s.length - 1) == ' ') return true
-    if (s.charAt(0) == '-') return true
+    var c   = s.charAt(0)
+    val len = s.length
+    if (c == '-' || c == ' ' || s.charAt(len - 1) == ' ') return true
     if (s == "true" || s == "false" || s == "null") return true
-    if (numericPattern.matcher(s).matches() || leadingZeroPattern.matcher(s).matches()) return true
-
+    if (c >= '0' && c <= '9') {
+      var hasDot = false
+      var i      = 1
+      while (
+        i < len && {
+          c = s.charAt(i)
+          c >= '0' && c <= '9' || c == '.' && !hasDot && {
+            hasDot = true
+            true
+          }
+        }
+      ) i += 1
+      if (
+        i < len && {
+          c = s.charAt(i)
+          c == 'e' || c == 'E'
+        }
+      ) {
+        i += 1
+        if (
+          i < len && {
+            c = s.charAt(i)
+            c == '+' || c == '-'
+          }
+        ) {
+          i += 1
+        }
+        while (
+          i < len && {
+            c = s.charAt(i)
+            c >= '0' && c <= '9'
+          }
+        ) i += 1
+      }
+      if (i == len) return true
+    }
     var i = 0
-    while (i < s.length) {
-      val c = s.charAt(i)
-      if (c == '"' || c == '\\') return true
-      if (c == '\n' || c == '\r' || c == '\t') return true
-      if (c == ':') return true
-      if (c == '[' || c == ']' || c == '{' || c == '}') return true
+    while (i < len) {
+      c = s.charAt(i)
+      if (
+        c == '"' || c == '\\' || c == '\n' || c == '\r' || c == '\t' || c == ':' || c == '[' || c == ']' || c == '{' || c == '}'
+      ) return true
       if (delimiter != null && c == delimiter.char) return true
       i += 1
     }
@@ -400,7 +515,7 @@ object ToonWriter {
   }
 
   private def stripTrailingZeros(s: String): String = {
-    if (!s.contains(".")) return s
+    if (s.indexOf('.') < 0) return s
     var end = s.length
     while (end > 0 && s.charAt(end - 1) == '0') end -= 1
     if (end > 0 && s.charAt(end - 1) == '.') end -= 1


### PR DESCRIPTION
2x times faster with 4x times less allocations:

```txt
Benchmark                                                       (size)   Mode  Cnt          Score        Error   Units
ToonListOfRecordsBenchmark.writingZioBlocks                          1  thrpt    5    6152855.991 ± 135178.868   ops/s
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate            1  thrpt    5       3285.306 ±     71.937  MB/sec
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate.norm       1  thrpt    5        560.001 ±      0.001    B/op
ToonListOfRecordsBenchmark.writingZioBlocks:gc.count                 1  thrpt    5         11.000               counts
ToonListOfRecordsBenchmark.writingZioBlocks:gc.time                  1  thrpt    5         16.000                   ms
ToonListOfRecordsBenchmark.writingZioBlocks                         10  thrpt    5     657152.600 ±   7187.251   ops/s
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate           10  thrpt    5       3122.988 ±     33.415  MB/sec
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate.norm      10  thrpt    5       4984.009 ±      0.001    B/op
ToonListOfRecordsBenchmark.writingZioBlocks:gc.count                10  thrpt    5         10.000               counts
ToonListOfRecordsBenchmark.writingZioBlocks:gc.time                 10  thrpt    5         16.000                   ms
ToonListOfRecordsBenchmark.writingZioBlocks                        100  thrpt    5      63256.709 ±   5200.569   ops/s
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate          100  thrpt    5       2966.013 ±    242.651  MB/sec
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate.norm     100  thrpt    5      49176.093 ±      0.008    B/op
ToonListOfRecordsBenchmark.writingZioBlocks:gc.count               100  thrpt    5         10.000               counts
ToonListOfRecordsBenchmark.writingZioBlocks:gc.time                100  thrpt    5         16.000                   ms
ToonListOfRecordsBenchmark.writingZioBlocks                       1000  thrpt    5       6190.778 ±    125.004   ops/s
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate         1000  thrpt    5       2898.713 ±     58.637  MB/sec
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate.norm    1000  thrpt    5     491072.951 ±      0.019    B/op
ToonListOfRecordsBenchmark.writingZioBlocks:gc.count              1000  thrpt    5          9.000               counts
ToonListOfRecordsBenchmark.writingZioBlocks:gc.time               1000  thrpt    5         17.000                   ms
ToonListOfRecordsBenchmark.writingZioBlocks                      10000  thrpt    5        617.857 ±      5.776   ops/s
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate        10000  thrpt    5       2892.317 ±     27.231  MB/sec
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate.norm   10000  thrpt    5    4910081.565 ±      0.400    B/op
ToonListOfRecordsBenchmark.writingZioBlocks:gc.count             10000  thrpt    5         10.000               counts
ToonListOfRecordsBenchmark.writingZioBlocks:gc.time              10000  thrpt    5         28.000                   ms
ToonListOfRecordsBenchmark.writingZioBlocks                     100000  thrpt    5         55.259 ±     14.137   ops/s
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate       100000  thrpt    5       2586.213 ±    661.983  MB/sec
ToonListOfRecordsBenchmark.writingZioBlocks:gc.alloc.rate.norm  100000  thrpt    5   49100226.442 ±     30.271    B/op
ToonListOfRecordsBenchmark.writingZioBlocks:gc.count            100000  thrpt    5          9.000               counts
ToonListOfRecordsBenchmark.writingZioBlocks:gc.time             100000  thrpt    5        206.000                   ms
```