### PR TITLE
Algebraic Migration System

### DIFF
--- a/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/MigrationBuilderMacroSpec.scala
+++ b/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/MigrationBuilderMacroSpec.scala
@@ -1,0 +1,361 @@
+package zio.blocks.schema.migration
+
+import zio.Scope
+import zio.blocks.schema.*
+import zio.test.*
+
+object MigrationBuilderMacroSpec extends SchemaBaseSpec {
+
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("MigrationBuilder Macro API")(
+    suite("Selector-based field operations")(
+      test("add using selector extracts field path") {
+        val builder = MigrationBuilder[PersonV1, PersonV2]
+          .add(_.age, DynamicValue.int(0))
+        val migration = builder.build
+        val original  = PersonV1("Alice")
+        val result    = migration(original)
+
+        assertTrue(result == Right(PersonV2("Alice", 0)))
+      },
+      test("drop using selector extracts field path") {
+        val builder = MigrationBuilder[PersonV2, PersonV1]
+          .drop(_.age, DynamicValue.int(0))
+        val migration = builder.build
+        val original  = PersonV2("Alice", 30)
+        val result    = migration(original)
+
+        assertTrue(result == Right(PersonV1("Alice")))
+      },
+      test("rename using selectors extracts both paths") {
+        val builder = MigrationBuilder[PersonV1, PersonRenamed]
+          .rename(_.name, _.fullName)
+        val migration = builder.build
+        val original  = PersonV1("Alice")
+        val result    = migration(original)
+
+        assertTrue(result == Right(PersonRenamed("Alice")))
+      },
+      test("changeType using selector extracts field path") {
+        val builder = MigrationBuilder[PersonWithIntId, PersonWithLongId]
+          .changeType(_.id, PrimitiveConversion.IntToLong, PrimitiveConversion.LongToInt)
+        val migration = builder.build
+        val original  = PersonWithIntId("Alice", 42)
+        val result    = migration(original)
+
+        assertTrue(result == Right(PersonWithLongId("Alice", 42L)))
+      },
+      test("nested selector path works for deeply nested fields") {
+        val builder = MigrationBuilder[NestedV1, NestedV2]
+          .add(_.person.contact.phone, DynamicValue.string("555-0000"))
+        val migration = builder.build
+        val original  = NestedV1(PersonWithContact("Alice", Contact("alice@example.com")))
+        val result    = migration(original)
+
+        assertTrue(result == Right(NestedV2(PersonWithContactV2("Alice", ContactV2("alice@example.com", "555-0000")))))
+      },
+      test("multiple selector operations chain correctly") {
+        val builder = MigrationBuilder[PersonV1, PersonV3]
+          .add(_.age, DynamicValue.int(0))
+          .add(_.active, DynamicValue.boolean(true))
+        val migration = builder.build
+        val original  = PersonV1("Alice")
+        val result    = migration(original)
+
+        assertTrue(result == Right(PersonV3("Alice", 0, true)))
+      },
+      test("transform using selector applies bidirectional transformation") {
+        val builder = MigrationBuilder[PersonWithCount, PersonWithCount]
+          .transform(
+            _.count,
+            DynamicValueTransform.numericMultiply(2),
+            DynamicValueTransform.numericMultiply(0.5)
+          )
+        val migration = builder.build
+        val original  = PersonWithCount("Alice", 10)
+        val result    = migration(original)
+
+        assertTrue(result == Right(PersonWithCount("Alice", 20)))
+      }
+    ),
+    suite("Macro compile-time extraction")(
+      test("fieldPath macro extracts simple field name") {
+        val path = MigrationBuilderMacros.fieldPath[PersonV1, String](_.name)
+        assertTrue(path == "name")
+      },
+      test("fieldPath macro extracts nested field path") {
+        val path = MigrationBuilderMacros.fieldPath[NestedV1, String](_.person.name)
+        assertTrue(path == "person.name")
+      },
+      test("fieldPath macro extracts deeply nested field path") {
+        val path = MigrationBuilderMacros.fieldPath[NestedV1, String](_.person.contact.email)
+        assertTrue(path == "person.contact.email")
+      },
+      test("lastFieldName macro extracts terminal field name") {
+        val name = MigrationBuilderMacros.lastFieldName[NestedV1, String](_.person.contact.email)
+        assertTrue(name == "email")
+      }
+    ),
+    suite("Mixed API usage")(
+      test("can mix selector-based and string-based operations") {
+        val builder = MigrationBuilder[PersonV1, PersonV3]
+          .add(_.age, DynamicValue.int(25))
+          .addField("active", DynamicValue.boolean(false))
+        val migration = builder.build
+        val original  = PersonV1("Alice")
+        val result    = migration(original)
+
+        assertTrue(result == Right(PersonV3("Alice", 25, false)))
+      }
+    ),
+    suite("MigrationExpr-based operations")(
+      test("addExpr using literal default") {
+        val builder = MigrationBuilder[PersonV1, PersonV2]
+          .addExpr(_.age, MigrationExpr.literal(42))
+        val migration = builder.build
+        val original  = PersonV1("Alice")
+        val result    = migration(original)
+
+        assertTrue(result == Right(PersonV2("Alice", 42)))
+      },
+      test("toDynamicOptic macro extracts simple field path") {
+        val optic = MigrationBuilderMacros.toDynamicOptic[PersonV1, String](_.name)
+        assertTrue(
+          optic.nodes.size == 1 &&
+            optic.nodes.head == DynamicOptic.Node.Field("name")
+        )
+      },
+      test("toDynamicOptic macro extracts nested field path") {
+        val optic = MigrationBuilderMacros.toDynamicOptic[NestedV1, String](_.person.contact.email)
+        assertTrue(
+          optic.nodes.size == 3 &&
+            optic.nodes(0) == DynamicOptic.Node.Field("person") &&
+            optic.nodes(1) == DynamicOptic.Node.Field("contact") &&
+            optic.nodes(2) == DynamicOptic.Node.Field("email")
+        )
+      }
+    ),
+    suite("Field name extraction macros")(
+      test("extractFieldNames extracts all field names from a case class") {
+        val fields = MigrationBuilderMacros.extractFieldNames[PersonV2]
+        assertTrue(
+          fields.contains("name") &&
+            fields.contains("age") &&
+            fields.size == 2
+        )
+      },
+      test("extractFieldNames works with multiple fields") {
+        val fields = MigrationBuilderMacros.extractFieldNames[PersonV3]
+        assertTrue(
+          fields.contains("name") &&
+            fields.contains("age") &&
+            fields.contains("active") &&
+            fields.size == 3
+        )
+      }
+    ),
+    suite("Migration completeness validation")(
+      test("validation passes when migration is complete") {
+        val sourceFields  = Set("name")
+        val targetFields  = Set("name", "age")
+        val addedFields   = Set("age")
+        val removedFields = Set.empty[String]
+        val renamedFields = Map.empty[String, String]
+
+        MigrationBuilderMacros.validateMigrationCompleteness[PersonV1, PersonV2](
+          sourceFields,
+          targetFields,
+          addedFields,
+          removedFields,
+          renamedFields
+        )
+        assertTrue(true)
+      },
+      test("validation passes with rename") {
+        val sourceFields  = Set("name")
+        val targetFields  = Set("fullName")
+        val addedFields   = Set.empty[String]
+        val removedFields = Set.empty[String]
+        val renamedFields = Map("name" -> "fullName")
+
+        MigrationBuilderMacros.validateMigrationCompleteness[PersonV1, PersonRenamed](
+          sourceFields,
+          targetFields,
+          addedFields,
+          removedFields,
+          renamedFields
+        )
+        assertTrue(true)
+      },
+      test("validation fails when migration is incomplete") {
+        val sourceFields  = Set("name")
+        val targetFields  = Set("name", "age")
+        val addedFields   = Set.empty[String]
+        val removedFields = Set.empty[String]
+        val renamedFields = Map.empty[String, String]
+
+        val result = scala.util.Try {
+          MigrationBuilderMacros.validateMigrationCompleteness[PersonV1, PersonV2](
+            sourceFields,
+            targetFields,
+            addedFields,
+            removedFields,
+            renamedFields
+          )
+        }
+        assertTrue(result.isFailure && result.failed.get.getMessage.contains("Missing fields"))
+      }
+    ),
+    suite("buildValidated extension method")(
+      test("buildValidated succeeds for complete migration") {
+        val builder = MigrationBuilder[PersonV1, PersonV2]
+          .add(_.age, DynamicValue.int(0))
+        val migration = builder.buildValidated
+        val original  = PersonV1("Alice")
+        val result    = migration(original)
+
+        assertTrue(result == Right(PersonV2("Alice", 0)))
+      },
+      test("buildValidated succeeds with rename") {
+        val builder = MigrationBuilder[PersonV1, PersonRenamed]
+          .rename(_.name, _.fullName)
+        val migration = builder.buildValidated
+        val original  = PersonV1("Alice")
+        val result    = migration(original)
+
+        assertTrue(result == Right(PersonRenamed("Alice")))
+      },
+      test("buildValidated succeeds with add and drop") {
+        val builder = MigrationBuilder[PersonV2, PersonRenamed]
+          .drop(_.age, DynamicValue.int(0))
+          .rename(_.name, _.fullName)
+        val migration = builder.buildValidated
+        val original  = PersonV2("Alice", 30)
+        val result    = migration(original)
+
+        assertTrue(result == Right(PersonRenamed("Alice")))
+      },
+      test("buildValidated tracks addedFieldNames correctly") {
+        val builder = MigrationBuilder[PersonV1, PersonV2]
+          .add(_.age, DynamicValue.int(0))
+
+        assertTrue(builder.addedFieldNames == Set("age"))
+      },
+      test("buildValidated tracks removedFieldNames correctly") {
+        val builder = MigrationBuilder[PersonV2, PersonV1]
+          .drop(_.age, DynamicValue.int(0))
+
+        assertTrue(builder.removedFieldNames == Set("age"))
+      },
+      test("buildValidated tracks renamedFromNames and renamedToNames correctly") {
+        val builder = MigrationBuilder[PersonV1, PersonRenamed]
+          .rename(_.name, _.fullName)
+
+        assertTrue(
+          builder.renamedFromNames == Set("name") &&
+            builder.renamedToNames == Set("fullName")
+        )
+      },
+      test("buildValidated handles joinFields tracking correctly") {
+        val combiner = DynamicValueTransform.stringJoinFields(Vector("firstName", "lastName"))
+        val splitter = DynamicValueTransform.stringSplitToFields(Vector("firstName", "lastName"), " ", 2)
+
+        val builder = MigrationBuilder[PersonWithSplitName, PersonWithFullName]
+          .joinFields("fullName", Vector("firstName", "lastName"), combiner, splitter)
+          .drop(_.age, DynamicValue.int(0))
+
+        assertTrue(
+          builder.addedFieldNames == Set("fullName"),
+          builder.removedFieldNames == Set("firstName", "lastName", "age")
+        )
+      },
+      test("buildValidated handles splitField tracking correctly") {
+        val splitter = DynamicValueTransform.stringSplitToFields(Vector("firstName", "lastName"), " ", 2)
+        val combiner = DynamicValueTransform.stringJoinFields(Vector("firstName", "lastName"))
+
+        val builder = MigrationBuilder[PersonWithFullName, PersonWithSplitName]
+          .splitField("fullName", Vector("firstName", "lastName"), splitter, combiner)
+          .add(_.age, DynamicValue.int(0))
+
+        assertTrue(
+          builder.addedFieldNames == Set("firstName", "lastName", "age"),
+          builder.removedFieldNames == Set("fullName")
+        )
+      }
+    ),
+    suite("buildChecked compile-time validation")(
+      test("buildChecked succeeds with correct literal field sets") {
+        val builder = MigrationBuilder[PersonV1, PersonV2]
+          .add(_.age, DynamicValue.int(0))
+        val migration = builder.buildChecked(
+          added = Set("age"),
+          removed = Set.empty
+        )
+        val original = PersonV1("Alice")
+        val result   = migration(original)
+
+        assertTrue(result == Right(PersonV2("Alice", 0)))
+      },
+      test("buildChecked succeeds with rename operations") {
+        val builder = MigrationBuilder[PersonV1, PersonRenamed]
+          .rename(_.name, _.fullName)
+        val migration = builder.buildChecked(
+          added = Set.empty,
+          removed = Set.empty,
+          renamedFrom = Set("name"),
+          renamedTo = Set("fullName")
+        )
+        val original = PersonV1("Alice")
+        val result   = migration(original)
+
+        assertTrue(result == Right(PersonRenamed("Alice")))
+      },
+      test("buildChecked succeeds with add and drop") {
+        val builder = MigrationBuilder[PersonV2, PersonRenamed]
+          .drop(_.age, DynamicValue.int(0))
+          .rename(_.name, _.fullName)
+        val migration = builder.buildChecked(
+          added = Set.empty,
+          removed = Set("age"),
+          renamedFrom = Set("name"),
+          renamedTo = Set("fullName")
+        )
+        val original = PersonV2("Alice", 30)
+        val result   = migration(original)
+
+        assertTrue(result == Right(PersonRenamed("Alice")))
+      },
+      test("validateCompileTime passes with correct operations") {
+        MigrationBuilderMacros.validateCompileTime[PersonV1, PersonV2](
+          added = Set("age"),
+          removed = Set.empty,
+          renamedFrom = Set.empty,
+          renamedTo = Set.empty
+        )
+        assertTrue(true)
+      },
+      test("validateCompileTime passes with rename") {
+        MigrationBuilderMacros.validateCompileTime[PersonV1, PersonRenamed](
+          added = Set.empty,
+          removed = Set.empty,
+          renamedFrom = Set("name"),
+          renamedTo = Set("fullName")
+        )
+        assertTrue(true)
+      },
+      test("validateCompileTime passes with complex migration") {
+        MigrationBuilderMacros.validateCompileTime[PersonV2, PersonRenamed](
+          added = Set.empty,
+          removed = Set("age"),
+          renamedFrom = Set("name"),
+          renamedTo = Set("fullName")
+        )
+        assertTrue(true)
+      }
+    )
+  )
+}
+
+case class PersonWithCount(name: String, count: Int)
+object PersonWithCount {
+  implicit val schema: Schema[PersonWithCount] = Schema.derived
+}

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderMacros.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderMacros.scala
@@ -1,0 +1,469 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.DynamicOptic
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+object MigrationBuilderMacros {
+
+  def fieldPath[S, A](selector: S => A): String = macro MigrationBuilderMacrosImpl.fieldPathImpl
+
+  def lastFieldName[S, A](selector: S => A): String = macro MigrationBuilderMacrosImpl.lastFieldNameImpl
+
+  def toDynamicOptic[S, A](selector: S => A): DynamicOptic = macro MigrationBuilderMacrosImpl.toDynamicOpticImpl
+
+  def extractFieldNames[T]: Set[String] = macro MigrationBuilderMacrosImpl.extractFieldNamesImpl[T]
+
+  def validateMigrationCompleteness[A, B](
+    sourceFields: Set[String],
+    targetFields: Set[String],
+    addedFields: Set[String],
+    removedFields: Set[String],
+    renamedFields: Map[String, String]
+  ): Unit = macro MigrationBuilderMacrosImpl.validateMigrationCompletenessImpl[A, B]
+
+  def validateTypesCompatible[A, B]: Unit = macro MigrationBuilderMacrosImpl.validateTypesCompatibleImpl[A, B]
+
+  def validateMigrationAtCompileTime[A, B](
+    addedFields: Set[String],
+    removedFields: Set[String],
+    renamedFrom: Set[String],
+    renamedTo: Set[String]
+  ): Unit = macro MigrationBuilderMacrosImpl.validateMigrationAtCompileTimeImpl[A, B]
+
+  def validateCompileTime[A, B](
+    added: Set[String],
+    removed: Set[String],
+    renamedFrom: Set[String],
+    renamedTo: Set[String]
+  ): Unit = macro MigrationBuilderMacrosImpl.validateCompileTimeImpl[A, B]
+}
+
+private[migration] object MigrationBuilderMacrosImpl {
+
+  def fieldPathImpl(c: whitebox.Context)(selector: c.Expr[Any]): c.Expr[String] = {
+    import c.universe._
+
+    def toPathBody(tree: Tree): Tree = tree match {
+      case q"($_) => $pathBody" => pathBody
+      case _                    => c.abort(c.enclosingPosition, s"Expected a lambda expression, got '$tree'")
+    }
+
+    def extractPath(tree: Tree): List[String] = tree match {
+      case q"$parent.$child" =>
+        extractPath(parent) :+ child.toString
+      case _: Ident =>
+        List.empty
+      case q"$_.apply($_)" =>
+        c.abort(c.enclosingPosition, "Index-based access is not supported in field paths")
+      case _ =>
+        c.abort(
+          c.enclosingPosition,
+          s"Unsupported path expression. Expected simple field access like _.field.nested, got '$tree'."
+        )
+    }
+
+    val pathBody  = toPathBody(selector.tree)
+    val pathParts = extractPath(pathBody)
+
+    if (pathParts.isEmpty) {
+      c.abort(c.enclosingPosition, "Selector must access at least one field, e.g., _.name")
+    }
+
+    val path = pathParts.mkString(".")
+    c.Expr[String](q"$path")
+  }
+
+  def lastFieldNameImpl(c: whitebox.Context)(selector: c.Expr[Any]): c.Expr[String] = {
+    import c.universe._
+
+    def toPathBody(tree: Tree): Tree = tree match {
+      case q"($_) => $pathBody" => pathBody
+      case _                    => c.abort(c.enclosingPosition, s"Expected a lambda expression, got '$tree'")
+    }
+
+    def extractLastField(tree: Tree): String = tree match {
+      case q"$_.$child" =>
+        child.toString
+      case q"$_.apply($i)" =>
+        s"_$i"
+      case _: Ident =>
+        c.abort(c.enclosingPosition, "Selector must access at least one field, e.g., _.name")
+      case _ =>
+        c.abort(
+          c.enclosingPosition,
+          s"Unsupported path expression. Expected simple field access like _.field, got '$tree'."
+        )
+    }
+
+    val pathBody  = toPathBody(selector.tree)
+    val fieldName = extractLastField(pathBody)
+
+    c.Expr[String](q"$fieldName")
+  }
+
+  def toDynamicOpticImpl(c: whitebox.Context)(selector: c.Expr[Any]): c.Expr[DynamicOptic] = {
+    import c.universe._
+
+    def toPathBody(tree: Tree): Tree = tree match {
+      case q"($_) => $pathBody" => pathBody
+      case _                    => c.abort(c.enclosingPosition, s"Expected a lambda expression, got '$tree'")
+    }
+
+    def extractPath(tree: Tree): List[String] = tree match {
+      case q"$parent.$child" =>
+        extractPath(parent) :+ child.toString
+      case _: Ident =>
+        List.empty
+      case q"$_.apply($_)" =>
+        c.abort(c.enclosingPosition, "Index-based access is not supported in field paths")
+      case _ =>
+        c.abort(
+          c.enclosingPosition,
+          s"Unsupported path expression. Expected simple field access like _.field.nested, got '$tree'."
+        )
+    }
+
+    val pathBody  = toPathBody(selector.tree)
+    val pathParts = extractPath(pathBody)
+
+    if (pathParts.isEmpty) {
+      c.abort(c.enclosingPosition, "Selector must access at least one field, e.g., _.name")
+    }
+
+    val fieldNodes = pathParts.map { name =>
+      q"_root_.zio.blocks.schema.DynamicOptic.Node.Field($name)"
+    }
+
+    c.Expr[DynamicOptic](
+      q"_root_.zio.blocks.schema.DynamicOptic(_root_.scala.collection.immutable.IndexedSeq(..$fieldNodes))"
+    )
+  }
+
+  def extractFieldNamesImpl[T: c.WeakTypeTag](c: whitebox.Context): c.Expr[Set[String]] = {
+    import c.universe._
+
+    val tpe = weakTypeOf[T].dealias
+
+    def getFieldNames(t: Type): List[String] = {
+      val sym = t.typeSymbol
+      if (sym.isClass && sym.asClass.isCaseClass) {
+        val primaryConstructor = t.decls.collectFirst {
+          case m: MethodSymbol if m.isPrimaryConstructor => m
+        }
+        primaryConstructor match {
+          case Some(ctor) =>
+            ctor.paramLists.flatten
+              .filterNot(_.isImplicit)
+              .map(_.name.toString.trim)
+          case None =>
+            Nil
+        }
+      } else {
+        t match {
+          case RefinedType(parents, scope) =>
+            val refinementNames = scope.collect {
+              case m: TermSymbol if m.isAbstract => m.name.toString.trim
+            }.toList
+            refinementNames ++ parents.flatMap(getFieldNames)
+          case _ =>
+            Nil
+        }
+      }
+    }
+
+    val fieldNames = getFieldNames(tpe)
+    val fieldExprs = fieldNames.map(name => q"$name")
+    c.Expr[Set[String]](q"_root_.scala.collection.immutable.Set(..$fieldExprs)")
+  }
+
+  def validateMigrationCompletenessImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    sourceFields: c.Expr[Set[String]],
+    targetFields: c.Expr[Set[String]],
+    addedFields: c.Expr[Set[String]],
+    removedFields: c.Expr[Set[String]],
+    renamedFields: c.Expr[Map[String, String]]
+  ): c.Expr[Unit] = {
+    import c.universe._
+
+    val aTypeName = weakTypeOf[A].toString
+    val bTypeName = weakTypeOf[B].toString
+
+    c.Expr[Unit](q"""
+      val source = $sourceFields
+      val target = $targetFields
+      val added = $addedFields
+      val removed = $removedFields
+      val renamed = $renamedFields
+
+      val transformedSource = (source -- removed -- renamed.keySet) ++ added ++ renamed.values
+
+      val missing = target -- transformedSource
+      val extra = transformedSource -- target
+
+      if (missing.nonEmpty || extra.nonEmpty) {
+        val missingMsg = if (missing.nonEmpty) "Missing fields in target: " + missing.mkString(", ") else ""
+        val extraMsg = if (extra.nonEmpty) "Extra fields not in target: " + extra.mkString(", ") else ""
+        val msgs = _root_.scala.Seq(missingMsg, extraMsg).filter(_.nonEmpty).mkString("; ")
+        throw new IllegalStateException(
+          "Migration validation failed from " + $aTypeName + " to " + $bTypeName + ": " + msgs
+        )
+      }
+    """)
+  }
+
+  def validateTypesCompatibleImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context): c.Expr[Unit] = {
+    import c.universe._
+
+    def getFieldNames(t: Type): Set[String] = {
+      val sym = t.typeSymbol
+      if (sym.isClass && sym.asClass.isCaseClass) {
+        val primaryConstructor = t.decls.collectFirst {
+          case m: MethodSymbol if m.isPrimaryConstructor => m
+        }
+        primaryConstructor match {
+          case Some(ctor) =>
+            ctor.paramLists.flatten
+              .filterNot(_.isImplicit)
+              .map(_.name.toString.trim)
+              .toSet
+          case None =>
+            Set.empty[String]
+        }
+      } else {
+        t match {
+          case RefinedType(parents, scope) =>
+            val refinementNames = scope.collect {
+              case m: TermSymbol if m.isAbstract => m.name.toString.trim
+            }.toSet
+            refinementNames ++ parents.flatMap(p => getFieldNames(p))
+          case _ =>
+            Set.empty[String]
+        }
+      }
+    }
+
+    val sourceFields = getFieldNames(weakTypeOf[A].dealias)
+    val targetFields = getFieldNames(weakTypeOf[B].dealias)
+
+    if (sourceFields == targetFields) {
+      c.Expr[Unit](q"()")
+    } else {
+      val added   = targetFields -- sourceFields
+      val removed = sourceFields -- targetFields
+
+      if (added.nonEmpty || removed.nonEmpty) {
+        val aTypeName  = weakTypeOf[A].toString
+        val bTypeName  = weakTypeOf[B].toString
+        val addedMsg   = if (added.nonEmpty) s"Fields added in target: ${added.mkString(", ")}" else ""
+        val removedMsg = if (removed.nonEmpty) s"Fields removed from source: ${removed.mkString(", ")}" else ""
+        val msg        = s"Types $aTypeName and $bTypeName have different structures. $addedMsg $removedMsg".trim
+        c.info(c.enclosingPosition, msg, force = false)
+      }
+      c.Expr[Unit](q"()")
+    }
+  }
+
+  def validateMigrationAtCompileTimeImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    addedFields: c.Expr[Set[String]],
+    removedFields: c.Expr[Set[String]],
+    renamedFrom: c.Expr[Set[String]],
+    renamedTo: c.Expr[Set[String]]
+  ): c.Expr[Unit] = {
+    import c.universe._
+
+    def getFieldNames(t: Type): Set[String] = {
+      val sym = t.typeSymbol
+      if (sym.isClass && sym.asClass.isCaseClass) {
+        val primaryConstructor = t.decls.collectFirst {
+          case m: MethodSymbol if m.isPrimaryConstructor => m
+        }
+        primaryConstructor match {
+          case Some(ctor) =>
+            ctor.paramLists.flatten
+              .filterNot(_.isImplicit)
+              .map(_.name.toString.trim)
+              .toSet
+          case None =>
+            Set.empty[String]
+        }
+      } else {
+        t match {
+          case RefinedType(parents, scope) =>
+            val refinementNames = scope.collect {
+              case m: TermSymbol if m.isAbstract => m.name.toString.trim
+            }.toSet
+            refinementNames ++ parents.flatMap(p => getFieldNames(p))
+          case _ =>
+            Set.empty[String]
+        }
+      }
+    }
+
+    def extractLiteralSet(tree: Tree): Option[Set[String]] =
+      tree match {
+        case Apply(_, List(arg)) =>
+          arg match {
+            case Typed(Apply(_, elems), _) =>
+              val strings = elems.collect { case Literal(Constant(s: String)) =>
+                s
+              }
+              if (strings.length == elems.length) Some(strings.toSet) else None
+            case _ => None
+          }
+        case Apply(TypeApply(Select(_, TermName("apply")), _), List(Typed(Apply(_, elems), _))) =>
+          val strings = elems.collect { case Literal(Constant(s: String)) =>
+            s
+          }
+          if (strings.length == elems.length) Some(strings.toSet) else None
+        case _ => None
+      }
+
+    val sourceFieldSet = getFieldNames(weakTypeOf[A].dealias)
+    val targetFieldSet = getFieldNames(weakTypeOf[B].dealias)
+
+    val addedOpt       = extractLiteralSet(addedFields.tree)
+    val removedOpt     = extractLiteralSet(removedFields.tree)
+    val renamedFromOpt = extractLiteralSet(renamedFrom.tree)
+    val renamedToOpt   = extractLiteralSet(renamedTo.tree)
+
+    (addedOpt, removedOpt, renamedFromOpt, renamedToOpt) match {
+      case (Some(added), Some(removed), Some(rFrom), Some(rTo)) =>
+        val transformedSource = (sourceFieldSet -- removed -- rFrom) ++ added ++ rTo
+        val missing           = targetFieldSet -- transformedSource
+        val extra             = transformedSource -- targetFieldSet
+
+        if (missing.nonEmpty || extra.nonEmpty) {
+          val aTypeName  = weakTypeOf[A].toString
+          val bTypeName  = weakTypeOf[B].toString
+          val missingMsg = if (missing.nonEmpty) s"Missing fields in target: ${missing.mkString(", ")}" else ""
+          val extraMsg   = if (extra.nonEmpty) s"Extra fields not in target: ${extra.mkString(", ")}" else ""
+          val msgs       = Seq(missingMsg, extraMsg).filter(_.nonEmpty).mkString("; ")
+          c.abort(c.enclosingPosition, s"Migration validation failed from $aTypeName to $bTypeName: $msgs")
+        }
+        c.Expr[Unit](q"()")
+
+      case _ =>
+        val sourceFieldsExpr = {
+          val fieldExprs = sourceFieldSet.map(name => q"$name")
+          q"_root_.scala.collection.immutable.Set(..$fieldExprs)"
+        }
+        val targetFieldsExpr = {
+          val fieldExprs = targetFieldSet.map(name => q"$name")
+          q"_root_.scala.collection.immutable.Set(..$fieldExprs)"
+        }
+
+        c.Expr[Unit](q"""
+          val source = $sourceFieldsExpr
+          val target = $targetFieldsExpr
+          val added = $addedFields
+          val removed = $removedFields
+          val renamedFrom = $renamedFrom
+          val renamedTo = $renamedTo
+
+          val transformedSource = (source -- removed -- renamedFrom) ++ added ++ renamedTo
+          val missing = target -- transformedSource
+          val extra = transformedSource -- target
+
+          if (missing.nonEmpty || extra.nonEmpty) {
+            val missingMsg = if (missing.nonEmpty) "Missing fields in target: " + missing.mkString(", ") else ""
+            val extraMsg = if (extra.nonEmpty) "Extra fields not in target: " + extra.mkString(", ") else ""
+            val msgs = _root_.scala.Seq(missingMsg, extraMsg).filter(_.nonEmpty).mkString("; ")
+            throw new IllegalStateException("Migration validation failed: " + msgs)
+          }
+        """)
+    }
+  }
+
+  def validateCompileTimeImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    added: c.Expr[Set[String]],
+    removed: c.Expr[Set[String]],
+    renamedFrom: c.Expr[Set[String]],
+    renamedTo: c.Expr[Set[String]]
+  ): c.Expr[Unit] = {
+    import c.universe._
+
+    def getFieldNames(t: Type): Set[String] = {
+      val sym = t.typeSymbol
+      if (sym.isClass && sym.asClass.isCaseClass) {
+        val primaryConstructor = t.decls.collectFirst {
+          case m: MethodSymbol if m.isPrimaryConstructor => m
+        }
+        primaryConstructor match {
+          case Some(ctor) =>
+            ctor.paramLists.flatten
+              .filterNot(_.isImplicit)
+              .map(_.name.toString.trim)
+              .toSet
+          case None =>
+            Set.empty[String]
+        }
+      } else {
+        t match {
+          case RefinedType(parents, scope) =>
+            val refinementNames = scope.collect {
+              case m: TermSymbol if m.isAbstract => m.name.toString.trim
+            }.toSet
+            refinementNames ++ parents.flatMap(p => getFieldNames(p))
+          case _ =>
+            Set.empty[String]
+        }
+      }
+    }
+
+    def extractLiteralSet(tree: Tree): Set[String] = {
+      def extractFromTree(t: Tree): Option[Set[String]] = t match {
+        case Apply(_, List(arg)) =>
+          arg match {
+            case Typed(Apply(_, elems), _) =>
+              val strings = elems.collect { case Literal(Constant(s: String)) =>
+                s
+              }
+              if (strings.length == elems.length) Some(strings.toSet) else None
+            case _ => None
+          }
+        case Apply(TypeApply(Select(_, TermName("apply")), _), List(Typed(Apply(_, elems), _))) =>
+          val strings = elems.collect { case Literal(Constant(s: String)) =>
+            s
+          }
+          if (strings.length == elems.length) Some(strings.toSet) else None
+        case TypeApply(Select(_, TermName("empty")), _) =>
+          Some(Set.empty)
+        case Select(_, TermName("empty")) =>
+          Some(Set.empty)
+        case _ => None
+      }
+
+      extractFromTree(tree).getOrElse {
+        c.abort(
+          c.enclosingPosition,
+          s"validateCompileTime requires literal Set values (e.g., Set(\"field1\", \"field2\") or Set.empty). Got: ${showRaw(tree)}"
+        )
+      }
+    }
+
+    val sourceFields = getFieldNames(weakTypeOf[A].dealias)
+    val targetFields = getFieldNames(weakTypeOf[B].dealias)
+
+    val addedSet       = extractLiteralSet(added.tree)
+    val removedSet     = extractLiteralSet(removed.tree)
+    val renamedFromSet = extractLiteralSet(renamedFrom.tree)
+    val renamedToSet   = extractLiteralSet(renamedTo.tree)
+
+    val transformedSource = (sourceFields -- removedSet -- renamedFromSet) ++ addedSet ++ renamedToSet
+    val missing           = targetFields -- transformedSource
+    val extra             = transformedSource -- targetFields
+
+    if (missing.nonEmpty || extra.nonEmpty) {
+      val aTypeName  = weakTypeOf[A].toString
+      val bTypeName  = weakTypeOf[B].toString
+      val missingMsg = if (missing.nonEmpty) s"Missing fields in target: ${missing.mkString(", ")}" else ""
+      val extraMsg   = if (extra.nonEmpty) s"Extra fields not in target: ${extra.mkString(", ")}" else ""
+      val msgs       = Seq(missingMsg, extraMsg).filter(_.nonEmpty).mkString("; ")
+      c.abort(c.enclosingPosition, s"Migration validation failed from $aTypeName to $bTypeName: $msgs")
+    }
+
+    c.Expr[Unit](q"()")
+  }
+}

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
@@ -1,0 +1,473 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicOptic, DynamicValue}
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+trait MigrationBuilderSyntax {
+
+  implicit class MigrationBuilderOps[A, B](private val builder: MigrationBuilder[A, B]) {
+
+    def add[T](
+      target: B => T,
+      defaultValue: DynamicValue
+    ): MigrationBuilder[A, B] = macro MigrationBuilderSyntaxMacros.addImpl[A, B]
+
+    def drop[T](
+      source: A => T,
+      defaultForReverse: DynamicValue
+    ): MigrationBuilder[A, B] = macro MigrationBuilderSyntaxMacros.dropImpl[A, B]
+
+    def rename[T1, T2](
+      from: A => T1,
+      to: B => T2
+    ): MigrationBuilder[A, B] = macro MigrationBuilderSyntaxMacros.renameImpl[A, B]
+
+    def transform[T](
+      path: A => T,
+      forward: DynamicValueTransform,
+      backward: DynamicValueTransform
+    ): MigrationBuilder[A, B] = macro MigrationBuilderSyntaxMacros.transformImpl[A, B]
+
+    def optionalize[T](
+      path: A => T,
+      defaultForReverse: DynamicValue
+    ): MigrationBuilder[A, B] = macro MigrationBuilderSyntaxMacros.optionalizeImpl[A, B]
+
+    def mandate[T](
+      path: A => Option[T],
+      defaultForNone: DynamicValue
+    ): MigrationBuilder[A, B] = macro MigrationBuilderSyntaxMacros.mandateImpl[A, B]
+
+    def changeType[T](
+      path: A => T,
+      forward: PrimitiveConversion,
+      backward: PrimitiveConversion
+    ): MigrationBuilder[A, B] = macro MigrationBuilderSyntaxMacros.changeTypeImpl[A, B]
+
+    def addExpr[T](
+      target: B => T,
+      default: MigrationExpr[A, T]
+    ): MigrationBuilder[A, B] = macro MigrationBuilderSyntaxMacros.addExprImpl[A, B]
+
+    def dropExpr[T](
+      source: A => T,
+      defaultForReverse: MigrationExpr[B, T]
+    ): MigrationBuilder[A, B] = macro MigrationBuilderSyntaxMacros.dropExprImpl[A, B]
+
+    def optionalizeExpr[T](
+      path: A => T,
+      defaultForReverse: MigrationExpr[B, T]
+    ): MigrationBuilder[A, B] = macro MigrationBuilderSyntaxMacros.optionalizeExprImpl[A, B]
+
+    def mandateExpr[T](
+      path: A => Option[T],
+      defaultForNone: MigrationExpr[A, T]
+    ): MigrationBuilder[A, B] = macro MigrationBuilderSyntaxMacros.mandateExprImpl[A, B]
+
+    def addCaseExpr[T](caseName: String, default: MigrationExpr[A, T]): MigrationBuilder[A, B] =
+      builder.addCaseExpr(caseName, default)
+
+    def dropCaseExpr[T](caseName: String, defaultForReverse: MigrationExpr[B, T]): MigrationBuilder[A, B] =
+      builder.dropCaseExpr(caseName, defaultForReverse)
+
+    def join[T](
+      target: B => T,
+      sourceNames: Vector[String],
+      combiner: DynamicValueTransform,
+      splitter: DynamicValueTransform
+    ): MigrationBuilder[A, B] = macro MigrationBuilderSyntaxMacros.joinImpl[A, B]
+
+    def split[T](
+      source: A => T,
+      targetNames: Vector[String],
+      splitter: DynamicValueTransform,
+      combiner: DynamicValueTransform
+    ): MigrationBuilder[A, B] = macro MigrationBuilderSyntaxMacros.splitImpl[A, B]
+
+    def buildValidated: Migration[A, B] = macro MigrationBuilderSyntaxMacros.buildValidatedImpl[A, B]
+
+    def buildChecked(
+      added: Set[String],
+      removed: Set[String],
+      renamedFrom: Set[String] = Set.empty[String],
+      renamedTo: Set[String] = Set.empty[String]
+    ): Migration[A, B] = macro MigrationBuilderSyntaxMacros.buildCheckedImpl[A, B]
+  }
+}
+
+object MigrationBuilderSyntax extends MigrationBuilderSyntax
+
+private[migration] object MigrationBuilderSyntaxMacros {
+
+  private def extractFieldPath(c: whitebox.Context)(selector: c.Expr[Any]): c.Expr[String] = {
+    import c.universe._
+
+    def toPathBody(tree: Tree): Tree = tree match {
+      case q"($_) => $pathBody" => pathBody
+      case _                    => c.abort(c.enclosingPosition, s"Expected a lambda expression, got '$tree'")
+    }
+
+    def extractPath(tree: Tree): List[String] = tree match {
+      case q"$parent.$child" =>
+        extractPath(parent) :+ child.toString
+      case _: Ident =>
+        List.empty
+      case q"$_.apply($_)" =>
+        c.abort(c.enclosingPosition, "Index-based access is not supported in field paths")
+      case _ =>
+        c.abort(
+          c.enclosingPosition,
+          s"Unsupported path expression. Expected simple field access like _.field.nested, got '$tree'."
+        )
+    }
+
+    val pathBody  = toPathBody(selector.tree)
+    val pathParts = extractPath(pathBody)
+
+    if (pathParts.isEmpty) {
+      c.abort(c.enclosingPosition, "Selector must access at least one field, e.g., _.name")
+    }
+
+    val path = pathParts.mkString(".")
+    c.Expr[String](q"$path")
+  }
+
+  private def extractDynamicOptic(c: whitebox.Context)(selector: c.Expr[Any]): c.Expr[DynamicOptic] = {
+    import c.universe._
+
+    def toPathBody(tree: Tree): Tree = tree match {
+      case q"($_) => $pathBody" => pathBody
+      case _                    => c.abort(c.enclosingPosition, s"Expected a lambda expression, got '$tree'")
+    }
+
+    def extractPath(tree: Tree): List[String] = tree match {
+      case q"$parent.$child" =>
+        extractPath(parent) :+ child.toString
+      case _: Ident =>
+        List.empty
+      case q"$_.apply($_)" =>
+        c.abort(c.enclosingPosition, "Index-based access is not supported in field paths")
+      case _ =>
+        c.abort(
+          c.enclosingPosition,
+          s"Unsupported path expression. Expected simple field access like _.field.nested, got '$tree'."
+        )
+    }
+
+    val pathBody  = toPathBody(selector.tree)
+    val pathParts = extractPath(pathBody)
+
+    if (pathParts.isEmpty) {
+      c.abort(c.enclosingPosition, "Selector must access at least one field, e.g., _.name")
+    }
+
+    val fieldNodes = pathParts.map { name =>
+      q"_root_.zio.blocks.schema.DynamicOptic.Node.Field($name)"
+    }
+
+    c.Expr[DynamicOptic](
+      q"_root_.zio.blocks.schema.DynamicOptic(_root_.scala.collection.immutable.IndexedSeq(..$fieldNodes))"
+    )
+  }
+
+  def addImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    target: c.Expr[Any],
+    defaultValue: c.Expr[DynamicValue]
+  ): c.Expr[MigrationBuilder[A, B]] = {
+    import c.universe._
+    val pathExpr   = extractFieldPath(c)(target)
+    val builderRef = c.prefix.tree
+    c.Expr[MigrationBuilder[A, B]](q"$builderRef.builder.addField($pathExpr, $defaultValue)")
+  }
+
+  def dropImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    source: c.Expr[Any],
+    defaultForReverse: c.Expr[DynamicValue]
+  ): c.Expr[MigrationBuilder[A, B]] = {
+    import c.universe._
+    val pathExpr   = extractFieldPath(c)(source)
+    val builderRef = c.prefix.tree
+    c.Expr[MigrationBuilder[A, B]](q"$builderRef.builder.dropField($pathExpr, $defaultForReverse)")
+  }
+
+  def renameImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    from: c.Expr[Any],
+    to: c.Expr[Any]
+  ): c.Expr[MigrationBuilder[A, B]] = {
+    import c.universe._
+    val fromPathExpr = extractFieldPath(c)(from)
+    val toPathExpr   = extractFieldPath(c)(to)
+    val builderRef   = c.prefix.tree
+    c.Expr[MigrationBuilder[A, B]](q"$builderRef.builder.renameField($fromPathExpr, $toPathExpr)")
+  }
+
+  def transformImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    path: c.Expr[Any],
+    forward: c.Expr[DynamicValueTransform],
+    backward: c.Expr[DynamicValueTransform]
+  ): c.Expr[MigrationBuilder[A, B]] = {
+    import c.universe._
+    val pathExpr   = extractFieldPath(c)(path)
+    val builderRef = c.prefix.tree
+    c.Expr[MigrationBuilder[A, B]](q"$builderRef.builder.transformField($pathExpr, $forward, $backward)")
+  }
+
+  def optionalizeImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    path: c.Expr[Any],
+    defaultForReverse: c.Expr[DynamicValue]
+  ): c.Expr[MigrationBuilder[A, B]] = {
+    import c.universe._
+    val pathExpr   = extractFieldPath(c)(path)
+    val builderRef = c.prefix.tree
+    c.Expr[MigrationBuilder[A, B]](q"$builderRef.builder.optionalizeField($pathExpr, $defaultForReverse)")
+  }
+
+  def mandateImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    path: c.Expr[Any],
+    defaultForNone: c.Expr[DynamicValue]
+  ): c.Expr[MigrationBuilder[A, B]] = {
+    import c.universe._
+    val pathExpr   = extractFieldPath(c)(path)
+    val builderRef = c.prefix.tree
+    c.Expr[MigrationBuilder[A, B]](q"$builderRef.builder.mandateField($pathExpr, $defaultForNone)")
+  }
+
+  def changeTypeImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    path: c.Expr[Any],
+    forward: c.Expr[PrimitiveConversion],
+    backward: c.Expr[PrimitiveConversion]
+  ): c.Expr[MigrationBuilder[A, B]] = {
+    import c.universe._
+    val pathExpr   = extractFieldPath(c)(path)
+    val builderRef = c.prefix.tree
+    c.Expr[MigrationBuilder[A, B]](q"$builderRef.builder.changeFieldType($pathExpr, $forward, $backward)")
+  }
+
+  def addExprImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    target: c.Expr[Any],
+    default: c.Expr[Any]
+  ): c.Expr[MigrationBuilder[A, B]] = {
+    import c.universe._
+    val opticExpr  = extractDynamicOptic(c)(target)
+    val builderRef = c.prefix.tree
+    c.Expr[MigrationBuilder[A, B]](q"$builderRef.builder.addFieldExpr($opticExpr, $default)")
+  }
+
+  def dropExprImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    source: c.Expr[Any],
+    defaultForReverse: c.Expr[Any]
+  ): c.Expr[MigrationBuilder[A, B]] = {
+    import c.universe._
+    val opticExpr  = extractDynamicOptic(c)(source)
+    val builderRef = c.prefix.tree
+    c.Expr[MigrationBuilder[A, B]](q"$builderRef.builder.dropFieldExpr($opticExpr, $defaultForReverse)")
+  }
+
+  def optionalizeExprImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    path: c.Expr[Any],
+    defaultForReverse: c.Expr[Any]
+  ): c.Expr[MigrationBuilder[A, B]] = {
+    import c.universe._
+    val opticExpr  = extractDynamicOptic(c)(path)
+    val builderRef = c.prefix.tree
+    c.Expr[MigrationBuilder[A, B]](q"$builderRef.builder.optionalizeFieldExpr($opticExpr, $defaultForReverse)")
+  }
+
+  def mandateExprImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    path: c.Expr[Any],
+    defaultForNone: c.Expr[Any]
+  ): c.Expr[MigrationBuilder[A, B]] = {
+    import c.universe._
+    val opticExpr  = extractDynamicOptic(c)(path)
+    val builderRef = c.prefix.tree
+    c.Expr[MigrationBuilder[A, B]](q"$builderRef.builder.mandateFieldExpr($opticExpr, $defaultForNone)")
+  }
+
+  def joinImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    target: c.Expr[Any],
+    sourceNames: c.Expr[Vector[String]],
+    combiner: c.Expr[DynamicValueTransform],
+    splitter: c.Expr[DynamicValueTransform]
+  ): c.Expr[MigrationBuilder[A, B]] = {
+    import c.universe._
+    val pathExpr   = extractFieldPath(c)(target)
+    val builderRef = c.prefix.tree
+    c.Expr[MigrationBuilder[A, B]](q"$builderRef.builder.joinFields($pathExpr, $sourceNames, $combiner, $splitter)")
+  }
+
+  def splitImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    source: c.Expr[Any],
+    targetNames: c.Expr[Vector[String]],
+    splitter: c.Expr[DynamicValueTransform],
+    combiner: c.Expr[DynamicValueTransform]
+  ): c.Expr[MigrationBuilder[A, B]] = {
+    import c.universe._
+    val pathExpr   = extractFieldPath(c)(source)
+    val builderRef = c.prefix.tree
+    c.Expr[MigrationBuilder[A, B]](q"$builderRef.builder.splitField($pathExpr, $targetNames, $splitter, $combiner)")
+  }
+
+  def buildValidatedImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context): c.Expr[Migration[A, B]] = {
+    import c.universe._
+
+    def getFieldNames(t: Type): Set[String] = {
+      val sym = t.typeSymbol
+      if (sym.isClass && sym.asClass.isCaseClass) {
+        val primaryConstructor = t.decls.collectFirst {
+          case m: MethodSymbol if m.isPrimaryConstructor => m
+        }
+        primaryConstructor match {
+          case Some(ctor) =>
+            ctor.paramLists.flatten
+              .filterNot(_.isImplicit)
+              .map(_.name.toString.trim)
+              .toSet
+          case None =>
+            Set.empty[String]
+        }
+      } else {
+        t match {
+          case RefinedType(parents, scope) =>
+            val refinementNames = scope.collect {
+              case m: TermSymbol if m.isAbstract => m.name.toString.trim
+            }.toSet
+            refinementNames ++ parents.flatMap(p => getFieldNames(p))
+          case _ =>
+            Set.empty[String]
+        }
+      }
+    }
+
+    val sourceFieldSet = getFieldNames(weakTypeOf[A].dealias)
+    val targetFieldSet = getFieldNames(weakTypeOf[B].dealias)
+    val builderRef     = c.prefix.tree
+
+    c.Expr[Migration[A, B]](q"""
+      {
+        val _builder = $builderRef.builder
+        val source = ${
+        val fieldExprs = sourceFieldSet.map(name => q"$name")
+        q"_root_.scala.collection.immutable.Set(..$fieldExprs)"
+      }
+        val target = ${
+        val fieldExprs = targetFieldSet.map(name => q"$name")
+        q"_root_.scala.collection.immutable.Set(..$fieldExprs)"
+      }
+        val added = _builder.addedFieldNames
+        val removed = _builder.removedFieldNames
+        val renamedFrom = _builder.renamedFromNames
+        val renamedTo = _builder.renamedToNames
+
+        val transformedSource = (source -- removed -- renamedFrom) ++ added ++ renamedTo
+        val missing = target -- transformedSource
+        val extra = transformedSource -- target
+
+        if (missing.nonEmpty || extra.nonEmpty) {
+          val missingMsg = if (missing.nonEmpty) "Missing fields in target: " + missing.mkString(", ") else ""
+          val extraMsg = if (extra.nonEmpty) "Extra fields not in target: " + extra.mkString(", ") else ""
+          val msgs = _root_.scala.Seq(missingMsg, extraMsg).filter(_.nonEmpty).mkString("; ")
+          throw new IllegalStateException(
+            "Migration validation failed from " + ${weakTypeOf[A].toString} + " to " + ${weakTypeOf[
+        B
+      ].toString} + ": " + msgs
+          )
+        }
+        _builder.buildPartial
+      }
+    """)
+  }
+
+  def buildCheckedImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    added: c.Expr[Set[String]],
+    removed: c.Expr[Set[String]],
+    renamedFrom: c.Expr[Set[String]],
+    renamedTo: c.Expr[Set[String]]
+  ): c.Expr[Migration[A, B]] = {
+    import c.universe._
+
+    def getFieldNames(t: Type): Set[String] = {
+      val sym = t.typeSymbol
+      if (sym.isClass && sym.asClass.isCaseClass) {
+        val primaryConstructor = t.decls.collectFirst {
+          case m: MethodSymbol if m.isPrimaryConstructor => m
+        }
+        primaryConstructor match {
+          case Some(ctor) =>
+            ctor.paramLists.flatten
+              .filterNot(_.isImplicit)
+              .map(_.name.toString.trim)
+              .toSet
+          case None =>
+            Set.empty[String]
+        }
+      } else {
+        t match {
+          case RefinedType(parents, scope) =>
+            val refinementNames = scope.collect {
+              case m: TermSymbol if m.isAbstract => m.name.toString.trim
+            }.toSet
+            refinementNames ++ parents.flatMap(p => getFieldNames(p))
+          case _ =>
+            Set.empty[String]
+        }
+      }
+    }
+
+    def extractLiteralSet(tree: Tree): Set[String] = {
+      def extractFromTree(t: Tree): Option[Set[String]] = t match {
+        case Apply(_, List(arg)) =>
+          arg match {
+            case Typed(Apply(_, elems), _) =>
+              val strings = elems.collect { case Literal(Constant(s: String)) =>
+                s
+              }
+              if (strings.length == elems.length) Some(strings.toSet) else None
+            case _ => None
+          }
+        case Apply(TypeApply(Select(_, TermName("apply")), _), List(Typed(Apply(_, elems), _))) =>
+          val strings = elems.collect { case Literal(Constant(s: String)) =>
+            s
+          }
+          if (strings.length == elems.length) Some(strings.toSet) else None
+        case TypeApply(Select(_, TermName("empty")), _) =>
+          Some(Set.empty)
+        case Select(_, TermName("empty")) =>
+          Some(Set.empty)
+        case _ => None
+      }
+
+      extractFromTree(tree).getOrElse {
+        c.abort(
+          c.enclosingPosition,
+          s"buildChecked requires literal Set values (e.g., Set(\"field1\", \"field2\")). Got: ${showRaw(tree)}"
+        )
+      }
+    }
+
+    val sourceFields = getFieldNames(weakTypeOf[A].dealias)
+    val targetFields = getFieldNames(weakTypeOf[B].dealias)
+
+    val addedSet       = extractLiteralSet(added.tree)
+    val removedSet     = extractLiteralSet(removed.tree)
+    val renamedFromSet = extractLiteralSet(renamedFrom.tree)
+    val renamedToSet   = extractLiteralSet(renamedTo.tree)
+
+    val transformedSource = (sourceFields -- removedSet -- renamedFromSet) ++ addedSet ++ renamedToSet
+    val missing           = targetFields -- transformedSource
+    val extra             = transformedSource -- targetFields
+
+    if (missing.nonEmpty || extra.nonEmpty) {
+      val aTypeName  = weakTypeOf[A].toString
+      val bTypeName  = weakTypeOf[B].toString
+      val missingMsg = if (missing.nonEmpty) s"Missing fields in target: ${missing.mkString(", ")}" else ""
+      val extraMsg   = if (extra.nonEmpty) s"Extra fields not in target: ${extra.mkString(", ")}" else ""
+      val msgs       = Seq(missingMsg, extraMsg).filter(_.nonEmpty).mkString("; ")
+      c.abort(c.enclosingPosition, s"Migration validation failed from $aTypeName to $bTypeName: $msgs")
+    }
+
+    val builderRef = c.prefix.tree
+    c.Expr[Migration[A, B]](q"$builderRef.builder.buildPartial")
+  }
+}

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
@@ -1,0 +1,527 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicOptic, DynamicValue}
+import scala.quoted.*
+
+object MigrationBuilderMacros {
+
+  inline def fieldPath[S, A](inline selector: S => A): String =
+    ${ fieldPathImpl[S, A]('selector) }
+
+  def fieldPathImpl[S: Type, A: Type](selector: Expr[S => A])(using q: Quotes): Expr[String] = {
+    import q.reflect.*
+
+    def toPathBody(term: Term): Term = term match {
+      case Inlined(_, _, inlinedBlock)                     => toPathBody(inlinedBlock)
+      case Block(List(DefDef(_, _, _, Some(pathBody))), _) => pathBody
+      case _                                               => report.errorAndAbort(s"Expected a lambda expression, got '${term.show}'")
+    }
+
+    def extractPath(term: Term): List[String] = term match {
+      case Select(parent, fieldName) =>
+        extractPath(parent) :+ fieldName
+      case _: Ident =>
+        List.empty
+      case Apply(Apply(_, List(parent)), List(Literal(IntConstant(_)))) =>
+        extractPath(parent)
+      case Apply(TypeApply(Select(parent, "apply"), _), List(Literal(IntConstant(_)))) =>
+        extractPath(parent)
+      case _ =>
+        report.errorAndAbort(
+          s"Unsupported path expression. Expected simple field access like _.field.nested, got '${term.show}'."
+        )
+    }
+
+    val pathBody  = toPathBody(selector.asTerm)
+    val pathParts = extractPath(pathBody)
+
+    if (pathParts.isEmpty) {
+      report.errorAndAbort("Selector must access at least one field, e.g., _.name")
+    }
+
+    val path = pathParts.mkString(".")
+    Expr(path)
+  }
+
+  inline def lastFieldName[S, A](inline selector: S => A): String =
+    ${ lastFieldNameImpl[S, A]('selector) }
+
+  def lastFieldNameImpl[S: Type, A: Type](selector: Expr[S => A])(using q: Quotes): Expr[String] = {
+    import q.reflect.*
+
+    def toPathBody(term: Term): Term = term match {
+      case Inlined(_, _, inlinedBlock)                     => toPathBody(inlinedBlock)
+      case Block(List(DefDef(_, _, _, Some(pathBody))), _) => pathBody
+      case _                                               => report.errorAndAbort(s"Expected a lambda expression, got '${term.show}'")
+    }
+
+    def extractLastField(term: Term): String = term match {
+      case Select(_, fieldName) =>
+        fieldName
+      case Apply(Apply(_, List(_)), List(Literal(IntConstant(i)))) =>
+        s"_$i"
+      case Apply(TypeApply(Select(_, "apply"), _), List(Literal(IntConstant(i)))) =>
+        s"_$i"
+      case _: Ident =>
+        report.errorAndAbort("Selector must access at least one field, e.g., _.name")
+      case _ =>
+        report.errorAndAbort(
+          s"Unsupported path expression. Expected simple field access like _.field, got '${term.show}'."
+        )
+    }
+
+    val pathBody  = toPathBody(selector.asTerm)
+    val fieldName = extractLastField(pathBody)
+
+    Expr(fieldName)
+  }
+
+  inline def toDynamicOptic[S, A](inline selector: S => A): DynamicOptic =
+    ${ toDynamicOpticImpl[S, A]('selector) }
+
+  def toDynamicOpticImpl[S: Type, A: Type](selector: Expr[S => A])(using q: Quotes): Expr[DynamicOptic] = {
+    import q.reflect.*
+
+    def toPathBody(term: Term): Term = term match {
+      case Inlined(_, _, inlinedBlock)                     => toPathBody(inlinedBlock)
+      case Block(List(DefDef(_, _, _, Some(pathBody))), _) => pathBody
+      case _                                               => report.errorAndAbort(s"Expected a lambda expression, got '${term.show}'")
+    }
+
+    def extractPath(term: Term): List[String] = term match {
+      case Select(parent, fieldName) =>
+        extractPath(parent) :+ fieldName
+      case _: Ident =>
+        List.empty
+      case Apply(Apply(_, List(parent)), List(Literal(IntConstant(_)))) =>
+        extractPath(parent)
+      case Apply(TypeApply(Select(parent, "apply"), _), List(Literal(IntConstant(_)))) =>
+        extractPath(parent)
+      case _ =>
+        report.errorAndAbort(
+          s"Unsupported path expression. Expected simple field access like _.field.nested, got '${term.show}'."
+        )
+    }
+
+    val pathBody  = toPathBody(selector.asTerm)
+    val pathParts = extractPath(pathBody)
+
+    if (pathParts.isEmpty) {
+      report.errorAndAbort("Selector must access at least one field, e.g., _.name")
+    }
+
+    val fieldExprs = pathParts.map(name => '{ DynamicOptic.Node.Field(${ Expr(name) }) })
+    val nodesExpr  = Expr.ofSeq(fieldExprs)
+    '{ DynamicOptic(IndexedSeq($nodesExpr*)) }
+  }
+
+  inline def extractFieldNames[T]: Set[String] =
+    ${ extractFieldNamesImpl[T] }
+
+  def extractFieldNamesImpl[T: Type](using q: Quotes): Expr[Set[String]] = {
+    import q.reflect.*
+
+    val tpe = TypeRepr.of[T].dealias
+
+    def getFieldNames(tpe: TypeRepr): List[String] =
+      tpe.classSymbol match {
+        case Some(sym) =>
+          sym.primaryConstructor.paramSymss.flatten
+            .filter(!_.isTypeParam)
+            .map(_.name)
+        case None =>
+          tpe match {
+            case Refinement(parent, name, _) =>
+              name :: getFieldNames(parent)
+            case _ =>
+              Nil
+          }
+      }
+
+    val fieldNames = getFieldNames(tpe)
+    val fieldExprs = fieldNames.map(Expr(_))
+    '{ Set(${ Expr.ofSeq(fieldExprs) }*) }
+  }
+
+  inline def validateMigrationCompleteness[A, B](
+    sourceFields: Set[String],
+    targetFields: Set[String],
+    addedFields: Set[String],
+    removedFields: Set[String],
+    renamedFields: Map[String, String]
+  ): Unit = ${
+    validateMigrationCompletenessImpl[A, B]('sourceFields, 'targetFields, 'addedFields, 'removedFields, 'renamedFields)
+  }
+
+  def validateMigrationCompletenessImpl[A: Type, B: Type](
+    sourceFields: Expr[Set[String]],
+    targetFields: Expr[Set[String]],
+    addedFields: Expr[Set[String]],
+    removedFields: Expr[Set[String]],
+    renamedFields: Expr[Map[String, String]]
+  )(using q: Quotes): Expr[Unit] = {
+    val aTypeName = Type.show[A]
+    val bTypeName = Type.show[B]
+
+    '{
+      val source  = $sourceFields
+      val target  = $targetFields
+      val added   = $addedFields
+      val removed = $removedFields
+      val renamed = $renamedFields
+
+      val transformedSource = (source -- removed -- renamed.keySet) ++ added ++ renamed.values
+
+      val missing = target -- transformedSource
+      val extra   = transformedSource -- target
+
+      if (missing.nonEmpty || extra.nonEmpty) {
+        val missingMsg = if (missing.nonEmpty) s"Missing fields in target: ${missing.mkString(", ")}" else ""
+        val extraMsg   = if (extra.nonEmpty) s"Extra fields not in target: ${extra.mkString(", ")}" else ""
+        val msgs       = Seq(missingMsg, extraMsg).filter(_.nonEmpty).mkString("; ")
+        throw new IllegalStateException(
+          s"Migration validation failed from ${${ Expr(aTypeName) }} to ${${ Expr(bTypeName) }}: $msgs"
+        )
+      }
+    }
+  }
+
+  inline def validateTypesCompatible[A, B]: Unit =
+    ${ validateTypesCompatibleImpl[A, B] }
+
+  def validateTypesCompatibleImpl[A: Type, B: Type](using q: Quotes): Expr[Unit] = {
+    import q.reflect.*
+
+    def getFieldNames(tpe: TypeRepr): List[String] =
+      tpe.classSymbol match {
+        case Some(sym) =>
+          sym.primaryConstructor.paramSymss.flatten
+            .filter(!_.isTypeParam)
+            .map(_.name)
+        case None =>
+          tpe match {
+            case Refinement(parent, name, _) =>
+              name :: getFieldNames(parent)
+            case _ =>
+              Nil
+          }
+      }
+
+    val sourceFields = getFieldNames(TypeRepr.of[A].dealias).toSet
+    val targetFields = getFieldNames(TypeRepr.of[B].dealias).toSet
+
+    if (sourceFields == targetFields) {
+      '{ () }
+    } else {
+      val added   = targetFields -- sourceFields
+      val removed = sourceFields -- targetFields
+
+      if (added.nonEmpty || removed.nonEmpty) {
+        val aTypeName  = Type.show[A]
+        val bTypeName  = Type.show[B]
+        val addedMsg   = if (added.nonEmpty) s"Fields added in target: ${added.mkString(", ")}" else ""
+        val removedMsg = if (removed.nonEmpty) s"Fields removed from source: ${removed.mkString(", ")}" else ""
+        val msg        = s"Types $aTypeName and $bTypeName have different structures. $addedMsg $removedMsg".trim
+        report.info(msg)
+      }
+      '{ () }
+    }
+  }
+
+  inline def validateMigrationAtCompileTime[A, B](
+    inline addedFields: Set[String],
+    inline removedFields: Set[String],
+    inline renamedFrom: Set[String],
+    inline renamedTo: Set[String]
+  ): Unit = ${ validateMigrationAtCompileTimeImpl[A, B]('addedFields, 'removedFields, 'renamedFrom, 'renamedTo) }
+
+  def validateMigrationAtCompileTimeImpl[A: Type, B: Type](
+    addedFieldsExpr: Expr[Set[String]],
+    removedFieldsExpr: Expr[Set[String]],
+    renamedFromExpr: Expr[Set[String]],
+    renamedToExpr: Expr[Set[String]]
+  )(using q: Quotes): Expr[Unit] = {
+    import q.reflect.*
+
+    def getFieldNames(tpe: TypeRepr): Set[String] =
+      tpe.classSymbol match {
+        case Some(sym) =>
+          sym.primaryConstructor.paramSymss.flatten
+            .filter(!_.isTypeParam)
+            .map(_.name)
+            .toSet
+        case None =>
+          tpe match {
+            case Refinement(parent, name, _) =>
+              Set(name) ++ getFieldNames(parent)
+            case _ =>
+              Set.empty
+          }
+      }
+
+    def extractLiteralSet(expr: Expr[Set[String]]): Option[Set[String]] =
+      expr.asTerm match {
+        case Apply(_, List(Typed(Repeated(elems, _), _))) =>
+          val strings = elems.collect { case Literal(StringConstant(s)) =>
+            s
+          }
+          if (strings.length == elems.length) Some(strings.toSet) else None
+        case Apply(TypeApply(Select(Ident("Set"), "apply"), _), List(Typed(Repeated(elems, _), _))) =>
+          val strings = elems.collect { case Literal(StringConstant(s)) =>
+            s
+          }
+          if (strings.length == elems.length) Some(strings.toSet) else None
+        case _ => None
+      }
+
+    val sourceFields = getFieldNames(TypeRepr.of[A].dealias)
+    val targetFields = getFieldNames(TypeRepr.of[B].dealias)
+
+    val addedOpt       = extractLiteralSet(addedFieldsExpr)
+    val removedOpt     = extractLiteralSet(removedFieldsExpr)
+    val renamedFromOpt = extractLiteralSet(renamedFromExpr)
+    val renamedToOpt   = extractLiteralSet(renamedToExpr)
+
+    (addedOpt, removedOpt, renamedFromOpt, renamedToOpt) match {
+      case (Some(added), Some(removed), Some(renamedFrom), Some(renamedTo)) =>
+        val transformedSource = (sourceFields -- removed -- renamedFrom) ++ added ++ renamedTo
+        val missing           = targetFields -- transformedSource
+        val extra             = transformedSource -- targetFields
+
+        if (missing.nonEmpty || extra.nonEmpty) {
+          val aTypeName  = Type.show[A]
+          val bTypeName  = Type.show[B]
+          val missingMsg = if (missing.nonEmpty) s"Missing fields in target: ${missing.mkString(", ")}" else ""
+          val extraMsg   = if (extra.nonEmpty) s"Extra fields not in target: ${extra.mkString(", ")}" else ""
+          val msgs       = Seq(missingMsg, extraMsg).filter(_.nonEmpty).mkString("; ")
+          report.errorAndAbort(
+            s"Migration validation failed from $aTypeName to $bTypeName: $msgs"
+          )
+        }
+        '{ () }
+      case _ =>
+        '{
+          val source      = ${ Expr(sourceFields) }
+          val target      = ${ Expr(targetFields) }
+          val added       = $addedFieldsExpr
+          val removed     = $removedFieldsExpr
+          val renamedFrom = $renamedFromExpr
+          val renamedTo   = $renamedToExpr
+
+          val transformedSource = (source -- removed -- renamedFrom) ++ added ++ renamedTo
+          val missing           = target -- transformedSource
+          val extra             = transformedSource -- target
+
+          if (missing.nonEmpty || extra.nonEmpty) {
+            val missingMsg = if (missing.nonEmpty) s"Missing fields in target: ${missing.mkString(", ")}" else ""
+            val extraMsg   = if (extra.nonEmpty) s"Extra fields not in target: ${extra.mkString(", ")}" else ""
+            val msgs       = Seq(missingMsg, extraMsg).filter(_.nonEmpty).mkString("; ")
+            throw new IllegalStateException(
+              s"Migration validation failed: $msgs"
+            )
+          }
+        }
+    }
+  }
+
+  inline def validateCompileTime[A, B](
+    inline added: Set[String],
+    inline removed: Set[String],
+    inline renamedFrom: Set[String],
+    inline renamedTo: Set[String]
+  ): Unit = ${ validateCompileTimeImpl[A, B]('added, 'removed, 'renamedFrom, 'renamedTo) }
+
+  def validateCompileTimeImpl[A: Type, B: Type](
+    addedExpr: Expr[Set[String]],
+    removedExpr: Expr[Set[String]],
+    renamedFromExpr: Expr[Set[String]],
+    renamedToExpr: Expr[Set[String]]
+  )(using q: Quotes): Expr[Unit] = {
+    import q.reflect.*
+
+    def getFieldNames(tpe: TypeRepr): Set[String] =
+      tpe.classSymbol match {
+        case Some(sym) =>
+          sym.primaryConstructor.paramSymss.flatten
+            .filter(!_.isTypeParam)
+            .map(_.name)
+            .toSet
+        case None =>
+          tpe match {
+            case Refinement(parent, name, _) =>
+              Set(name) ++ getFieldNames(parent)
+            case _ =>
+              Set.empty
+          }
+      }
+
+    def extractLiteralSet(expr: Expr[Set[String]]): Set[String] = {
+      def extractFromTerm(term: Term): Option[Set[String]] =
+        term match {
+          case Apply(_, List(Typed(Repeated(elems, _), _))) =>
+            val strings = elems.collect { case Literal(StringConstant(s)) => s }
+            if (strings.length == elems.length) Some(strings.toSet) else None
+
+          case Apply(TypeApply(Select(Ident("Set"), "apply"), _), List(Typed(Repeated(elems, _), _))) =>
+            val strings = elems.collect { case Literal(StringConstant(s)) => s }
+            if (strings.length == elems.length) Some(strings.toSet) else None
+
+          case TypeApply(Select(Ident("Set"), "empty"), _) =>
+            Some(Set.empty)
+
+          case TypeApply(
+                Select(Select(Select(Select(Ident("scala"), "collection"), "immutable"), "Set"), "empty"),
+                _
+              ) =>
+            Some(Set.empty)
+
+          case TypeApply(Select(Select(Ident("Predef"), "Set"), "empty"), _) =>
+            Some(Set.empty)
+
+          case TypeApply(Select(Select(Select(Ident("scala"), "Predef"), "Set"), "empty"), _) =>
+            Some(Set.empty)
+
+          case Typed(inner, _) =>
+            extractFromTerm(inner)
+
+          case Inlined(_, _, inner) =>
+            extractFromTerm(inner)
+
+          case Block(_, inner) =>
+            extractFromTerm(inner)
+
+          case _ => None
+        }
+
+      extractFromTerm(expr.asTerm).getOrElse {
+        report.errorAndAbort(
+          s"validateCompileTime requires literal Set values (e.g., Set(\"field1\", \"field2\") or Set.empty). " +
+            s"Got: ${expr.asTerm.show}"
+        )
+      }
+    }
+
+    val sourceFields = getFieldNames(TypeRepr.of[A].dealias)
+    val targetFields = getFieldNames(TypeRepr.of[B].dealias)
+
+    val added       = extractLiteralSet(addedExpr)
+    val removed     = extractLiteralSet(removedExpr)
+    val renamedFrom = extractLiteralSet(renamedFromExpr)
+    val renamedTo   = extractLiteralSet(renamedToExpr)
+
+    val transformedSource = (sourceFields -- removed -- renamedFrom) ++ added ++ renamedTo
+
+    val missing = targetFields -- transformedSource
+    val extra   = transformedSource -- targetFields
+
+    if (missing.nonEmpty || extra.nonEmpty) {
+      val aTypeName  = Type.show[A]
+      val bTypeName  = Type.show[B]
+      val missingMsg = if (missing.nonEmpty) s"Missing fields in target: ${missing.mkString(", ")}" else ""
+      val extraMsg   = if (extra.nonEmpty) s"Extra fields not in target: ${extra.mkString(", ")}" else ""
+      val msgs       = Seq(missingMsg, extraMsg).filter(_.nonEmpty).mkString("; ")
+      report.errorAndAbort(
+        s"Migration validation failed from $aTypeName to $bTypeName: $msgs"
+      )
+    }
+
+    '{ () }
+  }
+
+  inline def buildChecked[A, B](
+    builder: MigrationBuilder[A, B],
+    inline added: Set[String],
+    inline removed: Set[String],
+    inline renamedFrom: Set[String],
+    inline renamedTo: Set[String]
+  ): Migration[A, B] = {
+    validateCompileTime[A, B](added, removed, renamedFrom, renamedTo)
+    builder.build
+  }
+}
+
+extension [A, B](builder: MigrationBuilder[A, B]) {
+
+  inline def add[T](inline target: B => T, defaultValue: DynamicValue): MigrationBuilder[A, B] =
+    builder.addField(MigrationBuilderMacros.fieldPath(target), defaultValue)
+
+  inline def drop[T](inline source: A => T, defaultForReverse: DynamicValue): MigrationBuilder[A, B] =
+    builder.dropField(MigrationBuilderMacros.fieldPath(source), defaultForReverse)
+
+  inline def rename[T1, T2](inline from: A => T1, inline to: B => T2): MigrationBuilder[A, B] =
+    builder.renameField(MigrationBuilderMacros.fieldPath(from), MigrationBuilderMacros.fieldPath(to))
+
+  inline def transform[T](
+    inline path: A => T,
+    forward: DynamicValueTransform,
+    backward: DynamicValueTransform
+  ): MigrationBuilder[A, B] =
+    builder.transformField(MigrationBuilderMacros.fieldPath(path), forward, backward)
+
+  inline def optionalize[T](inline path: A => T, defaultForReverse: DynamicValue): MigrationBuilder[A, B] =
+    builder.optionalizeField(MigrationBuilderMacros.fieldPath(path), defaultForReverse)
+
+  inline def mandate[T](inline path: A => Option[T], defaultForNone: DynamicValue): MigrationBuilder[A, B] =
+    builder.mandateField(MigrationBuilderMacros.fieldPath(path), defaultForNone)
+
+  inline def changeType[T](
+    inline path: A => T,
+    forward: PrimitiveConversion,
+    backward: PrimitiveConversion
+  ): MigrationBuilder[A, B] =
+    builder.changeFieldType(MigrationBuilderMacros.fieldPath(path), forward, backward)
+
+  inline def addExpr[T](inline target: B => T, default: MigrationExpr[A, T]): MigrationBuilder[A, B] =
+    builder.addFieldExpr(MigrationBuilderMacros.toDynamicOptic(target), default)
+
+  inline def dropExpr[T](inline source: A => T, defaultForReverse: MigrationExpr[B, T]): MigrationBuilder[A, B] =
+    builder.dropFieldExpr(MigrationBuilderMacros.toDynamicOptic(source), defaultForReverse)
+
+  inline def optionalizeExpr[T](inline path: A => T, defaultForReverse: MigrationExpr[B, T]): MigrationBuilder[A, B] =
+    builder.optionalizeFieldExpr(MigrationBuilderMacros.toDynamicOptic(path), defaultForReverse)
+
+  inline def mandateExpr[T](inline path: A => Option[T], defaultForNone: MigrationExpr[A, T]): MigrationBuilder[A, B] =
+    builder.mandateFieldExpr(MigrationBuilderMacros.toDynamicOptic(path), defaultForNone)
+
+  inline def addCaseExpr[T](caseName: String, default: MigrationExpr[A, T]): MigrationBuilder[A, B] =
+    builder.addCaseExpr(caseName, default)
+
+  inline def dropCaseExpr[T](caseName: String, defaultForReverse: MigrationExpr[B, T]): MigrationBuilder[A, B] =
+    builder.dropCaseExpr(caseName, defaultForReverse)
+
+  inline def join[T](
+    inline target: B => T,
+    sourceNames: Vector[String],
+    combiner: DynamicValueTransform,
+    splitter: DynamicValueTransform
+  ): MigrationBuilder[A, B] =
+    builder.joinFields(MigrationBuilderMacros.fieldPath(target), sourceNames, combiner, splitter)
+
+  inline def split[T](
+    inline source: A => T,
+    targetNames: Vector[String],
+    splitter: DynamicValueTransform,
+    combiner: DynamicValueTransform
+  ): MigrationBuilder[A, B] =
+    builder.splitField(MigrationBuilderMacros.fieldPath(source), targetNames, splitter, combiner)
+
+  inline def buildValidated: Migration[A, B] = {
+    MigrationBuilderMacros.validateMigrationAtCompileTime[A, B](
+      builder.addedFieldNames,
+      builder.removedFieldNames,
+      builder.renamedFromNames,
+      builder.renamedToNames
+    )
+    builder.buildPartial
+  }
+
+  inline def buildChecked(
+    inline added: Set[String],
+    inline removed: Set[String],
+    inline renamedFrom: Set[String] = Set.empty[String],
+    inline renamedTo: Set[String] = Set.empty[String]
+  ): Migration[A, B] = {
+    MigrationBuilderMacros.validateCompileTime[A, B](added, removed, renamedFrom, renamedTo)
+    builder.buildPartial
+  }
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/CaseAction.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/CaseAction.scala
@@ -1,0 +1,160 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicValue, Schema}
+import zio.blocks.schema.binding._
+import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
+import zio.blocks.schema.Reflect
+import zio.blocks.typeid.TypeId
+
+sealed trait CaseAction {
+  def reverse: CaseAction
+}
+
+object CaseAction {
+
+  final case class Add(name: String, defaultValue: DynamicValue) extends CaseAction {
+    def reverse: CaseAction = Remove(name, defaultValue)
+  }
+
+  final case class Remove(name: String, defaultForReverse: DynamicValue) extends CaseAction {
+    def reverse: CaseAction = Add(name, defaultForReverse)
+  }
+
+  final case class Rename(from: String, to: String) extends CaseAction {
+    def reverse: CaseAction = Rename(to, from)
+  }
+
+  def add(name: String, defaultValue: DynamicValue): CaseAction =
+    Add(name, defaultValue)
+
+  def remove(name: String, defaultForReverse: DynamicValue): CaseAction =
+    Remove(name, defaultForReverse)
+
+  def rename(from: String, to: String): CaseAction =
+    Rename(from, to)
+
+  implicit lazy val addSchema: Schema[Add] = new Schema(
+    reflect = new Reflect.Record[Binding, Add](
+      fields = Vector(
+        Schema[String].reflect.asTerm("name"),
+        Schema[DynamicValue].reflect.asTerm("defaultValue")
+      ),
+      typeId = TypeId.of[Add],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Add] {
+          def usedRegisters: RegisterOffset                         = 2
+          def construct(in: Registers, offset: RegisterOffset): Add =
+            Add(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[DynamicValue]
+            )
+        },
+        deconstructor = new Deconstructor[Add] {
+          def usedRegisters: RegisterOffset                                      = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Add): Unit = {
+            out.setObject(offset + 0, in.name)
+            out.setObject(offset + 1, in.defaultValue)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val removeSchema: Schema[Remove] = new Schema(
+    reflect = new Reflect.Record[Binding, Remove](
+      fields = Vector(
+        Schema[String].reflect.asTerm("name"),
+        Schema[DynamicValue].reflect.asTerm("defaultForReverse")
+      ),
+      typeId = TypeId.of[Remove],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Remove] {
+          def usedRegisters: RegisterOffset                            = 2
+          def construct(in: Registers, offset: RegisterOffset): Remove =
+            Remove(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[DynamicValue]
+            )
+        },
+        deconstructor = new Deconstructor[Remove] {
+          def usedRegisters: RegisterOffset                                         = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Remove): Unit = {
+            out.setObject(offset + 0, in.name)
+            out.setObject(offset + 1, in.defaultForReverse)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val renameSchema: Schema[Rename] = new Schema(
+    reflect = new Reflect.Record[Binding, Rename](
+      fields = Vector(
+        Schema[String].reflect.asTerm("from"),
+        Schema[String].reflect.asTerm("to")
+      ),
+      typeId = TypeId.of[Rename],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Rename] {
+          def usedRegisters: RegisterOffset                            = 2
+          def construct(in: Registers, offset: RegisterOffset): Rename =
+            Rename(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[String]
+            )
+        },
+        deconstructor = new Deconstructor[Rename] {
+          def usedRegisters: RegisterOffset                                         = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Rename): Unit = {
+            out.setObject(offset + 0, in.from)
+            out.setObject(offset + 1, in.to)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val schema: Schema[CaseAction] = new Schema(
+    reflect = new Reflect.Variant[Binding, CaseAction](
+      cases = Vector(
+        addSchema.reflect.asTerm("Add"),
+        removeSchema.reflect.asTerm("Remove"),
+        renameSchema.reflect.asTerm("Rename")
+      ),
+      typeId = TypeId.of[CaseAction],
+      variantBinding = new Binding.Variant(
+        discriminator = new Discriminator[CaseAction] {
+          def discriminate(a: CaseAction): Int = a match {
+            case _: Add    => 0
+            case _: Remove => 1
+            case _: Rename => 2
+          }
+        },
+        matchers = Matchers(
+          new Matcher[Add] {
+            def downcastOrNull(a: Any): Add = a match {
+              case x: Add => x
+              case _      => null.asInstanceOf[Add]
+            }
+          },
+          new Matcher[Remove] {
+            def downcastOrNull(a: Any): Remove = a match {
+              case x: Remove => x
+              case _         => null.asInstanceOf[Remove]
+            }
+          },
+          new Matcher[Rename] {
+            def downcastOrNull(a: Any): Rename = a match {
+              case x: Rename => x
+              case _         => null.asInstanceOf[Rename]
+            }
+          }
+        )
+      ),
+      modifiers = Vector.empty
+    )
+  )
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -1,0 +1,378 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{DynamicOptic, DynamicValue, Schema}
+import zio.blocks.schema.binding._
+import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
+import zio.blocks.schema.Reflect
+import zio.blocks.typeid.TypeId
+
+final case class DynamicMigration(step: MigrationStep) {
+
+  def apply(value: DynamicValue): Either[MigrationError, DynamicValue] =
+    applyStep(value, step, DynamicOptic.root)
+
+  def reverse: DynamicMigration = DynamicMigration(step.reverse)
+
+  def andThen(that: DynamicMigration): DynamicMigration =
+    DynamicMigration(composeMigrationSteps(this.step, that.step))
+
+  private def composeMigrationSteps(first: MigrationStep, second: MigrationStep): MigrationStep =
+    (first, second) match {
+      case (MigrationStep.NoOp, s) => s
+      case (s, MigrationStep.NoOp) => s
+
+      case (r1: MigrationStep.Record, r2: MigrationStep.Record) =>
+        MigrationStep.Record(
+          r1.fieldActions ++ r2.fieldActions,
+          mergeNestedMaps(r1.nestedFields, r2.nestedFields)
+        )
+
+      case (v1: MigrationStep.Variant, v2: MigrationStep.Variant) =>
+        MigrationStep.Variant(
+          v1.caseActions ++ v2.caseActions,
+          mergeNestedMaps(v1.nestedCases, v2.nestedCases)
+        )
+
+      case (s1: MigrationStep.Sequence, s2: MigrationStep.Sequence) =>
+        MigrationStep.Sequence(composeMigrationSteps(s1.elementStep, s2.elementStep))
+
+      case (m1: MigrationStep.MapEntries, m2: MigrationStep.MapEntries) =>
+        MigrationStep.MapEntries(
+          composeMigrationSteps(m1.keyStep, m2.keyStep),
+          composeMigrationSteps(m1.valueStep, m2.valueStep)
+        )
+
+      case _ =>
+        second
+    }
+
+  private def mergeNestedMaps(
+    first: scala.collection.immutable.Map[String, MigrationStep],
+    second: scala.collection.immutable.Map[String, MigrationStep]
+  ): scala.collection.immutable.Map[String, MigrationStep] = {
+    val allKeys = first.keySet ++ second.keySet
+    allKeys.map { key =>
+      val merged = (first.get(key), second.get(key)) match {
+        case (Some(s1), Some(s2)) => composeMigrationSteps(s1, s2)
+        case (Some(s1), None)     => s1
+        case (None, Some(s2))     => s2
+        case (None, None)         => MigrationStep.NoOp
+      }
+      key -> merged
+    }.toMap
+  }
+
+  private def applyStep(
+    value: DynamicValue,
+    step: MigrationStep,
+    path: DynamicOptic
+  ): Either[MigrationError, DynamicValue] = step match {
+    case MigrationStep.NoOp =>
+      Right(value)
+
+    case r: MigrationStep.Record =>
+      applyRecordStep(value, r, path)
+
+    case v: MigrationStep.Variant =>
+      applyVariantStep(value, v, path)
+
+    case s: MigrationStep.Sequence =>
+      applySequenceStep(value, s, path)
+
+    case m: MigrationStep.MapEntries =>
+      applyMapStep(value, m, path)
+  }
+
+  private def applyRecordStep(
+    value: DynamicValue,
+    step: MigrationStep.Record,
+    path: DynamicOptic
+  ): Either[MigrationError, DynamicValue] = value match {
+    case DynamicValue.Record(fields) =>
+      val fieldsAfterActions = step.fieldActions.foldLeft[Either[MigrationError, Vector[(String, DynamicValue)]]](
+        Right(fields.toVector)
+      ) {
+        case (Right(currentFields), action) => applyFieldAction(currentFields, action, path)
+        case (left @ Left(_), _)            => left
+      }
+
+      fieldsAfterActions.flatMap { currentFields =>
+        step.nestedFields.foldLeft[Either[MigrationError, Vector[(String, DynamicValue)]]](Right(currentFields)) {
+          case (Right(flds), (fieldName, nestedStep)) =>
+            val fieldIdx = flds.indexWhere(_._1 == fieldName)
+            if (fieldIdx < 0) {
+              if (nestedStep.isEmpty) Right(flds)
+              else Left(MigrationError.fieldNotFound(fieldName, path))
+            } else {
+              val (name, fieldValue) = flds(fieldIdx)
+              applyStep(fieldValue, nestedStep, path.field(fieldName)).map { newValue =>
+                flds.updated(fieldIdx, (name, newValue))
+              }
+            }
+          case (left @ Left(_), _) => left
+        }
+      }.map(v => DynamicValue.Record(Chunk.from(v)))
+
+    case _ =>
+      Left(MigrationError.typeMismatch("Record", value.valueType.toString, path))
+  }
+
+  private def applyFieldAction(
+    fields: Vector[(String, DynamicValue)],
+    action: FieldAction,
+    path: DynamicOptic
+  ): Either[MigrationError, Vector[(String, DynamicValue)]] = action match {
+    case FieldAction.Add(name, defaultValue) =>
+      if (fields.exists(_._1 == name)) {
+        Left(MigrationError.fieldAlreadyExists(name, path))
+      } else {
+        Right(fields :+ (name -> defaultValue))
+      }
+
+    case FieldAction.Remove(name, _) =>
+      val idx = fields.indexWhere(_._1 == name)
+      if (idx < 0) {
+        Left(MigrationError.fieldNotFound(name, path))
+      } else {
+        Right(fields.patch(idx, Vector.empty, 1))
+      }
+
+    case FieldAction.Rename(from, to) =>
+      val idx = fields.indexWhere(_._1 == from)
+      if (idx < 0) {
+        Left(MigrationError.fieldNotFound(from, path))
+      } else if (fields.exists(_._1 == to)) {
+        Left(MigrationError.fieldAlreadyExists(to, path))
+      } else {
+        val (_, value) = fields(idx)
+        Right(fields.updated(idx, (to, value)))
+      }
+
+    case FieldAction.Transform(name, forward, _) =>
+      val idx = fields.indexWhere(_._1 == name)
+      if (idx < 0) {
+        Left(MigrationError.fieldNotFound(name, path))
+      } else {
+        val (_, value) = fields(idx)
+        forward(value) match {
+          case Right(newValue) => Right(fields.updated(idx, (name, newValue)))
+          case Left(err)       => Left(MigrationError.transformFailed(err, path.field(name)))
+        }
+      }
+
+    case FieldAction.MakeOptional(name, _) =>
+      val idx = fields.indexWhere(_._1 == name)
+      if (idx < 0) {
+        Left(MigrationError.fieldNotFound(name, path))
+      } else {
+        val (_, value) = fields(idx)
+        val wrapped    = DynamicValue.Variant("Some", DynamicValue.Record("value" -> value))
+        Right(fields.updated(idx, (name, wrapped)))
+      }
+
+    case FieldAction.MakeRequired(name, defaultForNone) =>
+      val idx = fields.indexWhere(_._1 == name)
+      if (idx < 0) {
+        Left(MigrationError.fieldNotFound(name, path))
+      } else {
+        val (_, value)              = fields(idx)
+        val unwrapped: DynamicValue = value match {
+          case DynamicValue.Variant("Some", inner) =>
+            inner.get("value").one.getOrElse(inner)
+          case DynamicValue.Variant("None", _) =>
+            defaultForNone
+          case DynamicValue.Null =>
+            defaultForNone
+          case other =>
+            other
+        }
+        Right(fields.updated(idx, (name, unwrapped)))
+      }
+
+    case FieldAction.ChangeType(name, forward, _) =>
+      val idx = fields.indexWhere(_._1 == name)
+      if (idx < 0) {
+        Left(MigrationError.fieldNotFound(name, path))
+      } else {
+        val (_, value) = fields(idx)
+        forward(value) match {
+          case Right(newValue) => Right(fields.updated(idx, (name, newValue)))
+          case Left(err)       => Left(MigrationError.transformFailed(err, path.field(name)))
+        }
+      }
+
+    case FieldAction.JoinFields(targetName, sourceNames, combiner, _) =>
+      if (fields.exists(_._1 == targetName)) {
+        Left(MigrationError.fieldAlreadyExists(targetName, path))
+      } else {
+        val sourceValues = sourceNames.flatMap { name =>
+          fields.find(_._1 == name).map(_._2)
+        }
+        if (sourceValues.length != sourceNames.length) {
+          sourceNames.find(name => !fields.exists(_._1 == name)) match {
+            case Some(missingField) => Left(MigrationError.fieldNotFound(missingField, path))
+            case None               => Left(MigrationError.transformFailed("Unknown missing field", path))
+          }
+        } else {
+          val sourceRecord = DynamicValue.Record(
+            Chunk.from(sourceNames.zip(sourceValues))
+          )
+          combiner(sourceRecord) match {
+            case Right(combinedValue) =>
+              val fieldsWithoutSources = fields.filterNot(f => sourceNames.contains(f._1))
+              Right(fieldsWithoutSources :+ (targetName -> combinedValue))
+            case Left(err) =>
+              Left(MigrationError.transformFailed(err, path.field(targetName)))
+          }
+        }
+      }
+
+    case FieldAction.SplitField(sourceName, targetNames, splitter, _) =>
+      val idx = fields.indexWhere(_._1 == sourceName)
+      if (idx < 0) {
+        Left(MigrationError.fieldNotFound(sourceName, path))
+      } else {
+        targetNames.find(name => fields.exists(_._1 == name)) match {
+          case Some(existingField) =>
+            Left(MigrationError.fieldAlreadyExists(existingField, path))
+          case None =>
+            val (_, sourceValue) = fields(idx)
+            splitter(sourceValue) match {
+              case Right(DynamicValue.Record(splitFields)) =>
+                val newFieldsMap      = splitFields.toMap
+                val targetFieldValues = targetNames.flatMap { name =>
+                  newFieldsMap.get(name).map(name -> _)
+                }
+                if (targetFieldValues.length != targetNames.length) {
+                  Left(
+                    MigrationError.transformFailed(
+                      s"Splitter did not produce all target fields: ${targetNames.mkString(", ")}",
+                      path.field(sourceName)
+                    )
+                  )
+                } else {
+                  val fieldsWithoutSource = fields.patch(idx, Vector.empty, 1)
+                  Right(fieldsWithoutSource ++ targetFieldValues)
+                }
+              case Right(_) =>
+                Left(
+                  MigrationError.transformFailed(
+                    "Splitter must return a Record with target field names",
+                    path.field(sourceName)
+                  )
+                )
+              case Left(err) =>
+                Left(MigrationError.transformFailed(err, path.field(sourceName)))
+            }
+        }
+      }
+  }
+
+  private def applyVariantStep(
+    value: DynamicValue,
+    step: MigrationStep.Variant,
+    path: DynamicOptic
+  ): Either[MigrationError, DynamicValue] = value match {
+    case DynamicValue.Variant(caseName, caseValue) =>
+      val currentCaseName = step.caseActions.foldLeft(caseName) { (name, action) =>
+        action match {
+          case CaseAction.Rename(from, to) if name == from => to
+          case _                                           => name
+        }
+      }
+
+      step.nestedCases.get(currentCaseName) match {
+        case Some(nestedStep) =>
+          applyStep(caseValue, nestedStep, path.caseOf(currentCaseName)).map { newValue =>
+            DynamicValue.Variant(currentCaseName, newValue)
+          }
+        case None =>
+          Right(DynamicValue.Variant(currentCaseName, caseValue))
+      }
+
+    case _ =>
+      Left(MigrationError.typeMismatch("Variant", value.valueType.toString, path))
+  }
+
+  private def applySequenceStep(
+    value: DynamicValue,
+    step: MigrationStep.Sequence,
+    path: DynamicOptic
+  ): Either[MigrationError, DynamicValue] = value match {
+    case DynamicValue.Sequence(elements) =>
+      elements.zipWithIndex
+        .foldLeft[Either[MigrationError, Vector[DynamicValue]]](Right(Vector.empty)) {
+          case (Right(acc), (elem, idx)) =>
+            applyStep(elem, step.elementStep, path.at(idx)).map(acc :+ _)
+          case (left @ Left(_), _) => left
+        }
+        .map(v => DynamicValue.Sequence(Chunk.from(v)))
+
+    case _ =>
+      Left(MigrationError.typeMismatch("Sequence", value.valueType.toString, path))
+  }
+
+  private def applyMapStep(
+    value: DynamicValue,
+    step: MigrationStep.MapEntries,
+    path: DynamicOptic
+  ): Either[MigrationError, DynamicValue] = value match {
+    case DynamicValue.Map(entries) =>
+      entries
+        .foldLeft[Either[MigrationError, Vector[(DynamicValue, DynamicValue)]]](Right(Vector.empty)) {
+          case (Right(acc), (key, entryValue)) =>
+            for {
+              newKey   <- applyStep(key, step.keyStep, path.mapKeys)
+              newValue <- applyStep(entryValue, step.valueStep, path.mapValues)
+            } yield acc :+ ((newKey, newValue))
+          case (left @ Left(_), _) => left
+        }
+        .map(v => DynamicValue.Map(Chunk.from(v)))
+
+    case _ =>
+      Left(MigrationError.typeMismatch("Map", value.valueType.toString, path))
+  }
+}
+
+object DynamicMigration {
+
+  val identity: DynamicMigration = DynamicMigration(MigrationStep.NoOp)
+
+  def record(build: MigrationStep.Record => MigrationStep.Record): DynamicMigration =
+    DynamicMigration(build(MigrationStep.Record.empty))
+
+  def variant(build: MigrationStep.Variant => MigrationStep.Variant): DynamicMigration =
+    DynamicMigration(build(MigrationStep.Variant.empty))
+
+  def sequence(elementMigration: DynamicMigration): DynamicMigration =
+    DynamicMigration(MigrationStep.Sequence(elementMigration.step))
+
+  def mapEntries(
+    keyMigration: DynamicMigration,
+    valueMigration: DynamicMigration
+  ): DynamicMigration =
+    DynamicMigration(MigrationStep.MapEntries(keyMigration.step, valueMigration.step))
+
+  implicit lazy val schema: Schema[DynamicMigration] = new Schema(
+    reflect = new Reflect.Record[Binding, DynamicMigration](
+      fields = Vector(
+        Schema[MigrationStep].reflect.asTerm("step")
+      ),
+      typeId = TypeId.of[DynamicMigration],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[DynamicMigration] {
+          def usedRegisters: RegisterOffset                                      = 1
+          def construct(in: Registers, offset: RegisterOffset): DynamicMigration =
+            DynamicMigration(in.getObject(offset + 0).asInstanceOf[MigrationStep])
+        },
+        deconstructor = new Deconstructor[DynamicMigration] {
+          def usedRegisters: RegisterOffset                                                   = 1
+          def deconstruct(out: Registers, offset: RegisterOffset, in: DynamicMigration): Unit =
+            out.setObject(offset + 0, in.step)
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicValueTransform.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicValueTransform.scala
@@ -1,0 +1,567 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicValue, PrimitiveValue, Schema}
+import zio.blocks.schema.binding._
+import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
+import zio.blocks.schema.Reflect
+import zio.blocks.typeid.TypeId
+
+sealed trait DynamicValueTransform {
+  def apply(value: DynamicValue): Either[String, DynamicValue]
+}
+
+object DynamicValueTransform {
+
+  case object Identity extends DynamicValueTransform {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = Right(value)
+  }
+
+  final case class Constant(result: DynamicValue) extends DynamicValueTransform {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = Right(result)
+  }
+
+  final case class StringAppend(suffix: String) extends DynamicValueTransform {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+        Right(DynamicValue.string(s + suffix))
+      case _ =>
+        Left(s"StringAppend requires a String value, got ${value.valueType}")
+    }
+  }
+
+  final case class StringPrepend(prefix: String) extends DynamicValueTransform {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+        Right(DynamicValue.string(prefix + s))
+      case _ =>
+        Left(s"StringPrepend requires a String value, got ${value.valueType}")
+    }
+  }
+
+  final case class StringReplace(target: String, replacement: String) extends DynamicValueTransform {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+        Right(DynamicValue.string(s.replace(target, replacement)))
+      case _ =>
+        Left(s"StringReplace requires a String value, got ${value.valueType}")
+    }
+  }
+
+  final case class NumericAdd(delta: BigDecimal) extends DynamicValueTransform {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.Int(n)) =>
+        Right(DynamicValue.int((BigDecimal(n) + delta).toInt))
+      case DynamicValue.Primitive(PrimitiveValue.Long(n)) =>
+        Right(DynamicValue.long((BigDecimal(n) + delta).toLong))
+      case DynamicValue.Primitive(PrimitiveValue.Double(n)) =>
+        Right(DynamicValue.double((BigDecimal(n) + delta).toDouble))
+      case DynamicValue.Primitive(PrimitiveValue.Float(n)) =>
+        Right(DynamicValue.float((BigDecimal(n.toDouble) + delta).toFloat))
+      case DynamicValue.Primitive(PrimitiveValue.BigDecimal(n)) =>
+        Right(DynamicValue.Primitive(PrimitiveValue.BigDecimal(n + delta)))
+      case DynamicValue.Primitive(PrimitiveValue.BigInt(n)) =>
+        Right(DynamicValue.bigInt(n + delta.toBigInt))
+      case _ =>
+        Left(s"NumericAdd requires a numeric value, got ${value.valueType}")
+    }
+  }
+
+  final case class NumericMultiply(factor: BigDecimal) extends DynamicValueTransform {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.Int(n)) =>
+        Right(DynamicValue.int((BigDecimal(n) * factor).toInt))
+      case DynamicValue.Primitive(PrimitiveValue.Long(n)) =>
+        Right(DynamicValue.long((BigDecimal(n) * factor).toLong))
+      case DynamicValue.Primitive(PrimitiveValue.Double(n)) =>
+        Right(DynamicValue.double((BigDecimal(n) * factor).toDouble))
+      case DynamicValue.Primitive(PrimitiveValue.Float(n)) =>
+        Right(DynamicValue.float((BigDecimal(n.toDouble) * factor).toFloat))
+      case DynamicValue.Primitive(PrimitiveValue.BigDecimal(n)) =>
+        Right(DynamicValue.Primitive(PrimitiveValue.BigDecimal(n * factor)))
+      case DynamicValue.Primitive(PrimitiveValue.BigInt(n)) =>
+        Right(DynamicValue.bigInt(n * factor.toBigInt))
+      case _ =>
+        Left(s"NumericMultiply requires a numeric value, got ${value.valueType}")
+    }
+  }
+
+  case object WrapInSome extends DynamicValueTransform {
+    def apply(value: DynamicValue): Either[String, DynamicValue] =
+      Right(DynamicValue.Variant("Some", DynamicValue.Record("value" -> value)))
+  }
+
+  final case class UnwrapSome(defaultForNone: DynamicValue) extends DynamicValueTransform {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Variant("Some", inner) =>
+        inner.get("value").one match {
+          case Right(v) => Right(v)
+          case Left(_)  => Right(inner)
+        }
+      case DynamicValue.Variant("None", _) =>
+        Right(defaultForNone)
+      case DynamicValue.Null =>
+        Right(defaultForNone)
+      case other =>
+        Right(other)
+    }
+  }
+
+  final case class Sequence(transforms: Vector[DynamicValueTransform]) extends DynamicValueTransform {
+    def apply(value: DynamicValue): Either[String, DynamicValue] =
+      transforms.foldLeft[Either[String, DynamicValue]](Right(value)) {
+        case (Right(current), transform) => transform(current)
+        case (left @ Left(_), _)         => left
+      }
+  }
+
+  /**
+   * Joins multiple string fields from a record into a single string. The record
+   * must contain string fields with the specified names. Fields are joined with
+   * the specified separator.
+   */
+  final case class StringJoinFields(fieldNames: Vector[String], separator: String) extends DynamicValueTransform {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Record(fields) =>
+        val fieldMap = fields.toMap
+        val values   = fieldNames.flatMap { name =>
+          fieldMap.get(name).flatMap {
+            case DynamicValue.Primitive(PrimitiveValue.String(s)) => Some(s)
+            case _                                                => None
+          }
+        }
+        if (values.length == fieldNames.length) {
+          Right(DynamicValue.string(values.mkString(separator)))
+        } else {
+          Left(s"StringJoinFields: not all fields found or not all are strings. Expected: ${fieldNames.mkString(", ")}")
+        }
+      case _ =>
+        Left(s"StringJoinFields requires a Record value, got ${value.valueType}")
+    }
+  }
+
+  /**
+   * Splits a string into multiple fields in a record. The string is split using
+   * the specified separator (regex). Each part is assigned to the corresponding
+   * field name.
+   */
+  final case class StringSplitToFields(fieldNames: Vector[String], separator: String, limit: Int = -1)
+      extends DynamicValueTransform {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+        val parts  = if (limit > 0) s.split(separator, limit) else s.split(separator)
+        val fields = fieldNames.zipWithIndex.map { case (name, idx) =>
+          val part = if (idx < parts.length) parts(idx) else ""
+          (name, DynamicValue.string(part))
+        }
+        Right(DynamicValue.Record(zio.blocks.chunk.Chunk.from(fields)))
+      case _ =>
+        Left(s"StringSplitToFields requires a String value, got ${value.valueType}")
+    }
+  }
+
+  def identity: DynamicValueTransform = Identity
+
+  def constant(value: DynamicValue): DynamicValueTransform = Constant(value)
+
+  def stringAppend(suffix: String): DynamicValueTransform = StringAppend(suffix)
+
+  def stringPrepend(prefix: String): DynamicValueTransform = StringPrepend(prefix)
+
+  def stringReplace(target: String, replacement: String): DynamicValueTransform =
+    StringReplace(target, replacement)
+
+  def numericAdd(delta: BigDecimal): DynamicValueTransform = NumericAdd(delta)
+
+  def numericMultiply(factor: BigDecimal): DynamicValueTransform = NumericMultiply(factor)
+
+  def wrapInSome: DynamicValueTransform = WrapInSome
+
+  def unwrapSome(defaultForNone: DynamicValue): DynamicValueTransform = UnwrapSome(defaultForNone)
+
+  def sequence(transforms: DynamicValueTransform*): DynamicValueTransform =
+    Sequence(transforms.toVector)
+
+  def stringJoinFields(fieldNames: Vector[String], separator: String = " "): DynamicValueTransform =
+    StringJoinFields(fieldNames, separator)
+
+  def stringSplitToFields(fieldNames: Vector[String], separator: String = " ", limit: Int = -1): DynamicValueTransform =
+    StringSplitToFields(fieldNames, separator, limit)
+
+  implicit lazy val identitySchema: Schema[Identity.type] = new Schema(
+    reflect = new Reflect.Record[Binding, Identity.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[Identity.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[Identity.type](Identity),
+        deconstructor = new ConstantDeconstructor[Identity.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val constantSchema: Schema[Constant] = new Schema(
+    reflect = new Reflect.Record[Binding, Constant](
+      fields = Vector(
+        Schema[DynamicValue].reflect.asTerm("result")
+      ),
+      typeId = TypeId.of[Constant],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Constant] {
+          def usedRegisters: RegisterOffset                              = 1
+          def construct(in: Registers, offset: RegisterOffset): Constant =
+            Constant(in.getObject(offset + 0).asInstanceOf[DynamicValue])
+        },
+        deconstructor = new Deconstructor[Constant] {
+          def usedRegisters: RegisterOffset                                           = 1
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Constant): Unit =
+            out.setObject(offset + 0, in.result)
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val stringAppendSchema: Schema[StringAppend] = new Schema(
+    reflect = new Reflect.Record[Binding, StringAppend](
+      fields = Vector(
+        Schema[String].reflect.asTerm("suffix")
+      ),
+      typeId = TypeId.of[StringAppend],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[StringAppend] {
+          def usedRegisters: RegisterOffset                                  = 1
+          def construct(in: Registers, offset: RegisterOffset): StringAppend =
+            StringAppend(in.getObject(offset + 0).asInstanceOf[String])
+        },
+        deconstructor = new Deconstructor[StringAppend] {
+          def usedRegisters: RegisterOffset                                               = 1
+          def deconstruct(out: Registers, offset: RegisterOffset, in: StringAppend): Unit =
+            out.setObject(offset + 0, in.suffix)
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val stringPrependSchema: Schema[StringPrepend] = new Schema(
+    reflect = new Reflect.Record[Binding, StringPrepend](
+      fields = Vector(
+        Schema[String].reflect.asTerm("prefix")
+      ),
+      typeId = TypeId.of[StringPrepend],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[StringPrepend] {
+          def usedRegisters: RegisterOffset                                   = 1
+          def construct(in: Registers, offset: RegisterOffset): StringPrepend =
+            StringPrepend(in.getObject(offset + 0).asInstanceOf[String])
+        },
+        deconstructor = new Deconstructor[StringPrepend] {
+          def usedRegisters: RegisterOffset                                                = 1
+          def deconstruct(out: Registers, offset: RegisterOffset, in: StringPrepend): Unit =
+            out.setObject(offset + 0, in.prefix)
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val stringReplaceSchema: Schema[StringReplace] = new Schema(
+    reflect = new Reflect.Record[Binding, StringReplace](
+      fields = Vector(
+        Schema[String].reflect.asTerm("target"),
+        Schema[String].reflect.asTerm("replacement")
+      ),
+      typeId = TypeId.of[StringReplace],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[StringReplace] {
+          def usedRegisters: RegisterOffset                                   = 2
+          def construct(in: Registers, offset: RegisterOffset): StringReplace =
+            StringReplace(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[String]
+            )
+        },
+        deconstructor = new Deconstructor[StringReplace] {
+          def usedRegisters: RegisterOffset                                                = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: StringReplace): Unit = {
+            out.setObject(offset + 0, in.target)
+            out.setObject(offset + 1, in.replacement)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val numericAddSchema: Schema[NumericAdd] = new Schema(
+    reflect = new Reflect.Record[Binding, NumericAdd](
+      fields = Vector(
+        Schema[BigDecimal].reflect.asTerm("delta")
+      ),
+      typeId = TypeId.of[NumericAdd],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[NumericAdd] {
+          def usedRegisters: RegisterOffset                                = 1
+          def construct(in: Registers, offset: RegisterOffset): NumericAdd =
+            NumericAdd(in.getObject(offset + 0).asInstanceOf[BigDecimal])
+        },
+        deconstructor = new Deconstructor[NumericAdd] {
+          def usedRegisters: RegisterOffset                                             = 1
+          def deconstruct(out: Registers, offset: RegisterOffset, in: NumericAdd): Unit =
+            out.setObject(offset + 0, in.delta)
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val numericMultiplySchema: Schema[NumericMultiply] = new Schema(
+    reflect = new Reflect.Record[Binding, NumericMultiply](
+      fields = Vector(
+        Schema[BigDecimal].reflect.asTerm("factor")
+      ),
+      typeId = TypeId.of[NumericMultiply],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[NumericMultiply] {
+          def usedRegisters: RegisterOffset                                     = 1
+          def construct(in: Registers, offset: RegisterOffset): NumericMultiply =
+            NumericMultiply(in.getObject(offset + 0).asInstanceOf[BigDecimal])
+        },
+        deconstructor = new Deconstructor[NumericMultiply] {
+          def usedRegisters: RegisterOffset                                                  = 1
+          def deconstruct(out: Registers, offset: RegisterOffset, in: NumericMultiply): Unit =
+            out.setObject(offset + 0, in.factor)
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val wrapInSomeSchema: Schema[WrapInSome.type] = new Schema(
+    reflect = new Reflect.Record[Binding, WrapInSome.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[WrapInSome.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[WrapInSome.type](WrapInSome),
+        deconstructor = new ConstantDeconstructor[WrapInSome.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val unwrapSomeSchema: Schema[UnwrapSome] = new Schema(
+    reflect = new Reflect.Record[Binding, UnwrapSome](
+      fields = Vector(
+        Schema[DynamicValue].reflect.asTerm("defaultForNone")
+      ),
+      typeId = TypeId.of[UnwrapSome],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[UnwrapSome] {
+          def usedRegisters: RegisterOffset                                = 1
+          def construct(in: Registers, offset: RegisterOffset): UnwrapSome =
+            UnwrapSome(in.getObject(offset + 0).asInstanceOf[DynamicValue])
+        },
+        deconstructor = new Deconstructor[UnwrapSome] {
+          def usedRegisters: RegisterOffset                                             = 1
+          def deconstruct(out: Registers, offset: RegisterOffset, in: UnwrapSome): Unit =
+            out.setObject(offset + 0, in.defaultForNone)
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val sequenceSchema: Schema[Sequence] = new Schema(
+    reflect = new Reflect.Record[Binding, Sequence](
+      fields = Vector(
+        Schema[Vector[DynamicValueTransform]].reflect.asTerm("transforms")
+      ),
+      typeId = TypeId.of[Sequence],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Sequence] {
+          def usedRegisters: RegisterOffset                              = 1
+          def construct(in: Registers, offset: RegisterOffset): Sequence =
+            Sequence(in.getObject(offset + 0).asInstanceOf[Vector[DynamicValueTransform]])
+        },
+        deconstructor = new Deconstructor[Sequence] {
+          def usedRegisters: RegisterOffset                                           = 1
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Sequence): Unit =
+            out.setObject(offset + 0, in.transforms)
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val stringJoinFieldsSchema: Schema[StringJoinFields] = new Schema(
+    reflect = new Reflect.Record[Binding, StringJoinFields](
+      fields = Vector(
+        Schema[Vector[String]].reflect.asTerm("fieldNames"),
+        Schema[String].reflect.asTerm("separator")
+      ),
+      typeId = TypeId.of[StringJoinFields],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[StringJoinFields] {
+          def usedRegisters: RegisterOffset                                      = 2
+          def construct(in: Registers, offset: RegisterOffset): StringJoinFields =
+            StringJoinFields(
+              in.getObject(offset + 0).asInstanceOf[Vector[String]],
+              in.getObject(offset + 1).asInstanceOf[String]
+            )
+        },
+        deconstructor = new Deconstructor[StringJoinFields] {
+          def usedRegisters: RegisterOffset                                                   = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: StringJoinFields): Unit = {
+            out.setObject(offset + 0, in.fieldNames)
+            out.setObject(offset + 1, in.separator)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val stringSplitToFieldsSchema: Schema[StringSplitToFields] = new Schema(
+    reflect = new Reflect.Record[Binding, StringSplitToFields](
+      fields = Vector(
+        Schema[Vector[String]].reflect.asTerm("fieldNames"),
+        Schema[String].reflect.asTerm("separator"),
+        Schema[Int].reflect.asTerm("limit")
+      ),
+      typeId = TypeId.of[StringSplitToFields],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[StringSplitToFields] {
+          def usedRegisters: RegisterOffset                                         = 3
+          def construct(in: Registers, offset: RegisterOffset): StringSplitToFields =
+            StringSplitToFields(
+              in.getObject(offset + 0).asInstanceOf[Vector[String]],
+              in.getObject(offset + 1).asInstanceOf[String],
+              in.getInt(offset + 2)
+            )
+        },
+        deconstructor = new Deconstructor[StringSplitToFields] {
+          def usedRegisters: RegisterOffset                                                      = 3
+          def deconstruct(out: Registers, offset: RegisterOffset, in: StringSplitToFields): Unit = {
+            out.setObject(offset + 0, in.fieldNames)
+            out.setObject(offset + 1, in.separator)
+            out.setInt(offset + 2, in.limit)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val schema: Schema[DynamicValueTransform] = new Schema(
+    reflect = new Reflect.Variant[Binding, DynamicValueTransform](
+      cases = Vector(
+        identitySchema.reflect.asTerm("Identity"),
+        constantSchema.reflect.asTerm("Constant"),
+        stringAppendSchema.reflect.asTerm("StringAppend"),
+        stringPrependSchema.reflect.asTerm("StringPrepend"),
+        stringReplaceSchema.reflect.asTerm("StringReplace"),
+        numericAddSchema.reflect.asTerm("NumericAdd"),
+        numericMultiplySchema.reflect.asTerm("NumericMultiply"),
+        wrapInSomeSchema.reflect.asTerm("WrapInSome"),
+        unwrapSomeSchema.reflect.asTerm("UnwrapSome"),
+        sequenceSchema.reflect.asTerm("Sequence"),
+        stringJoinFieldsSchema.reflect.asTerm("StringJoinFields"),
+        stringSplitToFieldsSchema.reflect.asTerm("StringSplitToFields")
+      ),
+      typeId = TypeId.of[DynamicValueTransform],
+      variantBinding = new Binding.Variant(
+        discriminator = new Discriminator[DynamicValueTransform] {
+          def discriminate(a: DynamicValueTransform): Int = a match {
+            case _: Identity.type       => 0
+            case _: Constant            => 1
+            case _: StringAppend        => 2
+            case _: StringPrepend       => 3
+            case _: StringReplace       => 4
+            case _: NumericAdd          => 5
+            case _: NumericMultiply     => 6
+            case _: WrapInSome.type     => 7
+            case _: UnwrapSome          => 8
+            case _: Sequence            => 9
+            case _: StringJoinFields    => 10
+            case _: StringSplitToFields => 11
+          }
+        },
+        matchers = Matchers(
+          new Matcher[Identity.type] {
+            def downcastOrNull(a: Any): Identity.type = a match {
+              case x: Identity.type => x
+              case _                => null.asInstanceOf[Identity.type]
+            }
+          },
+          new Matcher[Constant] {
+            def downcastOrNull(a: Any): Constant = a match {
+              case x: Constant => x
+              case _           => null.asInstanceOf[Constant]
+            }
+          },
+          new Matcher[StringAppend] {
+            def downcastOrNull(a: Any): StringAppend = a match {
+              case x: StringAppend => x
+              case _               => null.asInstanceOf[StringAppend]
+            }
+          },
+          new Matcher[StringPrepend] {
+            def downcastOrNull(a: Any): StringPrepend = a match {
+              case x: StringPrepend => x
+              case _                => null.asInstanceOf[StringPrepend]
+            }
+          },
+          new Matcher[StringReplace] {
+            def downcastOrNull(a: Any): StringReplace = a match {
+              case x: StringReplace => x
+              case _                => null.asInstanceOf[StringReplace]
+            }
+          },
+          new Matcher[NumericAdd] {
+            def downcastOrNull(a: Any): NumericAdd = a match {
+              case x: NumericAdd => x
+              case _             => null.asInstanceOf[NumericAdd]
+            }
+          },
+          new Matcher[NumericMultiply] {
+            def downcastOrNull(a: Any): NumericMultiply = a match {
+              case x: NumericMultiply => x
+              case _                  => null.asInstanceOf[NumericMultiply]
+            }
+          },
+          new Matcher[WrapInSome.type] {
+            def downcastOrNull(a: Any): WrapInSome.type = a match {
+              case x: WrapInSome.type => x
+              case _                  => null.asInstanceOf[WrapInSome.type]
+            }
+          },
+          new Matcher[UnwrapSome] {
+            def downcastOrNull(a: Any): UnwrapSome = a match {
+              case x: UnwrapSome => x
+              case _             => null.asInstanceOf[UnwrapSome]
+            }
+          },
+          new Matcher[Sequence] {
+            def downcastOrNull(a: Any): Sequence = a match {
+              case x: Sequence => x
+              case _           => null.asInstanceOf[Sequence]
+            }
+          },
+          new Matcher[StringJoinFields] {
+            def downcastOrNull(a: Any): StringJoinFields = a match {
+              case x: StringJoinFields => x
+              case _                   => null.asInstanceOf[StringJoinFields]
+            }
+          },
+          new Matcher[StringSplitToFields] {
+            def downcastOrNull(a: Any): StringSplitToFields = a match {
+              case x: StringSplitToFields => x
+              case _                      => null.asInstanceOf[StringSplitToFields]
+            }
+          }
+        )
+      ),
+      modifiers = Vector.empty
+    )
+  )
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/FieldAction.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/FieldAction.scala
@@ -1,0 +1,480 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicValue, Schema}
+import zio.blocks.schema.binding._
+import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
+import zio.blocks.schema.Reflect
+import zio.blocks.typeid.TypeId
+
+sealed trait FieldAction {
+  def reverse: FieldAction
+}
+
+object FieldAction {
+
+  final case class Add(name: String, defaultValue: DynamicValue) extends FieldAction {
+    def reverse: FieldAction = Remove(name, defaultValue)
+  }
+
+  final case class Remove(name: String, defaultForReverse: DynamicValue) extends FieldAction {
+    def reverse: FieldAction = Add(name, defaultForReverse)
+  }
+
+  final case class Rename(from: String, to: String) extends FieldAction {
+    def reverse: FieldAction = Rename(to, from)
+  }
+
+  final case class Transform(
+    name: String,
+    forward: DynamicValueTransform,
+    backward: DynamicValueTransform
+  ) extends FieldAction {
+    def reverse: FieldAction = Transform(name, backward, forward)
+  }
+
+  final case class MakeOptional(name: String, defaultForReverse: DynamicValue) extends FieldAction {
+    def reverse: FieldAction = MakeRequired(name, defaultForReverse)
+  }
+
+  final case class MakeRequired(name: String, defaultForNone: DynamicValue) extends FieldAction {
+    def reverse: FieldAction = MakeOptional(name, defaultForNone)
+  }
+
+  final case class ChangeType(
+    name: String,
+    forward: PrimitiveConversion,
+    backward: PrimitiveConversion
+  ) extends FieldAction {
+    def reverse: FieldAction = ChangeType(name, backward, forward)
+  }
+
+  /**
+   * Join multiple source fields into a single target field. Used when schema
+   * evolution combines fields (e.g., firstName + lastName -> fullName)
+   */
+  final case class JoinFields(
+    targetName: String,
+    sourceNames: Vector[String],
+    combiner: DynamicValueTransform,
+    splitter: DynamicValueTransform
+  ) extends FieldAction {
+    def reverse: FieldAction = SplitField(targetName, sourceNames, splitter, combiner)
+  }
+
+  /**
+   * Split a single source field into multiple target fields. Used when schema
+   * evolution splits fields (e.g., fullName -> firstName + lastName)
+   */
+  final case class SplitField(
+    sourceName: String,
+    targetNames: Vector[String],
+    splitter: DynamicValueTransform,
+    combiner: DynamicValueTransform
+  ) extends FieldAction {
+    def reverse: FieldAction = JoinFields(sourceName, targetNames, combiner, splitter)
+  }
+
+  def add(name: String, defaultValue: DynamicValue): FieldAction =
+    Add(name, defaultValue)
+
+  def remove(name: String, defaultForReverse: DynamicValue): FieldAction =
+    Remove(name, defaultForReverse)
+
+  def rename(from: String, to: String): FieldAction =
+    Rename(from, to)
+
+  def transform(
+    name: String,
+    forward: DynamicValueTransform,
+    backward: DynamicValueTransform
+  ): FieldAction =
+    Transform(name, forward, backward)
+
+  def makeOptional(name: String, defaultForReverse: DynamicValue): FieldAction =
+    MakeOptional(name, defaultForReverse)
+
+  def makeRequired(name: String, defaultForNone: DynamicValue): FieldAction =
+    MakeRequired(name, defaultForNone)
+
+  def changeType(
+    name: String,
+    forward: PrimitiveConversion,
+    backward: PrimitiveConversion
+  ): FieldAction =
+    ChangeType(name, forward, backward)
+
+  def joinFields(
+    targetName: String,
+    sourceNames: Vector[String],
+    combiner: DynamicValueTransform,
+    splitter: DynamicValueTransform
+  ): FieldAction =
+    JoinFields(targetName, sourceNames, combiner, splitter)
+
+  def splitField(
+    sourceName: String,
+    targetNames: Vector[String],
+    splitter: DynamicValueTransform,
+    combiner: DynamicValueTransform
+  ): FieldAction =
+    SplitField(sourceName, targetNames, splitter, combiner)
+
+  implicit lazy val addSchema: Schema[Add] = new Schema(
+    reflect = new Reflect.Record[Binding, Add](
+      fields = Vector(
+        Schema[String].reflect.asTerm("name"),
+        Schema[DynamicValue].reflect.asTerm("defaultValue")
+      ),
+      typeId = TypeId.of[Add],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Add] {
+          def usedRegisters: RegisterOffset                         = 2
+          def construct(in: Registers, offset: RegisterOffset): Add =
+            Add(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[DynamicValue]
+            )
+        },
+        deconstructor = new Deconstructor[Add] {
+          def usedRegisters: RegisterOffset                                      = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Add): Unit = {
+            out.setObject(offset + 0, in.name)
+            out.setObject(offset + 1, in.defaultValue)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val removeSchema: Schema[Remove] = new Schema(
+    reflect = new Reflect.Record[Binding, Remove](
+      fields = Vector(
+        Schema[String].reflect.asTerm("name"),
+        Schema[DynamicValue].reflect.asTerm("defaultForReverse")
+      ),
+      typeId = TypeId.of[Remove],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Remove] {
+          def usedRegisters: RegisterOffset                            = 2
+          def construct(in: Registers, offset: RegisterOffset): Remove =
+            Remove(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[DynamicValue]
+            )
+        },
+        deconstructor = new Deconstructor[Remove] {
+          def usedRegisters: RegisterOffset                                         = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Remove): Unit = {
+            out.setObject(offset + 0, in.name)
+            out.setObject(offset + 1, in.defaultForReverse)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val renameSchema: Schema[Rename] = new Schema(
+    reflect = new Reflect.Record[Binding, Rename](
+      fields = Vector(
+        Schema[String].reflect.asTerm("from"),
+        Schema[String].reflect.asTerm("to")
+      ),
+      typeId = TypeId.of[Rename],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Rename] {
+          def usedRegisters: RegisterOffset                            = 2
+          def construct(in: Registers, offset: RegisterOffset): Rename =
+            Rename(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[String]
+            )
+        },
+        deconstructor = new Deconstructor[Rename] {
+          def usedRegisters: RegisterOffset                                         = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Rename): Unit = {
+            out.setObject(offset + 0, in.from)
+            out.setObject(offset + 1, in.to)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val transformSchema: Schema[Transform] = new Schema(
+    reflect = new Reflect.Record[Binding, Transform](
+      fields = Vector(
+        Schema[String].reflect.asTerm("name"),
+        Schema[DynamicValueTransform].reflect.asTerm("forward"),
+        Schema[DynamicValueTransform].reflect.asTerm("backward")
+      ),
+      typeId = TypeId.of[Transform],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Transform] {
+          def usedRegisters: RegisterOffset                               = 3
+          def construct(in: Registers, offset: RegisterOffset): Transform =
+            Transform(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[DynamicValueTransform],
+              in.getObject(offset + 2).asInstanceOf[DynamicValueTransform]
+            )
+        },
+        deconstructor = new Deconstructor[Transform] {
+          def usedRegisters: RegisterOffset                                            = 3
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Transform): Unit = {
+            out.setObject(offset + 0, in.name)
+            out.setObject(offset + 1, in.forward)
+            out.setObject(offset + 2, in.backward)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val makeOptionalSchema: Schema[MakeOptional] = new Schema(
+    reflect = new Reflect.Record[Binding, MakeOptional](
+      fields = Vector(
+        Schema[String].reflect.asTerm("name"),
+        Schema[DynamicValue].reflect.asTerm("defaultForReverse")
+      ),
+      typeId = TypeId.of[MakeOptional],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[MakeOptional] {
+          def usedRegisters: RegisterOffset                                  = 2
+          def construct(in: Registers, offset: RegisterOffset): MakeOptional =
+            MakeOptional(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[DynamicValue]
+            )
+        },
+        deconstructor = new Deconstructor[MakeOptional] {
+          def usedRegisters: RegisterOffset                                               = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: MakeOptional): Unit = {
+            out.setObject(offset + 0, in.name)
+            out.setObject(offset + 1, in.defaultForReverse)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val makeRequiredSchema: Schema[MakeRequired] = new Schema(
+    reflect = new Reflect.Record[Binding, MakeRequired](
+      fields = Vector(
+        Schema[String].reflect.asTerm("name"),
+        Schema[DynamicValue].reflect.asTerm("defaultForNone")
+      ),
+      typeId = TypeId.of[MakeRequired],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[MakeRequired] {
+          def usedRegisters: RegisterOffset                                  = 2
+          def construct(in: Registers, offset: RegisterOffset): MakeRequired =
+            MakeRequired(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[DynamicValue]
+            )
+        },
+        deconstructor = new Deconstructor[MakeRequired] {
+          def usedRegisters: RegisterOffset                                               = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: MakeRequired): Unit = {
+            out.setObject(offset + 0, in.name)
+            out.setObject(offset + 1, in.defaultForNone)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val changeTypeSchema: Schema[ChangeType] = new Schema(
+    reflect = new Reflect.Record[Binding, ChangeType](
+      fields = Vector(
+        Schema[String].reflect.asTerm("name"),
+        Schema[PrimitiveConversion].reflect.asTerm("forward"),
+        Schema[PrimitiveConversion].reflect.asTerm("backward")
+      ),
+      typeId = TypeId.of[ChangeType],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[ChangeType] {
+          def usedRegisters: RegisterOffset                                = 3
+          def construct(in: Registers, offset: RegisterOffset): ChangeType =
+            ChangeType(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[PrimitiveConversion],
+              in.getObject(offset + 2).asInstanceOf[PrimitiveConversion]
+            )
+        },
+        deconstructor = new Deconstructor[ChangeType] {
+          def usedRegisters: RegisterOffset                                             = 3
+          def deconstruct(out: Registers, offset: RegisterOffset, in: ChangeType): Unit = {
+            out.setObject(offset + 0, in.name)
+            out.setObject(offset + 1, in.forward)
+            out.setObject(offset + 2, in.backward)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val joinFieldsSchema: Schema[JoinFields] = new Schema(
+    reflect = new Reflect.Record[Binding, JoinFields](
+      fields = Vector(
+        Schema[String].reflect.asTerm("targetName"),
+        Schema[Vector[String]].reflect.asTerm("sourceNames"),
+        Schema[DynamicValueTransform].reflect.asTerm("combiner"),
+        Schema[DynamicValueTransform].reflect.asTerm("splitter")
+      ),
+      typeId = TypeId.of[JoinFields],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[JoinFields] {
+          def usedRegisters: RegisterOffset                                = 4
+          def construct(in: Registers, offset: RegisterOffset): JoinFields =
+            JoinFields(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[Vector[String]],
+              in.getObject(offset + 2).asInstanceOf[DynamicValueTransform],
+              in.getObject(offset + 3).asInstanceOf[DynamicValueTransform]
+            )
+        },
+        deconstructor = new Deconstructor[JoinFields] {
+          def usedRegisters: RegisterOffset                                             = 4
+          def deconstruct(out: Registers, offset: RegisterOffset, in: JoinFields): Unit = {
+            out.setObject(offset + 0, in.targetName)
+            out.setObject(offset + 1, in.sourceNames)
+            out.setObject(offset + 2, in.combiner)
+            out.setObject(offset + 3, in.splitter)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val splitFieldSchema: Schema[SplitField] = new Schema(
+    reflect = new Reflect.Record[Binding, SplitField](
+      fields = Vector(
+        Schema[String].reflect.asTerm("sourceName"),
+        Schema[Vector[String]].reflect.asTerm("targetNames"),
+        Schema[DynamicValueTransform].reflect.asTerm("splitter"),
+        Schema[DynamicValueTransform].reflect.asTerm("combiner")
+      ),
+      typeId = TypeId.of[SplitField],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[SplitField] {
+          def usedRegisters: RegisterOffset                                = 4
+          def construct(in: Registers, offset: RegisterOffset): SplitField =
+            SplitField(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[Vector[String]],
+              in.getObject(offset + 2).asInstanceOf[DynamicValueTransform],
+              in.getObject(offset + 3).asInstanceOf[DynamicValueTransform]
+            )
+        },
+        deconstructor = new Deconstructor[SplitField] {
+          def usedRegisters: RegisterOffset                                             = 4
+          def deconstruct(out: Registers, offset: RegisterOffset, in: SplitField): Unit = {
+            out.setObject(offset + 0, in.sourceName)
+            out.setObject(offset + 1, in.targetNames)
+            out.setObject(offset + 2, in.splitter)
+            out.setObject(offset + 3, in.combiner)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val schema: Schema[FieldAction] = new Schema(
+    reflect = new Reflect.Variant[Binding, FieldAction](
+      cases = Vector(
+        addSchema.reflect.asTerm("Add"),
+        removeSchema.reflect.asTerm("Remove"),
+        renameSchema.reflect.asTerm("Rename"),
+        transformSchema.reflect.asTerm("Transform"),
+        makeOptionalSchema.reflect.asTerm("MakeOptional"),
+        makeRequiredSchema.reflect.asTerm("MakeRequired"),
+        changeTypeSchema.reflect.asTerm("ChangeType"),
+        joinFieldsSchema.reflect.asTerm("JoinFields"),
+        splitFieldSchema.reflect.asTerm("SplitField")
+      ),
+      typeId = TypeId.of[FieldAction],
+      variantBinding = new Binding.Variant(
+        discriminator = new Discriminator[FieldAction] {
+          def discriminate(a: FieldAction): Int = a match {
+            case _: Add          => 0
+            case _: Remove       => 1
+            case _: Rename       => 2
+            case _: Transform    => 3
+            case _: MakeOptional => 4
+            case _: MakeRequired => 5
+            case _: ChangeType   => 6
+            case _: JoinFields   => 7
+            case _: SplitField   => 8
+          }
+        },
+        matchers = Matchers(
+          new Matcher[Add] {
+            def downcastOrNull(a: Any): Add = a match {
+              case x: Add => x
+              case _      => null.asInstanceOf[Add]
+            }
+          },
+          new Matcher[Remove] {
+            def downcastOrNull(a: Any): Remove = a match {
+              case x: Remove => x
+              case _         => null.asInstanceOf[Remove]
+            }
+          },
+          new Matcher[Rename] {
+            def downcastOrNull(a: Any): Rename = a match {
+              case x: Rename => x
+              case _         => null.asInstanceOf[Rename]
+            }
+          },
+          new Matcher[Transform] {
+            def downcastOrNull(a: Any): Transform = a match {
+              case x: Transform => x
+              case _            => null.asInstanceOf[Transform]
+            }
+          },
+          new Matcher[MakeOptional] {
+            def downcastOrNull(a: Any): MakeOptional = a match {
+              case x: MakeOptional => x
+              case _               => null.asInstanceOf[MakeOptional]
+            }
+          },
+          new Matcher[MakeRequired] {
+            def downcastOrNull(a: Any): MakeRequired = a match {
+              case x: MakeRequired => x
+              case _               => null.asInstanceOf[MakeRequired]
+            }
+          },
+          new Matcher[ChangeType] {
+            def downcastOrNull(a: Any): ChangeType = a match {
+              case x: ChangeType => x
+              case _             => null.asInstanceOf[ChangeType]
+            }
+          },
+          new Matcher[JoinFields] {
+            def downcastOrNull(a: Any): JoinFields = a match {
+              case x: JoinFields => x
+              case _             => null.asInstanceOf[JoinFields]
+            }
+          },
+          new Matcher[SplitField] {
+            def downcastOrNull(a: Any): SplitField = a match {
+              case x: SplitField => x
+              case _             => null.asInstanceOf[SplitField]
+            }
+          }
+        )
+      ),
+      modifiers = Vector.empty
+    )
+  )
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
@@ -1,0 +1,66 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicOptic, DynamicValue, Schema}
+
+final case class Migration[A, B](
+  dynamicMigration: DynamicMigration,
+  sourceSchema: Schema[A],
+  targetSchema: Schema[B]
+) {
+
+  def apply(value: A): Either[MigrationError, B] = {
+    val dynamicValue = sourceSchema.toDynamicValue(value)
+    dynamicMigration(dynamicValue).flatMap { migratedDynamic =>
+      targetSchema.fromDynamicValue(migratedDynamic) match {
+        case Right(result) => Right(result)
+        case Left(err)     => Left(MigrationError.incompatibleValue(err.message, DynamicOptic.root))
+      }
+    }
+  }
+
+  def applyDynamic(value: DynamicValue): Either[MigrationError, DynamicValue] =
+    dynamicMigration(value)
+
+  def reverse(implicit
+    reverseSourceSchema: Schema[B],
+    reverseTargetSchema: Schema[A]
+  ): Migration[B, A] =
+    Migration(
+      dynamicMigration.reverse,
+      reverseSourceSchema,
+      reverseTargetSchema
+    )
+
+  def andThen[C](that: Migration[B, C]): Migration[A, C] =
+    Migration(
+      this.dynamicMigration.andThen(that.dynamicMigration),
+      this.sourceSchema,
+      that.targetSchema
+    )
+}
+
+object Migration {
+
+  def identity[A](implicit schema: Schema[A]): Migration[A, A] =
+    Migration(DynamicMigration.identity, schema, schema)
+
+  def apply[A, B](
+    build: MigrationStep.Record => MigrationStep.Record
+  )(implicit
+    sourceSchema: Schema[A],
+    targetSchema: Schema[B]
+  ): Migration[A, B] =
+    Migration(
+      DynamicMigration.record(build),
+      sourceSchema,
+      targetSchema
+    )
+
+  def fromDynamic[A, B](
+    dynamicMigration: DynamicMigration
+  )(implicit
+    sourceSchema: Schema[A],
+    targetSchema: Schema[B]
+  ): Migration[A, B] =
+    Migration(dynamicMigration, sourceSchema, targetSchema)
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -1,0 +1,374 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicOptic, DynamicValue, Schema}
+
+final class MigrationBuilder[A, B] private (
+  val sourceSchema: Schema[A],
+  val targetSchema: Schema[B],
+  private val step: MigrationStep.Record,
+  private val variantStep: MigrationStep.Variant
+) {
+
+  def addField(path: String, defaultValue: DynamicValue): MigrationBuilder[A, B] =
+    parsePath(path) match {
+      case (Nil, fieldName)          => copy(step = step.addField(fieldName, defaultValue))
+      case (head :: tail, fieldName) =>
+        copy(step = step.nested(head) { nested =>
+          applyNestedFieldAction(nested, tail, FieldAction.add(fieldName, defaultValue))
+        })
+    }
+
+  def addFieldExpr[T](path: DynamicOptic, default: MigrationExpr[A, T]): MigrationBuilder[A, B] = {
+    val pathString     = dynamicOpticToPath(path)
+    val defaultDynamic = default.evalDynamic(DynamicValue.Null) match {
+      case Right(dv) => dv
+      case Left(_)   => DynamicValue.Null
+    }
+    addField(pathString, defaultDynamic)
+  }
+
+  def dropField(path: String, defaultForReverse: DynamicValue): MigrationBuilder[A, B] =
+    parsePath(path) match {
+      case (Nil, fieldName)          => copy(step = step.removeField(fieldName, defaultForReverse))
+      case (head :: tail, fieldName) =>
+        copy(step = step.nested(head) { nested =>
+          applyNestedFieldAction(nested, tail, FieldAction.remove(fieldName, defaultForReverse))
+        })
+    }
+
+  def dropFieldExpr[T](path: DynamicOptic, defaultForReverse: MigrationExpr[B, T]): MigrationBuilder[A, B] = {
+    val pathString     = dynamicOpticToPath(path)
+    val defaultDynamic = defaultForReverse.evalDynamic(DynamicValue.Null) match {
+      case Right(dv) => dv
+      case Left(_)   => DynamicValue.Null
+    }
+    dropField(pathString, defaultDynamic)
+  }
+
+  def renameField(fromPath: String, toPath: String): MigrationBuilder[A, B] = {
+    val (fromParent, fromName) = parsePath(fromPath)
+    val (toParent, toName)     = parsePath(toPath)
+    if (fromParent != toParent) {
+      throw new IllegalArgumentException(
+        s"Cannot rename across different parent paths: '$fromPath' -> '$toPath'"
+      )
+    }
+    fromParent match {
+      case Nil          => copy(step = step.renameField(fromName, toName))
+      case head :: tail =>
+        copy(step = step.nested(head) { nested =>
+          applyNestedFieldAction(nested, tail, FieldAction.rename(fromName, toName))
+        })
+    }
+  }
+
+  def transformField(
+    path: String,
+    forward: DynamicValueTransform,
+    backward: DynamicValueTransform
+  ): MigrationBuilder[A, B] =
+    parsePath(path) match {
+      case (Nil, fieldName)          => copy(step = step.transformField(fieldName, forward, backward))
+      case (head :: tail, fieldName) =>
+        copy(step = step.nested(head) { nested =>
+          applyNestedFieldAction(nested, tail, FieldAction.transform(fieldName, forward, backward))
+        })
+    }
+
+  def optionalizeField(path: String, defaultForReverse: DynamicValue): MigrationBuilder[A, B] =
+    parsePath(path) match {
+      case (Nil, fieldName)          => copy(step = step.makeFieldOptional(fieldName, defaultForReverse))
+      case (head :: tail, fieldName) =>
+        copy(step = step.nested(head) { nested =>
+          applyNestedFieldAction(nested, tail, FieldAction.makeOptional(fieldName, defaultForReverse))
+        })
+    }
+
+  def optionalizeFieldExpr[T](path: DynamicOptic, defaultForReverse: MigrationExpr[B, T]): MigrationBuilder[A, B] = {
+    val pathString     = dynamicOpticToPath(path)
+    val defaultDynamic = defaultForReverse.evalDynamic(DynamicValue.Null) match {
+      case Right(dv) => dv
+      case Left(_)   => DynamicValue.Null
+    }
+    optionalizeField(pathString, defaultDynamic)
+  }
+
+  def mandateField(path: String, defaultForNone: DynamicValue): MigrationBuilder[A, B] =
+    parsePath(path) match {
+      case (Nil, fieldName)          => copy(step = step.makeFieldRequired(fieldName, defaultForNone))
+      case (head :: tail, fieldName) =>
+        copy(step = step.nested(head) { nested =>
+          applyNestedFieldAction(nested, tail, FieldAction.makeRequired(fieldName, defaultForNone))
+        })
+    }
+
+  def mandateFieldExpr[T](path: DynamicOptic, defaultForNone: MigrationExpr[A, T]): MigrationBuilder[A, B] = {
+    val pathString     = dynamicOpticToPath(path)
+    val defaultDynamic = defaultForNone.evalDynamic(DynamicValue.Null) match {
+      case Right(dv) => dv
+      case Left(_)   => DynamicValue.Null
+    }
+    mandateField(pathString, defaultDynamic)
+  }
+
+  def changeFieldType(
+    path: String,
+    forward: PrimitiveConversion,
+    backward: PrimitiveConversion
+  ): MigrationBuilder[A, B] =
+    parsePath(path) match {
+      case (Nil, fieldName)          => copy(step = step.changeFieldType(fieldName, forward, backward))
+      case (head :: tail, fieldName) =>
+        copy(step = step.nested(head) { nested =>
+          applyNestedFieldAction(nested, tail, FieldAction.changeType(fieldName, forward, backward))
+        })
+    }
+
+  def joinFields(
+    targetPath: String,
+    sourceNames: Vector[String],
+    combiner: DynamicValueTransform,
+    splitter: DynamicValueTransform
+  ): MigrationBuilder[A, B] =
+    parsePath(targetPath) match {
+      case (Nil, targetName) =>
+        copy(step = step.joinFields(targetName, sourceNames, combiner, splitter))
+      case (head :: tail, targetName) =>
+        copy(step = step.nested(head) { nested =>
+          applyNestedFieldAction(
+            nested,
+            tail,
+            FieldAction.joinFields(targetName, sourceNames, combiner, splitter)
+          )
+        })
+    }
+
+  def splitField(
+    sourcePath: String,
+    targetNames: Vector[String],
+    splitter: DynamicValueTransform,
+    combiner: DynamicValueTransform
+  ): MigrationBuilder[A, B] =
+    parsePath(sourcePath) match {
+      case (Nil, sourceName) =>
+        copy(step = step.splitField(sourceName, targetNames, splitter, combiner))
+      case (head :: tail, sourceName) =>
+        copy(step = step.nested(head) { nested =>
+          applyNestedFieldAction(
+            nested,
+            tail,
+            FieldAction.splitField(sourceName, targetNames, splitter, combiner)
+          )
+        })
+    }
+
+  def addCase(caseName: String, defaultValue: DynamicValue): MigrationBuilder[A, B] =
+    copy(variantStep = variantStep.addCase(caseName, defaultValue))
+
+  def addCaseExpr[T](caseName: String, default: MigrationExpr[A, T]): MigrationBuilder[A, B] = {
+    val defaultDynamic = default.evalDynamic(DynamicValue.Null) match {
+      case Right(dv) => dv
+      case Left(_)   => DynamicValue.Null
+    }
+    addCase(caseName, defaultDynamic)
+  }
+
+  private def dropCase(caseName: String, defaultForReverse: DynamicValue): MigrationBuilder[A, B] =
+    copy(variantStep = variantStep.removeCase(caseName, defaultForReverse))
+
+  def dropCaseExpr[T](caseName: String, defaultForReverse: MigrationExpr[B, T]): MigrationBuilder[A, B] = {
+    val defaultDynamic = defaultForReverse.evalDynamic(DynamicValue.Null) match {
+      case Right(dv) => dv
+      case Left(_)   => DynamicValue.Null
+    }
+    dropCase(caseName, defaultDynamic)
+  }
+
+  def renameCase(from: String, to: String): MigrationBuilder[A, B] =
+    copy(variantStep = variantStep.renameCase(from, to))
+
+  def nestedRecord(fieldName: String)(
+    buildNested: MigrationStep.Record => MigrationStep.Record
+  ): MigrationBuilder[A, B] =
+    copy(step = step.nested(fieldName)(buildNested))
+
+  def nestedVariant(caseName: String)(
+    buildNested: MigrationStep.Record => MigrationStep.Record
+  ): MigrationBuilder[A, B] =
+    copy(variantStep = variantStep.nested(caseName)(buildNested))
+
+  def transformElements(elementStep: MigrationStep): MigrationBuilder[A, B] = {
+    val sequenceStep = MigrationStep.sequence(elementStep)
+    copy(step =
+      MigrationStep.Record(
+        step.fieldActions,
+        step.nestedFields + ("_elements" -> sequenceStep)
+      )
+    )
+  }
+
+  def transformMapKeys(keyStep: MigrationStep): MigrationBuilder[A, B] = {
+    val existingMapStep = step.nestedFields.getOrElse("_map", MigrationStep.MapEntries.empty) match {
+      case m: MigrationStep.MapEntries => m
+      case _                           => MigrationStep.MapEntries.empty
+    }
+    copy(step =
+      MigrationStep.Record(
+        step.fieldActions,
+        step.nestedFields + ("_map" -> existingMapStep.copy(keyStep = keyStep))
+      )
+    )
+  }
+
+  def transformMapValues(valueStep: MigrationStep): MigrationBuilder[A, B] = {
+    val existingMapStep = step.nestedFields.getOrElse("_map", MigrationStep.MapEntries.empty) match {
+      case m: MigrationStep.MapEntries => m
+      case _                           => MigrationStep.MapEntries.empty
+    }
+    copy(step =
+      MigrationStep.Record(
+        step.fieldActions,
+        step.nestedFields + ("_map" -> existingMapStep.copy(valueStep = valueStep))
+      )
+    )
+  }
+
+  def buildPartial: Migration[A, B] = {
+    val finalStep = combineSteps
+    Migration(
+      DynamicMigration(finalStep),
+      sourceSchema,
+      targetSchema
+    )
+  }
+
+  def build: Migration[A, B] = {
+    validateAtRuntime()
+    buildPartial
+  }
+
+  private def validateAtRuntime(): Unit = {
+    val sourceFields = extractSchemaFields(sourceSchema)
+    val targetFields = extractSchemaFields(targetSchema)
+
+    val added       = addedFieldNames
+    val removed     = removedFieldNames
+    val renamedFrom = renamedFromNames
+    val renamedTo   = renamedToNames
+
+    val transformedSource = (sourceFields -- removed -- renamedFrom) ++ added ++ renamedTo
+    val missing           = targetFields -- transformedSource
+    val extra             = transformedSource -- targetFields
+
+    if (missing.nonEmpty || extra.nonEmpty) {
+      val missingMsg = if (missing.nonEmpty) s"Missing fields in target: ${missing.mkString(", ")}" else ""
+      val extraMsg   = if (extra.nonEmpty) s"Extra fields not in target: ${extra.mkString(", ")}" else ""
+      val msgs       = Seq(missingMsg, extraMsg).filter(_.nonEmpty).mkString("; ")
+      throw new IllegalStateException(s"Migration validation failed: $msgs")
+    }
+  }
+
+  private def extractSchemaFields(schema: Schema[_]): Set[String] =
+    schema.reflect.asRecord match {
+      case Some(record) => record.fields.map(_.name).toSet
+      case None         => Set.empty[String]
+    }
+
+  def toDynamicMigration: DynamicMigration =
+    DynamicMigration(combineSteps)
+
+  def addedFieldNames: Set[String] = extractAddedFields(step)
+
+  def removedFieldNames: Set[String] = extractRemovedFields(step)
+
+  def renamedFromNames: Set[String] = extractRenamedFrom(step)
+
+  def renamedToNames: Set[String] = extractRenamedTo(step)
+
+  private def extractAddedFields(record: MigrationStep.Record): Set[String] = {
+    val directAdds = record.fieldActions.collect {
+      case FieldAction.Add(name, _)                => name
+      case FieldAction.JoinFields(target, _, _, _) => target
+    }.toSet
+
+    // Also include fields added by split operations
+    val splitAdds = record.fieldActions.collect { case FieldAction.SplitField(_, targets, _, _) =>
+      targets
+    }.flatten.toSet
+
+    directAdds ++ splitAdds
+  }
+
+  private def extractRemovedFields(record: MigrationStep.Record): Set[String] = {
+    val directRemoves = record.fieldActions.collect {
+      case FieldAction.Remove(name, _)             => name
+      case FieldAction.SplitField(source, _, _, _) => source
+    }.toSet
+
+    // Also include fields removed by join operations
+    val joinRemoves = record.fieldActions.collect { case FieldAction.JoinFields(_, sources, _, _) =>
+      sources
+    }.flatten.toSet
+
+    directRemoves ++ joinRemoves
+  }
+
+  private def extractRenamedFrom(record: MigrationStep.Record): Set[String] =
+    record.fieldActions.collect { case FieldAction.Rename(from, _) =>
+      from
+    }.toSet
+
+  private def extractRenamedTo(record: MigrationStep.Record): Set[String] =
+    record.fieldActions.collect { case FieldAction.Rename(_, to) =>
+      to
+    }.toSet
+
+  private def combineSteps: MigrationStep =
+    if (variantStep.isEmpty) step
+    else if (step.isEmpty) variantStep
+    else step
+
+  private def copy(
+    step: MigrationStep.Record = this.step,
+    variantStep: MigrationStep.Variant = this.variantStep
+  ): MigrationBuilder[A, B] =
+    new MigrationBuilder(sourceSchema, targetSchema, step, variantStep)
+
+  private def parsePath(path: String): (List[String], String) = {
+    val parts = path.split('.').toList.filterNot(_.isEmpty)
+    parts.reverse match {
+      case Nil             => throw new IllegalArgumentException(s"Invalid empty path: '$path'")
+      case last :: Nil     => (Nil, last)
+      case last :: initRev => (initRev.reverse, last)
+    }
+  }
+
+  private def dynamicOpticToPath(optic: DynamicOptic): String =
+    optic.nodes.collect { case DynamicOptic.Node.Field(name) =>
+      name
+    }.mkString(".")
+
+  private def applyNestedFieldAction(
+    record: MigrationStep.Record,
+    path: List[String],
+    action: FieldAction
+  ): MigrationStep.Record =
+    path match {
+      case Nil          => record.withFieldAction(action)
+      case head :: tail => record.nested(head)(nested => applyNestedFieldAction(nested, tail, action))
+    }
+}
+
+object MigrationBuilder {
+
+  def apply[A, B](implicit sourceSchema: Schema[A], targetSchema: Schema[B]): MigrationBuilder[A, B] =
+    new MigrationBuilder(sourceSchema, targetSchema, MigrationStep.Record.empty, MigrationStep.Variant.empty)
+
+  def from[A](implicit sourceSchema: Schema[A]): FromBuilder[A] =
+    new FromBuilder[A](sourceSchema)
+
+  final class FromBuilder[A](sourceSchema: Schema[A]) {
+    def to[B](implicit targetSchema: Schema[B]): MigrationBuilder[A, B] =
+      new MigrationBuilder(sourceSchema, targetSchema, MigrationStep.Record.empty, MigrationStep.Variant.empty)
+  }
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationError.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationError.scala
@@ -1,0 +1,382 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicOptic, Schema}
+import zio.blocks.schema.binding._
+import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
+import zio.blocks.schema.Reflect
+import zio.blocks.typeid.TypeId
+
+sealed trait MigrationError {
+  def message: String
+  def path: DynamicOptic
+}
+
+object MigrationError {
+
+  final case class FieldNotFound(fieldName: String, path: DynamicOptic) extends MigrationError {
+    def message: String = s"Field '$fieldName' not found at path ${path.toString}"
+  }
+
+  final case class CaseNotFound(caseName: String, path: DynamicOptic) extends MigrationError {
+    def message: String = s"Case '$caseName' not found at path ${path.toString}"
+  }
+
+  final case class TypeMismatch(expected: String, actual: String, path: DynamicOptic) extends MigrationError {
+    def message: String = s"Type mismatch at ${path.toString}: expected $expected, got $actual"
+  }
+
+  final case class InvalidIndex(index: Int, size: Int, path: DynamicOptic) extends MigrationError {
+    def message: String = s"Index $index out of bounds (size: $size) at ${path.toString}"
+  }
+
+  final case class TransformFailed(reason: String, path: DynamicOptic) extends MigrationError {
+    def message: String = s"Transform failed at ${path.toString}: $reason"
+  }
+
+  final case class ExpressionEvalFailed(reason: String, path: DynamicOptic) extends MigrationError {
+    def message: String = s"Expression evaluation failed at ${path.toString}: $reason"
+  }
+
+  final case class FieldAlreadyExists(fieldName: String, path: DynamicOptic) extends MigrationError {
+    def message: String = s"Field '$fieldName' already exists at ${path.toString}"
+  }
+
+  final case class IncompatibleValue(reason: String, path: DynamicOptic) extends MigrationError {
+    def message: String = s"Incompatible value at ${path.toString}: $reason"
+  }
+
+  def fieldNotFound(fieldName: String, path: DynamicOptic): MigrationError =
+    FieldNotFound(fieldName, path)
+
+  def caseNotFound(caseName: String, path: DynamicOptic): MigrationError =
+    CaseNotFound(caseName, path)
+
+  def typeMismatch(expected: String, actual: String, path: DynamicOptic): MigrationError =
+    TypeMismatch(expected, actual, path)
+
+  def invalidIndex(index: Int, size: Int, path: DynamicOptic): MigrationError =
+    InvalidIndex(index, size, path)
+
+  def transformFailed(reason: String, path: DynamicOptic): MigrationError =
+    TransformFailed(reason, path)
+
+  def expressionEvalFailed(reason: String, path: DynamicOptic): MigrationError =
+    ExpressionEvalFailed(reason, path)
+
+  def fieldAlreadyExists(fieldName: String, path: DynamicOptic): MigrationError =
+    FieldAlreadyExists(fieldName, path)
+
+  def incompatibleValue(reason: String, path: DynamicOptic): MigrationError =
+    IncompatibleValue(reason, path)
+
+  implicit lazy val fieldNotFoundSchema: Schema[FieldNotFound] = new Schema(
+    reflect = new Reflect.Record[Binding, FieldNotFound](
+      fields = Vector(
+        Schema[String].reflect.asTerm("fieldName"),
+        Schema[DynamicOptic].reflect.asTerm("path")
+      ),
+      typeId = TypeId.of[FieldNotFound],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[FieldNotFound] {
+          def usedRegisters: RegisterOffset                                   = 2
+          def construct(in: Registers, offset: RegisterOffset): FieldNotFound =
+            FieldNotFound(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[DynamicOptic]
+            )
+        },
+        deconstructor = new Deconstructor[FieldNotFound] {
+          def usedRegisters: RegisterOffset                                                = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: FieldNotFound): Unit = {
+            out.setObject(offset + 0, in.fieldName)
+            out.setObject(offset + 1, in.path)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val caseNotFoundSchema: Schema[CaseNotFound] = new Schema(
+    reflect = new Reflect.Record[Binding, CaseNotFound](
+      fields = Vector(
+        Schema[String].reflect.asTerm("caseName"),
+        Schema[DynamicOptic].reflect.asTerm("path")
+      ),
+      typeId = TypeId.of[CaseNotFound],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[CaseNotFound] {
+          def usedRegisters: RegisterOffset                                  = 2
+          def construct(in: Registers, offset: RegisterOffset): CaseNotFound =
+            CaseNotFound(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[DynamicOptic]
+            )
+        },
+        deconstructor = new Deconstructor[CaseNotFound] {
+          def usedRegisters: RegisterOffset                                               = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: CaseNotFound): Unit = {
+            out.setObject(offset + 0, in.caseName)
+            out.setObject(offset + 1, in.path)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val typeMismatchSchema: Schema[TypeMismatch] = new Schema(
+    reflect = new Reflect.Record[Binding, TypeMismatch](
+      fields = Vector(
+        Schema[String].reflect.asTerm("expected"),
+        Schema[String].reflect.asTerm("actual"),
+        Schema[DynamicOptic].reflect.asTerm("path")
+      ),
+      typeId = TypeId.of[TypeMismatch],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[TypeMismatch] {
+          def usedRegisters: RegisterOffset                                  = 3
+          def construct(in: Registers, offset: RegisterOffset): TypeMismatch =
+            TypeMismatch(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[String],
+              in.getObject(offset + 2).asInstanceOf[DynamicOptic]
+            )
+        },
+        deconstructor = new Deconstructor[TypeMismatch] {
+          def usedRegisters: RegisterOffset                                               = 3
+          def deconstruct(out: Registers, offset: RegisterOffset, in: TypeMismatch): Unit = {
+            out.setObject(offset + 0, in.expected)
+            out.setObject(offset + 1, in.actual)
+            out.setObject(offset + 2, in.path)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val invalidIndexSchema: Schema[InvalidIndex] = new Schema(
+    reflect = new Reflect.Record[Binding, InvalidIndex](
+      fields = Vector(
+        Schema[Int].reflect.asTerm("index"),
+        Schema[Int].reflect.asTerm("size"),
+        Schema[DynamicOptic].reflect.asTerm("path")
+      ),
+      typeId = TypeId.of[InvalidIndex],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[InvalidIndex] {
+          def usedRegisters: RegisterOffset                                  = 3
+          def construct(in: Registers, offset: RegisterOffset): InvalidIndex =
+            InvalidIndex(
+              in.getInt(offset + 0),
+              in.getInt(offset + 1),
+              in.getObject(offset + 2).asInstanceOf[DynamicOptic]
+            )
+        },
+        deconstructor = new Deconstructor[InvalidIndex] {
+          def usedRegisters: RegisterOffset                                               = 3
+          def deconstruct(out: Registers, offset: RegisterOffset, in: InvalidIndex): Unit = {
+            out.setInt(offset + 0, in.index)
+            out.setInt(offset + 1, in.size)
+            out.setObject(offset + 2, in.path)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val transformFailedSchema: Schema[TransformFailed] = new Schema(
+    reflect = new Reflect.Record[Binding, TransformFailed](
+      fields = Vector(
+        Schema[String].reflect.asTerm("reason"),
+        Schema[DynamicOptic].reflect.asTerm("path")
+      ),
+      typeId = TypeId.of[TransformFailed],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[TransformFailed] {
+          def usedRegisters: RegisterOffset                                     = 2
+          def construct(in: Registers, offset: RegisterOffset): TransformFailed =
+            TransformFailed(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[DynamicOptic]
+            )
+        },
+        deconstructor = new Deconstructor[TransformFailed] {
+          def usedRegisters: RegisterOffset                                                  = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: TransformFailed): Unit = {
+            out.setObject(offset + 0, in.reason)
+            out.setObject(offset + 1, in.path)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val expressionEvalFailedSchema: Schema[ExpressionEvalFailed] = new Schema(
+    reflect = new Reflect.Record[Binding, ExpressionEvalFailed](
+      fields = Vector(
+        Schema[String].reflect.asTerm("reason"),
+        Schema[DynamicOptic].reflect.asTerm("path")
+      ),
+      typeId = TypeId.of[ExpressionEvalFailed],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[ExpressionEvalFailed] {
+          def usedRegisters: RegisterOffset                                          = 2
+          def construct(in: Registers, offset: RegisterOffset): ExpressionEvalFailed =
+            ExpressionEvalFailed(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[DynamicOptic]
+            )
+        },
+        deconstructor = new Deconstructor[ExpressionEvalFailed] {
+          def usedRegisters: RegisterOffset                                                       = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: ExpressionEvalFailed): Unit = {
+            out.setObject(offset + 0, in.reason)
+            out.setObject(offset + 1, in.path)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val fieldAlreadyExistsSchema: Schema[FieldAlreadyExists] = new Schema(
+    reflect = new Reflect.Record[Binding, FieldAlreadyExists](
+      fields = Vector(
+        Schema[String].reflect.asTerm("fieldName"),
+        Schema[DynamicOptic].reflect.asTerm("path")
+      ),
+      typeId = TypeId.of[FieldAlreadyExists],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[FieldAlreadyExists] {
+          def usedRegisters: RegisterOffset                                        = 2
+          def construct(in: Registers, offset: RegisterOffset): FieldAlreadyExists =
+            FieldAlreadyExists(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[DynamicOptic]
+            )
+        },
+        deconstructor = new Deconstructor[FieldAlreadyExists] {
+          def usedRegisters: RegisterOffset                                                     = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: FieldAlreadyExists): Unit = {
+            out.setObject(offset + 0, in.fieldName)
+            out.setObject(offset + 1, in.path)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val incompatibleValueSchema: Schema[IncompatibleValue] = new Schema(
+    reflect = new Reflect.Record[Binding, IncompatibleValue](
+      fields = Vector(
+        Schema[String].reflect.asTerm("reason"),
+        Schema[DynamicOptic].reflect.asTerm("path")
+      ),
+      typeId = TypeId.of[IncompatibleValue],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[IncompatibleValue] {
+          def usedRegisters: RegisterOffset                                       = 2
+          def construct(in: Registers, offset: RegisterOffset): IncompatibleValue =
+            IncompatibleValue(
+              in.getObject(offset + 0).asInstanceOf[String],
+              in.getObject(offset + 1).asInstanceOf[DynamicOptic]
+            )
+        },
+        deconstructor = new Deconstructor[IncompatibleValue] {
+          def usedRegisters: RegisterOffset                                                    = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: IncompatibleValue): Unit = {
+            out.setObject(offset + 0, in.reason)
+            out.setObject(offset + 1, in.path)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val schema: Schema[MigrationError] = new Schema(
+    reflect = new Reflect.Variant[Binding, MigrationError](
+      cases = Vector(
+        fieldNotFoundSchema.reflect.asTerm("FieldNotFound"),
+        caseNotFoundSchema.reflect.asTerm("CaseNotFound"),
+        typeMismatchSchema.reflect.asTerm("TypeMismatch"),
+        invalidIndexSchema.reflect.asTerm("InvalidIndex"),
+        transformFailedSchema.reflect.asTerm("TransformFailed"),
+        expressionEvalFailedSchema.reflect.asTerm("ExpressionEvalFailed"),
+        fieldAlreadyExistsSchema.reflect.asTerm("FieldAlreadyExists"),
+        incompatibleValueSchema.reflect.asTerm("IncompatibleValue")
+      ),
+      typeId = TypeId.of[MigrationError],
+      variantBinding = new Binding.Variant(
+        discriminator = new Discriminator[MigrationError] {
+          def discriminate(a: MigrationError): Int = a match {
+            case _: FieldNotFound        => 0
+            case _: CaseNotFound         => 1
+            case _: TypeMismatch         => 2
+            case _: InvalidIndex         => 3
+            case _: TransformFailed      => 4
+            case _: ExpressionEvalFailed => 5
+            case _: FieldAlreadyExists   => 6
+            case _: IncompatibleValue    => 7
+          }
+        },
+        matchers = Matchers(
+          new Matcher[FieldNotFound] {
+            def downcastOrNull(a: Any): FieldNotFound = a match {
+              case x: FieldNotFound => x
+              case _                => null.asInstanceOf[FieldNotFound]
+            }
+          },
+          new Matcher[CaseNotFound] {
+            def downcastOrNull(a: Any): CaseNotFound = a match {
+              case x: CaseNotFound => x
+              case _               => null.asInstanceOf[CaseNotFound]
+            }
+          },
+          new Matcher[TypeMismatch] {
+            def downcastOrNull(a: Any): TypeMismatch = a match {
+              case x: TypeMismatch => x
+              case _               => null.asInstanceOf[TypeMismatch]
+            }
+          },
+          new Matcher[InvalidIndex] {
+            def downcastOrNull(a: Any): InvalidIndex = a match {
+              case x: InvalidIndex => x
+              case _               => null.asInstanceOf[InvalidIndex]
+            }
+          },
+          new Matcher[TransformFailed] {
+            def downcastOrNull(a: Any): TransformFailed = a match {
+              case x: TransformFailed => x
+              case _                  => null.asInstanceOf[TransformFailed]
+            }
+          },
+          new Matcher[ExpressionEvalFailed] {
+            def downcastOrNull(a: Any): ExpressionEvalFailed = a match {
+              case x: ExpressionEvalFailed => x
+              case _                       => null.asInstanceOf[ExpressionEvalFailed]
+            }
+          },
+          new Matcher[FieldAlreadyExists] {
+            def downcastOrNull(a: Any): FieldAlreadyExists = a match {
+              case x: FieldAlreadyExists => x
+              case _                     => null.asInstanceOf[FieldAlreadyExists]
+            }
+          },
+          new Matcher[IncompatibleValue] {
+            def downcastOrNull(a: Any): IncompatibleValue = a match {
+              case x: IncompatibleValue => x
+              case _                    => null.asInstanceOf[IncompatibleValue]
+            }
+          }
+        )
+      ),
+      modifiers = Vector.empty
+    )
+  )
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationExpr.scala
@@ -1,0 +1,131 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{DynamicOptic, DynamicValue, PrimitiveValue, Schema}
+
+sealed trait MigrationExpr[-S, +A] {
+  def evalDynamic(input: DynamicValue): Either[String, DynamicValue]
+}
+
+object MigrationExpr {
+
+  final case class Literal[A](value: A, schema: Schema[A]) extends MigrationExpr[Any, A] {
+    private val dynamicValue: DynamicValue = schema.toDynamicValue(value)
+
+    def evalDynamic(input: DynamicValue): Either[String, DynamicValue] =
+      Right(dynamicValue)
+  }
+
+  final case class DefaultValue[S](fieldSchema: Schema[_]) extends MigrationExpr[S, Any] {
+    def evalDynamic(input: DynamicValue): Either[String, DynamicValue] =
+      fieldSchema.getDefaultValue match {
+        case Some(default) => Right(fieldSchema.asInstanceOf[Schema[Any]].toDynamicValue(default))
+        case None          => Left(s"No default value available for type ${fieldSchema.reflect.typeId}")
+      }
+  }
+
+  private final case class FieldAccess[S, A](path: DynamicOptic, fieldSchema: Schema[A]) extends MigrationExpr[S, A] {
+    def evalDynamic(input: DynamicValue): Either[String, DynamicValue] =
+      input.get(path).one match {
+        case Right(value) => Right(value)
+        case Left(err)    => Left(s"Field not found at path $path: ${err.message}")
+      }
+  }
+
+  final case class Transform[S, A, B](
+    source: MigrationExpr[S, A],
+    transform: DynamicValueTransform
+  ) extends MigrationExpr[S, B] {
+    def evalDynamic(input: DynamicValue): Either[String, DynamicValue] =
+      source.evalDynamic(input).flatMap(transform.apply)
+  }
+
+  final case class Concat[S](
+    left: MigrationExpr[S, String],
+    right: MigrationExpr[S, String]
+  ) extends MigrationExpr[S, String] {
+    def evalDynamic(input: DynamicValue): Either[String, DynamicValue] =
+      for {
+        l    <- left.evalDynamic(input)
+        r    <- right.evalDynamic(input)
+        lStr <- extractString(l).toRight("Expected string on left side of concat")
+        rStr <- extractString(r).toRight("Expected string on right side of concat")
+      } yield DynamicValue.string(lStr + rStr)
+
+    private def extractString(dv: DynamicValue): Option[String] = dv match {
+      case DynamicValue.Primitive(pv) =>
+        pv match {
+          case PrimitiveValue.String(s) => Some(s)
+          case _                        => None
+        }
+      case _ => None
+    }
+  }
+
+  private final case class Join[S](
+    sourcePaths: Vector[DynamicOptic],
+    combiner: Vector[DynamicValue] => Either[String, DynamicValue]
+  ) extends MigrationExpr[S, Any] {
+    def evalDynamic(input: DynamicValue): Either[String, DynamicValue] = {
+      val results = sourcePaths.map(path => input.get(path).one)
+      val errors  = results.collect { case Left(err) => err }
+      if (errors.nonEmpty)
+        Left(s"Not all source paths found for join: ${errors.map(_.message).mkString(", ")}")
+      else {
+        val values = results.collect { case Right(v) => v }
+        combiner(values)
+      }
+    }
+  }
+
+  final case class Split[S, A](
+    source: MigrationExpr[S, A],
+    splitter: DynamicValue => Either[String, Vector[DynamicValue]]
+  ) extends MigrationExpr[S, Vector[Any]] {
+    def evalDynamic(input: DynamicValue): Either[String, DynamicValue] =
+      source.evalDynamic(input).flatMap { v =>
+        splitter(v).map(values => DynamicValue.Sequence(Chunk.from(values)))
+      }
+  }
+
+  private final case class PrimitiveConvert[S, A, B](
+    source: MigrationExpr[S, A],
+    conversion: PrimitiveConversion
+  ) extends MigrationExpr[S, B] {
+    def evalDynamic(input: DynamicValue): Either[String, DynamicValue] =
+      source.evalDynamic(input).flatMap(conversion.apply)
+  }
+
+  def literal[A](value: A)(implicit schema: Schema[A]): MigrationExpr[Any, A] =
+    Literal(value, schema)
+
+  def defaultValue[S](implicit fieldSchema: Schema[_]): MigrationExpr[S, Any] =
+    DefaultValue(fieldSchema)
+
+  def field[S, A](path: DynamicOptic)(implicit fieldSchema: Schema[A]): MigrationExpr[S, A] =
+    FieldAccess(path, fieldSchema)
+
+  def transform[S, A, B](
+    source: MigrationExpr[S, A],
+    transform: DynamicValueTransform
+  ): MigrationExpr[S, B] =
+    Transform(source, transform)
+
+  def concat[S](
+    left: MigrationExpr[S, String],
+    right: MigrationExpr[S, String]
+  ): MigrationExpr[S, String] =
+    Concat(left, right)
+
+  def join[S](
+    paths: Vector[DynamicOptic],
+    combiner: Vector[DynamicValue] => Either[String, DynamicValue]
+  ): MigrationExpr[S, Any] =
+    Join(paths, combiner)
+
+  def convert[S, A, B](
+    source: MigrationExpr[S, A],
+    conversion: PrimitiveConversion
+  ): MigrationExpr[S, B] =
+    PrimitiveConvert(source, conversion)
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationStep.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationStep.scala
@@ -1,0 +1,343 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicValue, Schema}
+import zio.blocks.schema.binding._
+import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
+import zio.blocks.schema.Reflect
+import zio.blocks.typeid.TypeId
+
+sealed trait MigrationStep {
+  def reverse: MigrationStep
+  def isEmpty: Boolean
+}
+
+object MigrationStep {
+
+  final case class Record(
+    fieldActions: Vector[FieldAction],
+    nestedFields: scala.collection.immutable.Map[String, MigrationStep]
+  ) extends MigrationStep {
+
+    def reverse: MigrationStep = Record(
+      fieldActions.reverseIterator.map(_.reverse).toVector,
+      nestedFields.map { case (k, v) => k -> v.reverse }
+    )
+
+    def isEmpty: Boolean = fieldActions.isEmpty && nestedFields.values.forall(_.isEmpty)
+
+    def withFieldAction(action: FieldAction): Record =
+      copy(fieldActions = fieldActions :+ action)
+
+    private def withNestedField(fieldName: String, step: MigrationStep): Record =
+      copy(nestedFields = nestedFields + (fieldName -> step))
+
+    def addField(name: String, defaultValue: DynamicValue): Record =
+      withFieldAction(FieldAction.add(name, defaultValue))
+
+    def removeField(name: String, defaultForReverse: DynamicValue): Record =
+      withFieldAction(FieldAction.remove(name, defaultForReverse))
+
+    def renameField(from: String, to: String): Record =
+      withFieldAction(FieldAction.rename(from, to))
+
+    def transformField(
+      name: String,
+      forward: DynamicValueTransform,
+      backward: DynamicValueTransform
+    ): Record =
+      withFieldAction(FieldAction.transform(name, forward, backward))
+
+    def makeFieldOptional(name: String, defaultForReverse: DynamicValue): Record =
+      withFieldAction(FieldAction.makeOptional(name, defaultForReverse))
+
+    def makeFieldRequired(name: String, defaultForNone: DynamicValue): Record =
+      withFieldAction(FieldAction.makeRequired(name, defaultForNone))
+
+    def changeFieldType(
+      name: String,
+      forward: PrimitiveConversion,
+      backward: PrimitiveConversion
+    ): Record =
+      withFieldAction(FieldAction.changeType(name, forward, backward))
+
+    def joinFields(
+      targetName: String,
+      sourceNames: Vector[String],
+      combiner: DynamicValueTransform,
+      splitter: DynamicValueTransform
+    ): Record =
+      withFieldAction(FieldAction.joinFields(targetName, sourceNames, combiner, splitter))
+
+    def splitField(
+      sourceName: String,
+      targetNames: Vector[String],
+      splitter: DynamicValueTransform,
+      combiner: DynamicValueTransform
+    ): Record =
+      withFieldAction(FieldAction.splitField(sourceName, targetNames, splitter, combiner))
+
+    def nested(fieldName: String)(buildNested: Record => Record): Record = {
+      val existingNested = nestedFields.getOrElse(fieldName, Record.empty) match {
+        case r: Record => r
+        case _         => Record.empty
+      }
+      withNestedField(fieldName, buildNested(existingNested))
+    }
+  }
+
+  object Record {
+    val empty: Record = Record(Vector.empty, scala.collection.immutable.Map.empty)
+  }
+
+  final case class Variant(
+    caseActions: Vector[CaseAction],
+    nestedCases: scala.collection.immutable.Map[String, MigrationStep]
+  ) extends MigrationStep {
+
+    def reverse: MigrationStep = Variant(
+      caseActions.reverseIterator.map(_.reverse).toVector,
+      nestedCases.map { case (k, v) => k -> v.reverse }
+    )
+
+    def isEmpty: Boolean = caseActions.isEmpty && nestedCases.values.forall(_.isEmpty)
+
+    private def withCaseAction(action: CaseAction): Variant =
+      copy(caseActions = caseActions :+ action)
+
+    private def withNestedCase(caseName: String, step: MigrationStep): Variant =
+      copy(nestedCases = nestedCases + (caseName -> step))
+
+    def addCase(name: String, defaultValue: DynamicValue): Variant =
+      withCaseAction(CaseAction.add(name, defaultValue))
+
+    def removeCase(name: String, defaultForReverse: DynamicValue): Variant =
+      withCaseAction(CaseAction.remove(name, defaultForReverse))
+
+    def renameCase(from: String, to: String): Variant =
+      withCaseAction(CaseAction.rename(from, to))
+
+    def nested(caseName: String)(buildNested: Record => Record): Variant = {
+      val existingNested = nestedCases.getOrElse(caseName, Record.empty) match {
+        case r: Record => r
+        case _         => Record.empty
+      }
+      withNestedCase(caseName, buildNested(existingNested))
+    }
+  }
+
+  object Variant {
+    val empty: Variant = Variant(Vector.empty, scala.collection.immutable.Map.empty)
+  }
+
+  final case class Sequence(elementStep: MigrationStep) extends MigrationStep {
+    def reverse: MigrationStep = Sequence(elementStep.reverse)
+    def isEmpty: Boolean       = elementStep.isEmpty
+  }
+
+  object Sequence {
+    val empty: Sequence = Sequence(Record.empty)
+  }
+
+  final case class MapEntries(
+    keyStep: MigrationStep,
+    valueStep: MigrationStep
+  ) extends MigrationStep {
+    def reverse: MigrationStep = MapEntries(keyStep.reverse, valueStep.reverse)
+    def isEmpty: Boolean       = keyStep.isEmpty && valueStep.isEmpty
+  }
+
+  object MapEntries {
+    val empty: MapEntries = MapEntries(Record.empty, Record.empty)
+  }
+
+  case object NoOp extends MigrationStep {
+    def reverse: MigrationStep = NoOp
+    def isEmpty: Boolean       = true
+  }
+
+  def record: Record = Record.empty
+
+  def variant: Variant = Variant.empty
+
+  def sequence(elementStep: MigrationStep): Sequence = Sequence(elementStep)
+
+  def mapEntries(keyStep: MigrationStep, valueStep: MigrationStep): MapEntries =
+    MapEntries(keyStep, valueStep)
+
+  def noOp: MigrationStep = NoOp
+
+  implicit lazy val noOpSchema: Schema[NoOp.type] = new Schema(
+    reflect = new Reflect.Record[Binding, NoOp.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[NoOp.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[NoOp.type](NoOp),
+        deconstructor = new ConstantDeconstructor[NoOp.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val recordSchema: Schema[Record] = new Schema(
+    reflect = new Reflect.Record[Binding, Record](
+      fields = Vector(
+        Schema[Vector[FieldAction]].reflect.asTerm("fieldActions"),
+        Schema[scala.collection.immutable.Map[String, MigrationStep]].reflect.asTerm("nestedFields")
+      ),
+      typeId = TypeId.of[Record],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Record] {
+          def usedRegisters: RegisterOffset                            = 2
+          def construct(in: Registers, offset: RegisterOffset): Record =
+            Record(
+              in.getObject(offset + 0).asInstanceOf[Vector[FieldAction]],
+              in.getObject(offset + 1).asInstanceOf[scala.collection.immutable.Map[String, MigrationStep]]
+            )
+        },
+        deconstructor = new Deconstructor[Record] {
+          def usedRegisters: RegisterOffset                                         = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Record): Unit = {
+            out.setObject(offset + 0, in.fieldActions)
+            out.setObject(offset + 1, in.nestedFields)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val variantSchema: Schema[Variant] = new Schema(
+    reflect = new Reflect.Record[Binding, Variant](
+      fields = Vector(
+        Schema[Vector[CaseAction]].reflect.asTerm("caseActions"),
+        Schema[scala.collection.immutable.Map[String, MigrationStep]].reflect.asTerm("nestedCases")
+      ),
+      typeId = TypeId.of[Variant],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Variant] {
+          def usedRegisters: RegisterOffset                             = 2
+          def construct(in: Registers, offset: RegisterOffset): Variant =
+            Variant(
+              in.getObject(offset + 0).asInstanceOf[Vector[CaseAction]],
+              in.getObject(offset + 1).asInstanceOf[scala.collection.immutable.Map[String, MigrationStep]]
+            )
+        },
+        deconstructor = new Deconstructor[Variant] {
+          def usedRegisters: RegisterOffset                                          = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Variant): Unit = {
+            out.setObject(offset + 0, in.caseActions)
+            out.setObject(offset + 1, in.nestedCases)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val sequenceSchema: Schema[Sequence] = new Schema(
+    reflect = new Reflect.Record[Binding, Sequence](
+      fields = Vector(
+        Schema[MigrationStep].reflect.asTerm("elementStep")
+      ),
+      typeId = TypeId.of[Sequence],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Sequence] {
+          def usedRegisters: RegisterOffset                              = 1
+          def construct(in: Registers, offset: RegisterOffset): Sequence =
+            Sequence(in.getObject(offset + 0).asInstanceOf[MigrationStep])
+        },
+        deconstructor = new Deconstructor[Sequence] {
+          def usedRegisters: RegisterOffset                                           = 1
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Sequence): Unit =
+            out.setObject(offset + 0, in.elementStep)
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val mapEntriesSchema: Schema[MapEntries] = new Schema(
+    reflect = new Reflect.Record[Binding, MapEntries](
+      fields = Vector(
+        Schema[MigrationStep].reflect.asTerm("keyStep"),
+        Schema[MigrationStep].reflect.asTerm("valueStep")
+      ),
+      typeId = TypeId.of[MapEntries],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[MapEntries] {
+          def usedRegisters: RegisterOffset                                = 2
+          def construct(in: Registers, offset: RegisterOffset): MapEntries =
+            MapEntries(
+              in.getObject(offset + 0).asInstanceOf[MigrationStep],
+              in.getObject(offset + 1).asInstanceOf[MigrationStep]
+            )
+        },
+        deconstructor = new Deconstructor[MapEntries] {
+          def usedRegisters: RegisterOffset                                             = 2
+          def deconstruct(out: Registers, offset: RegisterOffset, in: MapEntries): Unit = {
+            out.setObject(offset + 0, in.keyStep)
+            out.setObject(offset + 1, in.valueStep)
+          }
+        }
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val schema: Schema[MigrationStep] = new Schema(
+    reflect = new Reflect.Variant[Binding, MigrationStep](
+      cases = Vector(
+        recordSchema.reflect.asTerm("Record"),
+        variantSchema.reflect.asTerm("Variant"),
+        sequenceSchema.reflect.asTerm("Sequence"),
+        mapEntriesSchema.reflect.asTerm("MapEntries"),
+        noOpSchema.reflect.asTerm("NoOp")
+      ),
+      typeId = TypeId.of[MigrationStep],
+      variantBinding = new Binding.Variant(
+        discriminator = new Discriminator[MigrationStep] {
+          def discriminate(a: MigrationStep): Int = a match {
+            case _: Record     => 0
+            case _: Variant    => 1
+            case _: Sequence   => 2
+            case _: MapEntries => 3
+            case _: NoOp.type  => 4
+          }
+        },
+        matchers = Matchers(
+          new Matcher[Record] {
+            def downcastOrNull(a: Any): Record = a match {
+              case x: Record => x
+              case _         => null.asInstanceOf[Record]
+            }
+          },
+          new Matcher[Variant] {
+            def downcastOrNull(a: Any): Variant = a match {
+              case x: Variant => x
+              case _          => null.asInstanceOf[Variant]
+            }
+          },
+          new Matcher[Sequence] {
+            def downcastOrNull(a: Any): Sequence = a match {
+              case x: Sequence => x
+              case _           => null.asInstanceOf[Sequence]
+            }
+          },
+          new Matcher[MapEntries] {
+            def downcastOrNull(a: Any): MapEntries = a match {
+              case x: MapEntries => x
+              case _             => null.asInstanceOf[MapEntries]
+            }
+          },
+          new Matcher[NoOp.type] {
+            def downcastOrNull(a: Any): NoOp.type = a match {
+              case x: NoOp.type => x
+              case _            => null.asInstanceOf[NoOp.type]
+            }
+          }
+        )
+      ),
+      modifiers = Vector.empty
+    )
+  )
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/PrimitiveConversion.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/PrimitiveConversion.scala
@@ -1,0 +1,464 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicValue, PrimitiveValue, Schema}
+import zio.blocks.schema.binding._
+import zio.blocks.schema.Reflect
+import zio.blocks.typeid.TypeId
+
+sealed trait PrimitiveConversion {
+  def apply(value: DynamicValue): Either[String, DynamicValue]
+}
+
+object PrimitiveConversion {
+
+  case object IntToLong extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.Int(n)) =>
+        Right(DynamicValue.long(n.toLong))
+      case _ =>
+        Left(s"IntToLong requires Int, got ${value.valueType}")
+    }
+  }
+
+  case object LongToInt extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.Long(n)) =>
+        Right(DynamicValue.int(n.toInt))
+      case _ =>
+        Left(s"LongToInt requires Long, got ${value.valueType}")
+    }
+  }
+
+  case object IntToString extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.Int(n)) =>
+        Right(DynamicValue.string(n.toString))
+      case _ =>
+        Left(s"IntToString requires Int, got ${value.valueType}")
+    }
+  }
+
+  case object StringToInt extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+        s.toIntOption match {
+          case Some(n) => Right(DynamicValue.int(n))
+          case None    => Left(s"Cannot parse '$s' as Int")
+        }
+      case _ =>
+        Left(s"StringToInt requires String, got ${value.valueType}")
+    }
+  }
+
+  case object LongToString extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.Long(n)) =>
+        Right(DynamicValue.string(n.toString))
+      case _ =>
+        Left(s"LongToString requires Long, got ${value.valueType}")
+    }
+  }
+
+  case object StringToLong extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+        s.toLongOption match {
+          case Some(n) => Right(DynamicValue.long(n))
+          case None    => Left(s"Cannot parse '$s' as Long")
+        }
+      case _ =>
+        Left(s"StringToLong requires String, got ${value.valueType}")
+    }
+  }
+
+  case object DoubleToString extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.Double(n)) =>
+        Right(DynamicValue.string(n.toString))
+      case _ =>
+        Left(s"DoubleToString requires Double, got ${value.valueType}")
+    }
+  }
+
+  case object StringToDouble extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+        s.toDoubleOption match {
+          case Some(n) => Right(DynamicValue.double(n))
+          case None    => Left(s"Cannot parse '$s' as Double")
+        }
+      case _ =>
+        Left(s"StringToDouble requires String, got ${value.valueType}")
+    }
+  }
+
+  case object FloatToDouble extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.Float(n)) =>
+        Right(DynamicValue.double(n.toDouble))
+      case _ =>
+        Left(s"FloatToDouble requires Float, got ${value.valueType}")
+    }
+  }
+
+  case object DoubleToFloat extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.Double(n)) =>
+        Right(DynamicValue.float(n.toFloat))
+      case _ =>
+        Left(s"DoubleToFloat requires Double, got ${value.valueType}")
+    }
+  }
+
+  case object BooleanToString extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.Boolean(b)) =>
+        Right(DynamicValue.string(b.toString))
+      case _ =>
+        Left(s"BooleanToString requires Boolean, got ${value.valueType}")
+    }
+  }
+
+  case object StringToBoolean extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+        s.toLowerCase match {
+          case "true"  => Right(DynamicValue.boolean(true))
+          case "false" => Right(DynamicValue.boolean(false))
+          case _       => Left(s"Cannot parse '$s' as Boolean")
+        }
+      case _ =>
+        Left(s"StringToBoolean requires String, got ${value.valueType}")
+    }
+  }
+
+  case object IntToDouble extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.Int(n)) =>
+        Right(DynamicValue.double(n.toDouble))
+      case _ =>
+        Left(s"IntToDouble requires Int, got ${value.valueType}")
+    }
+  }
+
+  case object DoubleToInt extends PrimitiveConversion {
+    def apply(value: DynamicValue): Either[String, DynamicValue] = value match {
+      case DynamicValue.Primitive(PrimitiveValue.Double(n)) =>
+        Right(DynamicValue.int(n.toInt))
+      case _ =>
+        Left(s"DoubleToInt requires Double, got ${value.valueType}")
+    }
+  }
+
+  def intToLong: PrimitiveConversion       = IntToLong
+  def longToInt: PrimitiveConversion       = LongToInt
+  def intToString: PrimitiveConversion     = IntToString
+  def stringToInt: PrimitiveConversion     = StringToInt
+  def longToString: PrimitiveConversion    = LongToString
+  def stringToLong: PrimitiveConversion    = StringToLong
+  def doubleToString: PrimitiveConversion  = DoubleToString
+  def stringToDouble: PrimitiveConversion  = StringToDouble
+  def floatToDouble: PrimitiveConversion   = FloatToDouble
+  def doubleToFloat: PrimitiveConversion   = DoubleToFloat
+  def booleanToString: PrimitiveConversion = BooleanToString
+  def stringToBoolean: PrimitiveConversion = StringToBoolean
+  def intToDouble: PrimitiveConversion     = IntToDouble
+  def doubleToInt: PrimitiveConversion     = DoubleToInt
+
+  implicit lazy val intToLongSchema: Schema[IntToLong.type] = new Schema(
+    reflect = new Reflect.Record[Binding, IntToLong.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[IntToLong.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[IntToLong.type](IntToLong),
+        deconstructor = new ConstantDeconstructor[IntToLong.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val longToIntSchema: Schema[LongToInt.type] = new Schema(
+    reflect = new Reflect.Record[Binding, LongToInt.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[LongToInt.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[LongToInt.type](LongToInt),
+        deconstructor = new ConstantDeconstructor[LongToInt.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val intToStringSchema: Schema[IntToString.type] = new Schema(
+    reflect = new Reflect.Record[Binding, IntToString.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[IntToString.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[IntToString.type](IntToString),
+        deconstructor = new ConstantDeconstructor[IntToString.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val stringToIntSchema: Schema[StringToInt.type] = new Schema(
+    reflect = new Reflect.Record[Binding, StringToInt.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[StringToInt.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[StringToInt.type](StringToInt),
+        deconstructor = new ConstantDeconstructor[StringToInt.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val longToStringSchema: Schema[LongToString.type] = new Schema(
+    reflect = new Reflect.Record[Binding, LongToString.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[LongToString.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[LongToString.type](LongToString),
+        deconstructor = new ConstantDeconstructor[LongToString.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val stringToLongSchema: Schema[StringToLong.type] = new Schema(
+    reflect = new Reflect.Record[Binding, StringToLong.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[StringToLong.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[StringToLong.type](StringToLong),
+        deconstructor = new ConstantDeconstructor[StringToLong.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val doubleToStringSchema: Schema[DoubleToString.type] = new Schema(
+    reflect = new Reflect.Record[Binding, DoubleToString.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[DoubleToString.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[DoubleToString.type](DoubleToString),
+        deconstructor = new ConstantDeconstructor[DoubleToString.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val stringToDoubleSchema: Schema[StringToDouble.type] = new Schema(
+    reflect = new Reflect.Record[Binding, StringToDouble.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[StringToDouble.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[StringToDouble.type](StringToDouble),
+        deconstructor = new ConstantDeconstructor[StringToDouble.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val floatToDoubleSchema: Schema[FloatToDouble.type] = new Schema(
+    reflect = new Reflect.Record[Binding, FloatToDouble.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[FloatToDouble.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[FloatToDouble.type](FloatToDouble),
+        deconstructor = new ConstantDeconstructor[FloatToDouble.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val doubleToFloatSchema: Schema[DoubleToFloat.type] = new Schema(
+    reflect = new Reflect.Record[Binding, DoubleToFloat.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[DoubleToFloat.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[DoubleToFloat.type](DoubleToFloat),
+        deconstructor = new ConstantDeconstructor[DoubleToFloat.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val booleanToStringSchema: Schema[BooleanToString.type] = new Schema(
+    reflect = new Reflect.Record[Binding, BooleanToString.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[BooleanToString.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[BooleanToString.type](BooleanToString),
+        deconstructor = new ConstantDeconstructor[BooleanToString.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val stringToBooleanSchema: Schema[StringToBoolean.type] = new Schema(
+    reflect = new Reflect.Record[Binding, StringToBoolean.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[StringToBoolean.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[StringToBoolean.type](StringToBoolean),
+        deconstructor = new ConstantDeconstructor[StringToBoolean.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val intToDoubleSchema: Schema[IntToDouble.type] = new Schema(
+    reflect = new Reflect.Record[Binding, IntToDouble.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[IntToDouble.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[IntToDouble.type](IntToDouble),
+        deconstructor = new ConstantDeconstructor[IntToDouble.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val doubleToIntSchema: Schema[DoubleToInt.type] = new Schema(
+    reflect = new Reflect.Record[Binding, DoubleToInt.type](
+      fields = Vector.empty,
+      typeId = TypeId.of[DoubleToInt.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[DoubleToInt.type](DoubleToInt),
+        deconstructor = new ConstantDeconstructor[DoubleToInt.type]
+      ),
+      modifiers = Vector.empty
+    )
+  )
+
+  implicit lazy val schema: Schema[PrimitiveConversion] = new Schema(
+    reflect = new Reflect.Variant[Binding, PrimitiveConversion](
+      cases = Vector(
+        intToLongSchema.reflect.asTerm("IntToLong"),
+        longToIntSchema.reflect.asTerm("LongToInt"),
+        intToStringSchema.reflect.asTerm("IntToString"),
+        stringToIntSchema.reflect.asTerm("StringToInt"),
+        longToStringSchema.reflect.asTerm("LongToString"),
+        stringToLongSchema.reflect.asTerm("StringToLong"),
+        doubleToStringSchema.reflect.asTerm("DoubleToString"),
+        stringToDoubleSchema.reflect.asTerm("StringToDouble"),
+        floatToDoubleSchema.reflect.asTerm("FloatToDouble"),
+        doubleToFloatSchema.reflect.asTerm("DoubleToFloat"),
+        booleanToStringSchema.reflect.asTerm("BooleanToString"),
+        stringToBooleanSchema.reflect.asTerm("StringToBoolean"),
+        intToDoubleSchema.reflect.asTerm("IntToDouble"),
+        doubleToIntSchema.reflect.asTerm("DoubleToInt")
+      ),
+      typeId = TypeId.of[PrimitiveConversion],
+      variantBinding = new Binding.Variant(
+        discriminator = new Discriminator[PrimitiveConversion] {
+          def discriminate(a: PrimitiveConversion): Int = a match {
+            case _: IntToLong.type       => 0
+            case _: LongToInt.type       => 1
+            case _: IntToString.type     => 2
+            case _: StringToInt.type     => 3
+            case _: LongToString.type    => 4
+            case _: StringToLong.type    => 5
+            case _: DoubleToString.type  => 6
+            case _: StringToDouble.type  => 7
+            case _: FloatToDouble.type   => 8
+            case _: DoubleToFloat.type   => 9
+            case _: BooleanToString.type => 10
+            case _: StringToBoolean.type => 11
+            case _: IntToDouble.type     => 12
+            case _: DoubleToInt.type     => 13
+          }
+        },
+        matchers = Matchers(
+          new Matcher[IntToLong.type] {
+            def downcastOrNull(a: Any): IntToLong.type = a match {
+              case x: IntToLong.type => x
+              case _                 => null.asInstanceOf[IntToLong.type]
+            }
+          },
+          new Matcher[LongToInt.type] {
+            def downcastOrNull(a: Any): LongToInt.type = a match {
+              case x: LongToInt.type => x
+              case _                 => null.asInstanceOf[LongToInt.type]
+            }
+          },
+          new Matcher[IntToString.type] {
+            def downcastOrNull(a: Any): IntToString.type = a match {
+              case x: IntToString.type => x
+              case _                   => null.asInstanceOf[IntToString.type]
+            }
+          },
+          new Matcher[StringToInt.type] {
+            def downcastOrNull(a: Any): StringToInt.type = a match {
+              case x: StringToInt.type => x
+              case _                   => null.asInstanceOf[StringToInt.type]
+            }
+          },
+          new Matcher[LongToString.type] {
+            def downcastOrNull(a: Any): LongToString.type = a match {
+              case x: LongToString.type => x
+              case _                    => null.asInstanceOf[LongToString.type]
+            }
+          },
+          new Matcher[StringToLong.type] {
+            def downcastOrNull(a: Any): StringToLong.type = a match {
+              case x: StringToLong.type => x
+              case _                    => null.asInstanceOf[StringToLong.type]
+            }
+          },
+          new Matcher[DoubleToString.type] {
+            def downcastOrNull(a: Any): DoubleToString.type = a match {
+              case x: DoubleToString.type => x
+              case _                      => null.asInstanceOf[DoubleToString.type]
+            }
+          },
+          new Matcher[StringToDouble.type] {
+            def downcastOrNull(a: Any): StringToDouble.type = a match {
+              case x: StringToDouble.type => x
+              case _                      => null.asInstanceOf[StringToDouble.type]
+            }
+          },
+          new Matcher[FloatToDouble.type] {
+            def downcastOrNull(a: Any): FloatToDouble.type = a match {
+              case x: FloatToDouble.type => x
+              case _                     => null.asInstanceOf[FloatToDouble.type]
+            }
+          },
+          new Matcher[DoubleToFloat.type] {
+            def downcastOrNull(a: Any): DoubleToFloat.type = a match {
+              case x: DoubleToFloat.type => x
+              case _                     => null.asInstanceOf[DoubleToFloat.type]
+            }
+          },
+          new Matcher[BooleanToString.type] {
+            def downcastOrNull(a: Any): BooleanToString.type = a match {
+              case x: BooleanToString.type => x
+              case _                       => null.asInstanceOf[BooleanToString.type]
+            }
+          },
+          new Matcher[StringToBoolean.type] {
+            def downcastOrNull(a: Any): StringToBoolean.type = a match {
+              case x: StringToBoolean.type => x
+              case _                       => null.asInstanceOf[StringToBoolean.type]
+            }
+          },
+          new Matcher[IntToDouble.type] {
+            def downcastOrNull(a: Any): IntToDouble.type = a match {
+              case x: IntToDouble.type => x
+              case _                   => null.asInstanceOf[IntToDouble.type]
+            }
+          },
+          new Matcher[DoubleToInt.type] {
+            def downcastOrNull(a: Any): DoubleToInt.type = a match {
+              case x: DoubleToInt.type => x
+              case _                   => null.asInstanceOf[DoubleToInt.type]
+            }
+          }
+        )
+      ),
+      modifiers = Vector.empty
+    )
+  )
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -1,0 +1,1073 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema._
+import zio.test._
+
+object MigrationSpec extends SchemaBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("Migration")(
+    suite("FieldAction")(
+      test("Add field adds a new field to a record") {
+        val original  = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val migration = DynamicMigration.record(_.addField("age", DynamicValue.int(30)))
+        val result    = migration(original)
+
+        assertTrue(
+          result == Right(
+            DynamicValue.Record(
+              "name" -> DynamicValue.string("Alice"),
+              "age"  -> DynamicValue.int(30)
+            )
+          )
+        )
+      },
+      test("Remove field removes a field from a record") {
+        val original = DynamicValue.Record(
+          "name" -> DynamicValue.string("Alice"),
+          "age"  -> DynamicValue.int(30)
+        )
+        val migration = DynamicMigration.record(_.removeField("age", DynamicValue.int(0)))
+        val result    = migration(original)
+
+        assertTrue(result == Right(DynamicValue.Record("name" -> DynamicValue.string("Alice"))))
+      },
+      test("Rename field renames a field in a record") {
+        val original  = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val migration = DynamicMigration.record(_.renameField("name", "fullName"))
+        val result    = migration(original)
+
+        assertTrue(result == Right(DynamicValue.Record("fullName" -> DynamicValue.string("Alice"))))
+      },
+      test("Transform field applies a transformation to a field value") {
+        val original  = DynamicValue.Record("count" -> DynamicValue.int(5))
+        val migration = DynamicMigration.record(
+          _.transformField(
+            "count",
+            DynamicValueTransform.numericAdd(10),
+            DynamicValueTransform.numericAdd(-10)
+          )
+        )
+        val result = migration(original)
+
+        assertTrue(result == Right(DynamicValue.Record("count" -> DynamicValue.int(15))))
+      },
+      test("MakeOptional wraps a field value in Some") {
+        val original  = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val migration = DynamicMigration.record(_.makeFieldOptional("name", DynamicValue.string("")))
+        val result    = migration(original)
+
+        result match {
+          case Right(DynamicValue.Record(fields)) =>
+            val nameField = fields.find(_._1 == "name").map(_._2)
+            nameField match {
+              case Some(DynamicValue.Variant("Some", _)) => assertTrue(true)
+              case _                                     => assertTrue(false)
+            }
+          case _ => assertTrue(false)
+        }
+      },
+      test("MakeRequired unwraps Some to extract the inner value") {
+        val original = DynamicValue.Record(
+          "name" -> DynamicValue.Variant("Some", DynamicValue.Record("value" -> DynamicValue.string("Alice")))
+        )
+        val migration = DynamicMigration.record(_.makeFieldRequired("name", DynamicValue.string("")))
+        val result    = migration(original)
+
+        assertTrue(result == Right(DynamicValue.Record("name" -> DynamicValue.string("Alice"))))
+      },
+      test("MakeRequired uses default for None") {
+        val original = DynamicValue.Record(
+          "name" -> DynamicValue.Variant("None", DynamicValue.Record())
+        )
+        val migration = DynamicMigration.record(_.makeFieldRequired("name", DynamicValue.string("default")))
+        val result    = migration(original)
+
+        assertTrue(result == Right(DynamicValue.Record("name" -> DynamicValue.string("default"))))
+      },
+      test("ChangeType converts field value type") {
+        val original  = DynamicValue.Record("count" -> DynamicValue.int(42))
+        val migration = DynamicMigration.record(
+          _.changeFieldType(
+            "count",
+            PrimitiveConversion.IntToLong,
+            PrimitiveConversion.LongToInt
+          )
+        )
+        val result = migration(original)
+
+        assertTrue(result == Right(DynamicValue.Record("count" -> DynamicValue.long(42L))))
+      }
+    ),
+    suite("Chained field actions")(
+      test("Multiple field actions are applied in order") {
+        val original  = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val migration = DynamicMigration.record(
+          _.addField("age", DynamicValue.int(30))
+            .renameField("name", "fullName")
+            .addField("active", DynamicValue.boolean(true))
+        )
+        val result = migration(original)
+
+        assertTrue(
+          result == Right(
+            DynamicValue.Record(
+              "fullName" -> DynamicValue.string("Alice"),
+              "age"      -> DynamicValue.int(30),
+              "active"   -> DynamicValue.boolean(true)
+            )
+          )
+        )
+      }
+    ),
+    suite("Nested migrations")(
+      test("Apply migration to nested record field") {
+        val original = DynamicValue.Record(
+          "name"    -> DynamicValue.string("Alice"),
+          "address" -> DynamicValue.Record(
+            "street" -> DynamicValue.string("123 Main St"),
+            "city"   -> DynamicValue.string("NYC")
+          )
+        )
+        val migration = DynamicMigration.record(
+          _.nested("address")(
+            _.addField("zip", DynamicValue.string("10001"))
+          )
+        )
+        val result = migration(original)
+
+        assertTrue(
+          result == Right(
+            DynamicValue.Record(
+              "name"    -> DynamicValue.string("Alice"),
+              "address" -> DynamicValue.Record(
+                "street" -> DynamicValue.string("123 Main St"),
+                "city"   -> DynamicValue.string("NYC"),
+                "zip"    -> DynamicValue.string("10001")
+              )
+            )
+          )
+        )
+      },
+      test("Deeply nested migrations") {
+        val original = DynamicValue.Record(
+          "person" -> DynamicValue.Record(
+            "name"    -> DynamicValue.string("Alice"),
+            "contact" -> DynamicValue.Record(
+              "email" -> DynamicValue.string("alice@example.com")
+            )
+          )
+        )
+        val migration = DynamicMigration.record(
+          _.nested("person")(
+            _.nested("contact")(
+              _.addField("phone", DynamicValue.string("555-1234"))
+            )
+          )
+        )
+        val result = migration(original)
+
+        assertTrue(
+          result == Right(
+            DynamicValue.Record(
+              "person" -> DynamicValue.Record(
+                "name"    -> DynamicValue.string("Alice"),
+                "contact" -> DynamicValue.Record(
+                  "email" -> DynamicValue.string("alice@example.com"),
+                  "phone" -> DynamicValue.string("555-1234")
+                )
+              )
+            )
+          )
+        )
+      }
+    ),
+    suite("Sequence migrations")(
+      test("Apply migration to each element in a sequence") {
+        val original = DynamicValue.Sequence(
+          DynamicValue.Record("name" -> DynamicValue.string("Alice")),
+          DynamicValue.Record("name" -> DynamicValue.string("Bob"))
+        )
+        val elementMigration = DynamicMigration.record(_.addField("active", DynamicValue.boolean(true)))
+        val migration        = DynamicMigration.sequence(elementMigration)
+        val result           = migration(original)
+
+        assertTrue(
+          result == Right(
+            DynamicValue.Sequence(
+              DynamicValue.Record(
+                "name"   -> DynamicValue.string("Alice"),
+                "active" -> DynamicValue.boolean(true)
+              ),
+              DynamicValue.Record(
+                "name"   -> DynamicValue.string("Bob"),
+                "active" -> DynamicValue.boolean(true)
+              )
+            )
+          )
+        )
+      }
+    ),
+    suite("Variant migrations")(
+      test("Rename a case in a variant") {
+        val original = DynamicValue.Variant(
+          "OldName",
+          DynamicValue.Record("value" -> DynamicValue.int(42))
+        )
+        val migration = DynamicMigration.variant(_.renameCase("OldName", "NewName"))
+        val result    = migration(original)
+
+        assertTrue(
+          result == Right(
+            DynamicValue.Variant(
+              "NewName",
+              DynamicValue.Record("value" -> DynamicValue.int(42))
+            )
+          )
+        )
+      },
+      test("Apply nested migration to variant case") {
+        val original = DynamicValue.Variant(
+          "User",
+          DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        )
+        val migration = DynamicMigration.variant(
+          _.nested("User")(
+            _.addField("role", DynamicValue.string("admin"))
+          )
+        )
+        val result = migration(original)
+
+        assertTrue(
+          result == Right(
+            DynamicValue.Variant(
+              "User",
+              DynamicValue.Record(
+                "name" -> DynamicValue.string("Alice"),
+                "role" -> DynamicValue.string("admin")
+              )
+            )
+          )
+        )
+      }
+    ),
+    suite("Reversibility")(
+      test("Adding and removing a field are inverses") {
+        val original  = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val migration = DynamicMigration.record(_.addField("age", DynamicValue.int(30)))
+        val migrated  = migration(original)
+        val reversed  = migration.reverse(migrated.toOption.get)
+
+        assertTrue(reversed == Right(original))
+      },
+      test("Renaming a field is reversible") {
+        val original  = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val migration = DynamicMigration.record(_.renameField("name", "fullName"))
+        val migrated  = migration(original)
+        val reversed  = migration.reverse(migrated.toOption.get)
+
+        assertTrue(reversed == Right(original))
+      },
+      test("Complex migration is reversible") {
+        val original = DynamicValue.Record(
+          "name" -> DynamicValue.string("Alice"),
+          "age"  -> DynamicValue.int(30)
+        )
+        val migration = DynamicMigration.record(
+          _.renameField("name", "fullName")
+            .addField("active", DynamicValue.boolean(true))
+        )
+        val migrated = migration(original)
+        val reversed = migration.reverse(migrated.toOption.get)
+
+        assertTrue(reversed == Right(original))
+      }
+    ),
+    suite("DynamicValueTransform")(
+      test("Identity transform returns the same value") {
+        val value  = DynamicValue.int(42)
+        val result = DynamicValueTransform.identity(value)
+        assertTrue(result == Right(value))
+      },
+      test("Constant transform returns the constant value") {
+        val value    = DynamicValue.int(42)
+        val constant = DynamicValue.string("hello")
+        val result   = DynamicValueTransform.constant(constant)(value)
+        assertTrue(result == Right(constant))
+      },
+      test("StringAppend appends a suffix") {
+        val value  = DynamicValue.string("hello")
+        val result = DynamicValueTransform.stringAppend(" world")(value)
+        assertTrue(result == Right(DynamicValue.string("hello world")))
+      },
+      test("StringPrepend prepends a prefix") {
+        val value  = DynamicValue.string("world")
+        val result = DynamicValueTransform.stringPrepend("hello ")(value)
+        assertTrue(result == Right(DynamicValue.string("hello world")))
+      },
+      test("StringReplace replaces occurrences") {
+        val value  = DynamicValue.string("hello world")
+        val result = DynamicValueTransform.stringReplace("world", "universe")(value)
+        assertTrue(result == Right(DynamicValue.string("hello universe")))
+      },
+      test("NumericAdd adds to integer") {
+        val value  = DynamicValue.int(10)
+        val result = DynamicValueTransform.numericAdd(5)(value)
+        assertTrue(result == Right(DynamicValue.int(15)))
+      },
+      test("NumericMultiply multiplies integer") {
+        val value  = DynamicValue.int(10)
+        val result = DynamicValueTransform.numericMultiply(3)(value)
+        assertTrue(result == Right(DynamicValue.int(30)))
+      },
+      test("WrapInSome wraps value in Some variant") {
+        val value  = DynamicValue.int(42)
+        val result = DynamicValueTransform.wrapInSome(value)
+        result match {
+          case Right(DynamicValue.Variant("Some", _)) => assertTrue(true)
+          case _                                      => assertTrue(false)
+        }
+      },
+      test("Sequence applies transforms in order") {
+        val value     = DynamicValue.int(10)
+        val transform = DynamicValueTransform.sequence(
+          DynamicValueTransform.numericAdd(5),
+          DynamicValueTransform.numericMultiply(2)
+        )
+        val result = transform(value)
+        assertTrue(result == Right(DynamicValue.int(30)))
+      }
+    ),
+    suite("PrimitiveConversion")(
+      test("IntToLong converts Int to Long") {
+        val value  = DynamicValue.int(42)
+        val result = PrimitiveConversion.IntToLong(value)
+        assertTrue(result == Right(DynamicValue.long(42L)))
+      },
+      test("LongToInt converts Long to Int") {
+        val value  = DynamicValue.long(42L)
+        val result = PrimitiveConversion.LongToInt(value)
+        assertTrue(result == Right(DynamicValue.int(42)))
+      },
+      test("IntToString converts Int to String") {
+        val value  = DynamicValue.int(42)
+        val result = PrimitiveConversion.IntToString(value)
+        assertTrue(result == Right(DynamicValue.string("42")))
+      },
+      test("StringToInt converts String to Int") {
+        val value  = DynamicValue.string("42")
+        val result = PrimitiveConversion.StringToInt(value)
+        assertTrue(result == Right(DynamicValue.int(42)))
+      },
+      test("StringToInt fails for non-numeric string") {
+        val value  = DynamicValue.string("hello")
+        val result = PrimitiveConversion.StringToInt(value)
+        assertTrue(result.isLeft)
+      },
+      test("DoubleToInt truncates decimal part") {
+        val value  = DynamicValue.double(42.9)
+        val result = PrimitiveConversion.DoubleToInt(value)
+        assertTrue(result == Right(DynamicValue.int(42)))
+      }
+    ),
+    suite("MigrationExpr")(
+      test("Literal returns constant DynamicValue") {
+        val expr   = MigrationExpr.literal(42)
+        val result = expr.evalDynamic(DynamicValue.Null)
+        assertTrue(result == Right(DynamicValue.int(42)))
+      },
+      test("DefaultValue extracts schema default when available") {
+        val schemaWithDefault = Schema[Int].defaultValue(99)
+        val expr              = MigrationExpr.DefaultValue[Any](schemaWithDefault)
+        val result            = expr.evalDynamic(DynamicValue.Null)
+        assertTrue(result == Right(DynamicValue.int(99)))
+      },
+      test("DefaultValue fails when schema has no default") {
+        val schemaWithoutDefault = Schema[Int]
+        val expr                 = MigrationExpr.DefaultValue[Any](schemaWithoutDefault)
+        val result               = expr.evalDynamic(DynamicValue.Null)
+        assertTrue(result.isLeft)
+      },
+      test("FieldAccess retrieves value from input") {
+        val input  = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val expr   = MigrationExpr.field[Any, String](DynamicOptic.root.field("name"))
+        val result = expr.evalDynamic(input)
+        assertTrue(result == Right(DynamicValue.string("Alice")))
+      },
+      test("Transform applies DynamicValueTransform to result") {
+        val expr = MigrationExpr.transform[Any, Int, Int](
+          MigrationExpr.literal(10),
+          DynamicValueTransform.numericMultiply(2)
+        )
+        val result = expr.evalDynamic(DynamicValue.Null)
+        assertTrue(result == Right(DynamicValue.int(20)))
+      },
+      test("Concat joins two string expressions") {
+        val expr = MigrationExpr.concat(
+          MigrationExpr.literal("Hello"),
+          MigrationExpr.literal(" World")
+        )
+        val result = expr.evalDynamic(DynamicValue.Null)
+        assertTrue(result == Right(DynamicValue.string("Hello World")))
+      },
+      test("PrimitiveConvert applies conversion") {
+        val expr = MigrationExpr.convert[Any, Int, Long](
+          MigrationExpr.literal(42),
+          PrimitiveConversion.IntToLong
+        )
+        val result = expr.evalDynamic(DynamicValue.Null)
+        assertTrue(result == Right(DynamicValue.long(42L)))
+      }
+    ),
+    suite("Error handling")(
+      test("Returns FieldNotFound when field does not exist") {
+        val original  = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val migration = DynamicMigration.record(_.removeField("age", DynamicValue.int(0)))
+        val result    = migration(original)
+
+        result match {
+          case Left(MigrationError.FieldNotFound(_, _)) => assertTrue(true)
+          case _                                        => assertTrue(false)
+        }
+      },
+      test("Returns FieldAlreadyExists when adding duplicate field") {
+        val original  = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val migration = DynamicMigration.record(_.addField("name", DynamicValue.string("Bob")))
+        val result    = migration(original)
+
+        result match {
+          case Left(MigrationError.FieldAlreadyExists(_, _)) => assertTrue(true)
+          case _                                             => assertTrue(false)
+        }
+      },
+      test("Returns TypeMismatch when applying record migration to non-record") {
+        val original  = DynamicValue.int(42)
+        val migration = DynamicMigration.record(_.addField("name", DynamicValue.string("Alice")))
+        val result    = migration(original)
+
+        result match {
+          case Left(MigrationError.TypeMismatch(_, _, _)) => assertTrue(true)
+          case _                                          => assertTrue(false)
+        }
+      }
+    ),
+    suite("Composition")(
+      test("andThen composes two migrations") {
+        val original   = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val migration1 = DynamicMigration.record(_.addField("age", DynamicValue.int(30)))
+        val migration2 = DynamicMigration.record(_.addField("active", DynamicValue.boolean(true)))
+        val composed   = migration1.andThen(migration2)
+        val result     = composed(original)
+
+        assertTrue(
+          result == Right(
+            DynamicValue.Record(
+              "name"   -> DynamicValue.string("Alice"),
+              "age"    -> DynamicValue.int(30),
+              "active" -> DynamicValue.boolean(true)
+            )
+          )
+        )
+      },
+      test("Identity migration is neutral for andThen") {
+        val original     = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val migration    = DynamicMigration.record(_.addField("age", DynamicValue.int(30)))
+        val withIdentity = DynamicMigration.identity.andThen(migration)
+        val result       = withIdentity(original)
+
+        assertTrue(
+          result == Right(
+            DynamicValue.Record(
+              "name" -> DynamicValue.string("Alice"),
+              "age"  -> DynamicValue.int(30)
+            )
+          )
+        )
+      },
+      test("andThen is associative: (m1 andThen m2) andThen m3 == m1 andThen (m2 andThen m3)") {
+        val original = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val m1       = DynamicMigration.record(_.addField("age", DynamicValue.int(30)))
+        val m2       = DynamicMigration.record(_.addField("active", DynamicValue.boolean(true)))
+        val m3       = DynamicMigration.record(_.addField("score", DynamicValue.int(100)))
+
+        val leftAssoc  = (m1.andThen(m2)).andThen(m3)
+        val rightAssoc = m1.andThen(m2.andThen(m3))
+
+        val resultLeft  = leftAssoc(original)
+        val resultRight = rightAssoc(original)
+
+        assertTrue(resultLeft == resultRight)
+      },
+      test("Identity migration is right-neutral: m andThen identity == m") {
+        val original          = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val migration         = DynamicMigration.record(_.addField("age", DynamicValue.int(30)))
+        val withIdentityRight = migration.andThen(DynamicMigration.identity)
+
+        val resultMigration    = migration(original)
+        val resultWithIdentity = withIdentityRight(original)
+
+        assertTrue(resultMigration == resultWithIdentity)
+      }
+    ),
+    suite("MigrationStep")(
+      test("NoOp step does nothing") {
+        val original  = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val migration = DynamicMigration(MigrationStep.NoOp)
+        val result    = migration(original)
+
+        assertTrue(result == Right(original))
+      },
+      test("Empty record step is equivalent to NoOp") {
+        val original  = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+        val migration = DynamicMigration(MigrationStep.Record.empty)
+        val result    = migration(original)
+
+        assertTrue(result == Right(original))
+      },
+      test("isEmpty returns true for empty steps") {
+        assertTrue(MigrationStep.NoOp.isEmpty) &&
+        assertTrue(MigrationStep.Record.empty.isEmpty) &&
+        assertTrue(MigrationStep.Variant.empty.isEmpty)
+      },
+      test("isEmpty returns false for non-empty steps") {
+        val recordStep  = MigrationStep.Record.empty.addField("x", DynamicValue.int(1))
+        val variantStep = MigrationStep.Variant.empty.renameCase("A", "B")
+        assertTrue(!recordStep.isEmpty) &&
+        assertTrue(!variantStep.isEmpty)
+      }
+    ),
+    suite("Schema serialization")(
+      test("PrimitiveConversion round-trips through DynamicValue") {
+        val conversions: Vector[PrimitiveConversion] = Vector(
+          PrimitiveConversion.IntToLong,
+          PrimitiveConversion.LongToInt,
+          PrimitiveConversion.IntToString,
+          PrimitiveConversion.StringToInt
+        )
+        val schema  = Schema[PrimitiveConversion]
+        val results = conversions.map { conv =>
+          val dv = schema.toDynamicValue(conv)
+          schema.fromDynamicValue(dv)
+        }
+        assertTrue(results.forall(_.isRight)) &&
+        assertTrue(results.map(_.toOption.get) == conversions)
+      },
+      test("MigrationError round-trips through DynamicValue") {
+        val errors: Vector[MigrationError] = Vector(
+          MigrationError.FieldNotFound("name", DynamicOptic.root),
+          MigrationError.TypeMismatch("Record", "Int", DynamicOptic.root.field("x")),
+          MigrationError.TransformFailed("reason", DynamicOptic.root)
+        )
+        val schema  = Schema[MigrationError]
+        val results = errors.map { e =>
+          val dv = schema.toDynamicValue(e)
+          schema.fromDynamicValue(dv)
+        }
+        assertTrue(results.forall(_.isRight)) &&
+        assertTrue(results.map(_.toOption.get) == errors)
+      }
+    ),
+    suite("MigrationBuilder")(
+      suite("String-based API")(
+        test("addField adds a field using path string") {
+          val builder = MigrationBuilder[PersonV1, PersonV2]
+            .addField("age", DynamicValue.int(0))
+          val migration = builder.build
+          val original  = PersonV1("Alice")
+          val result    = migration(original)
+
+          assertTrue(result == Right(PersonV2("Alice", 0)))
+        },
+        test("dropField removes a field using path string") {
+          val builder = MigrationBuilder[PersonV2, PersonV1]
+            .dropField("age", DynamicValue.int(0))
+          val migration = builder.build
+          val original  = PersonV2("Alice", 30)
+          val result    = migration(original)
+
+          assertTrue(result == Right(PersonV1("Alice")))
+        },
+        test("renameField renames a field using path strings") {
+          val builder = MigrationBuilder[PersonV1, PersonRenamed]
+            .renameField("name", "fullName")
+          val migration = builder.build
+          val original  = PersonV1("Alice")
+          val result    = migration(original)
+
+          assertTrue(result == Right(PersonRenamed("Alice")))
+        },
+        test("changeFieldType converts field type") {
+          val builder = MigrationBuilder[PersonWithIntId, PersonWithLongId]
+            .changeFieldType("id", PrimitiveConversion.IntToLong, PrimitiveConversion.LongToInt)
+          val migration = builder.build
+          val original  = PersonWithIntId("Alice", 42)
+          val result    = migration(original)
+
+          assertTrue(result == Right(PersonWithLongId("Alice", 42L)))
+        },
+        test("nested path string works for deeply nested fields") {
+          val builder = MigrationBuilder[NestedV1, NestedV2]
+            .addField("person.contact.phone", DynamicValue.string("555-0000"))
+          val migration = builder.build
+          val original  = NestedV1(PersonWithContact("Alice", Contact("alice@example.com")))
+          val result    = migration(original)
+
+          assertTrue(
+            result == Right(NestedV2(PersonWithContactV2("Alice", ContactV2("alice@example.com", "555-0000"))))
+          )
+        },
+        test("multiple field operations chain correctly") {
+          val builder = MigrationBuilder[PersonV1, PersonV3]
+            .addField("age", DynamicValue.int(0))
+            .addField("active", DynamicValue.boolean(true))
+          val migration = builder.build
+          val original  = PersonV1("Alice")
+          val result    = migration(original)
+
+          assertTrue(result == Right(PersonV3("Alice", 0, true)))
+        }
+      ),
+      suite("Builder chaining")(
+        test("builder is immutable and chainable") {
+          val base      = MigrationBuilder[PersonV1, PersonV2]
+          val withAge   = base.addField("age", DynamicValue.int(25))
+          val migration = withAge.build
+          val original  = PersonV1("Alice")
+          val result    = migration(original)
+
+          assertTrue(result == Right(PersonV2("Alice", 25)))
+        },
+        test("fromBuilder provides fluent API") {
+          val migration = MigrationBuilder
+            .from[PersonV1]
+            .to[PersonV2]
+            .addField("age", DynamicValue.int(18))
+            .build
+          val result = migration(PersonV1("Bob"))
+
+          assertTrue(result == Right(PersonV2("Bob", 18)))
+        }
+      ),
+      suite("Variant operations")(
+        test("renameCase renames enum case") {
+          val builder = MigrationBuilder[StatusV1, StatusV2]
+            .renameCase("Active", "Enabled")
+          val migration = builder.build
+          val original  = StatusV1.Active
+          val result    = migration(original)
+
+          assertTrue(result == Right(StatusV2.Enabled))
+        },
+        test("addCase adds new case with default") {
+          val builder = MigrationBuilder[StatusV1, StatusV3]
+            .addCase("Pending", DynamicValue.Variant("Pending", DynamicValue.Record()))
+          val migration = builder.build
+          val original  = StatusV1.Active
+          val result    = migration(original)
+
+          assertTrue(result == Right(StatusV3.Active))
+        }
+      ),
+      suite("Dynamic migration extraction")(
+        test("toDynamicMigration returns serializable migration") {
+          val builder = MigrationBuilder[PersonV1, PersonV2]
+            .addField("age", DynamicValue.int(0))
+          val dynamic = builder.toDynamicMigration
+
+          val original = DynamicValue.Record("name" -> DynamicValue.string("Alice"))
+          val result   = dynamic(original)
+
+          assertTrue(
+            result == Right(
+              DynamicValue.Record(
+                "name" -> DynamicValue.string("Alice"),
+                "age"  -> DynamicValue.int(0)
+              )
+            )
+          )
+        }
+      )
+    ),
+    suite("JoinFields and SplitField")(
+      test("JoinFields combines multiple fields into one using StringAppend") {
+        val original = DynamicValue.Record(
+          "prefix" -> DynamicValue.string("Hello"),
+          "suffix" -> DynamicValue.string("World"),
+          "age"    -> DynamicValue.int(30)
+        )
+
+        val migration = DynamicMigration.record(
+          _.joinFields(
+            "combined",
+            Vector("prefix", "suffix"),
+            DynamicValueTransform.identity,
+            DynamicValueTransform.identity
+          )
+        )
+        val result = migration(original)
+
+        result match {
+          case Right(DynamicValue.Record(fields)) =>
+            val fieldMap = fields.toVector.toMap
+            assertTrue(
+              fieldMap.contains("combined"),
+              fieldMap.contains("age"),
+              !fieldMap.contains("prefix"),
+              !fieldMap.contains("suffix")
+            )
+          case _ => assertTrue(false)
+        }
+      },
+      test("SplitField splits one field into multiple") {
+        val original = DynamicValue.Record(
+          "source" -> DynamicValue.Record(
+            "first"  -> DynamicValue.string("Hello"),
+            "second" -> DynamicValue.string("World")
+          ),
+          "age" -> DynamicValue.int(30)
+        )
+
+        val migration = DynamicMigration.record(
+          _.splitField(
+            "source",
+            Vector("first", "second"),
+            DynamicValueTransform.identity,
+            DynamicValueTransform.identity
+          )
+        )
+        val result = migration(original)
+
+        result match {
+          case Right(DynamicValue.Record(fields)) =>
+            val fieldMap = fields.toVector.toMap
+            assertTrue(
+              fieldMap.contains("first"),
+              fieldMap.contains("second"),
+              fieldMap.contains("age"),
+              !fieldMap.contains("source")
+            )
+          case _ => assertTrue(false)
+        }
+      },
+      test("JoinFields fails when source field not found") {
+        val original = DynamicValue.Record(
+          "firstName" -> DynamicValue.string("John"),
+          "age"       -> DynamicValue.int(30)
+        )
+
+        val migration = DynamicMigration.record(
+          _.joinFields(
+            "fullName",
+            Vector("firstName", "lastName"),
+            DynamicValueTransform.identity,
+            DynamicValueTransform.identity
+          )
+        )
+        val result = migration(original)
+
+        result match {
+          case Left(MigrationError.FieldNotFound("lastName", _)) => assertTrue(true)
+          case _                                                 => assertTrue(false)
+        }
+      },
+      test("JoinFields fails when target field already exists") {
+        val original = DynamicValue.Record(
+          "firstName" -> DynamicValue.string("John"),
+          "lastName"  -> DynamicValue.string("Doe"),
+          "fullName"  -> DynamicValue.string("Existing")
+        )
+
+        val migration = DynamicMigration.record(
+          _.joinFields(
+            "fullName",
+            Vector("firstName", "lastName"),
+            DynamicValueTransform.identity,
+            DynamicValueTransform.identity
+          )
+        )
+        val result = migration(original)
+
+        result match {
+          case Left(MigrationError.FieldAlreadyExists("fullName", _)) => assertTrue(true)
+          case _                                                      => assertTrue(false)
+        }
+      },
+      test("SplitField fails when source field not found") {
+        val original = DynamicValue.Record(
+          "age" -> DynamicValue.int(30)
+        )
+
+        val migration = DynamicMigration.record(
+          _.splitField("fullName", Vector("a", "b"), DynamicValueTransform.identity, DynamicValueTransform.identity)
+        )
+        val result = migration(original)
+
+        result match {
+          case Left(MigrationError.FieldNotFound("fullName", _)) => assertTrue(true)
+          case _                                                 => assertTrue(false)
+        }
+      },
+      test("SplitField fails when target field already exists") {
+        val original = DynamicValue.Record(
+          "fullName"  -> DynamicValue.string("John Doe"),
+          "firstName" -> DynamicValue.string("Existing")
+        )
+
+        val splitter = DynamicValueTransform.stringSplitToFields(Vector("firstName", "lastName"), " ", 2)
+
+        val migration = DynamicMigration.record(
+          _.splitField("fullName", Vector("firstName", "lastName"), splitter, DynamicValueTransform.identity)
+        )
+        val result = migration(original)
+
+        result match {
+          case Left(MigrationError.FieldAlreadyExists("firstName", _)) => assertTrue(true)
+          case _                                                       => assertTrue(false)
+        }
+      },
+      test("JoinFields and SplitField are reversible") {
+        val original = DynamicValue.Record(
+          "firstName" -> DynamicValue.string("Jane"),
+          "lastName"  -> DynamicValue.string("Smith"),
+          "age"       -> DynamicValue.int(25)
+        )
+
+        val combiner = DynamicValueTransform.stringJoinFields(Vector("firstName", "lastName"), " ")
+        val splitter = DynamicValueTransform.stringSplitToFields(Vector("firstName", "lastName"), " ", 2)
+
+        val migration = DynamicMigration.record(
+          _.joinFields("fullName", Vector("firstName", "lastName"), combiner, splitter)
+        )
+        val migrated = migration(original)
+        val reversed = migration.reverse(migrated.toOption.get)
+
+        reversed match {
+          case Right(DynamicValue.Record(fields)) =>
+            val fieldMap    = fields.toVector.toMap
+            val originalMap = original.fields.toVector.toMap
+            assertTrue(
+              fieldMap == originalMap
+            )
+          case _ => assertTrue(false)
+        }
+      }
+    ),
+    suite("Four-level nested migrations")(
+      test("Apply migration at depth 4") {
+        val original = DynamicValue.Record(
+          "level1" -> DynamicValue.Record(
+            "level2" -> DynamicValue.Record(
+              "level3" -> DynamicValue.Record(
+                "level4" -> DynamicValue.Record(
+                  "value" -> DynamicValue.string("original")
+                )
+              )
+            )
+          )
+        )
+
+        val migration = DynamicMigration.record(
+          _.nested("level1")(
+            _.nested("level2")(
+              _.nested("level3")(
+                _.nested("level4")(
+                  _.addField("added", DynamicValue.int(42))
+                    .renameField("value", "renamed")
+                )
+              )
+            )
+          )
+        )
+        val result = migration(original)
+
+        assertTrue(
+          result == Right(
+            DynamicValue.Record(
+              "level1" -> DynamicValue.Record(
+                "level2" -> DynamicValue.Record(
+                  "level3" -> DynamicValue.Record(
+                    "level4" -> DynamicValue.Record(
+                      "renamed" -> DynamicValue.string("original"),
+                      "added"   -> DynamicValue.int(42)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      },
+      test("Deeply nested migration is reversible") {
+        val original = DynamicValue.Record(
+          "a" -> DynamicValue.Record(
+            "b" -> DynamicValue.Record(
+              "c" -> DynamicValue.Record(
+                "d" -> DynamicValue.string("deep")
+              )
+            )
+          )
+        )
+
+        val migration = DynamicMigration.record(
+          _.nested("a")(
+            _.nested("b")(
+              _.nested("c")(
+                _.addField("e", DynamicValue.int(1))
+              )
+            )
+          )
+        )
+        val migrated = migration(original)
+        val reversed = migration.reverse(migrated.toOption.get)
+
+        assertTrue(reversed == Right(original))
+      }
+    ),
+    suite("MigrationBuilder with JoinFields/SplitField")(
+      test("joinFields via builder works correctly") {
+        val combiner = DynamicValueTransform.stringJoinFields(Vector("firstName", "lastName"), " ")
+        val splitter = DynamicValueTransform.stringSplitToFields(Vector("firstName", "lastName"), " ", 2)
+
+        val builder = MigrationBuilder[PersonWithSplitName, PersonWithFullName]
+          .joinFields("fullName", Vector("firstName", "lastName"), combiner, splitter)
+        val dynamic = builder.toDynamicMigration
+
+        val original = DynamicValue.Record(
+          "firstName" -> DynamicValue.string("Alice"),
+          "lastName"  -> DynamicValue.string("Wonder"),
+          "age"       -> DynamicValue.int(28)
+        )
+        val result = dynamic(original)
+
+        result match {
+          case Right(DynamicValue.Record(fields)) =>
+            val fieldMap = fields.toVector.toMap
+            assertTrue(
+              fieldMap.get("fullName") == Some(DynamicValue.string("Alice Wonder")),
+              fieldMap.get("age") == Some(DynamicValue.int(28)),
+              !fieldMap.contains("firstName"),
+              !fieldMap.contains("lastName")
+            )
+          case _ => assertTrue(false)
+        }
+      },
+      test("splitField via builder works correctly") {
+        val splitter = DynamicValueTransform.stringSplitToFields(Vector("firstName", "lastName"), " ", 2)
+        val combiner = DynamicValueTransform.stringJoinFields(Vector("firstName", "lastName"))
+
+        val builder = MigrationBuilder[PersonWithFullName, PersonWithSplitName]
+          .splitField("fullName", Vector("firstName", "lastName"), splitter, combiner)
+        val dynamic = builder.toDynamicMigration
+
+        val original = DynamicValue.Record(
+          "fullName" -> DynamicValue.string("Bob Builder"),
+          "age"      -> DynamicValue.int(35)
+        )
+        val result = dynamic(original)
+
+        result match {
+          case Right(DynamicValue.Record(fields)) =>
+            val fieldMap = fields.toVector.toMap
+            assertTrue(
+              fieldMap.get("firstName") == Some(DynamicValue.string("Bob")),
+              fieldMap.get("lastName") == Some(DynamicValue.string("Builder")),
+              fieldMap.get("age") == Some(DynamicValue.int(35)),
+              !fieldMap.contains("fullName")
+            )
+          case _ => assertTrue(false)
+        }
+      }
+    )
+  )
+}
+
+case class PersonV1(name: String)
+object PersonV1 {
+  implicit val schema: Schema[PersonV1] = Schema.derived
+}
+
+case class PersonV2(name: String, age: Int)
+object PersonV2 {
+  implicit val schema: Schema[PersonV2] = Schema.derived
+}
+
+case class PersonV3(name: String, age: Int, active: Boolean)
+object PersonV3 {
+  implicit val schema: Schema[PersonV3] = Schema.derived
+}
+
+case class PersonRenamed(fullName: String)
+object PersonRenamed {
+  implicit val schema: Schema[PersonRenamed] = Schema.derived
+}
+
+case class PersonWithIntId(name: String, id: Int)
+object PersonWithIntId {
+  implicit val schema: Schema[PersonWithIntId] = Schema.derived
+}
+
+case class PersonWithLongId(name: String, id: Long)
+object PersonWithLongId {
+  implicit val schema: Schema[PersonWithLongId] = Schema.derived
+}
+
+case class Contact(email: String)
+object Contact {
+  implicit val schema: Schema[Contact] = Schema.derived
+}
+
+case class ContactV2(email: String, phone: String)
+object ContactV2 {
+  implicit val schema: Schema[ContactV2] = Schema.derived
+}
+
+case class PersonWithContact(name: String, contact: Contact)
+object PersonWithContact {
+  implicit val schema: Schema[PersonWithContact] = Schema.derived
+}
+
+case class PersonWithContactV2(name: String, contact: ContactV2)
+object PersonWithContactV2 {
+  implicit val schema: Schema[PersonWithContactV2] = Schema.derived
+}
+
+case class NestedV1(person: PersonWithContact)
+object NestedV1 {
+  implicit val schema: Schema[NestedV1] = Schema.derived
+}
+
+case class NestedV2(person: PersonWithContactV2)
+object NestedV2 {
+  implicit val schema: Schema[NestedV2] = Schema.derived
+}
+
+sealed trait StatusV1
+object StatusV1 {
+  case object Active   extends StatusV1
+  case object Inactive extends StatusV1
+  implicit val schema: Schema[StatusV1] = Schema.derived
+}
+
+sealed trait StatusV2
+object StatusV2 {
+  case object Enabled  extends StatusV2
+  case object Inactive extends StatusV2
+  implicit val schema: Schema[StatusV2] = Schema.derived
+}
+
+sealed trait StatusV3
+object StatusV3 {
+  case object Active   extends StatusV3
+  case object Inactive extends StatusV3
+  case object Pending  extends StatusV3
+  implicit val schema: Schema[StatusV3] = Schema.derived
+}
+
+case class PersonWithFullName(fullName: String, age: Int)
+object PersonWithFullName {
+  implicit val schema: Schema[PersonWithFullName] = Schema.derived
+}
+
+case class PersonWithSplitName(firstName: String, lastName: String, age: Int)
+object PersonWithSplitName {
+  implicit val schema: Schema[PersonWithSplitName] = Schema.derived
+}


### PR DESCRIPTION
this implementation uses a hierarchical structure in `MigrationStep.Record`:

```scala
final case class Record(
  fieldActions: Vector[FieldAction],           // Bottom level: add/remove/update at THIS depth
  nestedFields: Map[String, MigrationStep]     // Top level: how deep (recursion)
)
```

Sample for migrating nested structures:

```scala
// Source: Person(name, address: Address(street, city, zip))
// Target: Person(name, address: Address(street, city, postalCode), age)

Record(
  fieldActions = Vector(Add("age", default)),     // depth 0: Person level
  nestedFields = Map(
    "address" -> Record(
      fieldActions = Vector(Rename("zip", "postalCode")),  // depth 1: Address level
      nestedFields = Map.empty
    )
  )
)
```

## API Examples

**String-based API (Scala 2 & 3):**
```scala
MigrationBuilder.from[PersonV1].to[PersonV2]
  .renameField("name", "fullName")
  .addField("email", DynamicValue.Primitive("unknown", StandardType.StringType))
  .build
```

**Selector-based API (Scala 3):**
```scala
MigrationBuilder.from[PersonV1].to[PersonV2]
  .rename(_.name, _.fullName)
  .add(_.email, DynamicValue.Primitive("unknown", StandardType.StringType))
  .buildValidated
```

**Nested paths:**
```scala
MigrationBuilder.from[OrderV1].to[OrderV2]
  .addField("customer.loyaltyPoints", default)
  .renameField("customer.address.zip", "customer.address.postalCode")
  .build
```

Closes #519
/claim #519 