### PR TITLE
fix(schema): move defaultValue and examples from Binding to Reflect (#869)

### DIFF
--- a/schema-toon/src/main/scala/zio/blocks/schema/toon/codec/RecordCodecBuilder.scala
+++ b/schema-toon/src/main/scala/zio/blocks/schema/toon/codec/RecordCodecBuilder.scala
@@ -2,7 +2,6 @@ package zio.blocks.schema.toon.codec
 
 import zio.blocks.schema._
 import zio.blocks.schema.binding.{Binding, Registers, RegisterOffset}
-import zio.blocks.schema.derive.BindingInstance
 import zio.blocks.schema.toon._
 import zio.blocks.schema.toon.ToonCodecUtils.unescapeQuoted
 
@@ -33,16 +32,7 @@ private[toon] final class RecordCodecBuilder(
 
   private def defaultValue[F[_, _], A](fieldReflect: Reflect[F, A]): Option[() => Any] =
     if (requireDefaultValueFields) None
-    else
-      {
-        if (fieldReflect.isPrimitive) fieldReflect.asPrimitive.get.primitiveBinding
-        else if (fieldReflect.isRecord) fieldReflect.asRecord.get.recordBinding
-        else if (fieldReflect.isVariant) fieldReflect.asVariant.get.variantBinding
-        else if (fieldReflect.isSequence) fieldReflect.asSequenceUnknown.get.sequence.seqBinding
-        else if (fieldReflect.isMap) fieldReflect.asMapUnknown.get.map.mapBinding
-        else if (fieldReflect.isWrapper) fieldReflect.asWrapperUnknown.get.wrapper.wrapperBinding
-        else fieldReflect.asDynamic.get.dynamicBinding
-      }.asInstanceOf[BindingInstance[ToonBinaryCodec, _, A]].binding.defaultValue
+    else fieldReflect.asInstanceOf[Reflect[Binding, A]].getDefaultValue.map(v => () => v)
 
   private def stripQuotes(s: String, from: Int, to: Int): String =
     if (to - from >= 2 && s.charAt(from) == '"' && s.charAt(to - 1) == '"') s.substring(from + 1, to - 1)

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/DerivedOptics.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/DerivedOptics.scala
@@ -186,11 +186,7 @@ object DerivedOptics {
           val b = wrapper.binding.unwrap(value)
           writer(registers, offset, b)
         }
-      },
-      defaultValue = wrapper.wrapped.binding.defaultValue.map(b =>
-        () => wrapper.binding.wrap(b()).getOrElse(throw new RuntimeException("Default value invalid"))
-      ),
-      examples = Nil
+      }
     )
 
     Reflect.Record(

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
@@ -232,11 +232,9 @@ private object SchemaCompanionVersionSpecific {
         fieldInfo.defaultValue match {
           case Some(dv) =>
             if (ms eq Nil) {
-              if (isNonRec) q"$schema.reflect.defaultValue($dv).asTerm[$sTpe]($name)"
-              else q"new Reflect.Deferred(() => $schema.reflect.defaultValue($dv)).asTerm[$sTpe]($name)"
-            } else if (isNonRec) q"$schema.reflect.defaultValue($dv).asTerm[$sTpe]($name).copy(modifiers = $ms)"
-            else {
-              q"new Reflect.Deferred(() => $schema.reflect.defaultValue($dv)).asTerm[$sTpe]($name).copy(modifiers = $ms)"
+              q"new Reflect.Deferred(() => $schema.reflect).defaultValue($dv).asTerm[$sTpe]($name)"
+            } else {
+              q"new Reflect.Deferred(() => $schema.reflect).defaultValue($dv).asTerm[$sTpe]($name).copy(modifiers = $ms)"
             }
           case _ =>
             if (ms eq Nil) {

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/DerivedOptics.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/DerivedOptics.scala
@@ -251,11 +251,7 @@ object DerivedOptics {
           val b = wrapper.binding.unwrap(value)
           writer(registers, offset, b)
         }
-      },
-      defaultValue = wrapper.wrapped.binding.defaultValue.map(b =>
-        () => wrapper.binding.wrap(b()).getOrElse(throw new RuntimeException("Default value invalid"))
-      ),
-      examples = Nil
+      }
     )
 
     Reflect.Record(

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
@@ -427,17 +427,13 @@ private class SchemaCompanionVersionSpecificImpl(using Quotes) {
               case Some(dvSelect) =>
                 val dv = dvSelect.asExpr.asInstanceOf[Expr[ft]]
                 if (modifiers eq Nil) {
-                  if (isNonRec) '{ $schema.reflect.defaultValue($dv).asTerm[S]($name) }
-                  else '{ new Reflect.Deferred(() => $schema.reflect).defaultValue($dv).asTerm[S]($name) }
+                  '{ new Reflect.Deferred(() => $schema.reflect).defaultValue($dv).asTerm[S]($name) }
                 } else {
-                  if (isNonRec) '{ $schema.reflect.defaultValue($dv).asTerm[S]($name).copy(modifiers = $ms) }
-                  else {
-                    '{
-                      new Reflect.Deferred(() => $schema.reflect)
-                        .defaultValue($dv)
-                        .asTerm[S]($name)
-                        .copy(modifiers = $ms)
-                    }
+                  '{
+                    new Reflect.Deferred(() => $schema.reflect)
+                      .defaultValue($dv)
+                      .asTerm[S]($name)
+                      .copy(modifiers = $ms)
                   }
                 }
               case _ =>

--- a/schema/shared/src/main/scala/zio/blocks/schema/ReflectTransformer.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/ReflectTransformer.scala
@@ -9,7 +9,9 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
     typeName: TypeName[A],
     metadata: F[BindingType.Record, A],
     doc: Doc,
-    modifiers: Seq[Modifier.Reflect]
+    modifiers: Seq[Modifier.Reflect],
+    storedDefaultValue: Option[DynamicValue],
+    storedExamples: collection.immutable.Seq[DynamicValue]
   ): Lazy[Reflect.Record[G, A]]
 
   def transformVariant[A](
@@ -18,7 +20,9 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
     typeName: TypeName[A],
     metadata: F[BindingType.Variant, A],
     doc: Doc,
-    modifiers: Seq[Modifier.Reflect]
+    modifiers: Seq[Modifier.Reflect],
+    storedDefaultValue: Option[DynamicValue],
+    storedExamples: collection.immutable.Seq[DynamicValue]
   ): Lazy[Reflect.Variant[G, A]]
 
   def transformSequence[A, C[_]](
@@ -27,7 +31,9 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
     typeName: TypeName[C[A]],
     metadata: F[BindingType.Seq[C], C[A]],
     doc: Doc,
-    modifiers: Seq[Modifier.Reflect]
+    modifiers: Seq[Modifier.Reflect],
+    storedDefaultValue: Option[DynamicValue],
+    storedExamples: collection.immutable.Seq[DynamicValue]
   ): Lazy[Reflect.Sequence[G, A, C]]
 
   def transformMap[Key, Value, M[_, _]](
@@ -37,7 +43,9 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
     typeName: TypeName[M[Key, Value]],
     metadata: F[BindingType.Map[M], M[Key, Value]],
     doc: Doc,
-    modifiers: Seq[Modifier.Reflect]
+    modifiers: Seq[Modifier.Reflect],
+    storedDefaultValue: Option[DynamicValue],
+    storedExamples: collection.immutable.Seq[DynamicValue]
   ): Lazy[Reflect.Map[G, Key, Value, M]]
 
   def transformDynamic(
@@ -45,7 +53,9 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
     typeName: TypeName[DynamicValue],
     metadata: F[BindingType.Dynamic, DynamicValue],
     doc: Doc,
-    modifiers: Seq[Modifier.Reflect]
+    modifiers: Seq[Modifier.Reflect],
+    storedDefaultValue: Option[DynamicValue],
+    storedExamples: collection.immutable.Seq[DynamicValue]
   ): Lazy[Reflect.Dynamic[G]]
 
   def transformPrimitive[A](
@@ -54,7 +64,9 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
     typeName: TypeName[A],
     metadata: F[BindingType.Primitive, A],
     doc: Doc,
-    modifiers: Seq[Modifier.Reflect]
+    modifiers: Seq[Modifier.Reflect],
+    storedDefaultValue: Option[DynamicValue],
+    storedExamples: collection.immutable.Seq[DynamicValue]
   ): Lazy[Reflect.Primitive[G, A]]
 
   def transformWrapper[A, B](
@@ -64,7 +76,9 @@ trait ReflectTransformer[-F[_, _], G[_, _]] {
     wrapperPrimitiveType: Option[PrimitiveType[A]],
     metadata: F[BindingType.Wrapper[A, B], A],
     doc: Doc,
-    modifiers: Seq[Modifier.Reflect]
+    modifiers: Seq[Modifier.Reflect],
+    storedDefaultValue: Option[DynamicValue],
+    storedExamples: collection.immutable.Seq[DynamicValue]
   ): Lazy[Reflect.Wrapper[G, A, B]]
 }
 
@@ -78,11 +92,13 @@ object ReflectTransformer {
       typeName: TypeName[A],
       metadata: F[BindingType.Record, A],
       doc: Doc,
-      modifiers: Seq[Modifier.Reflect]
+      modifiers: Seq[Modifier.Reflect],
+      storedDefaultValue: Option[DynamicValue],
+      storedExamples: collection.immutable.Seq[DynamicValue]
     ): Lazy[Reflect.Record[G, A]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield new Reflect.Record(fields, typeName, binding, doc, modifiers)
+      } yield new Reflect.Record(fields, typeName, binding, doc, modifiers, storedDefaultValue, storedExamples)
 
     def transformVariant[A](
       path: DynamicOptic,
@@ -90,11 +106,13 @@ object ReflectTransformer {
       typeName: TypeName[A],
       metadata: F[BindingType.Variant, A],
       doc: Doc,
-      modifiers: Seq[Modifier.Reflect]
+      modifiers: Seq[Modifier.Reflect],
+      storedDefaultValue: Option[DynamicValue],
+      storedExamples: collection.immutable.Seq[DynamicValue]
     ): Lazy[Reflect.Variant[G, A]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield new Reflect.Variant(cases, typeName, binding, doc, modifiers)
+      } yield new Reflect.Variant(cases, typeName, binding, doc, modifiers, storedDefaultValue, storedExamples)
 
     def transformSequence[A, C[_]](
       path: DynamicOptic,
@@ -102,11 +120,13 @@ object ReflectTransformer {
       typeName: TypeName[C[A]],
       metadata: F[BindingType.Seq[C], C[A]],
       doc: Doc,
-      modifiers: Seq[Modifier.Reflect]
+      modifiers: Seq[Modifier.Reflect],
+      storedDefaultValue: Option[DynamicValue],
+      storedExamples: collection.immutable.Seq[DynamicValue]
     ): Lazy[Reflect.Sequence[G, A, C]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield new Reflect.Sequence(element, typeName, binding, doc, modifiers)
+      } yield new Reflect.Sequence(element, typeName, binding, doc, modifiers, storedDefaultValue, storedExamples)
 
     def transformMap[Key, Value, M[_, _]](
       path: DynamicOptic,
@@ -115,22 +135,26 @@ object ReflectTransformer {
       typeName: TypeName[M[Key, Value]],
       metadata: F[BindingType.Map[M], M[Key, Value]],
       doc: Doc,
-      modifiers: Seq[Modifier.Reflect]
+      modifiers: Seq[Modifier.Reflect],
+      storedDefaultValue: Option[DynamicValue],
+      storedExamples: collection.immutable.Seq[DynamicValue]
     ): Lazy[Reflect.Map[G, Key, Value, M]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield Reflect.Map(key, value, typeName, binding, doc, modifiers)
+      } yield Reflect.Map(key, value, typeName, binding, doc, modifiers, storedDefaultValue, storedExamples)
 
     def transformDynamic(
       path: DynamicOptic,
       typeName: TypeName[DynamicValue],
       metadata: F[BindingType.Dynamic, DynamicValue],
       doc: Doc,
-      modifiers: Seq[Modifier.Reflect]
+      modifiers: Seq[Modifier.Reflect],
+      storedDefaultValue: Option[DynamicValue],
+      storedExamples: collection.immutable.Seq[DynamicValue]
     ): Lazy[Reflect.Dynamic[G]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield new Reflect.Dynamic(binding, typeName, doc, modifiers)
+      } yield new Reflect.Dynamic(binding, typeName, doc, modifiers, storedDefaultValue, storedExamples)
 
     def transformPrimitive[A](
       path: DynamicOptic,
@@ -138,11 +162,21 @@ object ReflectTransformer {
       typeName: TypeName[A],
       metadata: F[BindingType.Primitive, A],
       doc: Doc,
-      modifiers: Seq[Modifier.Reflect]
+      modifiers: Seq[Modifier.Reflect],
+      storedDefaultValue: Option[DynamicValue],
+      storedExamples: collection.immutable.Seq[DynamicValue]
     ): Lazy[Reflect.Primitive[G, A]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield new Reflect.Primitive(primitiveType, typeName, binding, doc, modifiers)
+      } yield new Reflect.Primitive(
+        primitiveType,
+        typeName,
+        binding,
+        doc,
+        modifiers,
+        storedDefaultValue,
+        storedExamples
+      )
 
     def transformWrapper[A, B](
       path: DynamicOptic,
@@ -151,11 +185,22 @@ object ReflectTransformer {
       wrapperPrimitiveType: Option[PrimitiveType[A]],
       metadata: F[BindingType.Wrapper[A, B], A],
       doc: Doc,
-      modifiers: Seq[Modifier.Reflect]
+      modifiers: Seq[Modifier.Reflect],
+      storedDefaultValue: Option[DynamicValue],
+      storedExamples: collection.immutable.Seq[DynamicValue]
     ): Lazy[Reflect.Wrapper[G, A, B]] =
       for {
         binding <- transformMetadata(metadata)
-      } yield new Reflect.Wrapper(wrapped, typeName, wrapperPrimitiveType, binding, doc, modifiers)
+      } yield new Reflect.Wrapper(
+        wrapped,
+        typeName,
+        wrapperPrimitiveType,
+        binding,
+        doc,
+        modifiers,
+        storedDefaultValue,
+        storedExamples
+      )
   }
 
   private type Any2[_, _] = Any

--- a/schema/shared/src/main/scala/zio/blocks/schema/binding/Binding.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/binding/Binding.scala
@@ -15,33 +15,10 @@ import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
  * the reflection type `Int` that has a record binding (and therefore, both a
  * constructor and a deconstructor).
  */
-sealed trait Binding[T, A] {
-
-  /**
-   * An optional generator for a default value for the type `A`.
-   */
-  def defaultValue: Option[() => A]
-
-  def defaultValue(value: => A): Binding[T, A]
-
-  /**
-   * A user-defined list of example values for the type `A`, to be used for
-   * testing and documentation.
-   */
-  def examples: Seq[A]
-
-  def examples(value: A, values: A*): Binding[T, A]
-}
+sealed trait Binding[T, +A]
 
 object Binding {
-  final case class Primitive[A](
-    defaultValue: Option[() => A] = None,
-    examples: collection.immutable.Seq[A] = Nil
-  ) extends Binding[BindingType.Primitive, A] {
-    def defaultValue(value: => A): Primitive[A] = copy(defaultValue = new Some(() => value))
-
-    def examples(value: A, values: A*): Primitive[A] = copy(examples = value :: values.toList)
-  }
+  final case class Primitive[A]() extends Binding[BindingType.Primitive, A]
 
   object Primitive {
     val unit: Primitive[Unit] = new Primitive[Unit]()
@@ -107,14 +84,8 @@ object Binding {
 
   final case class Record[A](
     constructor: Constructor[A],
-    deconstructor: Deconstructor[A],
-    defaultValue: Option[() => A] = None,
-    examples: collection.immutable.Seq[A] = Nil
-  ) extends Binding[BindingType.Record, A] {
-    def defaultValue(value: => A): Record[A] = copy(defaultValue = new Some(() => value))
-
-    def examples(value: A, values: A*): Record[A] = copy(examples = value :: values.toList)
-  }
+    deconstructor: Deconstructor[A]
+  ) extends Binding[BindingType.Record, A]
 
   object Record {
     def some[A <: AnyRef]: Record[Some[A]] = new Record(
@@ -294,14 +265,8 @@ object Binding {
 
   final case class Variant[A](
     discriminator: Discriminator[A],
-    matchers: Matchers[A],
-    defaultValue: Option[() => A] = None,
-    examples: collection.immutable.Seq[A] = Nil
-  ) extends Binding[BindingType.Variant, A] {
-    def defaultValue(value: => A): Variant[A] = copy(defaultValue = new Some(() => value))
-
-    def examples(value: A, values: A*): Variant[A] = copy(examples = value :: values.toList)
-  }
+    matchers: Matchers[A]
+  ) extends Binding[BindingType.Variant, A]
 
   object Variant {
     def option[A]: Variant[Option[A]] = new Variant(
@@ -349,14 +314,8 @@ object Binding {
 
   final case class Seq[C[_], A](
     constructor: SeqConstructor[C],
-    deconstructor: SeqDeconstructor[C],
-    defaultValue: Option[() => C[A]] = None,
-    examples: collection.immutable.Seq[C[A]] = Nil
-  ) extends Binding[BindingType.Seq[C], C[A]] {
-    def defaultValue(value: => C[A]): Seq[C, A] = copy(defaultValue = new Some(() => value))
-
-    def examples(value: C[A], values: C[A]*): Seq[C, A] = copy(examples = value :: values.toList)
-  }
+    deconstructor: SeqDeconstructor[C]
+  ) extends Binding[BindingType.Seq[C], C[A]]
 
   object Seq {
     def set[A]: Seq[Set, A] = new Seq(SeqConstructor.setConstructor, SeqDeconstructor.setDeconstructor)
@@ -376,14 +335,8 @@ object Binding {
 
   final case class Map[M[_, _], K, V](
     constructor: MapConstructor[M],
-    deconstructor: MapDeconstructor[M],
-    defaultValue: Option[() => M[K, V]] = None,
-    examples: collection.immutable.Seq[M[K, V]] = Nil
-  ) extends Binding[BindingType.Map[M], M[K, V]] {
-    def defaultValue(value: => M[K, V]): Map[M, K, V] = copy(defaultValue = new Some(() => value))
-
-    def examples(value: M[K, V], values: M[K, V]*): Map[M, K, V] = copy(examples = value :: values.toList)
-  }
+    deconstructor: MapDeconstructor[M]
+  ) extends Binding[BindingType.Map[M], M[K, V]]
 
   object Map {
     def map[K, V]: Map[Predef.Map, K, V] = new Map(MapConstructor.map, MapDeconstructor.map)
@@ -391,23 +344,10 @@ object Binding {
 
   final case class Wrapper[A, B](
     wrap: B => Either[SchemaError, A],
-    unwrap: A => B,
-    defaultValue: Option[() => A] = None,
-    examples: collection.immutable.Seq[A] = Nil
-  ) extends Binding[BindingType.Wrapper[A, B], A] {
-    def defaultValue(value: => A): Wrapper[A, B] = copy(defaultValue = new Some(() => value))
+    unwrap: A => B
+  ) extends Binding[BindingType.Wrapper[A, B], A]
 
-    def examples(value: A, values: A*): Wrapper[A, B] = copy(examples = value :: values.toList)
-  }
-
-  final case class Dynamic(
-    defaultValue: Option[() => DynamicValue] = None,
-    examples: collection.immutable.Seq[DynamicValue] = Nil
-  ) extends Binding[BindingType.Dynamic, DynamicValue] {
-    def defaultValue(value: => DynamicValue): Dynamic = copy(defaultValue = new Some(() => value))
-
-    def examples(value: DynamicValue, values: DynamicValue*): Dynamic = copy(examples = value :: values.toList)
-  }
+  final case class Dynamic() extends Binding[BindingType.Dynamic, DynamicValue]
 
   implicit val bindingHasBinding: HasBinding[Binding] = new HasBinding[Binding] {
     def binding[T, A](fa: Binding[T, A]): Binding[T, A] = fa

--- a/schema/shared/src/main/scala/zio/blocks/schema/binding/HasBinding.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/binding/HasBinding.scala
@@ -11,8 +11,8 @@ trait HasBinding[F[_, _]] extends ReflectTransformer.OnlyMetadata[F, Binding] {
 
   final def primitive[A](fa: F[BindingType.Primitive, A]): Binding.Primitive[A] =
     binding(fa) match {
-      case primitive: Binding.Primitive[A] => primitive
-      case _                               => sys.error("Expected Binding.Primitive")
+      case primitive: Binding.Primitive[A] @scala.unchecked => primitive
+      case _                                                => sys.error("Expected Binding.Primitive")
     }
 
   final def updatePrimitive[A](
@@ -22,21 +22,21 @@ trait HasBinding[F[_, _]] extends ReflectTransformer.OnlyMetadata[F, Binding] {
     updateBinding(
       fa,
       {
-        case primitive: Binding.Primitive[A] => f(primitive)
-        case _                               => sys.error("Expected Binding.Primitive")
+        case primitive: Binding.Primitive[A] @scala.unchecked => f(primitive)
+        case _                                                => sys.error("Expected Binding.Primitive")
       }
     )
 
   final def record[A](fa: F[BindingType.Record, A]): Binding.Record[A] =
     binding(fa) match {
-      case record: Binding.Record[A] => record
-      case _                         => sys.error("Expected Binding.Record")
+      case record: Binding.Record[A] @scala.unchecked => record
+      case _                                          => sys.error("Expected Binding.Record")
     }
 
   final def variant[A](fa: F[BindingType.Variant, A]): Binding.Variant[A] =
     binding(fa) match {
-      case variant: Binding.Variant[A] => variant
-      case _                           => sys.error("Expected Binding.Variant")
+      case variant: Binding.Variant[A] @scala.unchecked => variant
+      case _                                            => sys.error("Expected Binding.Variant")
     }
 
   final def constructor[A](fa: F[BindingType.Record, A]): Constructor[A] = record(fa).constructor
@@ -48,8 +48,8 @@ trait HasBinding[F[_, _]] extends ReflectTransformer.OnlyMetadata[F, Binding] {
     updateBinding(
       fa,
       {
-        case record: Binding.Record[A] => record.copy(constructor = f(record.constructor))
-        case _                         => sys.error("Expected Binding.Record")
+        case record: Binding.Record[A] @scala.unchecked => record.copy(constructor = f(record.constructor))
+        case _                                          => sys.error("Expected Binding.Record")
       }
     )
 
@@ -62,8 +62,8 @@ trait HasBinding[F[_, _]] extends ReflectTransformer.OnlyMetadata[F, Binding] {
     updateBinding(
       fa,
       {
-        case record: Binding.Record[A] => record.copy(deconstructor = f(record.deconstructor))
-        case _                         => sys.error("Expected Binding.Record")
+        case record: Binding.Record[A] @scala.unchecked => record.copy(deconstructor = f(record.deconstructor))
+        case _                                          => sys.error("Expected Binding.Record")
       }
     )
 
@@ -76,8 +76,8 @@ trait HasBinding[F[_, _]] extends ReflectTransformer.OnlyMetadata[F, Binding] {
     updateBinding(
       fa,
       {
-        case variant: Binding.Variant[A] => variant.copy(discriminator = f(variant.discriminator))
-        case _                           => sys.error("Expected Binding.Variant")
+        case variant: Binding.Variant[A] @scala.unchecked => variant.copy(discriminator = f(variant.discriminator))
+        case _                                            => sys.error("Expected Binding.Variant")
       }
     )
 
@@ -87,8 +87,8 @@ trait HasBinding[F[_, _]] extends ReflectTransformer.OnlyMetadata[F, Binding] {
     updateBinding(
       fa,
       {
-        case variant: Binding.Variant[A] => variant.copy(matchers = f(variant.matchers))
-        case _                           => sys.error("Expected Binding.Variant")
+        case variant: Binding.Variant[A] @scala.unchecked => variant.copy(matchers = f(variant.matchers))
+        case _                                            => sys.error("Expected Binding.Variant")
       }
     )
 
@@ -142,7 +142,7 @@ trait HasBinding[F[_, _]] extends ReflectTransformer.OnlyMetadata[F, Binding] {
 
   final def wrapper[A, B](fa: F[BindingType.Wrapper[A, B], A]): Binding.Wrapper[A, B] =
     binding(fa) match {
-      case wrapper: Binding.Wrapper[A, B] => wrapper
-      case _                              => sys.error("Expected Binding.Wrapper")
+      case wrapper: Binding.Wrapper[A, B] @scala.unchecked => wrapper
+      case _                                               => sys.error("Expected Binding.Wrapper")
     }
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
@@ -121,7 +121,9 @@ final case class DerivationBuilder[TC[_], A](
             typeName: TypeName[A0],
             metadata: F[BindingType.Record, A0],
             doc: Doc,
-            modifiers: Seq[Modifier.Reflect]
+            modifiers: Seq[Modifier.Reflect],
+            storedDefaultValue: Option[DynamicValue],
+            storedExamples: collection.immutable.Seq[DynamicValue]
           ): Lazy[Reflect.Record[G, A0]] = Lazy {
             val instance = getCustomInstance[A0](path, typeName).getOrElse {
               val modifiersToPrepend = combineModifiers(path, typeName)
@@ -145,7 +147,15 @@ final case class DerivationBuilder[TC[_], A](
                   prependCombinedModifiers(modifiers, path, typeName)
                 )
             }
-            new Reflect.Record(fields, typeName, new BindingInstance(metadata, instance), doc, modifiers)
+            new Reflect.Record(
+              fields,
+              typeName,
+              new BindingInstance(metadata, instance),
+              doc,
+              modifiers,
+              storedDefaultValue,
+              storedExamples
+            )
           }
 
           override def transformVariant[A0](
@@ -154,7 +164,9 @@ final case class DerivationBuilder[TC[_], A](
             typeName: TypeName[A0],
             metadata: F[BindingType.Variant, A0],
             doc: Doc,
-            modifiers: Seq[Modifier.Reflect]
+            modifiers: Seq[Modifier.Reflect],
+            storedDefaultValue: Option[DynamicValue],
+            storedExamples: collection.immutable.Seq[DynamicValue]
           ): Lazy[Reflect.Variant[G, A0]] = Lazy {
             val instance = getCustomInstance[A0](path, typeName).getOrElse {
               val modifiersToAdd = combineModifiers(path, typeName)
@@ -181,7 +193,15 @@ final case class DerivationBuilder[TC[_], A](
                   prependCombinedModifiers(modifiers, path, typeName)
                 )
             }
-            new Reflect.Variant(cases, typeName, new BindingInstance(metadata, instance), doc, modifiers)
+            new Reflect.Variant(
+              cases,
+              typeName,
+              new BindingInstance(metadata, instance),
+              doc,
+              modifiers,
+              storedDefaultValue,
+              storedExamples
+            )
           }
 
           override def transformSequence[A0, C[_]](
@@ -190,13 +210,23 @@ final case class DerivationBuilder[TC[_], A](
             typeName: TypeName[C[A0]],
             metadata: F[BindingType.Seq[C], C[A0]],
             doc: Doc,
-            modifiers: Seq[Modifier.Reflect]
+            modifiers: Seq[Modifier.Reflect],
+            storedDefaultValue: Option[DynamicValue],
+            storedExamples: collection.immutable.Seq[DynamicValue]
           ): Lazy[Reflect.Sequence[G, A0, C]] = Lazy {
             val instance = getCustomInstance[C[A0]](path, typeName).getOrElse(
               deriver
                 .deriveSequence(element, typeName, metadata, doc, prependCombinedModifiers(modifiers, path, typeName))
             )
-            new Reflect.Sequence(element, typeName, new BindingInstance(metadata, instance), doc, modifiers)
+            new Reflect.Sequence(
+              element,
+              typeName,
+              new BindingInstance(metadata, instance),
+              doc,
+              modifiers,
+              storedDefaultValue,
+              storedExamples
+            )
           }
 
           override def transformMap[Key, Value, M[_, _]](
@@ -206,13 +236,24 @@ final case class DerivationBuilder[TC[_], A](
             typeName: TypeName[M[Key, Value]],
             metadata: F[BindingType.Map[M], M[Key, Value]],
             doc: Doc,
-            modifiers: Seq[Modifier.Reflect]
+            modifiers: Seq[Modifier.Reflect],
+            storedDefaultValue: Option[DynamicValue],
+            storedExamples: collection.immutable.Seq[DynamicValue]
           ): Lazy[Reflect.Map[G, Key, Value, M]] = Lazy {
             val instance = getCustomInstance[M[Key, Value]](path, typeName).getOrElse(
               deriver
                 .deriveMap(key, value, typeName, metadata, doc, prependCombinedModifiers(modifiers, path, typeName))
             )
-            new Reflect.Map(key, value, typeName, new BindingInstance(metadata, instance), doc, modifiers)
+            new Reflect.Map(
+              key,
+              value,
+              typeName,
+              new BindingInstance(metadata, instance),
+              doc,
+              modifiers,
+              storedDefaultValue,
+              storedExamples
+            )
           }
 
           override def transformDynamic(
@@ -220,11 +261,20 @@ final case class DerivationBuilder[TC[_], A](
             typeName: TypeName[DynamicValue],
             metadata: F[BindingType.Dynamic, DynamicValue],
             doc: Doc,
-            modifiers: Seq[Modifier.Reflect]
+            modifiers: Seq[Modifier.Reflect],
+            storedDefaultValue: Option[DynamicValue],
+            storedExamples: collection.immutable.Seq[DynamicValue]
           ): Lazy[Reflect.Dynamic[G]] = Lazy {
             val instance = getCustomInstance[DynamicValue](path, TypeName.dynamicValue)
               .getOrElse(deriver.deriveDynamic[G](metadata, doc, prependCombinedModifiers(modifiers, path, typeName)))
-            new Reflect.Dynamic(new BindingInstance(metadata, instance), typeName, doc, modifiers)
+            new Reflect.Dynamic(
+              new BindingInstance(metadata, instance),
+              typeName,
+              doc,
+              modifiers,
+              storedDefaultValue,
+              storedExamples
+            )
           }
 
           override def transformPrimitive[A0](
@@ -233,7 +283,9 @@ final case class DerivationBuilder[TC[_], A](
             typeName: TypeName[A0],
             metadata: F[BindingType.Primitive, A0],
             doc: Doc,
-            modifiers: Seq[Modifier.Reflect]
+            modifiers: Seq[Modifier.Reflect],
+            storedDefaultValue: Option[DynamicValue],
+            storedExamples: collection.immutable.Seq[DynamicValue]
           ): Lazy[Reflect.Primitive[G, A0]] = Lazy {
             val instance = getCustomInstance[A0](path, typeName).getOrElse(
               deriver
@@ -245,7 +297,15 @@ final case class DerivationBuilder[TC[_], A](
                   prependCombinedModifiers(modifiers, path, typeName)
                 )
             )
-            new Reflect.Primitive(primitiveType, typeName, new BindingInstance(metadata, instance), doc, modifiers)
+            new Reflect.Primitive(
+              primitiveType,
+              typeName,
+              new BindingInstance(metadata, instance),
+              doc,
+              modifiers,
+              storedDefaultValue,
+              storedExamples
+            )
           }
 
           override def transformWrapper[A0, B](
@@ -255,7 +315,9 @@ final case class DerivationBuilder[TC[_], A](
             wrapperPrimitiveType: Option[PrimitiveType[A0]],
             metadata: F[BindingType.Wrapper[A0, B], A0],
             doc: Doc,
-            modifiers: Seq[Modifier.Reflect]
+            modifiers: Seq[Modifier.Reflect],
+            storedDefaultValue: Option[DynamicValue],
+            storedExamples: collection.immutable.Seq[DynamicValue]
           ): Lazy[Reflect.Wrapper[G, A0, B]] = Lazy {
             val instance = getCustomInstance[A0](path, typeName)
               .getOrElse(
@@ -274,7 +336,9 @@ final case class DerivationBuilder[TC[_], A](
               wrapperPrimitiveType,
               new BindingInstance(metadata, instance),
               doc,
-              modifiers
+              modifiers,
+              storedDefaultValue,
+              storedExamples
             )
           }
         }

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonBinaryCodecDeriver.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonBinaryCodecDeriver.scala
@@ -2033,16 +2033,7 @@ class JsonBinaryCodecDeriver private[json] (
 
   private[this] def defaultValue[F[_, _], A](fieldReflect: Reflect[F, A]): Option[() => ?] =
     if (requireDefaultValueFields) None
-    else
-      {
-        if (fieldReflect.isPrimitive) fieldReflect.asPrimitive.get.primitiveBinding
-        else if (fieldReflect.isRecord) fieldReflect.asRecord.get.recordBinding
-        else if (fieldReflect.isVariant) fieldReflect.asVariant.get.variantBinding
-        else if (fieldReflect.isSequence) fieldReflect.asSequenceUnknown.get.sequence.seqBinding
-        else if (fieldReflect.isMap) fieldReflect.asMapUnknown.get.map.mapBinding
-        else if (fieldReflect.isWrapper) fieldReflect.asWrapperUnknown.get.wrapper.wrapperBinding
-        else fieldReflect.asDynamic.get.dynamicBinding
-      }.asInstanceOf[BindingInstance[TC, ?, A]].binding.defaultValue
+    else fieldReflect.asInstanceOf[Reflect[Binding, A]].getDefaultValue.map(v => () => v)
 
   private[this] def discriminator[F[_, _], A](caseReflect: Reflect[F, A]): Discriminator[?] =
     caseReflect.asVariant.get.variantBinding

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
@@ -1430,8 +1430,16 @@ object SchemaSpec extends SchemaBaseSpec {
           typeName = TypeName.map(TypeName.int, TypeName.long),
           mapBinding = Binding.Map[Map, Int, Long](
             constructor = MapConstructor.map,
-            deconstructor = MapDeconstructor.map,
-            examples = Map(1 -> 1L, 2 -> 2L, 3 -> 3L) :: Nil
+            deconstructor = MapDeconstructor.map
+          ),
+          storedExamples = Seq(
+            DynamicValue.Map(
+              zio.blocks.chunk.Chunk(
+                (DynamicValue.Primitive(PrimitiveValue.Int(1)), DynamicValue.Primitive(PrimitiveValue.Long(1L))),
+                (DynamicValue.Primitive(PrimitiveValue.Int(2)), DynamicValue.Primitive(PrimitiveValue.Long(2L))),
+                (DynamicValue.Primitive(PrimitiveValue.Int(3)), DynamicValue.Primitive(PrimitiveValue.Long(3L)))
+              )
+            )
           )
         )
         assert(Schema(map1).examples)(equalTo(Map(1 -> 1L, 2 -> 2L, 3 -> 3L) :: Nil)) &&
@@ -1594,7 +1602,8 @@ object SchemaSpec extends SchemaBaseSpec {
           Primitive(
             PrimitiveType.Int(Validation.Numeric.Positive),
             TypeName.int,
-            Binding.Primitive(examples = Seq(1, 2, 3))
+            Binding.Primitive(),
+            storedExamples = Seq(1, 2, 3).map(i => DynamicValue.Primitive(PrimitiveValue.Int(i)))
           )
         }
         assert(Schema(deferred1).examples)(equalTo(Seq(1, 2, 3))) &&


### PR DESCRIPTION
## Summary

This PR moves the storage of `defaultValue` and `examples` from `Binding` subtypes to `Reflect` subtypes, storing them as `DynamicValue`. The public API remains unchanged.

## Changes

### Core Changes
- Add `storedDefaultValue: Option[DynamicValue]` and `storedExamples: Seq[DynamicValue]` fields to all `Reflect` subtypes (`Record`, `Variant`, `Sequence`, `Map`, `Wrapper`, `Dynamic`, `Primitive`)
- For `Deferred`, use `deferredDefaultValue: Option[() => A]` and `deferredExamples: Seq[() => A]` to defer evaluation
- Update `getDefaultValue`/`examples` getters to read from stored fields (deserializing from `DynamicValue`)
- Update `defaultValue`/`examples` setters to serialize to `DynamicValue`
- Remove `defaultValue` and `examples` from all `Binding` subtypes
- Make `Binding` trait covariant in `A` type parameter (`sealed trait Binding[T, +A]`)
- Update `ReflectTransformer` to pass through `storedDefaultValue` and `storedExamples`

### Bug Fixes
Fixed a `StackOverflowError` during `Schema.derived` for case classes with default values:
- Always use `Deferred` for fields with default values (both Scala 2 and 3 macros)
- Call `.defaultValue()` on the `Deferred` rather than inside the thunk to defer evaluation of the default value expression
- Preserve `deferredDefaultValue`/`deferredExamples` in `Deferred.transform` to ensure defaults survive schema transformations

### Consumer Updates
- `JsonBinaryCodecDeriver`: Use `fieldReflect.getDefaultValue` instead of `binding.defaultValue`
- `RecordCodecBuilder` (schema-toon): Same update

## Testing
- All `schemaJVM` tests pass (Scala 2.13 and 3.3.7)
- All downstream module tests pass (`schema-avro`, `schema-bson`, `schema-messagepack`, `schema-thrift`, `schema-toon`, `streams`)
- Coverage run completed

Closes #869