### PR TITLE
Add guideline for monitoring PR checks without context bloat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Commit often, whenever fast loop is green.
 PR already open (check!) and think you're done? Push, update PR title/description, then loop: monitor CI and review comments, fix all CI issues (including conflicts) and all **valid** review comments via Workflow. Don't stop until CI is green, & PR is approved & merged.
 
 When waiting on PR checks, suppress watch output to avoid context bloat:
-`sleep 10 && gh pr checks <PR> --watch --fail-fast > /dev/null 2>&1 || true && gh pr checks <PR>`
+`sleep 30 && gh pr checks <PR> --watch --fail-fast > /dev/null 2>&1 || true && gh pr checks <PR>`
 
 ## Boundaries
 


### PR DESCRIPTION
Adds a tip to the Git & CI section of AGENTS.md for suppressing `gh pr checks --watch` output to avoid flooding agent context while waiting on CI.