### PR TITLE
chore: Remove redundant @experimental annotations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,13 +28,13 @@ sbt --client -Dsbt.color=false <command> >"$LOG" 2>&1; echo "Exit: $? | Log: $LO
 # Query: tail -50 "$LOG" or grep -i error "$LOG"
 
 # <command> examples:
-#   "++3.3.6; <project>/test"                             — fast loop, Scala 3
+#   "++3.7.4; <project>/test"                             — fast loop, Scala 3
 #   "++<scala2>; <project>/test"                          — fast loop, Scala 2
-#   "++3.3.6; project <project>; coverage; test; coverageReport"   — coverage, Scala 3
+#   "++3.7.4; project <project>; coverage; test; coverageReport"   — coverage, Scala 3
 #   "++<scala2>; project <project>; coverage; test; coverageReport"  — coverage, Scala 2
-#   "++3.3.6; <project>/test; ++<scala2>; <project>/test" — cross-Scala
-#   "++3.3.6; <project>/scalafmt"                         — format main sources
-#   "++3.3.6; <project>/Test/scalafmt"                    — format test sources
+#   "++3.7.4; <project>/test; ++<scala2>; <project>/test" — cross-Scala
+#   "++3.7.4; <project>/scalafmt"                         — format main sources
+#   "++3.7.4; <project>/Test/scalafmt"                    — format test sources
 #   scalafmtSbt                                           — format build files
 #
 # IMPORTANT: --client mode preserves Scala version across invocations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ The philosophy is simple: **use what you need, nothing more**. Each block is ind
 - **Zero Lock-In**: No dependencies on ZIO, Cats Effect, or any effect system. Use with whatever stack you prefer.
 - **Modular**: Each block is a separate artifact. Import only what you need.
 - **Cross-Platform**: Full support for JVM, Scala.js, and Scala Native.
-- **Cross-Version**: Full support for Scala 2.13 and Scala 3.5+ with source compatibility—adopt Scala 3 on your timeline, not ours.
+- **Cross-Version**: Full support for Scala 2.13 and Scala 3.x with source compatibility—adopt Scala 3 on your timeline, not ours.
 - **High Performance**: Optimized implementations that avoid boxing, minimize allocations, and leverage platform-specific features.
 - **Type Safety**: Leverage Scala's type system for correctness without runtime overhead.
 
@@ -290,7 +290,7 @@ Each block has zero dependencies on effect systems. Use the blocks directly, or 
 
 ## Scala & Platform Support
 
-ZIO Blocks supports **Scala 2.13** and **Scala 3.5+** with full source compatibility. Write your code once and compile it against either version—migrate to Scala 3 when your team is ready, not when your dependencies force you.
+ZIO Blocks supports **Scala 2.13** and **Scala 3.x** with full source compatibility. Write your code once and compile it against either version—migrate to Scala 3 when your team is ready, not when your dependencies force you.
 
 | Platform | Schema | Chunk | Docs | Streams |
 |----------|--------|-------|------|---------|

--- a/docs/path-interpolator.md
+++ b/docs/path-interpolator.md
@@ -38,7 +38,7 @@ val path = p".users[0].name"
 ## Key Features
 
 - **✅ Zero Runtime Overhead**: All parsing happens at compile time
-- **✅ Cross-Platform**: Works on Scala 2.13.x and Scala 3.5.x
+- **✅ Cross-Platform**: Works on Scala 2.13.x and Scala 3.x
 - **✅ Compile-Time Safety**: Invalid paths are rejected during compilation
 - **✅ No Runtime Interpolation**: Prevents accidental use of runtime values
 - **✅ Rich Syntax**: Supports all `DynamicOptic` operations

--- a/schema/jvm/src/test/scala-3/zio/blocks/schema/binding/structural/BindingOfStructuralSpec.scala
+++ b/schema/jvm/src/test/scala-3/zio/blocks/schema/binding/structural/BindingOfStructuralSpec.scala
@@ -14,7 +14,6 @@ import scala.language.reflectiveCalls
  * structural types (refinement types), with full constructor/deconstructor
  * support using register-based serialization.
  */
-@experimental
 object BindingOfStructuralSpec extends SchemaBaseSpec {
 
   def spec: Spec[TestEnvironment, Any] = suite("BindingOfStructuralSpec")(

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/binding/BindingCompanionVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/binding/BindingCompanionVersionSpecific.scala
@@ -20,7 +20,7 @@ trait BindingCompanionVersionSpecific {
    *   - Option, Either, and their subtypes
    *   - Standard collections (List, Vector, Set, Map, etc.)
    *   - [[DynamicValue]]
-   *   - Structural types (JVM only, requires `@experimental`)
+   *   - Structural types (JVM only)
    *
    * @tparam A
    *   the type to derive a binding for
@@ -51,14 +51,12 @@ trait BindingCompanionVersionSpecific {
     new Binding.Map(mc, md)
 }
 
-@experimental
 private object BindingCompanionVersionSpecificImpl {
   import scala.quoted.*
 
   def of[A: Type](using Quotes): Expr[Any] = new BindingCompanionVersionSpecificImpl().of[A]
 }
 
-@experimental
 private class BindingCompanionVersionSpecificImpl(using Quotes) {
   import quotes.reflect.*
 
@@ -1963,7 +1961,6 @@ private class BindingCompanionVersionSpecificImpl(using Quotes) {
 
   private case class StructuralFieldForGen(name: String, memberTpe: TypeRepr, kind: String, index: Int)
 
-  @experimental
   private def deriveStructuralRecordBindingSimple[A: Type](tpe: TypeRepr): Expr[Any] = {
     if (!Platform.supportsReflection) {
       fail(
@@ -1999,7 +1996,6 @@ private class BindingCompanionVersionSpecificImpl(using Quotes) {
     '{ new Binding.Record[A]($constructorExpr, $deconstructorExpr) }
   }
 
-  @experimental
   private def generateStructuralConstructorWithRealMethods[A: Type](
     fields: Seq[StructuralFieldForGen],
     totalUsedRegistersExpr: Expr[RegisterOffset.RegisterOffset]
@@ -2069,7 +2065,6 @@ private class BindingCompanionVersionSpecificImpl(using Quotes) {
     }
   }
 
-  @experimental
   private def generateAnonymousClassFactory[A: Type](fields: Seq[StructuralFieldForGen]): Expr[Array[Any] => A] = {
     // Generate a lambda using quoted expressions that creates an anonymous class with real methods.
     // Each method reads from the captured `values` array at a specific index.

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/binding/BindingOfVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/binding/BindingOfVersionSpecificSpec.scala
@@ -5,7 +5,6 @@ import zio.blocks.schema.{SchemaBaseSpec, SchemaError}
 import zio.prelude.Newtype
 import zio.test._
 
-@experimental
 object BindingOfVersionSpecificSpec extends SchemaBaseSpec {
   private def isSeq(b: Any): Boolean = b match {
     case _: Binding.Seq[?, ?] => true


### PR DESCRIPTION
## Summary

Remove redundant `@experimental` annotations from structural type binding code. 

The project already uses the `-experimental` compiler flag (in `project/BuildHelper.scala`), which automatically adds `@experimental` to all top-level definitions. This makes the explicit annotations unnecessary.

## Changes

- Remove `@experimental` annotations from 3 files (7 total annotations)
- Update docs to reference "Scala 3.x" instead of specific versions
- Update AGENTS.md examples to use Scala 3.7.4

Fixes #926