### PR TITLE
Remove Scala Native references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # ZIO Blocks Agent Guidelines
 
-Zero-dependency Scala building blocks (2.13 + 3.x; JVM/JS/Native).
+Zero-dependency Scala building blocks (2.13 + 3.x; JVM/JS).
 
 ## Setup
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ title: "ZIO Blocks"
 
 ZIO Blocks is a **family of type-safe, modular building blocks** for Scala applications. Each block is a standalone library with zero or minimal dependencies, designed to work with *any* Scala stack—ZIO, Cats Effect, Kyo, Ox, Akka, or plain Scala.
 
-The philosophy is simple: **use what you need, nothing more**. Each block is independently useful, cross-platform (JVM, JS, Native), and designed to compose with other blocks or your existing code.
+The philosophy is simple: **use what you need, nothing more**. Each block is independently useful, cross-platform (JVM, JS), and designed to compose with other blocks or your existing code.
 
 ## The Blocks
 
@@ -28,7 +28,7 @@ The philosophy is simple: **use what you need, nothing more**. Each block is ind
 
 - **Zero Lock-In**: No dependencies on ZIO, Cats Effect, or any effect system. Use with whatever stack you prefer.
 - **Modular**: Each block is a separate artifact. Import only what you need.
-- **Cross-Platform**: Full support for JVM, Scala.js, and Scala Native.
+- **Cross-Platform**: Full support for JVM and Scala.js.
 - **Cross-Version**: Full support for Scala 2.13 and Scala 3.x with source compatibility—adopt Scala 3 on your timeline, not ours.
 - **High Performance**: Optimized implementations that avoid boxing, minimize allocations, and leverage platform-specific features.
 - **Type Safety**: Leverage Scala's type system for correctness without runtime overhead.
@@ -187,7 +187,7 @@ Generating documentation, README files, or any Markdown content programmatically
 
 - **GFM Compliant**: Tables, strikethrough, autolinks, task lists, fenced code blocks
 - **Zero Dependencies**: Only depends on zio-blocks-chunk
-- **Cross-Platform**: Full support for JVM, Scala.js, and Scala Native
+- **Cross-Platform**: Full support for JVM and Scala.js
 - **Type-Safe Interpolator**: `md"# Hello $name"` with compile-time validation
 - **Multiple Renderers**: Markdown, HTML (full document or fragment), ANSI terminal
 
@@ -273,7 +273,7 @@ Compile-time type identity with rich metadata. TypeId captures comprehensive inf
 - **Rich Metadata**: Captures type name, owner, kind (class/trait/object/enum), parent types, and annotations
 - **Higher-Kinded Support**: Works with proper types and type constructors via `AnyKind`
 - **Subtype Checking**: Runtime subtype/supertype relationship checks using compile-time extracted information
-- **Cross-Platform**: Works identically on JVM, Scala.js, and Scala Native
+- **Cross-Platform**: Works identically on JVM and Scala.js
 
 ### Installation
 
@@ -389,7 +389,6 @@ ZIO Blocks supports **Scala 2.13** and **Scala 3.x** with full source compatibil
 |----------|--------|-------|------|--------|---------|---------|
 | JVM | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Scala.js | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Scala Native | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ## Documentation
 

--- a/docs/reference/chunk.md
+++ b/docs/reference/chunk.md
@@ -34,7 +34,7 @@ Add the following to your `build.sbt`:
 libraryDependencies += "dev.zio" %% "zio-blocks-chunk" % "<version>"
 ```
 
-For cross-platform projects (Scala.js or Scala Native):
+For cross-platform projects (Scala.js):
 
 ```scala
 libraryDependencies += "dev.zio" %%% "zio-blocks-chunk" % "<version>"

--- a/docs/reference/context.md
+++ b/docs/reference/context.md
@@ -151,4 +151,4 @@ Not supported (compile error):
 
 - **Caching**: Retrieved values are cached for O(1) subsequent lookups
 - **Subtype matching**: Supertype lookups find matching subtypes and cache results
-- **Platform-optimized**: JVM uses `ConcurrentHashMap`; JS/Native use efficient mutable maps
+- **Platform-optimized**: JVM uses `ConcurrentHashMap`; JS uses efficient mutable maps

--- a/docs/reference/formats.md
+++ b/docs/reference/formats.md
@@ -33,9 +33,9 @@ Each format provides a `BinaryFormat` object that can be passed to `derive`:
 
 | Format | Object | MIME Type | Platform Support |
 |--------|--------|-----------|------------------|
-| JSON | `JsonFormat` | `application/json` | JVM, JS, Native |
-| TOON | `ToonFormat` | `text/toon` | JVM, JS, Native |
-| MessagePack | `MessagePackFormat` | `application/msgpack` | JVM, JS, Native |
+| JSON | `JsonFormat` | `application/json` | JVM, JS |
+| TOON | `ToonFormat` | `text/toon` | JVM, JS |
+| MessagePack | `MessagePackFormat` | `application/msgpack` | JVM, JS |
 | Avro | `AvroFormat` | `application/avro` | JVM only |
 | Thrift | `ThriftFormat` | `application/thrift` | JVM only |
 | BSON | `BsonSchemaCodec` | Binary | JVM only |
@@ -192,7 +192,7 @@ TOON (Token-Oriented Object Notation) is a line-oriented, indentation-based text
 - **Human readable**: Clean, YAML-like syntax without YAML's complexity
 - **LLM optimized**: Designed for AI/ML use cases where token count matters
 - **Explicit lengths**: Arrays declare their size upfront for reliable parsing
-- **Cross-platform**: Works on JVM, Scala.js, and Scala Native
+- **Cross-platform**: Works on JVM and Scala.js
 
 ### Installation
 
@@ -603,14 +603,14 @@ All formats support the full set of ZIO Blocks Schema primitive types:
 
 ## Cross-Platform Support
 
-| Format | JVM | Scala.js | Scala Native |
-|--------|-----|----------|--------------|
-| JSON | ✓ | ✓ | ✓ |
-| TOON | ✓ | ✓ | ✓ |
-| MessagePack | ✓ | ✓ | ✓ |
-| Avro | ✓ | ✗ | ✗ |
-| Thrift | ✓ | ✗ | ✗ |
-| BSON | ✓ | ✗ | ✗ |
+| Format | JVM | Scala.js |
+|--------|-----|----------|
+| JSON | ✓ | ✓ |
+| TOON | ✓ | ✓ |
+| MessagePack | ✓ | ✓ |
+| Avro | ✓ | ✗ |
+| Thrift | ✓ | ✗ |
+| BSON | ✓ | ✗ |
 
 ## Error Handling
 

--- a/docs/reference/json-schema.md
+++ b/docs/reference/json-schema.md
@@ -622,6 +622,5 @@ val schemaJson = userSchema.toJson.print
 
 - **JVM** - Full functionality
 - **Scala.js** - Browser and Node.js
-- **Scala Native** - Native compilation
 
 All features work identically across platforms.

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -975,6 +975,5 @@ The `Json` type works across all platforms:
 
 - **JVM** - Full functionality
 - **Scala.js** - Browser and Node.js
-- **Scala Native** - Native compilation
 
 String interpolators use compile-time validation that works on all platforms.

--- a/docs/reference/schema-evolution.md
+++ b/docs/reference/schema-evolution.md
@@ -347,19 +347,19 @@ ZIO Blocks supports conversions involving structural types on JVM only, as they 
 
 ### Platform Compatibility Matrix
 
-| Conversion | JVM | JS | Native | Notes |
-|------------|-----|-----|--------|-------|
-| Product → Structural | ✅ | ❌ | ❌ | JVM only (reflection) |
-| Structural → Product | ✅ | ❌ | ❌ | JVM only (reflection) |
+| Conversion | JVM | JS | Notes |
+|------------|-----|-----|-------|
+| Product → Structural | ✅ | ❌ | JVM only (reflection) |
+| Structural → Product | ✅ | ❌ | JVM only (reflection) |
 
-**Key insight**: Structural types require runtime reflection to access their members, which is only available on JVM. On JS and Native platforms, structural type conversions will fail at compile time with a helpful error message.
+**Key insight**: Structural types require runtime reflection to access their members, which is only available on JVM. On JS, structural type conversions will fail at compile time with a helpful error message.
 
 ### Structural Types (JVM Only)
 
 Structural types are types defined by their members rather than their name:
 
 ```scala
-// JVM ONLY - will fail at compile time on JS/Native
+// JVM ONLY - will fail at compile time on JS
 case class Person(name: String, age: Int)
 
 // Structural type to case class

--- a/docs/reference/typeid.md
+++ b/docs/reference/typeid.md
@@ -42,7 +42,7 @@ TypeId is included in the `zio-blocks-typeid` module. Add it to your build:
 libraryDependencies += "dev.zio" %% "zio-blocks-typeid" % "<version>"
 ```
 
-Cross-platform support: TypeId works on JVM, Scala.js, and Scala Native.
+Cross-platform support: TypeId works on JVM and Scala.js.
 
 ## Creating TypeIds
 

--- a/markdown/shared/src/test/scala/zio/blocks/docs/MarkdownBaseSpec.scala
+++ b/markdown/shared/src/test/scala/zio/blocks/docs/MarkdownBaseSpec.scala
@@ -6,13 +6,5 @@ import zio.test._
 trait MarkdownBaseSpec extends ZIOSpecDefault {
   override def aspects: zio.Chunk[TestAspectAtLeastR[TestEnvironment]] =
     if (TestPlatform.isJVM) zio.Chunk(TestAspect.timeout(120.seconds), TestAspect.timed)
-    else if (TestPlatform.isNative) {
-      zio.Chunk(
-        TestAspect.timeout(120.seconds),
-        TestAspect.timed,
-        TestAspect.sequential,
-        TestAspect.size(10),
-        TestAspect.samples(50)
-      )
-    } else zio.Chunk(TestAspect.timeout(120.seconds), TestAspect.timed, TestAspect.sequential, TestAspect.size(10))
+    else zio.Chunk(TestAspect.timeout(120.seconds), TestAspect.timed, TestAspect.sequential, TestAspect.size(10))
 }

--- a/markdown/shared/src/test/scala/zio/blocks/docs/MdInterpolatorSpec.scala
+++ b/markdown/shared/src/test/scala/zio/blocks/docs/MdInterpolatorSpec.scala
@@ -3,7 +3,6 @@ package zio.blocks.docs
 import zio.blocks.chunk.Chunk
 import zio.test._
 import zio.test.Assertion._
-import zio.test.TestAspect.exceptNative
 
 object MdInterpolatorSpec extends MarkdownBaseSpec {
   def spec = suite("md interpolator")(
@@ -454,7 +453,7 @@ This is $bold information."""
           md"```scala\nval x = 1"
           """
         }.map(assert(_)(isLeft(containsString("Invalid markdown"))))
-      } @@ exceptNative,
+      },
       test("rejects type without ToMarkdown instance") {
         typeCheck {
           """
@@ -464,7 +463,7 @@ This is $bold information."""
           md"Value: $c"
           """
         }.map(assert(_)(isLeft(containsString("No ToMarkdown instance"))))
-      } @@ exceptNative,
+      },
       test("rejects class without ToMarkdown instance") {
         typeCheck {
           """
@@ -474,7 +473,7 @@ This is $bold information."""
           md"Object: $obj"
           """
         }.map(assert(_)(isLeft(containsString("No ToMarkdown instance"))))
-      } @@ exceptNative,
+      },
       test("accepts List with ToMarkdown instance") {
         typeCheck {
           """
@@ -483,7 +482,7 @@ This is $bold information."""
           md"Items: $list"
           """
         }.map(assert(_)(isRight))
-      } @@ exceptNative,
+      },
       test("rejects Map without ToMarkdown instance") {
         typeCheck {
           """
@@ -492,7 +491,7 @@ This is $bold information."""
           md"Mapping: $map"
           """
         }.map(assert(_)(isLeft(containsString("No ToMarkdown instance"))))
-      } @@ exceptNative
+      }
     )
   )
 }

--- a/schema-bson/README.md
+++ b/schema-bson/README.md
@@ -2,7 +2,7 @@
 
 BSON (Binary JSON) codec support for ZIO Blocks Schema.
 
-> **Note:** This module is JVM-only. It does not support Scala.js or Scala Native.
+> **Note:** This module is JVM-only. It does not support Scala.js.
 
 ## Overview
 

--- a/schema/js/src/main/scala/zio/blocks/schema/PlatformSpecific.scala
+++ b/schema/js/src/main/scala/zio/blocks/schema/PlatformSpecific.scala
@@ -4,8 +4,7 @@ package zio.blocks.schema
  * JavaScript-specific platform implementation.
  */
 trait PlatformSpecific extends Platform {
-  override val isJVM: Boolean    = false
-  override val isJS: Boolean     = true
-  override val isNative: Boolean = false
-  override val name: String      = "JS"
+  override val isJVM: Boolean = false
+  override val isJS: Boolean  = true
+  override val name: String   = "JS"
 }

--- a/schema/jvm/src/main/scala/zio/blocks/schema/PlatformSpecific.scala
+++ b/schema/jvm/src/main/scala/zio/blocks/schema/PlatformSpecific.scala
@@ -4,8 +4,7 @@ package zio.blocks.schema
  * JVM-specific platform implementation.
  */
 trait PlatformSpecific extends Platform {
-  override val isJVM: Boolean    = true
-  override val isJS: Boolean     = false
-  override val isNative: Boolean = false
-  override val name: String      = "JVM"
+  override val isJVM: Boolean = true
+  override val isJS: Boolean  = false
+  override val name: String   = "JVM"
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/Platform.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Platform.scala
@@ -10,7 +10,6 @@ package zio.blocks.schema
  * Platform-specific implementations are provided in:
  *   - jvm/src/main/scala/zio/blocks/schema/PlatformSpecific.scala
  *   - js/src/main/scala/zio/blocks/schema/PlatformSpecific.scala
- *   - native/src/main/scala/zio/blocks/schema/PlatformSpecific.scala
  */
 trait Platform {
 
@@ -19,9 +18,6 @@ trait Platform {
 
   /** Whether this is the JavaScript platform */
   def isJS: Boolean
-
-  /** Whether this is the Native platform */
-  def isNative: Boolean
 
   /** Human-readable name of the platform */
   def name: String

--- a/schema/shared/src/test/scala/zio/blocks/schema/DynamicValueGen.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/DynamicValueGen.scala
@@ -44,7 +44,7 @@ object DynamicValueGen {
   // Null generator
   val genNull: Gen[Any, DynamicValue.Null.type] = Gen.const(DynamicValue.Null)
 
-  // Depth-limited generators for Scala Native compatibility
+  // Depth-limited generators to keep test execution time manageable
   val genDynamicValue: Gen[Any, DynamicValue] = genDynamicValueWithDepth(2)
 
   private[this] def genDynamicValueWithDepth(maxDepth: Int): Gen[Any, DynamicValue] =

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaBaseSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaBaseSpec.scala
@@ -6,13 +6,5 @@ import zio.test._
 trait SchemaBaseSpec extends ZIOSpecDefault {
   override def aspects: zio.Chunk[TestAspectAtLeastR[TestEnvironment]] =
     if (TestPlatform.isJVM) zio.Chunk(TestAspect.timeout(120.seconds), TestAspect.timed)
-    else if (TestPlatform.isNative) {
-      zio.Chunk(
-        TestAspect.timeout(120.seconds),
-        TestAspect.timed,
-        TestAspect.sequential,
-        TestAspect.size(10),
-        TestAspect.samples(50)
-      )
-    } else zio.Chunk(TestAspect.timeout(120.seconds), TestAspect.timed, TestAspect.sequential, TestAspect.size(10))
+    else zio.Chunk(TestAspect.timeout(120.seconds), TestAspect.timed, TestAspect.sequential, TestAspect.size(10))
 }

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonInterpolatorSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonInterpolatorSpec.scala
@@ -5,7 +5,6 @@ import zio.blocks.schema.JavaTimeGen._
 import zio.blocks.schema._
 import zio.test._
 import zio.test.Assertion.{containsString, isLeft}
-import zio.test.TestAspect.exceptNative
 import java.time._
 import java.util.{Currency, UUID}
 
@@ -526,7 +525,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
       typeCheck {
         """json"[1,02]""""
       }.map(assert(_)(isLeft(containsString("Invalid JSON literal: illegal number with leading zero at: .at(1)"))))
-    } @@ exceptNative,
+    },
     suite("key position type checking")(
       test("String key works") {
         val s: String = "myKey"
@@ -647,7 +646,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           json"{$xs: 1}"
           """
         }.map(assert(_)(isLeft(containsString("key"))))
-      } @@ exceptNative,
+      },
       test("compile fails for Map as key") {
         typeCheck {
           """
@@ -655,7 +654,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           json"{$m: 1}"
           """
         }.map(assert(_)(isLeft(containsString("key"))))
-      } @@ exceptNative,
+      },
       test("compile fails for case class as key") {
         typeCheck {
           """
@@ -664,7 +663,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           json"{$p: 1}"
           """
         }.map(assert(_)(isLeft(containsString("key"))))
-      } @@ exceptNative,
+      },
       test("compile fails for Option as key") {
         typeCheck {
           """
@@ -672,7 +671,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           json"{$opt: 1}"
           """
         }.map(assert(_)(isLeft(containsString("key"))))
-      } @@ exceptNative,
+      },
       test("compile fails for Vector as key") {
         typeCheck {
           """
@@ -680,7 +679,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           json"{$v: 1}"
           """
         }.map(assert(_)(isLeft(containsString("key"))))
-      } @@ exceptNative,
+      },
       test("compile fails for Set as key") {
         typeCheck {
           """
@@ -688,7 +687,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           json"{$s: 1}"
           """
         }.map(assert(_)(isLeft(containsString("key"))))
-      } @@ exceptNative,
+      },
       test("compile fails for Array as key") {
         typeCheck {
           """
@@ -696,7 +695,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           json"{$arr: 1}"
           """
         }.map(assert(_)(isLeft(containsString("key"))))
-      } @@ exceptNative,
+      },
       test("compile fails for Either as key") {
         typeCheck {
           """
@@ -704,7 +703,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           json"{$e: 1}"
           """
         }.map(assert(_)(isLeft(containsString("key"))))
-      } @@ exceptNative,
+      },
       test("compile fails for tuple as key") {
         typeCheck {
           """
@@ -712,7 +711,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           json"{$t: 1}"
           """
         }.map(assert(_)(isLeft(containsString("key"))))
-      } @@ exceptNative,
+      },
       test("error message mentions JSON key and keyable types") {
         typeCheck {
           """
@@ -724,7 +723,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           assert(result)(isLeft(containsString("key"))) &&
             assert(result)(isLeft(containsString("keyable")))
         )
-      } @@ exceptNative,
+      },
       test("multiple keys with different keyable types") {
         val intKey  = 1
         val uuidKey = java.util.UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
@@ -959,7 +958,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           json"[$v]"
           """
         }.map(assert(_)(isLeft(containsString("JsonEncoder"))))
-      } @@ exceptNative,
+      },
       test("compile fails for class without any encoder in value position") {
         typeCheck {
           """
@@ -968,7 +967,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           json"[$v]"
           """
         }.map(assert(_)(isLeft(containsString("JsonEncoder"))))
-      } @@ exceptNative,
+      },
       test("error message mentions JsonEncoder and Schema") {
         typeCheck {
           """
@@ -980,7 +979,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           assert(result)(isLeft(containsString("JsonEncoder"))) &&
             assert(result)(isLeft(containsString("Schema")))
         )
-      } @@ exceptNative,
+      },
       test("property-based: collections with encoders work") {
         check(Gen.listOf(Gen.int)) { ints =>
           assertTrue(json"""{"v": $ints}""".get("v").one.map(_.elements.size) == Right(ints.size))
@@ -1222,26 +1221,26 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           "val xs: List[Int] = List(1, 2, 3); " +
             "json\"\"\"{\"msg\": \"list is $xs\"}\"\"\""
         ).map(assert(_)(isLeft(containsString("string literal"))))
-      } @@ exceptNative,
+      },
       test("compile fails for case class in string literal") {
         typeCheck(
           "case class Point(x: Int, y: Int); " +
             "val p = Point(1, 2); " +
             "json\"\"\"{\"msg\": \"point is $p\"}\"\"\""
         ).map(assert(_)(isLeft(containsString("string literal"))))
-      } @@ exceptNative,
+      },
       test("compile fails for Map in string literal") {
         typeCheck(
           "val m: Map[String, Int] = Map(\"a\" -> 1); " +
             "json\"\"\"{\"msg\": \"map is $m\"}\"\"\""
         ).map(assert(_)(isLeft(containsString("string literal"))))
-      } @@ exceptNative,
+      },
       test("compile fails for Option in string literal") {
         typeCheck(
           "val opt: Option[Int] = Some(42); " +
             "json\"\"\"{\"msg\": \"opt is $opt\"}\"\"\""
         ).map(assert(_)(isLeft(containsString("string literal"))))
-      } @@ exceptNative,
+      },
       test("error message mentions string literal and keyable types") {
         typeCheck(
           "case class Custom(value: Int); " +
@@ -1251,7 +1250,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           assert(result)(isLeft(containsString("string literal"))) &&
             assert(result)(isLeft(containsString("keyable")))
         )
-      } @@ exceptNative
+      }
     ),
     suite("mixed interpolation contexts")(
       test("combines key, value, and string interpolation") {
@@ -1434,7 +1433,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           assert(result)(isLeft(containsString("NotKeyable"))) &&
           assert(result)(isLeft(containsString("keyable")))
         }
-      } @@ exceptNative,
+      },
       test("value position error includes type and guidance") {
         typeCheck {
           """
@@ -1447,7 +1446,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           assert(result)(isLeft(containsString("NoEncoder"))) &&
           assert(result)(isLeft(containsString("Schema")))
         }
-      } @@ exceptNative,
+      },
       test("string literal error includes type and context") {
         typeCheck(
           "case class NotKeyable(x: Int); " +
@@ -1458,7 +1457,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           assert(result)(isLeft(containsString("NotKeyable"))) &&
           assert(result)(isLeft(containsString("keyable")))
         }
-      } @@ exceptNative,
+      },
       test("invalid JSON syntax error is clear") {
         typeCheck {
           """json"[1,02]""""
@@ -1466,7 +1465,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
           assert(result)(isLeft(containsString("Invalid JSON"))) &&
           assert(result)(isLeft(containsString("leading zero")))
         }
-      } @@ exceptNative
+      }
     ),
     suite("special character escaping in strings")(
       test("escapes backslash in string interpolation") {

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/KeyableSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/KeyableSpec.scala
@@ -3,7 +3,6 @@ package zio.blocks.schema.json
 import zio.blocks.schema.SchemaBaseSpec
 import zio.blocks.schema.JavaTimeGen._
 import zio.test._
-import zio.test.TestAspect.exceptNative
 
 import java.time._
 import java.util.{Currency, UUID}
@@ -207,41 +206,41 @@ object KeyableSpec extends SchemaBaseSpec {
     suite("non-keyable types have no instance")(
       test("List[Int] has no Keyable instance") {
         typeCheck("Keyable[List[Int]]").map(result => assertTrue(result.isLeft))
-      } @@ exceptNative,
+      },
       test("Map[String, Int] has no Keyable instance") {
         typeCheck("Keyable[Map[String, Int]]").map(result => assertTrue(result.isLeft))
-      } @@ exceptNative,
+      },
       test("Option[Int] has no Keyable instance") {
         typeCheck("Keyable[Option[Int]]").map(result => assertTrue(result.isLeft))
-      } @@ exceptNative,
+      },
       test("Vector[String] has no Keyable instance") {
         typeCheck("Keyable[Vector[String]]").map(result => assertTrue(result.isLeft))
-      } @@ exceptNative,
+      },
       test("Set[Int] has no Keyable instance") {
         typeCheck("Keyable[Set[Int]]").map(result => assertTrue(result.isLeft))
-      } @@ exceptNative,
+      },
       test("Array[Int] has no Keyable instance") {
         typeCheck("Keyable[Array[Int]]").map(result => assertTrue(result.isLeft))
-      } @@ exceptNative,
+      },
       test("case class has no Keyable instance") {
         typeCheck("""
           case class Point(x: Int, y: Int)
           Keyable[Point]
         """).map(result => assertTrue(result.isLeft))
-      } @@ exceptNative,
+      },
       test("sealed trait has no Keyable instance") {
         typeCheck("""
           sealed trait Color
           case object Red extends Color
           Keyable[Color]
         """).map(result => assertTrue(result.isLeft))
-      } @@ exceptNative,
+      },
       test("tuple has no Keyable instance") {
         typeCheck("Keyable[(Int, String)]").map(result => assertTrue(result.isLeft))
-      } @@ exceptNative,
+      },
       test("Either has no Keyable instance") {
         typeCheck("Keyable[Either[String, Int]]").map(result => assertTrue(result.isLeft))
-      } @@ exceptNative
+      }
     )
   )
 }

--- a/schema/shared/src/test/scala/zio/blocks/schema/tostring/OpticTypesToString.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/tostring/OpticTypesToString.scala
@@ -2,7 +2,6 @@ package zio.blocks.schema.tostring
 
 import zio.blocks.schema._
 import zio.test._
-import zio.test.TestAspect.exceptNative
 
 object OpticTypesSpec extends ZIOSpecDefault {
 
@@ -199,5 +198,5 @@ object OpticTypesSpec extends ZIOSpecDefault {
         assertTrue(composedLens.toString == "Lens(_.address.street)")
       }
     )
-  ) @@ exceptNative
+  )
 }

--- a/typeid/shared/src/main/scala-2/zio/blocks/typeid/TypeIdPlatformSpecific.scala
+++ b/typeid/shared/src/main/scala-2/zio/blocks/typeid/TypeIdPlatformSpecific.scala
@@ -5,8 +5,8 @@ import zio.blocks.chunk.Chunk
 /**
  * Platform-specific methods for TypeId.
  *
- * On JVM, provides reflection-based capabilities. On JS/Native, returns None
- * for reflection operations.
+ * On JVM, provides reflection-based capabilities. On JS, returns None for
+ * reflection operations.
  */
 trait TypeIdPlatformSpecific { self: TypeId[_] =>
 
@@ -14,8 +14,7 @@ trait TypeIdPlatformSpecific { self: TypeId[_] =>
    * Returns the `Class` associated with this TypeId, if available.
    *
    * On the JVM, for nominal types, this returns the `Class` object
-   * corresponding to this type's fullName. On JS/Native platforms, always
-   * returns `None`.
+   * corresponding to this type's fullName. On JS, always returns `None`.
    *
    * Note: This only works for nominal types (not aliases or opaque types). For
    * generic types, returns the erased class (e.g., `List[Int]` returns
@@ -30,7 +29,7 @@ trait TypeIdPlatformSpecific { self: TypeId[_] =>
    * On the JVM, this uses reflection to invoke the primary constructor. For
    * known types (collections, java.time, etc.), optimized construction is used.
    *
-   * On JS/Native platforms, always returns `Left` with an error message.
+   * On JS, always returns `Left` with an error message.
    *
    * @param args
    *   the constructor arguments

--- a/typeid/shared/src/main/scala-3/zio/blocks/typeid/TypeIdPlatformSpecific.scala
+++ b/typeid/shared/src/main/scala-3/zio/blocks/typeid/TypeIdPlatformSpecific.scala
@@ -5,8 +5,8 @@ import zio.blocks.chunk.Chunk
 /**
  * Platform-specific methods for TypeId.
  *
- * On JVM, provides reflection-based capabilities. On JS/Native, returns None
- * for reflection operations.
+ * On JVM, provides reflection-based capabilities. On JS, returns None for
+ * reflection operations.
  */
 trait TypeIdPlatformSpecific { self: TypeId[?] =>
 
@@ -14,8 +14,7 @@ trait TypeIdPlatformSpecific { self: TypeId[?] =>
    * Returns the `Class` associated with this TypeId, if available.
    *
    * On the JVM, for nominal types, this returns the `Class` object
-   * corresponding to this type's fullName. On JS/Native platforms, always
-   * returns `None`.
+   * corresponding to this type's fullName. On JS, always returns `None`.
    *
    * Note: This only works for nominal types (not aliases or opaque types). For
    * generic types, returns the erased class (e.g., `List[Int]` returns
@@ -30,7 +29,7 @@ trait TypeIdPlatformSpecific { self: TypeId[?] =>
    * On the JVM, this uses reflection to invoke the primary constructor. For
    * known types (collections, java.time, etc.), optimized construction is used.
    *
-   * On JS/Native platforms, always returns `Left` with an error message.
+   * On JS, always returns `Left` with an error message.
    *
    * @param args
    *   the constructor arguments


### PR DESCRIPTION
## Summary

Since Scala Native was recently removed from the build, this PR removes all remaining references to it.

## Changes

### Platform Code
- Remove `isNative` from `Platform` trait and `PlatformSpecific` implementations (JVM + JS)
- Remove Native branch from `SchemaBaseSpec` and `MarkdownBaseSpec`

### Test Code
- Remove `exceptNative` test annotations from test files:
  - `JsonInterpolatorSpec`
  - `KeyableSpec`
  - `MdInterpolatorSpec`
  - `OpticTypesToString`
- Update comment in `DynamicValueGen` (no longer Native-specific)

### Documentation
- Update AGENTS.md to reflect JVM+JS only
- Update docs/index.md (philosophy, core principles, platform table)
- Update docs/reference/chunk.md
- Update docs/reference/context.md
- Update docs/reference/formats.md (platform tables)
- Update docs/reference/json.md
- Update docs/reference/json-schema.md
- Update docs/reference/schema-evolution.md (platform matrix)
- Update docs/reference/typeid.md
- Update TypeIdPlatformSpecific comments (Scala 2 + 3)
- Update schema-bson/README.md

## Testing

- ✅ Scala 3.7.4 JVM tests pass
- ✅ Scala 2.13.18 JVM tests pass
- ✅ Both JVM and JS compile successfully