### PR TITLE
feat: add Json data type with encoder/decoder

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/json/Json.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/Json.scala
@@ -1,0 +1,149 @@
+package zio.blocks.schema.json
+
+import zio.Chunk
+
+sealed trait Json { self =>
+  def typeIndex: Int
+
+  def isNull: Boolean = this == Json.Null
+  def isBoolean: Boolean = this.isInstanceOf[Json.Bool]
+  def isNumber: Boolean = this.isInstanceOf[Json.Num]
+  def isString: Boolean = this.isInstanceOf[Json.Str]
+  def isArray: Boolean = this.isInstanceOf[Json.Arr]
+  def isObject: Boolean = this.isInstanceOf[Json.Obj]
+
+  def asBoolean: Option[Boolean] = this match {
+    case Json.Bool(value) => Some(value)
+    case _                => None
+  }
+
+  def asNumber: Option[java.math.BigDecimal] = this match {
+    case Json.Num(value) => Some(value)
+    case _               => None
+  }
+
+  def asString: Option[String] = this match {
+    case Json.Str(value) => Some(value)
+    case _               => None
+  }
+
+  def asArray: Option[Chunk[Json]] = this match {
+    case Json.Arr(elements) => Some(elements)
+    case _                  => None
+  }
+
+  def asObject: Option[Chunk[(String, Json)]] = this match {
+    case Json.Obj(fields) => Some(fields)
+    case _                => None
+  }
+
+  def apply(key: String): Option[Json] = this match {
+    case Json.Obj(fields) => fields.find(_._1 == key).map(_._2)
+    case _                => None
+  }
+
+  def apply(index: Int): Option[Json] = this match {
+    case Json.Arr(elements) if index >= 0 && index < elements.length => Some(elements(index))
+    case _ => None
+  }
+
+  def merge(that: Json): Json = (this, that) match {
+    case (Json.Obj(fields1), Json.Obj(fields2)) =>
+      val merged = fields1.foldLeft(fields2.toMap) { case (acc, (k, v)) =>
+        acc.get(k) match {
+          case Some(existing) => acc.updated(k, v.merge(existing))
+          case None           => acc.updated(k, v)
+        }
+      }
+      Json.Obj(Chunk.fromIterable(merged.toSeq))
+    case (_, that) => that
+  }
+
+  def foldDown[A](z: A)(f: (A, Json) => A): A = {
+    val acc = f(z, this)
+    this match {
+      case Json.Arr(elements) => elements.foldLeft(acc)((a, j) => j.foldDown(a)(f))
+      case Json.Obj(fields)   => fields.foldLeft(acc)((a, kv) => kv._2.foldDown(a)(f))
+      case _                  => acc
+    }
+  }
+
+  def foldUp[A](z: A)(f: (A, Json) => A): A = {
+    val inner = this match {
+      case Json.Arr(elements) => elements.foldLeft(z)((a, j) => j.foldUp(a)(f))
+      case Json.Obj(fields)   => fields.foldLeft(z)((a, kv) => kv._2.foldUp(a)(f))
+      case _                  => z
+    }
+    f(inner, this)
+  }
+
+  def transformDown(f: Json => Json): Json = {
+    val transformed = f(this)
+    transformed match {
+      case Json.Arr(elements) => Json.Arr(elements.map(_.transformDown(f)))
+      case Json.Obj(fields)   => Json.Obj(fields.map { case (k, v) => (k, v.transformDown(f)) })
+      case other              => other
+    }
+  }
+
+  def transformUp(f: Json => Json): Json = {
+    val inner = this match {
+      case Json.Arr(elements) => Json.Arr(elements.map(_.transformUp(f)))
+      case Json.Obj(fields)   => Json.Obj(fields.map { case (k, v) => (k, v.transformUp(f)) })
+      case other              => other
+    }
+    f(inner)
+  }
+
+  def dropNulls: Json = transformDown {
+    case Json.Obj(fields) => Json.Obj(fields.filter(_._2 != Json.Null))
+    case other            => other
+  }
+
+  def sortKeys: Json = transformDown {
+    case Json.Obj(fields) => Json.Obj(Chunk.fromIterable(fields.sortBy(_._1)))
+    case other            => other
+  }
+
+  def normalize: Json = dropNulls.sortKeys
+}
+
+object Json {
+  case object Null extends Json {
+    def typeIndex: Int = 0
+  }
+
+  final case class Bool(value: Boolean) extends Json {
+    def typeIndex: Int = 1
+  }
+
+  final case class Num(value: java.math.BigDecimal) extends Json {
+    def typeIndex: Int = 2
+  }
+
+  final case class Str(value: String) extends Json {
+    def typeIndex: Int = 3
+  }
+
+  final case class Arr(elements: Chunk[Json]) extends Json {
+    def typeIndex: Int = 4
+  }
+
+  final case class Obj(fields: Chunk[(String, Json)]) extends Json {
+    def typeIndex: Int = 5
+
+    def toMap: Map[String, Json] = fields.toMap
+  }
+
+  def obj(fields: (String, Json)*): Obj = Obj(Chunk.fromIterable(fields))
+  def arr(elements: Json*): Arr = Arr(Chunk.fromIterable(elements))
+  def str(value: String): Str = Str(value)
+  def num(value: Int): Num = Num(java.math.BigDecimal.valueOf(value.toLong))
+  def num(value: Long): Num = Num(java.math.BigDecimal.valueOf(value))
+  def num(value: Double): Num = Num(java.math.BigDecimal.valueOf(value))
+  def num(value: java.math.BigDecimal): Num = Num(value)
+  def bool(value: Boolean): Bool = Bool(value)
+  val `null`: Null.type = Null
+  val `true`: Bool = Bool(true)
+  val `false`: Bool = Bool(false)
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonCodec.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonCodec.scala
@@ -1,0 +1,147 @@
+package zio.blocks.schema.json
+
+import zio.Chunk
+
+trait JsonDecoder[A] { self =>
+  def decode(json: Json): Either[JsonError, A]
+
+  def map[B](f: A => B): JsonDecoder[B] = new JsonDecoder[B] {
+    def decode(json: Json): Either[JsonError, B] = self.decode(json).map(f)
+  }
+
+  def flatMap[B](f: A => JsonDecoder[B]): JsonDecoder[B] = new JsonDecoder[B] {
+    def decode(json: Json): Either[JsonError, B] =
+      self.decode(json).flatMap(a => f(a).decode(json))
+  }
+
+  def orElse[A1 >: A](that: => JsonDecoder[A1]): JsonDecoder[A1] = new JsonDecoder[A1] {
+    def decode(json: Json): Either[JsonError, A1] =
+      self.decode(json).orElse(that.decode(json))
+  }
+}
+
+object JsonDecoder {
+  def apply[A](implicit decoder: JsonDecoder[A]): JsonDecoder[A] = decoder
+
+  def instance[A](f: Json => Either[JsonError, A]): JsonDecoder[A] = new JsonDecoder[A] {
+    def decode(json: Json): Either[JsonError, A] = f(json)
+  }
+
+  implicit val jsonDecoder: JsonDecoder[Json] = instance(Right(_))
+
+  implicit val stringDecoder: JsonDecoder[String] = instance {
+    case Json.Str(value) => Right(value)
+    case other           => Left(JsonError.typeMismatch("String", other.getClass.getSimpleName))
+  }
+
+  implicit val booleanDecoder: JsonDecoder[Boolean] = instance {
+    case Json.Bool(value) => Right(value)
+    case other            => Left(JsonError.typeMismatch("Boolean", other.getClass.getSimpleName))
+  }
+
+  implicit val intDecoder: JsonDecoder[Int] = instance {
+    case Json.Num(value) => Right(value.intValue)
+    case other           => Left(JsonError.typeMismatch("Number", other.getClass.getSimpleName))
+  }
+
+  implicit val longDecoder: JsonDecoder[Long] = instance {
+    case Json.Num(value) => Right(value.longValue)
+    case other           => Left(JsonError.typeMismatch("Number", other.getClass.getSimpleName))
+  }
+
+  implicit val doubleDecoder: JsonDecoder[Double] = instance {
+    case Json.Num(value) => Right(value.doubleValue)
+    case other           => Left(JsonError.typeMismatch("Number", other.getClass.getSimpleName))
+  }
+
+  implicit val bigDecimalDecoder: JsonDecoder[java.math.BigDecimal] = instance {
+    case Json.Num(value) => Right(value)
+    case other           => Left(JsonError.typeMismatch("Number", other.getClass.getSimpleName))
+  }
+
+  implicit def optionDecoder[A](implicit decoder: JsonDecoder[A]): JsonDecoder[Option[A]] = instance {
+    case Json.Null => Right(None)
+    case json      => decoder.decode(json).map(Some(_))
+  }
+
+  implicit def chunkDecoder[A](implicit decoder: JsonDecoder[A]): JsonDecoder[Chunk[A]] = instance {
+    case Json.Arr(elements) =>
+      elements.zipWithIndex.foldLeft[Either[JsonError, Chunk[A]]](Right(Chunk.empty)) {
+        case (Right(acc), (elem, idx)) =>
+          decoder.decode(elem) match {
+            case Right(a)    => Right(acc :+ a)
+            case Left(error) => Left(error.atIndex(idx))
+          }
+        case (left, _) => left
+      }
+    case other => Left(JsonError.typeMismatch("Array", other.getClass.getSimpleName))
+  }
+
+  implicit def listDecoder[A](implicit decoder: JsonDecoder[A]): JsonDecoder[List[A]] =
+    chunkDecoder[A].map(_.toList)
+
+  implicit def vectorDecoder[A](implicit decoder: JsonDecoder[A]): JsonDecoder[Vector[A]] =
+    chunkDecoder[A].map(_.toVector)
+
+  implicit def mapDecoder[A](implicit decoder: JsonDecoder[A]): JsonDecoder[Map[String, A]] = instance {
+    case Json.Obj(fields) =>
+      fields.foldLeft[Either[JsonError, Map[String, A]]](Right(Map.empty)) {
+        case (Right(acc), (key, value)) =>
+          decoder.decode(value) match {
+            case Right(a)    => Right(acc + (key -> a))
+            case Left(error) => Left(error.atKey(key))
+          }
+        case (left, _) => left
+      }
+    case other => Left(JsonError.typeMismatch("Object", other.getClass.getSimpleName))
+  }
+}
+
+trait JsonEncoder[A] { self =>
+  def encode(value: A): Json
+
+  def contramap[B](f: B => A): JsonEncoder[B] = new JsonEncoder[B] {
+    def encode(value: B): Json = self.encode(f(value))
+  }
+}
+
+object JsonEncoder {
+  def apply[A](implicit encoder: JsonEncoder[A]): JsonEncoder[A] = encoder
+
+  def instance[A](f: A => Json): JsonEncoder[A] = new JsonEncoder[A] {
+    def encode(value: A): Json = f(value)
+  }
+
+  implicit val jsonEncoder: JsonEncoder[Json] = instance(identity)
+
+  implicit val stringEncoder: JsonEncoder[String] = instance(Json.Str(_))
+
+  implicit val booleanEncoder: JsonEncoder[Boolean] = instance(Json.Bool(_))
+
+  implicit val intEncoder: JsonEncoder[Int] = instance(n => Json.num(n))
+
+  implicit val longEncoder: JsonEncoder[Long] = instance(n => Json.num(n))
+
+  implicit val doubleEncoder: JsonEncoder[Double] = instance(n => Json.num(n))
+
+  implicit val bigDecimalEncoder: JsonEncoder[java.math.BigDecimal] = instance(Json.Num(_))
+
+  implicit def optionEncoder[A](implicit encoder: JsonEncoder[A]): JsonEncoder[Option[A]] = instance {
+    case Some(value) => encoder.encode(value)
+    case None        => Json.Null
+  }
+
+  implicit def chunkEncoder[A](implicit encoder: JsonEncoder[A]): JsonEncoder[Chunk[A]] = instance { chunk =>
+    Json.Arr(chunk.map(encoder.encode))
+  }
+
+  implicit def listEncoder[A](implicit encoder: JsonEncoder[A]): JsonEncoder[List[A]] =
+    chunkEncoder[A].contramap(Chunk.fromIterable(_))
+
+  implicit def vectorEncoder[A](implicit encoder: JsonEncoder[A]): JsonEncoder[Vector[A]] =
+    chunkEncoder[A].contramap(Chunk.fromIterable(_))
+
+  implicit def mapEncoder[A](implicit encoder: JsonEncoder[A]): JsonEncoder[Map[String, A]] = instance { m =>
+    Json.Obj(Chunk.fromIterable(m.map { case (k, v) => (k, encoder.encode(v)) }))
+  }
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonError.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonError.scala
@@ -1,0 +1,98 @@
+package zio.blocks.schema.json
+
+import zio.Chunk
+
+sealed trait JsonError {
+  def message: String
+  def path: Chunk[JsonPathSegment]
+  def position: Option[JsonPosition]
+
+  def atPath(segment: JsonPathSegment): JsonError
+  def atIndex(index: Int): JsonError = atPath(JsonPathSegment.Index(index))
+  def atKey(key: String): JsonError = atPath(JsonPathSegment.Key(key))
+
+  def withPosition(pos: JsonPosition): JsonError
+
+  def pathString: String = path.map {
+    case JsonPathSegment.Key(k)   => s".$k"
+    case JsonPathSegment.Index(i) => s"[$i]"
+  }.mkString
+
+  override def toString: String = {
+    val posStr = position.map(p => s" at line ${p.line}, column ${p.column}").getOrElse("")
+    s"$message$posStr (path: $pathString)"
+  }
+}
+
+object JsonError {
+  final case class ParseError(
+    message: String,
+    path: Chunk[JsonPathSegment] = Chunk.empty,
+    position: Option[JsonPosition] = None
+  ) extends JsonError {
+    def atPath(segment: JsonPathSegment): JsonError =
+      copy(path = segment +: path)
+
+    def withPosition(pos: JsonPosition): JsonError =
+      copy(position = Some(pos))
+  }
+
+  final case class DecodeError(
+    message: String,
+    path: Chunk[JsonPathSegment] = Chunk.empty,
+    position: Option[JsonPosition] = None
+  ) extends JsonError {
+    def atPath(segment: JsonPathSegment): JsonError =
+      copy(path = segment +: path)
+
+    def withPosition(pos: JsonPosition): JsonError =
+      copy(position = Some(pos))
+  }
+
+  final case class TypeMismatch(
+    expected: String,
+    actual: String,
+    path: Chunk[JsonPathSegment] = Chunk.empty,
+    position: Option[JsonPosition] = None
+  ) extends JsonError {
+    def message: String = s"Expected $expected but found $actual"
+
+    def atPath(segment: JsonPathSegment): JsonError =
+      copy(path = segment +: path)
+
+    def withPosition(pos: JsonPosition): JsonError =
+      copy(position = Some(pos))
+  }
+
+  final case class MissingField(
+    fieldName: String,
+    path: Chunk[JsonPathSegment] = Chunk.empty,
+    position: Option[JsonPosition] = None
+  ) extends JsonError {
+    def message: String = s"Missing required field: $fieldName"
+
+    def atPath(segment: JsonPathSegment): JsonError =
+      copy(path = segment +: path)
+
+    def withPosition(pos: JsonPosition): JsonError =
+      copy(position = Some(pos))
+  }
+
+  def parse(message: String): JsonError = ParseError(message)
+  def decode(message: String): JsonError = DecodeError(message)
+  def typeMismatch(expected: String, actual: String): JsonError = TypeMismatch(expected, actual)
+  def missingField(name: String): JsonError = MissingField(name)
+}
+
+sealed trait JsonPathSegment
+
+object JsonPathSegment {
+  final case class Key(name: String) extends JsonPathSegment
+  final case class Index(index: Int) extends JsonPathSegment
+}
+
+final case class JsonPosition(
+  line: Int,
+  column: Int,
+  offset: Long
+)

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSpec.scala
@@ -1,0 +1,103 @@
+package zio.blocks.schema.json
+
+import zio.Chunk
+import zio.test._
+import zio.test.Assertion._
+
+object JsonSpec extends ZIOSpecDefault {
+  def spec = suite("JsonSpec")(
+    suite("Json construction")(
+      test("obj creates object") {
+        val json = Json.obj("name" -> Json.str("test"), "value" -> Json.num(42))
+        assertTrue(json.isObject)
+      },
+      test("arr creates array") {
+        val json = Json.arr(Json.num(1), Json.num(2), Json.num(3))
+        assertTrue(json.isArray)
+      },
+      test("null is null") {
+        assertTrue(Json.`null`.isNull)
+      },
+      test("true is boolean") {
+        assertTrue(Json.`true`.isBoolean && Json.`true`.asBoolean.contains(true))
+      },
+      test("false is boolean") {
+        assertTrue(Json.`false`.isBoolean && Json.`false`.asBoolean.contains(false))
+      }
+    ),
+    suite("Json access")(
+      test("apply with key returns field value") {
+        val json = Json.obj("name" -> Json.str("test"))
+        assertTrue(json("name").contains(Json.str("test")))
+      },
+      test("apply with missing key returns None") {
+        val json = Json.obj("name" -> Json.str("test"))
+        assertTrue(json("missing").isEmpty)
+      },
+      test("apply with index returns element") {
+        val json = Json.arr(Json.num(1), Json.num(2), Json.num(3))
+        assertTrue(json(1).contains(Json.num(2)))
+      },
+      test("apply with out of bounds index returns None") {
+        val json = Json.arr(Json.num(1))
+        assertTrue(json(5).isEmpty)
+      }
+    ),
+    suite("Json transformations")(
+      test("dropNulls removes null values") {
+        val json = Json.obj("a" -> Json.str("value"), "b" -> Json.Null)
+        val result = json.dropNulls
+        assertTrue(result.asObject.exists(_.length == 1))
+      },
+      test("sortKeys sorts object keys") {
+        val json = Json.obj("z" -> Json.num(1), "a" -> Json.num(2))
+        val result = json.sortKeys
+        val keys = result.asObject.map(_.map(_._1).toList)
+        assertTrue(keys.contains(List("a", "z")))
+      },
+      test("merge combines objects") {
+        val json1 = Json.obj("a" -> Json.num(1))
+        val json2 = Json.obj("b" -> Json.num(2))
+        val merged = json1.merge(json2)
+        assertTrue(merged.asObject.exists(_.length == 2))
+      }
+    ),
+    suite("JsonDecoder")(
+      test("decodes string") {
+        val result = JsonDecoder[String].decode(Json.str("hello"))
+        assertTrue(result == Right("hello"))
+      },
+      test("decodes int") {
+        val result = JsonDecoder[Int].decode(Json.num(42))
+        assertTrue(result == Right(42))
+      },
+      test("decodes list") {
+        val json = Json.arr(Json.num(1), Json.num(2), Json.num(3))
+        val result = JsonDecoder[List[Int]].decode(json)
+        assertTrue(result == Right(List(1, 2, 3)))
+      },
+      test("returns error for type mismatch") {
+        val result = JsonDecoder[String].decode(Json.num(42))
+        assertTrue(result.isLeft)
+      }
+    ),
+    suite("JsonEncoder")(
+      test("encodes string") {
+        val result = JsonEncoder[String].encode("hello")
+        assertTrue(result == Json.str("hello"))
+      },
+      test("encodes int") {
+        val result = JsonEncoder[Int].encode(42)
+        assertTrue(result.asNumber.exists(_.intValue == 42))
+      },
+      test("encodes list") {
+        val result = JsonEncoder[List[Int]].encode(List(1, 2, 3))
+        assertTrue(result.isArray && result.asArray.exists(_.length == 3))
+      },
+      test("encodes map") {
+        val result = JsonEncoder[Map[String, Int]].encode(Map("a" -> 1))
+        assertTrue(result.isObject && result("a").exists(_.asNumber.exists(_.intValue == 1)))
+      }
+    )
+  )
+}


### PR DESCRIPTION
/claim #679

## Summary
Initial implementation of the Json ADT for ZIO Schema 2 as specified in #679.

## Implemented Features

### Core Types
- `Json` sealed trait with six cases: `Null`, `Bool`, `Num`, `Str`, `Arr`, `Obj`
- `JsonError` with path tracking, position info, and common error types
- `JsonDecoder[A]` and `JsonEncoder[A]` type classes

### Json Operations
- Type checking methods: `isNull`, `isBoolean`, `isNumber`, `isString`, `isArray`, `isObject`
- Safe accessors: `asBoolean`, `asNumber`, `asString`, `asArray`, `asObject`
- Path-based navigation: `apply(key: String)`, `apply(index: Int)`
- Transformations: `transformDown`, `transformUp`, `foldDown`, `foldUp`
- Utilities: `dropNulls`, `sortKeys`, `normalize`, `merge`

### Type Class Instances
- Primitives: `String`, `Boolean`, `Int`, `Long`, `Double`, `BigDecimal`
- Collections: `Option[A]`, `Chunk[A]`, `List[A]`, `Vector[A]`, `Map[String, A]`
- Json passthrough

### Tests
- Construction tests
- Access/navigation tests
- Transformation tests
- Encoder/decoder tests

## TODO (Not Yet Implemented)
- [ ] JsonSelection for fluent chaining
- [ ] DynamicValue bidirectional conversion
- [ ] Parsing from String/Chunk/ByteBuffer
- [ ] Schema derivation integration
- [ ] More comprehensive transformation operations

This is a partial implementation to start the conversation and get feedback on the direction.

Addresses #679