### PR TITLE
feat(binding): make Binding.Seq and Binding.Map covariant in element types

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/binding/Binding.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/binding/Binding.scala
@@ -1,5 +1,7 @@
 package zio.blocks.schema.binding
 
+import scala.annotation.unchecked.uncheckedVariance
+
 import zio.blocks.chunk.Chunk
 import zio.blocks.schema.{DynamicValue, SchemaError}
 import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
@@ -312,10 +314,10 @@ object Binding {
     )
   }
 
-  final case class Seq[C[_], A](
+  final case class Seq[C[_], +A](
     constructor: SeqConstructor[C],
     deconstructor: SeqDeconstructor[C]
-  ) extends Binding[BindingType.Seq[C], C[A]]
+  ) extends Binding[BindingType.Seq[C], C[A @uncheckedVariance]]
 
   object Seq {
     def set[A]: Seq[Set, A] = new Seq(SeqConstructor.setConstructor, SeqDeconstructor.setDeconstructor)
@@ -333,10 +335,10 @@ object Binding {
     def chunk[A]: Seq[Chunk, A] = new Seq(SeqConstructor.chunkConstructor, SeqDeconstructor.chunkDeconstructor)
   }
 
-  final case class Map[M[_, _], K, V](
+  final case class Map[M[_, _], +K, +V](
     constructor: MapConstructor[M],
     deconstructor: MapDeconstructor[M]
-  ) extends Binding[BindingType.Map[M], M[K, V]]
+  ) extends Binding[BindingType.Map[M], M[K @uncheckedVariance, V @uncheckedVariance]]
 
   object Map {
     def map[K, V]: Map[Predef.Map, K, V] = new Map(MapConstructor.map, MapDeconstructor.map)


### PR DESCRIPTION
## Summary

Makes `Binding.Seq` and `Binding.Map` covariant in their element type parameters using `@uncheckedVariance`.

## Changes

- `Binding.Seq[C[_], A]` → `Binding.Seq[C[_], +A]`
- `Binding.Map[M[_, _], K, V]` → `Binding.Map[M[_, _], +K, +V]`

## Why @uncheckedVariance is safe

The type parameters `A`, `K`, and `V` are **phantom types** in these case classes - they don't appear in any fields:

```scala
final case class Seq[C[_], +A](
  constructor: SeqConstructor[C],    // doesn't use A
  deconstructor: SeqDeconstructor[C] // doesn't use A
)

final case class Map[M[_, _], +K, +V](
  constructor: MapConstructor[M],    // doesn't use K or V
  deconstructor: MapDeconstructor[M] // doesn't use K or V
)
```

The runtime representation is identical regardless of the type parameters, so upcasting is safe:
- `Binding.Seq[List, String]` can safely be used as `Binding.Seq[List, Any]`
- `Binding.Map[Predef.Map, String, Int]` can safely be used as `Binding.Map[Predef.Map, Any, Any]`

## Testing

- ✅ schemaJVM/test (Scala 3.3.7 with coverage)
- ✅ schemaJVM/test (Scala 2.13.18)
- ✅ Formatted