### PR TITLE
Fix pruneImpl to recurse into Variant values

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/DynamicValue.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/DynamicValue.scala
@@ -1637,8 +1637,7 @@ object DynamicValue {
       })
     case v: Variant =>
       val childPath = path.caseOf(v.caseNameValue)
-      if (p(childPath, v.value)) dv
-      else Variant(v.caseNameValue, pruneImpl(v.value, childPath, p))
+      Variant(v.caseNameValue, pruneImpl(v.value, childPath, p))
     case other => other
   }
 


### PR DESCRIPTION
## Summary

The `Variant` case in `pruneImpl` incorrectly returned the original value unchanged when `p(childPath, v.value)` was true, instead of recursing into nested values. This made pruning inconsistent for values wrapped in variants compared to `Record`/`Sequence`/`Map`.

## The Bug

```scala
case v: Variant =>
  val childPath = path.caseOf(v.caseNameValue)
  if (p(childPath, v.value)) dv  // ← Returns original, unpruned!
  else Variant(v.caseNameValue, pruneImpl(v.value, childPath, p))
```

When the variant's inner value matched the predicate, pruning short-circuited and returned `dv` unchanged—nested values that should have been pruned were preserved.

## The Fix

`Variant` is now treated as a transparent wrapper that always recurses:

```scala
case v: Variant =>
  val childPath = path.caseOf(v.caseNameValue)
  Variant(v.caseNameValue, pruneImpl(v.value, childPath, p))
```

This matches the semantics of how prune works on other container types.