### PR TITLE
feat(schema): implement Schema Migration System (#519)

### DIFF
--- a/docs/guides/query-dsl-extending.md
+++ b/docs/guides/query-dsl-extending.md
@@ -45,7 +45,7 @@ FROM products
 
 None of these can be expressed with `SchemaExpr` alone. You could generate the SQL strings manually, but then you lose composability — you can no longer mix these operations with the type-safe `SchemaExpr` predicates from Parts 1 and 2.
 
-Since `SchemaExpr` is a sealed trait, you cannot add new cases to it. Instead, we define an `Expr` ADT that is a superset of `SchemaExpr` — it includes equivalent nodes for everything `SchemaExpr` can express, plus our custom SQL-specific operations. A `fromSchemaExpr` function translates `SchemaExpr` values into `Expr`, enabling seamless interoperability with a single unified interpreter.
+`SchemaExpr` wraps a `DynamicSchemaExpr` sealed trait that you cannot add new cases to. Instead, we define an `Expr` ADT that is a superset — it includes equivalent nodes for everything `SchemaExpr` can express, plus our custom SQL-specific operations. A `fromSchemaExpr` function translates `SchemaExpr` values into `Expr` by accessing the underlying `DynamicSchemaExpr`, enabling seamless interoperability with a single unified interpreter.
 
 ## Prerequisites
 
@@ -85,31 +85,31 @@ object Product extends CompanionOptics[Product] {
 
 ## Designing the Expr ADT
 
-The key insight is the **translation pattern**: define your own sealed trait whose node types are a superset of `SchemaExpr`'s, then provide a `fromSchemaExpr` function that converts any `SchemaExpr` into your ADT. This gives you a single unified interpreter.
+The key insight is the **translation pattern**: define your own sealed trait whose node types are a superset of `SchemaExpr`'s underlying `DynamicSchemaExpr` cases, then provide a `fromSchemaExpr` function that converts any `SchemaExpr` into your ADT by accessing its `.dynamic` field. This gives you a single unified interpreter.
 
 ```
-  Built-in (sealed, not extensible)          Your extension (superset)
+  Built-in (not extensible)                    Your extension (superset)
 ┌───────────────────────────────┐       ┌───────────────────────────────────────┐
 │  SchemaExpr[S, A]             │       │  Expr[S, A]                           │
-│  ├── Literal                  │──────▶│  ├── Lit(value, schema)               │
-│  ├── Optic                    │──────▶│  ├── Column(Optic)                    │
-│  ├── Relational               │──────▶│  ├── Relational(left, right, RelOp)   │
-│  ├── Logical (And/Or)         │──────▶│  ├── And / Or                         │
-│  ├── Not                      │──────▶│  ├── Not                              │
-│  ├── Arithmetic               │──────▶│  ├── Arithmetic(left, right, ArithOp) │
-│  ├── StringConcat             │──────▶│  ├── StringConcat                     │
-│  ├── StringRegexMatch         │──────▶│  ├── StringRegexMatch                 │
-│  └── StringLength             │──────▶│  ├── StringLength                     │
-└───────────────────────────────┘       │  ├── In(expr, values, schema)         ← new   │
-         fromSchemaExpr ────────────────│  ├── Between(expr, low, high, schema) ← new   │
-                                        │  ├── IsNull(expr)             ← new   │
-                                        │  ├── Like(expr, pattern)      ← new   │
+│  └── .dynamic:                │       │  ├── Lit(DynamicValue)                │
+│      DynamicSchemaExpr        │       │  ├── Column(DynamicOptic)             │
+│      ├── Literal              │──────▶│  ├── Relational(left, right, RelOp)   │
+│      ├── Select               │──────▶│  ├── And / Or                         │
+│      ├── Relational           │──────▶│  ├── Not                              │
+│      ├── Logical (And/Or)     │──────▶│  ├── Arithmetic(left, right, ArithOp) │
+│      ├── Not                  │──────▶│  ├── StringConcat                     │
+│      ├── Arithmetic           │──────▶│  ├── StringRegexMatch                 │
+│      ├── StringConcat         │──────▶│  ├── StringLength                     │
+│      ├── StringRegexMatch     │──────▶│  ├── In(expr, values, schema)         ← new   │
+│      └── StringLength         │──────▶│  ├── Between(expr, low, high, schema) ← new   │
+└───────────────────────────────┘       │  ├── IsNull(expr)             ← new   │
+         fromSchemaExpr ────────────────│  ├── Like(expr, pattern)      ← new   │
                                         │  ├── Agg(function, expr)      ← new   │
                                         │  └── CaseWhen(branches, else) ← new   │
                                         └───────────────────────────────────────┘
 ```
 
-The `Expr` ADT includes mirrored nodes for every `SchemaExpr` case, plus SQL-specific extensions. It uses its own operator types (`RelOp`, `ArithOp`) and type-safe aggregate functions (`AggFunction[A, B]`).
+The `Expr` ADT includes mirrored nodes for every `DynamicSchemaExpr` case, plus SQL-specific extensions. It uses its own operator types (`RelOp`, `ArithOp`) and type-safe aggregate functions (`AggFunction[A, B]`).
 
 Here is the full `Expr` ADT with its supporting types:
 
@@ -118,9 +118,9 @@ sealed trait Expr[S, A]
 
 object Expr {
 
-  // --- Core nodes (superset of SchemaExpr's nodes) ---
-  final case class Column[S, A](optic: Optic[S, A]) extends Expr[S, A]
-  final case class Lit[S, A](value: A, schema: Schema[A]) extends Expr[S, A]
+  // --- Core nodes (superset of DynamicSchemaExpr's nodes) ---
+  final case class Column[S, A](path: DynamicOptic) extends Expr[S, A]
+  final case class Lit[S, A](value: DynamicValue) extends Expr[S, A]
 
   // Relational
   final case class Relational[S, A](left: Expr[S, A], right: Expr[S, A], op: RelOp) extends Expr[S, Boolean]
@@ -154,8 +154,8 @@ object Expr {
   ) extends Expr[S, A]
 
   // --- Factory methods ---
-  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic)
-  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(value, schema)
+  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic.toDynamic)
+  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(schema.toDynamicValue(value))
 
   def count[S, A](expr: Expr[S, A]): Expr[S, Long]   = Agg(AggFunction.Count(), expr)
   def sum[S](expr: Expr[S, Double]): Expr[S, Double]  = Agg(AggFunction.Sum, expr)
@@ -173,41 +173,46 @@ object Expr {
 
   // --- Translation from SchemaExpr ---
   def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = {
-    val result = se match {
-      case SchemaExpr.Optic(optic)       => Column(optic)
-      case l: SchemaExpr.Literal[_, _]   => Lit(l.value, l.schema)
+    val result = fromDynamic[S](se.dynamic)
+    result.asInstanceOf[Expr[S, A]]
+  }
 
-      case SchemaExpr.Relational(l, r, op) =>
-        val relOp = op match {
-          case SchemaExpr.RelationalOperator.Equal              => RelOp.Equal
-          case SchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
-          case SchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
-          case SchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
-          case SchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
-          case SchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
-        }
-        Relational(fromSchemaExpr(l), fromSchemaExpr(r), relOp)
+  private def fromDynamic[S](dse: DynamicSchemaExpr): Expr[S, ?] = dse match {
+    case DynamicSchemaExpr.Select(path)    => Column[S, Any](path)
+    case DynamicSchemaExpr.Literal(value)  => Lit[S, Any](value)
 
-      case SchemaExpr.Logical(l, r, op) => op match {
-        case SchemaExpr.LogicalOperator.And => And(fromSchemaExpr(l), fromSchemaExpr(r))
-        case SchemaExpr.LogicalOperator.Or  => Or(fromSchemaExpr(l), fromSchemaExpr(r))
+    case DynamicSchemaExpr.Relational(l, r, op) =>
+      val relOp = op match {
+        case DynamicSchemaExpr.RelationalOperator.Equal              => RelOp.Equal
+        case DynamicSchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
+        case DynamicSchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
+        case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
+        case DynamicSchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
+        case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
+      }
+      Relational(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], relOp)
+
+    case DynamicSchemaExpr.Logical(l, r, op) =>
+      op match {
+        case DynamicSchemaExpr.LogicalOperator.And => And(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
+        case DynamicSchemaExpr.LogicalOperator.Or  => Or(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
       }
 
-      case SchemaExpr.Not(inner) => Not(fromSchemaExpr(inner))
+    case DynamicSchemaExpr.Not(inner) => Not(fromDynamic[S](inner).asInstanceOf[Expr[S, Boolean]])
 
-      case SchemaExpr.Arithmetic(l, r, op, _) =>
-        val arithOp = op match {
-          case SchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
-          case SchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
-          case SchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
-        }
-        Arithmetic(fromSchemaExpr(l), fromSchemaExpr(r), arithOp)
+    case DynamicSchemaExpr.Arithmetic(l, r, op, _) =>
+      val arithOp = op match {
+        case DynamicSchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
+        case DynamicSchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
+        case DynamicSchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
+        case _                                             => ArithOp.Add
+      }
+      Arithmetic(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], arithOp)
 
-      case SchemaExpr.StringConcat(l, r)              => StringConcat(fromSchemaExpr(l), fromSchemaExpr(r))
-      case SchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromSchemaExpr(regex), fromSchemaExpr(string))
-      case SchemaExpr.StringLength(string)            => StringLength(fromSchemaExpr(string))
-    }
-    result.asInstanceOf[Expr[S, A]]
+    case DynamicSchemaExpr.StringConcat(l, r)              => StringConcat(fromDynamic[S](l).asInstanceOf[Expr[S, String]], fromDynamic[S](r).asInstanceOf[Expr[S, String]])
+    case DynamicSchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromDynamic[S](regex).asInstanceOf[Expr[S, String]], fromDynamic[S](string).asInstanceOf[Expr[S, String]])
+    case DynamicSchemaExpr.StringLength(string)            => StringLength(fromDynamic[S](string).asInstanceOf[Expr[S, String]])
+    case _                                                 => Lit[S, Any](DynamicValue.Null)
   }
 }
 
@@ -246,8 +251,8 @@ object AggFunction {
 Here are some keynotes on the design:
 
 - **Type-safe aggregates** — `AggFunction[A, B]` encodes the return type: `COUNT` returns `Long`, `SUM`/`AVG` return `Double`, `MIN`/`MAX` preserve the input type.
-- **Typed literals and predicates** — `Lit(value, schema)`, `In(expr, values, schema)`, and `Between(expr, low, high, schema)` all carry a `Schema[A]` so the SQL renderer can format values correctly using the schema rather than runtime type checks.
-- **`fromSchemaExpr`** — one-way translation recursively converts every `SchemaExpr` node into its `Expr` equivalent, mapping operators along the way.
+- **Dynamic values** — `Column` stores a `DynamicOptic` and `Lit` stores a `DynamicValue`, matching the dynamic representation used by `DynamicSchemaExpr`.
+- **`fromSchemaExpr`** — accesses `se.dynamic` to get the `DynamicSchemaExpr`, then recursively converts every node into its `Expr` equivalent, mapping operators along the way.
 
 ## Extension Methods
 
@@ -296,6 +301,9 @@ With the `Expr` ADT, we write a single interpreter that handles all cases direct
 def columnName(optic: zio.blocks.schema.Optic[_, _]): String =
   optic.toDynamic.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
 
+def columnName(path: DynamicOptic): String =
+  path.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
+
 def sqlLiteral[A](value: A, schema: Schema[A]): String = {
   val dv = schema.toDynamicValue(value)
   dv match {
@@ -308,9 +316,25 @@ def sqlLiteral[A](value: A, schema: Schema[A]): String = {
   }
 }
 
+def sqlLiteralDV(dv: DynamicValue): String = dv match {
+  case DynamicValue.Primitive(pv) =>
+    pv match {
+      case PrimitiveValue.String(s)  => s"'${s.replace("'", "''")}'"
+      case PrimitiveValue.Boolean(b) => if (b) "TRUE" else "FALSE"
+      case PrimitiveValue.Int(n)     => n.toString
+      case PrimitiveValue.Long(n)    => n.toString
+      case PrimitiveValue.Double(n)  => n.toString
+      case PrimitiveValue.Float(n)   => n.toString
+      case PrimitiveValue.Short(n)   => n.toString
+      case PrimitiveValue.Byte(n)    => n.toString
+      case other                     => other.toString
+    }
+  case other => other.toString
+}
+
 def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
-  case Expr.Column(optic)      => columnName(optic)
-  case Expr.Lit(value, schema) => sqlLiteral(value, schema)
+  case Expr.Column(path)    => columnName(path)
+  case Expr.Lit(value)      => sqlLiteralDV(value)
 
   case Expr.Relational(left, right, op) =>
     val sqlOp = op match {
@@ -360,7 +384,7 @@ def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
 }
 ```
 
-The typed `sqlLiteral[A](value, schema)` uses the `Schema` carried by `Lit`, `In`, and `Between` to format values correctly — strings get quoted, booleans become `TRUE`/`FALSE`, numbers stay as-is. Every AST node that holds literal values carries a `Schema[A]`, so a single `sqlLiteral` function handles all formatting with no untyped fallbacks.
+The typed `sqlLiteral[A](value, schema)` uses the `Schema` carried by `In` and `Between` to format values correctly — strings get quoted, booleans become `TRUE`/`FALSE`, numbers stay as-is. The `sqlLiteralDV` handles `DynamicValue` directly for `Lit` nodes.
 
 ## SQL-Specific Predicates
 
@@ -527,8 +551,8 @@ object Product extends CompanionOptics[Product] {
 sealed trait Expr[S, A]
 
 object Expr {
-  final case class Column[S, A](optic: Optic[S, A]) extends Expr[S, A]
-  final case class Lit[S, A](value: A, schema: Schema[A]) extends Expr[S, A]
+  final case class Column[S, A](path: DynamicOptic) extends Expr[S, A]
+  final case class Lit[S, A](value: DynamicValue) extends Expr[S, A]
 
   final case class Relational[S, A](left: Expr[S, A], right: Expr[S, A], op: RelOp) extends Expr[S, Boolean]
   final case class And[S](left: Expr[S, Boolean], right: Expr[S, Boolean]) extends Expr[S, Boolean]
@@ -550,8 +574,8 @@ object Expr {
     otherwise: Option[Expr[S, A]]
   ) extends Expr[S, A]
 
-  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic)
-  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(value, schema)
+  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic.toDynamic)
+  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(schema.toDynamicValue(value))
   def count[S, A](expr: Expr[S, A]): Expr[S, Long]   = Agg(AggFunction.Count(), expr)
   def sum[S](expr: Expr[S, Double]): Expr[S, Double]  = Agg(AggFunction.Sum, expr)
   def avg[S](expr: Expr[S, Double]): Expr[S, Double]  = Agg(AggFunction.Avg, expr)
@@ -567,36 +591,41 @@ object Expr {
   }
 
   def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = {
-    val result = se match {
-      case SchemaExpr.Optic(optic)       => Column(optic)
-      case l: SchemaExpr.Literal[_, _]   => Lit(l.value, l.schema)
-      case SchemaExpr.Relational(l, r, op) =>
-        val relOp = op match {
-          case SchemaExpr.RelationalOperator.Equal              => RelOp.Equal
-          case SchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
-          case SchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
-          case SchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
-          case SchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
-          case SchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
-        }
-        Relational(fromSchemaExpr(l), fromSchemaExpr(r), relOp)
-      case SchemaExpr.Logical(l, r, op) => op match {
-        case SchemaExpr.LogicalOperator.And => And(fromSchemaExpr(l), fromSchemaExpr(r))
-        case SchemaExpr.LogicalOperator.Or  => Or(fromSchemaExpr(l), fromSchemaExpr(r))
-      }
-      case SchemaExpr.Not(inner) => Not(fromSchemaExpr(inner))
-      case SchemaExpr.Arithmetic(l, r, op, _) =>
-        val arithOp = op match {
-          case SchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
-          case SchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
-          case SchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
-        }
-        Arithmetic(fromSchemaExpr(l), fromSchemaExpr(r), arithOp)
-      case SchemaExpr.StringConcat(l, r)              => StringConcat(fromSchemaExpr(l), fromSchemaExpr(r))
-      case SchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromSchemaExpr(regex), fromSchemaExpr(string))
-      case SchemaExpr.StringLength(string)            => StringLength(fromSchemaExpr(string))
-    }
+    val result = fromDynamic[S](se.dynamic)
     result.asInstanceOf[Expr[S, A]]
+  }
+
+  private def fromDynamic[S](dse: DynamicSchemaExpr): Expr[S, ?] = dse match {
+    case DynamicSchemaExpr.Select(path)    => Column[S, Any](path)
+    case DynamicSchemaExpr.Literal(value)  => Lit[S, Any](value)
+    case DynamicSchemaExpr.Relational(l, r, op) =>
+      val relOp = op match {
+        case DynamicSchemaExpr.RelationalOperator.Equal              => RelOp.Equal
+        case DynamicSchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
+        case DynamicSchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
+        case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
+        case DynamicSchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
+        case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
+      }
+      Relational(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], relOp)
+    case DynamicSchemaExpr.Logical(l, r, op) =>
+      op match {
+        case DynamicSchemaExpr.LogicalOperator.And => And(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
+        case DynamicSchemaExpr.LogicalOperator.Or  => Or(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
+      }
+    case DynamicSchemaExpr.Not(inner) => Not(fromDynamic[S](inner).asInstanceOf[Expr[S, Boolean]])
+    case DynamicSchemaExpr.Arithmetic(l, r, op, _) =>
+      val arithOp = op match {
+        case DynamicSchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
+        case DynamicSchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
+        case DynamicSchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
+        case _                                             => ArithOp.Add
+      }
+      Arithmetic(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], arithOp)
+    case DynamicSchemaExpr.StringConcat(l, r)              => StringConcat(fromDynamic[S](l).asInstanceOf[Expr[S, String]], fromDynamic[S](r).asInstanceOf[Expr[S, String]])
+    case DynamicSchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromDynamic[S](regex).asInstanceOf[Expr[S, String]], fromDynamic[S](string).asInstanceOf[Expr[S, String]])
+    case DynamicSchemaExpr.StringLength(string)            => StringLength(fromDynamic[S](string).asInstanceOf[Expr[S, String]])
+    case _                                                 => Lit[S, Any](DynamicValue.Null)
   }
 }
 
@@ -658,6 +687,9 @@ implicit final class SchemaExprBooleanBridge[S](private val self: SchemaExpr[S, 
 def columnName(optic: zio.blocks.schema.Optic[_, _]): String =
   optic.toDynamic.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
 
+def columnName(path: DynamicOptic): String =
+  path.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
+
 def sqlLiteral[A](value: A, schema: Schema[A]): String = {
   val dv = schema.toDynamicValue(value)
   dv match {
@@ -670,9 +702,25 @@ def sqlLiteral[A](value: A, schema: Schema[A]): String = {
   }
 }
 
+def sqlLiteralDV(dv: DynamicValue): String = dv match {
+  case DynamicValue.Primitive(pv) =>
+    pv match {
+      case PrimitiveValue.String(s)  => s"'${s.replace("'", "''")}'"
+      case PrimitiveValue.Boolean(b) => if (b) "TRUE" else "FALSE"
+      case PrimitiveValue.Int(n)     => n.toString
+      case PrimitiveValue.Long(n)    => n.toString
+      case PrimitiveValue.Double(n)  => n.toString
+      case PrimitiveValue.Float(n)   => n.toString
+      case PrimitiveValue.Short(n)   => n.toString
+      case PrimitiveValue.Byte(n)    => n.toString
+      case other                     => other.toString
+    }
+  case other => other.toString
+}
+
 def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
-  case Expr.Column(optic)      => columnName(optic)
-  case Expr.Lit(value, schema) => sqlLiteral(value, schema)
+  case Expr.Column(path)    => columnName(path)
+  case Expr.Lit(value)      => sqlLiteralDV(value)
   case Expr.Relational(left, right, op) =>
     val sqlOp = op match {
       case RelOp.Equal => "="; case RelOp.NotEqual => "<>"
@@ -740,4 +788,4 @@ println(s"SELECT name, price, ${exprToSql(tier)} AS tier FROM products")
 - **[SchemaExpr Reference](../reference/schema/schema-expr.md)** -- Full API coverage of expression types
 - **[Optics Reference](../reference/schema/optics.md)** -- Lens, Prism, Optional, and Traversal
 
-The translation pattern shown here extends to any domain where `SchemaExpr` falls short. The same approach works for MongoDB operators (`$in`, `$exists`, `$elemMatch`), Elasticsearch queries (`terms`, `range`, `exists`), or GraphQL filters. Define an independent ADT, provide a `fromSchemaExpr` translation, add your domain-specific nodes, and write a single unified interpreter.
+The translation pattern shown here extends to any domain where `SchemaExpr` falls short. The same approach works for MongoDB operators (`$in`, `$exists`, `$elemMatch`), Elasticsearch queries (`terms`, `range`, `exists`), or GraphQL filters. Define an independent ADT, provide a `fromSchemaExpr` translation (accessing `.dynamic` for the `DynamicSchemaExpr`), add your domain-specific nodes, and write a single unified interpreter.

--- a/docs/guides/query-dsl-extending.md
+++ b/docs/guides/query-dsl-extending.md
@@ -45,7 +45,7 @@ FROM products
 
 None of these can be expressed with `SchemaExpr` alone. You could generate the SQL strings manually, but then you lose composability — you can no longer mix these operations with the type-safe `SchemaExpr` predicates from Parts 1 and 2.
 
-`SchemaExpr` wraps a `DynamicSchemaExpr` sealed trait that you cannot add new cases to. Instead, we define an `Expr` ADT that is a superset — it includes equivalent nodes for everything `SchemaExpr` can express, plus our custom SQL-specific operations. A `fromSchemaExpr` function translates `SchemaExpr` values into `Expr` by accessing the underlying `DynamicSchemaExpr`, enabling seamless interoperability with a single unified interpreter.
+`SchemaExpr` wraps a `DynamicSchemaExpr` sealed trait that you cannot add new cases to. The public API is `SchemaExpr`; `DynamicSchemaExpr` is the raw serializable AST exposed through `.dynamic`. Instead of extending `DynamicSchemaExpr` directly, we define an `Expr` ADT that is a superset — it includes equivalent nodes for everything `SchemaExpr` can express, plus our custom SQL-specific operations. A `fromSchemaExpr` function translates `SchemaExpr` values into `Expr` by reading the underlying `DynamicSchemaExpr`, enabling seamless interoperability with a single unified interpreter.
 
 ## Prerequisites
 
@@ -85,31 +85,25 @@ object Product extends CompanionOptics[Product] {
 
 ## Designing the Expr ADT
 
-The key insight is the **translation pattern**: define your own sealed trait whose node types are a superset of `SchemaExpr`'s underlying `DynamicSchemaExpr` cases, then provide a `fromSchemaExpr` function that converts any `SchemaExpr` into your ADT by accessing its `.dynamic` field. This gives you a single unified interpreter.
+The key insight is the **translation pattern**: keep your public extension API typed, then provide a `fromSchemaExpr` function that lifts any built-in `SchemaExpr` into your extended ADT. Ordinary application code stays on `SchemaExpr`, `Optic`, and typed constructors. Only the interpreter internals need to inspect `.dynamic`.
 
 ```
-  Built-in (not extensible)                    Your extension (superset)
+  Built-in API                               Your extension layer
 ┌───────────────────────────────┐       ┌───────────────────────────────────────┐
 │  SchemaExpr[S, A]             │       │  Expr[S, A]                           │
-│  └── .dynamic:                │       │  ├── Lit(DynamicValue)                │
-│      DynamicSchemaExpr        │       │  ├── Column(DynamicOptic)             │
-│      ├── Literal              │──────▶│  ├── Relational(left, right, RelOp)   │
-│      ├── Select               │──────▶│  ├── And / Or                         │
-│      ├── Relational           │──────▶│  ├── Not                              │
-│      ├── Logical (And/Or)     │──────▶│  ├── Arithmetic(left, right, ArithOp) │
-│      ├── Not                  │──────▶│  ├── StringConcat                     │
-│      ├── Arithmetic           │──────▶│  ├── StringRegexMatch                 │
-│      ├── StringConcat         │──────▶│  ├── StringLength                     │
-│      ├── StringRegexMatch     │──────▶│  ├── In(expr, values, schema)         ← new   │
-│      └── StringLength         │──────▶│  ├── Between(expr, low, high, schema) ← new   │
-└───────────────────────────────┘       │  ├── IsNull(expr)             ← new   │
-         fromSchemaExpr ────────────────│  ├── Like(expr, pattern)      ← new   │
-                                        │  ├── Agg(function, expr)      ← new   │
-                                        │  └── CaseWhen(branches, else) ← new   │
+│  built with optics/operators  │──────▶│  ├── Builtin(schemaExpr)              │
+└───────────────────────────────┘       │  ├── Column(optic)                    │
+         fromSchemaExpr ────────────────│  ├── Lit(value, schema)               │
+                                        │  ├── In(expr, values, schema)         │
+                                        │  ├── Between(expr, low, high, schema) │
+                                        │  ├── IsNull(expr)                     │
+                                        │  ├── Like(expr, pattern)              │
+                                        │  ├── Agg(function, expr)              │
+                                        │  └── CaseWhen(branches, else)         │
                                         └───────────────────────────────────────┘
 ```
 
-The `Expr` ADT includes mirrored nodes for every `DynamicSchemaExpr` case, plus SQL-specific extensions. It uses its own operator types (`RelOp`, `ArithOp`) and type-safe aggregate functions (`AggFunction[A, B]`).
+The `Expr` ADT keeps the public surface typed. It can wrap any built-in `SchemaExpr` through `Builtin`, and it adds SQL-specific nodes on top. The interpreter is still free to inspect `schemaExpr.dynamic` internally when it needs to translate the built-in pieces.
 
 Here is the full `Expr` ADT with its supporting types:
 
@@ -118,9 +112,10 @@ sealed trait Expr[S, A]
 
 object Expr {
 
-  // --- Core nodes (superset of DynamicSchemaExpr's nodes) ---
-  final case class Column[S, A](path: DynamicOptic) extends Expr[S, A]
-  final case class Lit[S, A](value: DynamicValue) extends Expr[S, A]
+  // --- Typed public nodes ---
+  final case class Builtin[S, A](schemaExpr: SchemaExpr[S, A]) extends Expr[S, A]
+  final case class Column[S, A](optic: Optic[S, A]) extends Expr[S, A]
+  final case class Lit[S, A](value: A, schema: Schema[A]) extends Expr[S, A]
 
   // Relational
   final case class Relational[S, A](left: Expr[S, A], right: Expr[S, A], op: RelOp) extends Expr[S, Boolean]
@@ -154,8 +149,8 @@ object Expr {
   ) extends Expr[S, A]
 
   // --- Factory methods ---
-  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic.toDynamic)
-  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(schema.toDynamicValue(value))
+  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic)
+  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(value, schema)
 
   def count[S, A](expr: Expr[S, A]): Expr[S, Long]   = Agg(AggFunction.Count(), expr)
   def sum[S](expr: Expr[S, Double]): Expr[S, Double]  = Agg(AggFunction.Sum, expr)
@@ -172,48 +167,7 @@ object Expr {
   }
 
   // --- Translation from SchemaExpr ---
-  def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = {
-    val result = fromDynamic[S](se.dynamic)
-    result.asInstanceOf[Expr[S, A]]
-  }
-
-  private def fromDynamic[S](dse: DynamicSchemaExpr): Expr[S, ?] = dse match {
-    case DynamicSchemaExpr.Select(path)    => Column[S, Any](path)
-    case DynamicSchemaExpr.Literal(value)  => Lit[S, Any](value)
-
-    case DynamicSchemaExpr.Relational(l, r, op) =>
-      val relOp = op match {
-        case DynamicSchemaExpr.RelationalOperator.Equal              => RelOp.Equal
-        case DynamicSchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
-        case DynamicSchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
-        case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
-        case DynamicSchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
-        case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
-      }
-      Relational(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], relOp)
-
-    case DynamicSchemaExpr.Logical(l, r, op) =>
-      op match {
-        case DynamicSchemaExpr.LogicalOperator.And => And(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
-        case DynamicSchemaExpr.LogicalOperator.Or  => Or(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
-      }
-
-    case DynamicSchemaExpr.Not(inner) => Not(fromDynamic[S](inner).asInstanceOf[Expr[S, Boolean]])
-
-    case DynamicSchemaExpr.Arithmetic(l, r, op, _) =>
-      val arithOp = op match {
-        case DynamicSchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
-        case DynamicSchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
-        case DynamicSchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
-        case _                                             => ArithOp.Add
-      }
-      Arithmetic(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], arithOp)
-
-    case DynamicSchemaExpr.StringConcat(l, r)              => StringConcat(fromDynamic[S](l).asInstanceOf[Expr[S, String]], fromDynamic[S](r).asInstanceOf[Expr[S, String]])
-    case DynamicSchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromDynamic[S](regex).asInstanceOf[Expr[S, String]], fromDynamic[S](string).asInstanceOf[Expr[S, String]])
-    case DynamicSchemaExpr.StringLength(string)            => StringLength(fromDynamic[S](string).asInstanceOf[Expr[S, String]])
-    case _                                                 => Lit[S, Any](DynamicValue.Null)
-  }
+  def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = Builtin(se)
 }
 
 // --- Operators ---
@@ -251,8 +205,8 @@ object AggFunction {
 Here are some keynotes on the design:
 
 - **Type-safe aggregates** — `AggFunction[A, B]` encodes the return type: `COUNT` returns `Long`, `SUM`/`AVG` return `Double`, `MIN`/`MAX` preserve the input type.
-- **Dynamic values** — `Column` stores a `DynamicOptic` and `Lit` stores a `DynamicValue`, matching the dynamic representation used by `DynamicSchemaExpr`.
-- **`fromSchemaExpr`** — accesses `se.dynamic` to get the `DynamicSchemaExpr`, then recursively converts every node into its `Expr` equivalent, mapping operators along the way.
+- **Typed public constructors** — `Column` stores an `Optic` and `Lit` stores a typed value plus its `Schema`, so extension code stays on the same public abstractions as ordinary `SchemaExpr` code.
+- **`fromSchemaExpr`** — lifts a built-in `SchemaExpr` into the extended ADT. The dynamic representation is only consulted later by the interpreter.
 
 ## Extension Methods
 
@@ -295,7 +249,7 @@ The `.toExpr` method is still available for cases where you need to explicitly l
 
 ## The Unified SQL Interpreter
 
-With the `Expr` ADT, we write a single interpreter that handles all cases directly:
+With the `Expr` ADT, we write a single interpreter that handles all cases directly. Typed extension nodes stay typed; built-in `SchemaExpr` fragments delegate to a helper that reads `.dynamic` internally:
 
 ```scala mdoc:silent
 def columnName(optic: zio.blocks.schema.Optic[_, _]): String =
@@ -333,8 +287,9 @@ def sqlLiteralDV(dv: DynamicValue): String = dv match {
 }
 
 def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
-  case Expr.Column(path)    => columnName(path)
-  case Expr.Lit(value)      => sqlLiteralDV(value)
+  case Expr.Builtin(schemaExpr) => schemaExprToSql(schemaExpr)
+  case Expr.Column(optic)       => columnName(optic)
+  case Expr.Lit(value, schema)  => sqlLiteral(value, schema)
 
   case Expr.Relational(left, right, op) =>
     val sqlOp = op match {
@@ -382,9 +337,58 @@ def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
     val elseClause = otherwise.map(e => s" ELSE ${exprToSql(e)}").getOrElse("")
     s"CASE $cases$elseClause END"
 }
+
+def schemaExprToSql[S, A](expr: SchemaExpr[S, A]): String =
+  toSqlDynamic(expr.dynamic)
+
+def toSqlDynamic(expr: DynamicSchemaExpr): String = expr match {
+  case DynamicSchemaExpr.Select(path)   => columnName(path)
+  case DynamicSchemaExpr.Literal(value) => sqlLiteralDV(value)
+
+  case DynamicSchemaExpr.Relational(left, right, op) =>
+    val sqlOp = op match {
+      case DynamicSchemaExpr.RelationalOperator.Equal              => "="
+      case DynamicSchemaExpr.RelationalOperator.NotEqual           => "<>"
+      case DynamicSchemaExpr.RelationalOperator.LessThan           => "<"
+      case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
+      case DynamicSchemaExpr.RelationalOperator.GreaterThan        => ">"
+      case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
+    }
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+
+  case DynamicSchemaExpr.Logical(left, right, op) =>
+    val sqlOp = op match {
+      case DynamicSchemaExpr.LogicalOperator.And => "AND"
+      case DynamicSchemaExpr.LogicalOperator.Or  => "OR"
+    }
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+
+  case DynamicSchemaExpr.Not(inner) =>
+    s"NOT (${toSqlDynamic(inner)})"
+
+  case DynamicSchemaExpr.Arithmetic(left, right, op, _) =>
+    val sqlOp = op match {
+      case DynamicSchemaExpr.ArithmeticOperator.Add      => "+"
+      case DynamicSchemaExpr.ArithmeticOperator.Subtract => "-"
+      case DynamicSchemaExpr.ArithmeticOperator.Multiply => "*"
+      case _                                             => "?"
+    }
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+
+  case DynamicSchemaExpr.StringConcat(left, right) =>
+    s"CONCAT(${toSqlDynamic(left)}, ${toSqlDynamic(right)})"
+
+  case DynamicSchemaExpr.StringRegexMatch(regex, string) =>
+    s"(${toSqlDynamic(string)} LIKE ${toSqlDynamic(regex)})"
+
+  case DynamicSchemaExpr.StringLength(string) =>
+    s"LENGTH(${toSqlDynamic(string)})"
+
+  case _ => "?"
+}
 ```
 
-The typed `sqlLiteral[A](value, schema)` uses the `Schema` carried by `In` and `Between` to format values correctly — strings get quoted, booleans become `TRUE`/`FALSE`, numbers stay as-is. The `sqlLiteralDV` handles `DynamicValue` directly for `Lit` nodes.
+The typed `sqlLiteral[A](value, schema)` uses the `Schema` carried by `Lit`, `In`, and `Between` to format values correctly — strings get quoted, booleans become `TRUE`/`FALSE`, numbers stay as-is. `sqlLiteralDV` is only needed inside `toSqlDynamic`, where built-in `SchemaExpr` nodes have already crossed into the dynamic representation.
 
 ## SQL-Specific Predicates
 
@@ -521,7 +525,7 @@ println(selectSql)
 
 ## Putting It Together
 
-Here is a complete, self-contained example that defines the independent expression ADT, translates from `SchemaExpr`, and generates advanced SQL:
+Here is a complete, self-contained example that defines the independent expression ADT, lifts built-in `SchemaExpr` values into it, and generates advanced SQL:
 
 ```scala mdoc:compile-only
 import zio.blocks.schema._
@@ -551,8 +555,9 @@ object Product extends CompanionOptics[Product] {
 sealed trait Expr[S, A]
 
 object Expr {
-  final case class Column[S, A](path: DynamicOptic) extends Expr[S, A]
-  final case class Lit[S, A](value: DynamicValue) extends Expr[S, A]
+  final case class Builtin[S, A](schemaExpr: SchemaExpr[S, A]) extends Expr[S, A]
+  final case class Column[S, A](optic: Optic[S, A]) extends Expr[S, A]
+  final case class Lit[S, A](value: A, schema: Schema[A]) extends Expr[S, A]
 
   final case class Relational[S, A](left: Expr[S, A], right: Expr[S, A], op: RelOp) extends Expr[S, Boolean]
   final case class And[S](left: Expr[S, Boolean], right: Expr[S, Boolean]) extends Expr[S, Boolean]
@@ -574,8 +579,8 @@ object Expr {
     otherwise: Option[Expr[S, A]]
   ) extends Expr[S, A]
 
-  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic.toDynamic)
-  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(schema.toDynamicValue(value))
+  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic)
+  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(value, schema)
   def count[S, A](expr: Expr[S, A]): Expr[S, Long]   = Agg(AggFunction.Count(), expr)
   def sum[S](expr: Expr[S, Double]): Expr[S, Double]  = Agg(AggFunction.Sum, expr)
   def avg[S](expr: Expr[S, Double]): Expr[S, Double]  = Agg(AggFunction.Avg, expr)
@@ -590,43 +595,7 @@ object Expr {
     def end: Expr[S, A] = CaseWhen(branches, None)
   }
 
-  def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = {
-    val result = fromDynamic[S](se.dynamic)
-    result.asInstanceOf[Expr[S, A]]
-  }
-
-  private def fromDynamic[S](dse: DynamicSchemaExpr): Expr[S, ?] = dse match {
-    case DynamicSchemaExpr.Select(path)    => Column[S, Any](path)
-    case DynamicSchemaExpr.Literal(value)  => Lit[S, Any](value)
-    case DynamicSchemaExpr.Relational(l, r, op) =>
-      val relOp = op match {
-        case DynamicSchemaExpr.RelationalOperator.Equal              => RelOp.Equal
-        case DynamicSchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
-        case DynamicSchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
-        case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
-        case DynamicSchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
-        case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
-      }
-      Relational(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], relOp)
-    case DynamicSchemaExpr.Logical(l, r, op) =>
-      op match {
-        case DynamicSchemaExpr.LogicalOperator.And => And(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
-        case DynamicSchemaExpr.LogicalOperator.Or  => Or(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
-      }
-    case DynamicSchemaExpr.Not(inner) => Not(fromDynamic[S](inner).asInstanceOf[Expr[S, Boolean]])
-    case DynamicSchemaExpr.Arithmetic(l, r, op, _) =>
-      val arithOp = op match {
-        case DynamicSchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
-        case DynamicSchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
-        case DynamicSchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
-        case _                                             => ArithOp.Add
-      }
-      Arithmetic(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], arithOp)
-    case DynamicSchemaExpr.StringConcat(l, r)              => StringConcat(fromDynamic[S](l).asInstanceOf[Expr[S, String]], fromDynamic[S](r).asInstanceOf[Expr[S, String]])
-    case DynamicSchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromDynamic[S](regex).asInstanceOf[Expr[S, String]], fromDynamic[S](string).asInstanceOf[Expr[S, String]])
-    case DynamicSchemaExpr.StringLength(string)            => StringLength(fromDynamic[S](string).asInstanceOf[Expr[S, String]])
-    case _                                                 => Lit[S, Any](DynamicValue.Null)
-  }
+  def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = Builtin(se)
 }
 
 sealed trait RelOp
@@ -719,8 +688,9 @@ def sqlLiteralDV(dv: DynamicValue): String = dv match {
 }
 
 def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
-  case Expr.Column(path)    => columnName(path)
-  case Expr.Lit(value)      => sqlLiteralDV(value)
+  case Expr.Builtin(schemaExpr) => schemaExprToSql(schemaExpr)
+  case Expr.Column(optic)       => columnName(optic)
+  case Expr.Lit(value, schema)  => sqlLiteral(value, schema)
   case Expr.Relational(left, right, op) =>
     val sqlOp = op match {
       case RelOp.Equal => "="; case RelOp.NotEqual => "<>"
@@ -752,6 +722,47 @@ def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
     }.mkString(" ")
     val elseClause = otherwise.map(e => s" ELSE ${exprToSql(e)}").getOrElse("")
     s"CASE $cases$elseClause END"
+}
+
+def schemaExprToSql[S, A](expr: SchemaExpr[S, A]): String =
+  toSqlDynamic(expr.dynamic)
+
+def toSqlDynamic(expr: DynamicSchemaExpr): String = expr match {
+  case DynamicSchemaExpr.Select(path)   => columnName(path)
+  case DynamicSchemaExpr.Literal(value) => sqlLiteralDV(value)
+  case DynamicSchemaExpr.Relational(left, right, op) =>
+    val sqlOp = op match {
+      case DynamicSchemaExpr.RelationalOperator.Equal              => "="
+      case DynamicSchemaExpr.RelationalOperator.NotEqual           => "<>"
+      case DynamicSchemaExpr.RelationalOperator.LessThan           => "<"
+      case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
+      case DynamicSchemaExpr.RelationalOperator.GreaterThan        => ">"
+      case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
+    }
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.Logical(left, right, op) =>
+    val sqlOp = op match {
+      case DynamicSchemaExpr.LogicalOperator.And => "AND"
+      case DynamicSchemaExpr.LogicalOperator.Or  => "OR"
+    }
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.Not(inner) =>
+    s"NOT (${toSqlDynamic(inner)})"
+  case DynamicSchemaExpr.Arithmetic(left, right, op, _) =>
+    val sqlOp = op match {
+      case DynamicSchemaExpr.ArithmeticOperator.Add      => "+"
+      case DynamicSchemaExpr.ArithmeticOperator.Subtract => "-"
+      case DynamicSchemaExpr.ArithmeticOperator.Multiply => "*"
+      case _                                             => "?"
+    }
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.StringConcat(left, right) =>
+    s"CONCAT(${toSqlDynamic(left)}, ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.StringRegexMatch(regex, string) =>
+    s"(${toSqlDynamic(string)} LIKE ${toSqlDynamic(regex)})"
+  case DynamicSchemaExpr.StringLength(string) =>
+    s"LENGTH(${toSqlDynamic(string)})"
+  case _ => "?"
 }
 
 // --- Usage ---
@@ -788,4 +799,4 @@ println(s"SELECT name, price, ${exprToSql(tier)} AS tier FROM products")
 - **[SchemaExpr Reference](../reference/schema/schema-expr.md)** -- Full API coverage of expression types
 - **[Optics Reference](../reference/schema/optics.md)** -- Lens, Prism, Optional, and Traversal
 
-The translation pattern shown here extends to any domain where `SchemaExpr` falls short. The same approach works for MongoDB operators (`$in`, `$exists`, `$elemMatch`), Elasticsearch queries (`terms`, `range`, `exists`), or GraphQL filters. Define an independent ADT, provide a `fromSchemaExpr` translation (accessing `.dynamic` for the `DynamicSchemaExpr`), add your domain-specific nodes, and write a single unified interpreter.
+The translation pattern shown here extends to any domain where `SchemaExpr` falls short. The same approach works for MongoDB operators (`$in`, `$exists`, `$elemMatch`), Elasticsearch queries (`terms`, `range`, `exists`), or GraphQL filters. Define an independent ADT, provide a `fromSchemaExpr` lift for built-in expressions, add your domain-specific nodes, and let your interpreter inspect `.dynamic` only inside its internal translation helpers.

--- a/docs/guides/query-dsl-fluent-builder.md
+++ b/docs/guides/query-dsl-fluent-builder.md
@@ -135,8 +135,8 @@ object OrderItem extends CompanionOptics[OrderItem] {
 sealed trait Expr[S, A]
 
 object Expr {
-  final case class Column[S, A](optic: Optic[S, A]) extends Expr[S, A]
-  final case class Lit[S, A](value: A, schema: Schema[A]) extends Expr[S, A]
+  final case class Column[S, A](path: DynamicOptic) extends Expr[S, A]
+  final case class Lit[S, A](value: DynamicValue) extends Expr[S, A]
 
   final case class Relational[S, A](left: Expr[S, A], right: Expr[S, A], op: RelOp) extends Expr[S, Boolean]
   final case class And[S](left: Expr[S, Boolean], right: Expr[S, Boolean]) extends Expr[S, Boolean]
@@ -152,40 +152,49 @@ object Expr {
   final case class IsNull[S, A](expr: Expr[S, A]) extends Expr[S, Boolean]
   final case class Like[S](expr: Expr[S, String], pattern: String) extends Expr[S, Boolean]
 
-  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic)
-  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(value, schema)
+  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic.toDynamic)
+  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(schema.toDynamicValue(value))
 
   def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = {
-    val result = se match {
-      case SchemaExpr.Optic(optic)      => Column(optic)
-      case l: SchemaExpr.Literal[_, _]  => Lit(l.value, l.schema)
-      case SchemaExpr.Relational(l, r, op) =>
-        val relOp = op match {
-          case SchemaExpr.RelationalOperator.Equal              => RelOp.Equal
-          case SchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
-          case SchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
-          case SchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
-          case SchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
-          case SchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
-        }
-        Relational(fromSchemaExpr(l), fromSchemaExpr(r), relOp)
-      case SchemaExpr.Logical(l, r, op) => op match {
-        case SchemaExpr.LogicalOperator.And => And(fromSchemaExpr(l), fromSchemaExpr(r))
-        case SchemaExpr.LogicalOperator.Or  => Or(fromSchemaExpr(l), fromSchemaExpr(r))
-      }
-      case SchemaExpr.Not(inner) => Not(fromSchemaExpr(inner))
-      case SchemaExpr.Arithmetic(l, r, op, _) =>
-        val arithOp = op match {
-          case SchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
-          case SchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
-          case SchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
-        }
-        Arithmetic(fromSchemaExpr(l), fromSchemaExpr(r), arithOp)
-      case SchemaExpr.StringConcat(l, r)              => StringConcat(fromSchemaExpr(l), fromSchemaExpr(r))
-      case SchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromSchemaExpr(regex), fromSchemaExpr(string))
-      case SchemaExpr.StringLength(string)            => StringLength(fromSchemaExpr(string))
-    }
+    val result = fromDynamic[S](se.dynamic)
     result.asInstanceOf[Expr[S, A]]
+  }
+
+  private def fromDynamic[S](dse: DynamicSchemaExpr): Expr[S, ?] = dse match {
+    case DynamicSchemaExpr.Select(path)    => Column[S, Any](path)
+    case DynamicSchemaExpr.Literal(value)  => Lit[S, Any](value)
+
+    case DynamicSchemaExpr.Relational(l, r, op) =>
+      val relOp = op match {
+        case DynamicSchemaExpr.RelationalOperator.Equal              => RelOp.Equal
+        case DynamicSchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
+        case DynamicSchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
+        case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
+        case DynamicSchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
+        case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
+      }
+      Relational(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], relOp)
+
+    case DynamicSchemaExpr.Logical(l, r, op) => op match {
+      case DynamicSchemaExpr.LogicalOperator.And => And(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
+      case DynamicSchemaExpr.LogicalOperator.Or  => Or(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
+    }
+
+    case DynamicSchemaExpr.Not(inner) => Not(fromDynamic[S](inner).asInstanceOf[Expr[S, Boolean]])
+
+    case DynamicSchemaExpr.Arithmetic(l, r, op, _) =>
+      val arithOp = op match {
+        case DynamicSchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
+        case DynamicSchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
+        case DynamicSchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
+        case _                                             => ArithOp.Add
+      }
+      Arithmetic(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], arithOp)
+
+    case DynamicSchemaExpr.StringConcat(l, r)              => StringConcat(fromDynamic[S](l).asInstanceOf[Expr[S, String]], fromDynamic[S](r).asInstanceOf[Expr[S, String]])
+    case DynamicSchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromDynamic[S](regex).asInstanceOf[Expr[S, String]], fromDynamic[S](string).asInstanceOf[Expr[S, String]])
+    case DynamicSchemaExpr.StringLength(string)            => StringLength(fromDynamic[S](string).asInstanceOf[Expr[S, String]])
+    case _                                                 => Lit[S, Any](DynamicValue.Null)
   }
 }
 
@@ -211,6 +220,9 @@ object ArithOp {
 def columnName(optic: zio.blocks.schema.Optic[_, _]): String =
   optic.toDynamic.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
 
+def columnName(path: DynamicOptic): String =
+  path.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
+
 def sqlLiteral[A](value: A, schema: Schema[A]): String = {
   val dv = schema.toDynamicValue(value)
   dv match {
@@ -221,6 +233,22 @@ def sqlLiteral[A](value: A, schema: Schema[A]): String = {
     }
     case _ => value.toString
   }
+}
+
+def sqlLiteralDV(dv: DynamicValue): String = dv match {
+  case DynamicValue.Primitive(pv) =>
+    pv match {
+      case PrimitiveValue.String(s)  => s"'${s.replace("'", "''")}'"
+      case PrimitiveValue.Boolean(b) => if (b) "TRUE" else "FALSE"
+      case PrimitiveValue.Int(n)     => n.toString
+      case PrimitiveValue.Long(n)    => n.toString
+      case PrimitiveValue.Double(n)  => n.toString
+      case PrimitiveValue.Float(n)   => n.toString
+      case PrimitiveValue.Short(n)   => n.toString
+      case PrimitiveValue.Byte(n)    => n.toString
+      case other                     => other.toString
+    }
+  case other => other.toString
 }
 
 // --- Optic extension methods ---
@@ -255,8 +283,8 @@ implicit final class SchemaExprBooleanBridge[S](private val self: SchemaExpr[S, 
 // --- Single unified SQL interpreter ---
 
 def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
-  case Expr.Column(optic)      => columnName(optic)
-  case Expr.Lit(value, schema) => sqlLiteral(value, schema)
+  case Expr.Column(path)     => columnName(path)
+  case Expr.Lit(value)       => sqlLiteralDV(value)
   case Expr.Relational(left, right, op) =>
     val sqlOp = op match {
       case RelOp.Equal              => "="
@@ -653,8 +681,8 @@ object OrderItem extends CompanionOptics[OrderItem] {
 sealed trait Expr[S, A]
 
 object Expr {
-  final case class Column[S, A](optic: Optic[S, A]) extends Expr[S, A]
-  final case class Lit[S, A](value: A, schema: Schema[A]) extends Expr[S, A]
+  final case class Column[S, A](path: DynamicOptic) extends Expr[S, A]
+  final case class Lit[S, A](value: DynamicValue) extends Expr[S, A]
 
   final case class Relational[S, A](left: Expr[S, A], right: Expr[S, A], op: RelOp) extends Expr[S, Boolean]
   final case class And[S](left: Expr[S, Boolean], right: Expr[S, Boolean]) extends Expr[S, Boolean]
@@ -670,40 +698,44 @@ object Expr {
   final case class IsNull[S, A](expr: Expr[S, A]) extends Expr[S, Boolean]
   final case class Like[S](expr: Expr[S, String], pattern: String) extends Expr[S, Boolean]
 
-  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic)
-  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(value, schema)
+  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic.toDynamic)
+  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(schema.toDynamicValue(value))
 
   def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = {
-    val result = se match {
-      case SchemaExpr.Optic(optic)      => Column(optic)
-      case l: SchemaExpr.Literal[_, _]  => Lit(l.value, l.schema)
-      case SchemaExpr.Relational(l, r, op) =>
-        val relOp = op match {
-          case SchemaExpr.RelationalOperator.Equal              => RelOp.Equal
-          case SchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
-          case SchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
-          case SchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
-          case SchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
-          case SchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
-        }
-        Relational(fromSchemaExpr(l), fromSchemaExpr(r), relOp)
-      case SchemaExpr.Logical(l, r, op) => op match {
-        case SchemaExpr.LogicalOperator.And => And(fromSchemaExpr(l), fromSchemaExpr(r))
-        case SchemaExpr.LogicalOperator.Or  => Or(fromSchemaExpr(l), fromSchemaExpr(r))
-      }
-      case SchemaExpr.Not(inner) => Not(fromSchemaExpr(inner))
-      case SchemaExpr.Arithmetic(l, r, op, _) =>
-        val arithOp = op match {
-          case SchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
-          case SchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
-          case SchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
-        }
-        Arithmetic(fromSchemaExpr(l), fromSchemaExpr(r), arithOp)
-      case SchemaExpr.StringConcat(l, r)              => StringConcat(fromSchemaExpr(l), fromSchemaExpr(r))
-      case SchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromSchemaExpr(regex), fromSchemaExpr(string))
-      case SchemaExpr.StringLength(string)            => StringLength(fromSchemaExpr(string))
-    }
+    val result = fromDynamic[S](se.dynamic)
     result.asInstanceOf[Expr[S, A]]
+  }
+
+  private def fromDynamic[S](dse: DynamicSchemaExpr): Expr[S, ?] = dse match {
+    case DynamicSchemaExpr.Select(path)    => Column[S, Any](path)
+    case DynamicSchemaExpr.Literal(value)  => Lit[S, Any](value)
+    case DynamicSchemaExpr.Relational(l, r, op) =>
+      val relOp = op match {
+        case DynamicSchemaExpr.RelationalOperator.Equal              => RelOp.Equal
+        case DynamicSchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
+        case DynamicSchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
+        case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
+        case DynamicSchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
+        case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
+      }
+      Relational(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], relOp)
+    case DynamicSchemaExpr.Logical(l, r, op) => op match {
+      case DynamicSchemaExpr.LogicalOperator.And => And(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
+      case DynamicSchemaExpr.LogicalOperator.Or  => Or(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
+    }
+    case DynamicSchemaExpr.Not(inner) => Not(fromDynamic[S](inner).asInstanceOf[Expr[S, Boolean]])
+    case DynamicSchemaExpr.Arithmetic(l, r, op, _) =>
+      val arithOp = op match {
+        case DynamicSchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
+        case DynamicSchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
+        case DynamicSchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
+        case _                                             => ArithOp.Add
+      }
+      Arithmetic(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], arithOp)
+    case DynamicSchemaExpr.StringConcat(l, r)              => StringConcat(fromDynamic[S](l).asInstanceOf[Expr[S, String]], fromDynamic[S](r).asInstanceOf[Expr[S, String]])
+    case DynamicSchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromDynamic[S](regex).asInstanceOf[Expr[S, String]], fromDynamic[S](string).asInstanceOf[Expr[S, String]])
+    case DynamicSchemaExpr.StringLength(string)            => StringLength(fromDynamic[S](string).asInstanceOf[Expr[S, String]])
+    case _                                                 => Lit[S, Any](DynamicValue.Null)
   }
 }
 
@@ -756,6 +788,9 @@ implicit final class SchemaExprBooleanBridge[S](private val self: SchemaExpr[S, 
 def columnName(optic: zio.blocks.schema.Optic[_, _]): String =
   optic.toDynamic.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
 
+def columnName(path: DynamicOptic): String =
+  path.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
+
 def sqlLiteral[A](value: A, schema: Schema[A]): String = {
   val dv = schema.toDynamicValue(value)
   dv match {
@@ -768,9 +803,25 @@ def sqlLiteral[A](value: A, schema: Schema[A]): String = {
   }
 }
 
+def sqlLiteralDV(dv: DynamicValue): String = dv match {
+  case DynamicValue.Primitive(pv) =>
+    pv match {
+      case PrimitiveValue.String(s)  => s"'${s.replace("'", "''")}'"
+      case PrimitiveValue.Boolean(b) => if (b) "TRUE" else "FALSE"
+      case PrimitiveValue.Int(n)     => n.toString
+      case PrimitiveValue.Long(n)    => n.toString
+      case PrimitiveValue.Double(n)  => n.toString
+      case PrimitiveValue.Float(n)   => n.toString
+      case PrimitiveValue.Short(n)   => n.toString
+      case PrimitiveValue.Byte(n)    => n.toString
+      case other                     => other.toString
+    }
+  case other => other.toString
+}
+
 def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
-  case Expr.Column(optic)      => columnName(optic)
-  case Expr.Lit(value, schema) => sqlLiteral(value, schema)
+  case Expr.Column(path)     => columnName(path)
+  case Expr.Lit(value)       => sqlLiteralDV(value)
   case Expr.Relational(left, right, op) =>
     val sqlOp = op match {
       case RelOp.Equal              => "="

--- a/docs/guides/query-dsl-fluent-builder.md
+++ b/docs/guides/query-dsl-fluent-builder.md
@@ -62,7 +62,7 @@ libraryDependencies += "dev.zio" %% "zio-blocks-schema" % "@VERSION@"
 
 ## Domain Setup
 
-We carry forward the product catalog domain and the Part 3 independent `Expr` ADT. The key additions in Part 4 are bridge extension methods, schema-driven table names, and statement builder types. The `Expr` ADT used here is the same independent design from Part 3.
+We carry forward the product catalog domain and the Part 3 independent `Expr` ADT. The key additions in Part 4 are bridge extension methods, schema-driven table names, and statement builder types. As in Part 3, the public expression layer stays typed: built-in logic remains `SchemaExpr`, and the SQL builder only drops to the dynamic AST inside interpreter helpers.
 
 ```scala mdoc:silent
 import zio.blocks.schema._
@@ -135,8 +135,9 @@ object OrderItem extends CompanionOptics[OrderItem] {
 sealed trait Expr[S, A]
 
 object Expr {
-  final case class Column[S, A](path: DynamicOptic) extends Expr[S, A]
-  final case class Lit[S, A](value: DynamicValue) extends Expr[S, A]
+  final case class Builtin[S, A](schemaExpr: SchemaExpr[S, A]) extends Expr[S, A]
+  final case class Column[S, A](optic: Optic[S, A]) extends Expr[S, A]
+  final case class Lit[S, A](value: A, schema: Schema[A]) extends Expr[S, A]
 
   final case class Relational[S, A](left: Expr[S, A], right: Expr[S, A], op: RelOp) extends Expr[S, Boolean]
   final case class And[S](left: Expr[S, Boolean], right: Expr[S, Boolean]) extends Expr[S, Boolean]
@@ -152,50 +153,10 @@ object Expr {
   final case class IsNull[S, A](expr: Expr[S, A]) extends Expr[S, Boolean]
   final case class Like[S](expr: Expr[S, String], pattern: String) extends Expr[S, Boolean]
 
-  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic.toDynamic)
-  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(schema.toDynamicValue(value))
+  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic)
+  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(value, schema)
 
-  def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = {
-    val result = fromDynamic[S](se.dynamic)
-    result.asInstanceOf[Expr[S, A]]
-  }
-
-  private def fromDynamic[S](dse: DynamicSchemaExpr): Expr[S, ?] = dse match {
-    case DynamicSchemaExpr.Select(path)    => Column[S, Any](path)
-    case DynamicSchemaExpr.Literal(value)  => Lit[S, Any](value)
-
-    case DynamicSchemaExpr.Relational(l, r, op) =>
-      val relOp = op match {
-        case DynamicSchemaExpr.RelationalOperator.Equal              => RelOp.Equal
-        case DynamicSchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
-        case DynamicSchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
-        case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
-        case DynamicSchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
-        case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
-      }
-      Relational(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], relOp)
-
-    case DynamicSchemaExpr.Logical(l, r, op) => op match {
-      case DynamicSchemaExpr.LogicalOperator.And => And(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
-      case DynamicSchemaExpr.LogicalOperator.Or  => Or(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
-    }
-
-    case DynamicSchemaExpr.Not(inner) => Not(fromDynamic[S](inner).asInstanceOf[Expr[S, Boolean]])
-
-    case DynamicSchemaExpr.Arithmetic(l, r, op, _) =>
-      val arithOp = op match {
-        case DynamicSchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
-        case DynamicSchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
-        case DynamicSchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
-        case _                                             => ArithOp.Add
-      }
-      Arithmetic(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], arithOp)
-
-    case DynamicSchemaExpr.StringConcat(l, r)              => StringConcat(fromDynamic[S](l).asInstanceOf[Expr[S, String]], fromDynamic[S](r).asInstanceOf[Expr[S, String]])
-    case DynamicSchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromDynamic[S](regex).asInstanceOf[Expr[S, String]], fromDynamic[S](string).asInstanceOf[Expr[S, String]])
-    case DynamicSchemaExpr.StringLength(string)            => StringLength(fromDynamic[S](string).asInstanceOf[Expr[S, String]])
-    case _                                                 => Lit[S, Any](DynamicValue.Null)
-  }
+  def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = Builtin(se)
 }
 
 sealed trait RelOp
@@ -283,8 +244,9 @@ implicit final class SchemaExprBooleanBridge[S](private val self: SchemaExpr[S, 
 // --- Single unified SQL interpreter ---
 
 def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
-  case Expr.Column(path)     => columnName(path)
-  case Expr.Lit(value)       => sqlLiteralDV(value)
+  case Expr.Builtin(schemaExpr) => schemaExprToSql(schemaExpr)
+  case Expr.Column(optic)       => columnName(optic)
+  case Expr.Lit(value, schema)  => sqlLiteral(value, schema)
   case Expr.Relational(left, right, op) =>
     val sqlOp = op match {
       case RelOp.Equal              => "="
@@ -314,6 +276,46 @@ def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
     s"(${exprToSql(e)} BETWEEN ${sqlLiteral(low, schema)} AND ${sqlLiteral(high, schema)})"
   case Expr.IsNull(e)        => s"${exprToSql(e)} IS NULL"
   case Expr.Like(e, pattern) => s"${exprToSql(e)} LIKE '${pattern.replace("'", "''")}'"
+}
+
+def schemaExprToSql[S, A](expr: SchemaExpr[S, A]): String =
+  toSqlDynamic(expr.dynamic)
+
+def toSqlDynamic(expr: DynamicSchemaExpr): String = expr match {
+  case DynamicSchemaExpr.Select(path)   => columnName(path)
+  case DynamicSchemaExpr.Literal(value) => sqlLiteralDV(value)
+  case DynamicSchemaExpr.Relational(left, right, op) =>
+    val sqlOp = op match {
+      case DynamicSchemaExpr.RelationalOperator.Equal              => "="
+      case DynamicSchemaExpr.RelationalOperator.NotEqual           => "<>"
+      case DynamicSchemaExpr.RelationalOperator.LessThan           => "<"
+      case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
+      case DynamicSchemaExpr.RelationalOperator.GreaterThan        => ">"
+      case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
+    }
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.Logical(left, right, op) =>
+    val sqlOp = op match {
+      case DynamicSchemaExpr.LogicalOperator.And => "AND"
+      case DynamicSchemaExpr.LogicalOperator.Or  => "OR"
+    }
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.Not(inner) =>
+    s"NOT (${toSqlDynamic(inner)})"
+  case DynamicSchemaExpr.Arithmetic(left, right, op, _) =>
+    val sqlOp = op match {
+      case DynamicSchemaExpr.ArithmeticOperator.Add      => "+"
+      case DynamicSchemaExpr.ArithmeticOperator.Subtract => "-"
+      case DynamicSchemaExpr.ArithmeticOperator.Multiply => "*"
+      case _                                             => "?"
+    }
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.StringConcat(left, right) =>
+    s"CONCAT(${toSqlDynamic(left)}, ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.StringRegexMatch(regex, string) =>
+    s"(${toSqlDynamic(string)} LIKE ${toSqlDynamic(regex)})"
+  case DynamicSchemaExpr.StringLength(string) =>
+    s"LENGTH(${toSqlDynamic(string)})"
 }
 ```
 
@@ -357,7 +359,7 @@ val condition =
 exprToSql(condition)
 ```
 
-The first two `&&` calls stay in `SchemaExpr` land (direct method). The third `&&` encounters `between` (returns `Expr`), triggering the bridge. From that point on, everything is `Expr`.
+The first `&&` already involves `between`, so the bridge activates as soon as an `Expr` enters the chain. From that point on, the whole condition is represented as `Expr`.
 
 ## Schema-Driven Table Names
 
@@ -610,7 +612,7 @@ For batch inserts, create one `InsertStmt` per row and render each separately. T
 
 ## Putting It Together
 
-Here is a complete example combining schema-driven table names, bridge extensions, all four statement builders, and the renderers. The `Expr` ADT, extension methods, SQL rendering, and builder types are defined in `Common.scala` and `package.scala` — the usage code stays focused on building queries:
+Here is a complete example combining schema-driven table names, bridge extensions, all four statement builders, and the renderers. The `Expr` ADT, extension methods, SQL rendering, and builder types are defined in `Common.scala` and `package.scala` — the usage code stays focused on building queries with typed optics and `SchemaExpr`, not on manipulating `Dynamic*` nodes directly:
 
 ```scala mdoc:compile-only
 import zio.blocks.schema._
@@ -681,8 +683,9 @@ object OrderItem extends CompanionOptics[OrderItem] {
 sealed trait Expr[S, A]
 
 object Expr {
-  final case class Column[S, A](path: DynamicOptic) extends Expr[S, A]
-  final case class Lit[S, A](value: DynamicValue) extends Expr[S, A]
+  final case class Builtin[S, A](schemaExpr: SchemaExpr[S, A]) extends Expr[S, A]
+  final case class Column[S, A](optic: Optic[S, A]) extends Expr[S, A]
+  final case class Lit[S, A](value: A, schema: Schema[A]) extends Expr[S, A]
 
   final case class Relational[S, A](left: Expr[S, A], right: Expr[S, A], op: RelOp) extends Expr[S, Boolean]
   final case class And[S](left: Expr[S, Boolean], right: Expr[S, Boolean]) extends Expr[S, Boolean]
@@ -698,45 +701,10 @@ object Expr {
   final case class IsNull[S, A](expr: Expr[S, A]) extends Expr[S, Boolean]
   final case class Like[S](expr: Expr[S, String], pattern: String) extends Expr[S, Boolean]
 
-  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic.toDynamic)
-  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(schema.toDynamicValue(value))
+  def col[S, A](optic: Optic[S, A]): Expr[S, A] = Column(optic)
+  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(value, schema)
 
-  def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = {
-    val result = fromDynamic[S](se.dynamic)
-    result.asInstanceOf[Expr[S, A]]
-  }
-
-  private def fromDynamic[S](dse: DynamicSchemaExpr): Expr[S, ?] = dse match {
-    case DynamicSchemaExpr.Select(path)    => Column[S, Any](path)
-    case DynamicSchemaExpr.Literal(value)  => Lit[S, Any](value)
-    case DynamicSchemaExpr.Relational(l, r, op) =>
-      val relOp = op match {
-        case DynamicSchemaExpr.RelationalOperator.Equal              => RelOp.Equal
-        case DynamicSchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
-        case DynamicSchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
-        case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
-        case DynamicSchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
-        case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
-      }
-      Relational(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], relOp)
-    case DynamicSchemaExpr.Logical(l, r, op) => op match {
-      case DynamicSchemaExpr.LogicalOperator.And => And(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
-      case DynamicSchemaExpr.LogicalOperator.Or  => Or(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
-    }
-    case DynamicSchemaExpr.Not(inner) => Not(fromDynamic[S](inner).asInstanceOf[Expr[S, Boolean]])
-    case DynamicSchemaExpr.Arithmetic(l, r, op, _) =>
-      val arithOp = op match {
-        case DynamicSchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
-        case DynamicSchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
-        case DynamicSchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
-        case _                                             => ArithOp.Add
-      }
-      Arithmetic(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], arithOp)
-    case DynamicSchemaExpr.StringConcat(l, r)              => StringConcat(fromDynamic[S](l).asInstanceOf[Expr[S, String]], fromDynamic[S](r).asInstanceOf[Expr[S, String]])
-    case DynamicSchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromDynamic[S](regex).asInstanceOf[Expr[S, String]], fromDynamic[S](string).asInstanceOf[Expr[S, String]])
-    case DynamicSchemaExpr.StringLength(string)            => StringLength(fromDynamic[S](string).asInstanceOf[Expr[S, String]])
-    case _                                                 => Lit[S, Any](DynamicValue.Null)
-  }
+  def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = Builtin(se)
 }
 
 sealed trait RelOp
@@ -820,8 +788,9 @@ def sqlLiteralDV(dv: DynamicValue): String = dv match {
 }
 
 def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
-  case Expr.Column(path)     => columnName(path)
-  case Expr.Lit(value)       => sqlLiteralDV(value)
+  case Expr.Builtin(schemaExpr) => schemaExprToSql(schemaExpr)
+  case Expr.Column(optic)       => columnName(optic)
+  case Expr.Lit(value, schema)  => sqlLiteral(value, schema)
   case Expr.Relational(left, right, op) =>
     val sqlOp = op match {
       case RelOp.Equal              => "="
@@ -851,6 +820,46 @@ def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
     s"(${exprToSql(e)} BETWEEN ${sqlLiteral(low, schema)} AND ${sqlLiteral(high, schema)})"
   case Expr.IsNull(e)        => s"${exprToSql(e)} IS NULL"
   case Expr.Like(e, pattern) => s"${exprToSql(e)} LIKE '${pattern.replace("'", "''")}'"
+}
+
+def schemaExprToSql[S, A](expr: SchemaExpr[S, A]): String =
+  toSqlDynamic(expr.dynamic)
+
+def toSqlDynamic(expr: DynamicSchemaExpr): String = expr match {
+  case DynamicSchemaExpr.Select(path)   => columnName(path)
+  case DynamicSchemaExpr.Literal(value) => sqlLiteralDV(value)
+  case DynamicSchemaExpr.Relational(left, right, op) =>
+    val sqlOp = op match {
+      case DynamicSchemaExpr.RelationalOperator.Equal              => "="
+      case DynamicSchemaExpr.RelationalOperator.NotEqual           => "<>"
+      case DynamicSchemaExpr.RelationalOperator.LessThan           => "<"
+      case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
+      case DynamicSchemaExpr.RelationalOperator.GreaterThan        => ">"
+      case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
+    }
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.Logical(left, right, op) =>
+    val sqlOp = op match {
+      case DynamicSchemaExpr.LogicalOperator.And => "AND"
+      case DynamicSchemaExpr.LogicalOperator.Or  => "OR"
+    }
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.Not(inner) =>
+    s"NOT (${toSqlDynamic(inner)})"
+  case DynamicSchemaExpr.Arithmetic(left, right, op, _) =>
+    val sqlOp = op match {
+      case DynamicSchemaExpr.ArithmeticOperator.Add      => "+"
+      case DynamicSchemaExpr.ArithmeticOperator.Subtract => "-"
+      case DynamicSchemaExpr.ArithmeticOperator.Multiply => "*"
+      case _                                             => "?"
+    }
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.StringConcat(left, right) =>
+    s"CONCAT(${toSqlDynamic(left)}, ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.StringRegexMatch(regex, string) =>
+    s"(${toSqlDynamic(string)} LIKE ${toSqlDynamic(regex)})"
+  case DynamicSchemaExpr.StringLength(string) =>
+    s"LENGTH(${toSqlDynamic(string)})"
 }
 
 // --- Statement builders ---
@@ -963,7 +972,7 @@ val q = select(Product.table)
   .where(
     Product.category.in("Electronics", "Books") &&
     Product.price.between(10.0, 500.0) &&
-    (Product.rating >= 4).toExpr
+    (Product.rating >= 4)
   )
   .orderBy(Product.price, SortOrder.Desc)
   .limit(20)

--- a/docs/guides/query-dsl-reified-optics.md
+++ b/docs/guides/query-dsl-reified-optics.md
@@ -469,4 +469,4 @@ catalog.foreach { p =>
 - **[Schema Reference](../reference/schema/schema.md)** -- Schema derivation and type-level metadata
 - **[Path Interpolator](../path-interpolator.md)** -- String-based path construction with `p"..."` syntax
 
-The `SchemaExpr` expression tree is a sealed trait, making it straightforward to write interpreters that translate queries to SQL, MongoDB filters, Elasticsearch queries, or any other target language. Because each optic carries its `DynamicOptic` path (via `toDynamic`), you can extract field names and paths programmatically for these translations.
+`SchemaExpr` is a typed wrapper around a serializable `DynamicSchemaExpr` tree, making it straightforward to write interpreters that translate queries to SQL, MongoDB filters, Elasticsearch queries, or any other target language. Because each optic carries its `DynamicOptic` path (via `toDynamic`), you can extract field names and paths programmatically for these translations.

--- a/docs/guides/query-dsl-sql.md
+++ b/docs/guides/query-dsl-sql.md
@@ -9,7 +9,7 @@ This is Part 2 of the Query DSL series. [Part 1](./query-dsl-reified-optics.md) 
 
 **What we'll cover:**
 
-- Interpreting `SchemaExpr` as a sealed AST via pattern matching
+- Interpreting `SchemaExpr` via its `DynamicSchemaExpr` representation using pattern matching
 - Extracting column names from optic paths using `DynamicOptic`
 - Translating relational, logical, arithmetic, and string operations to SQL
 - Building complete `SELECT ... FROM ... WHERE ...` statements
@@ -36,7 +36,7 @@ def findProducts(category: Option[String], maxPrice: Option[Double], inStock: Op
 
 This is fragile, repetitive, and vulnerable to SQL injection. Every new query shape requires new string-building code. The query logic is duplicated -- once as a `SchemaExpr` for in-memory filtering, and again as hand-written SQL for the database.
 
-Since `SchemaExpr` is a sealed trait, we can write a single interpreter that translates *any* query expression into SQL. Write the interpreter once, and every query you build with the Part 1 DSL automatically gets a SQL translation.
+`SchemaExpr` wraps a `DynamicSchemaExpr` — a sealed trait whose cases represent the full expression AST. We can write a single interpreter that pattern-matches on this AST to translate *any* query expression into SQL. Write the interpreter once, and every query you build with the Part 1 DSL automatically gets a SQL translation.
 
 ## Prerequisites
 
@@ -74,23 +74,22 @@ object Product extends CompanionOptics[Product] {
 }
 ```
 
-## The SchemaExpr AST
+## The SchemaExpr Structure
 
-Before we build the interpreter, let's understand the structure we are interpreting. `SchemaExpr` is a sealed trait with these cases:
+Before we build the interpreter, let's understand the structure we are interpreting. `SchemaExpr[A, B]` is a case class that wraps a `DynamicSchemaExpr` — a sealed trait with cases representing the expression AST:
 
 ```
 SchemaExpr[A, B]
-├── Literal[S, A](value, schema)                              -- a constant value
-├── Optic[A, B](optic)                                        -- a field reference
-├── StringRegexMatch[A](regex, string)                       -- regex pattern matching
-├── StringLength[A](string)                                  -- string length calculation
-├── UnaryOp[A, B]                                            -- abstract trait for unary operations
-│   └── Not[A](expr)                                         -- boolean negation
-└── BinaryOp[A, B, C]                                        -- abstract trait for binary operations
-    ├── Relational[A, B](left, right, operator)              -- comparison operations
-    ├── Logical[A](left, right, operator)                    -- boolean operations
-    ├── Arithmetic[S, A](left, right, operator, isNumeric)   -- numeric operations
-    └── StringConcat[A](left, right)                         -- string concatenation
+└── .dynamic: DynamicSchemaExpr
+    ├── Select(path: DynamicOptic)                         -- a field reference
+    ├── Literal(value: DynamicValue)                       -- a constant value
+    ├── Relational(left, right, op: RelationalOperator)    -- comparison operations
+    ├── Logical(left, right, op: LogicalOperator)          -- boolean operations
+    ├── Not(expr)                                          -- boolean negation
+    ├── Arithmetic(left, right, op, numericTag)            -- numeric operations
+    ├── StringConcat(left, right)                          -- string concatenation
+    ├── StringRegexMatch(regex, string)                    -- regex pattern matching
+    └── StringLength(string)                               -- string length calculation
 
 RelationalOperator
 ├── LessThan
@@ -110,7 +109,7 @@ ArithmeticOperator
 └── Multiply
 ```
 
-Each case carries enough information to produce SQL: `Optic` nodes carry field paths, `Literal` nodes carry values, and operator nodes carry the operation type. Our interpreter walks this tree and emits SQL fragments.
+Each case carries enough information to produce SQL: `Select` nodes carry field paths, `Literal` nodes carry values, and operator nodes carry the operation type. Our interpreter walks this tree and emits SQL fragments.
 
 ## Extracting Column Names from Optics
 
@@ -121,6 +120,9 @@ def columnName(optic: zio.blocks.schema.Optic[?, ?]): String = {
   val nodes = optic.toDynamic.nodes
   nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
 }
+
+def columnName(path: DynamicOptic): String =
+  path.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
 ```
 
 This converts the optic path to a column name. For a simple field like `Product.price`, it produces `"price"`. For a nested path, it joins field names with underscores (we will refine this for table-qualified names later).
@@ -133,92 +135,106 @@ columnName(Product.category)
 
 ## Translating Literals to SQL
 
-Literal values need proper SQL formatting -- strings must be quoted, booleans converted to SQL syntax:
+Literal values in `DynamicSchemaExpr` are stored as `DynamicValue`. We need a function to format them as SQL:
 
 ```scala mdoc:silent
-def sqlLiteral(value: Any): String = value match {
-  case s: String     => s"'${s.replace("'", "''")}'"
-  case b: Boolean    => if (b) "TRUE" else "FALSE"
-  case n: Number     => n.toString
-  case other         => other.toString
+def sqlLiteralDV(dv: DynamicValue): String = dv match {
+  case DynamicValue.Primitive(pv) =>
+    pv match {
+      case PrimitiveValue.String(s)  => s"'${s.replace("'", "''")}'"
+      case PrimitiveValue.Boolean(b) => if (b) "TRUE" else "FALSE"
+      case PrimitiveValue.Int(n)     => n.toString
+      case PrimitiveValue.Long(n)    => n.toString
+      case PrimitiveValue.Double(n)  => n.toString
+      case PrimitiveValue.Float(n)   => n.toString
+      case PrimitiveValue.Short(n)   => n.toString
+      case PrimitiveValue.Byte(n)    => n.toString
+      case other                     => other.toString
+    }
+  case other => other.toString
 }
 ```
 
 ## Building the SQL Interpreter
 
-Now we build the core interpreter. It pattern-matches on each `SchemaExpr` case and produces a SQL string:
+Now we build the core interpreter. `SchemaExpr` wraps a `DynamicSchemaExpr`, so we access it via `.dynamic` and pattern-match on each case:
 
 ```scala mdoc:silent
-def toSql[A, B](expr: SchemaExpr[A, B]): String = expr match {
+def toSql[A, B](expr: SchemaExpr[A, B]): String = toSqlDynamic(expr.dynamic)
+
+private def toSqlDynamic(expr: DynamicSchemaExpr): String = expr match {
 
   // Field reference → column name
-  case SchemaExpr.Optic(optic) =>
-    columnName(optic)
+  case DynamicSchemaExpr.Select(path) =>
+    columnName(path)
 
   // Constant value → SQL literal
-  case SchemaExpr.Literal(value, _) =>
-    sqlLiteral(value)
+  case DynamicSchemaExpr.Literal(value) =>
+    sqlLiteralDV(value)
 
   // Comparison operators → SQL relational operators
-  case SchemaExpr.Relational(left, right, op) =>
+  case DynamicSchemaExpr.Relational(left, right, op) =>
     val sqlOp = op match {
-      case SchemaExpr.RelationalOperator.Equal              => "="
-      case SchemaExpr.RelationalOperator.NotEqual           => "<>"
-      case SchemaExpr.RelationalOperator.LessThan           => "<"
-      case SchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
-      case SchemaExpr.RelationalOperator.GreaterThan        => ">"
-      case SchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
+      case DynamicSchemaExpr.RelationalOperator.Equal              => "="
+      case DynamicSchemaExpr.RelationalOperator.NotEqual           => "<>"
+      case DynamicSchemaExpr.RelationalOperator.LessThan           => "<"
+      case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
+      case DynamicSchemaExpr.RelationalOperator.GreaterThan        => ">"
+      case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
     }
-    s"(${toSql(left)} $sqlOp ${toSql(right)})"
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
 
   // Boolean operators → AND / OR
-  case SchemaExpr.Logical(left, right, op) =>
+  case DynamicSchemaExpr.Logical(left, right, op) =>
     val sqlOp = op match {
-      case SchemaExpr.LogicalOperator.And => "AND"
-      case SchemaExpr.LogicalOperator.Or  => "OR"
+      case DynamicSchemaExpr.LogicalOperator.And => "AND"
+      case DynamicSchemaExpr.LogicalOperator.Or  => "OR"
     }
-    s"(${toSql(left)} $sqlOp ${toSql(right)})"
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
 
   // Negation → NOT
-  case SchemaExpr.Not(inner) =>
-    s"NOT (${toSql(inner)})"
+  case DynamicSchemaExpr.Not(inner) =>
+    s"NOT (${toSqlDynamic(inner)})"
 
   // Arithmetic → SQL math operators
-  case SchemaExpr.Arithmetic(left, right, op, _) =>
+  case DynamicSchemaExpr.Arithmetic(left, right, op, _) =>
     val sqlOp = op match {
-      case SchemaExpr.ArithmeticOperator.Add      => "+"
-      case SchemaExpr.ArithmeticOperator.Subtract => "-"
-      case SchemaExpr.ArithmeticOperator.Multiply => "*"
+      case DynamicSchemaExpr.ArithmeticOperator.Add      => "+"
+      case DynamicSchemaExpr.ArithmeticOperator.Subtract => "-"
+      case DynamicSchemaExpr.ArithmeticOperator.Multiply => "*"
+      case _                                             => "?"
     }
-    s"(${toSql(left)} $sqlOp ${toSql(right)})"
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
 
   // String concatenation → CONCAT()
-  case SchemaExpr.StringConcat(left, right) =>
-    s"CONCAT(${toSql(left)}, ${toSql(right)})"
+  case DynamicSchemaExpr.StringConcat(left, right) =>
+    s"CONCAT(${toSqlDynamic(left)}, ${toSqlDynamic(right)})"
 
   // Regex match → column LIKE pattern (simplified)
-  case SchemaExpr.StringRegexMatch(regex, string) =>
-    s"(${toSql(string)} LIKE ${toSql(regex)})"
+  case DynamicSchemaExpr.StringRegexMatch(regex, string) =>
+    s"(${toSqlDynamic(string)} LIKE ${toSqlDynamic(regex)})"
 
   // String length → LENGTH()
-  case SchemaExpr.StringLength(string) =>
-    s"LENGTH(${toSql(string)})"
+  case DynamicSchemaExpr.StringLength(string) =>
+    s"LENGTH(${toSqlDynamic(string)})"
+
+  case _ => "?"
 }
 ```
 
-The mapping from `SchemaExpr` to SQL is direct:
+The mapping from `DynamicSchemaExpr` to SQL is direct:
 
-| SchemaExpr Case     | SQL Output                           |
-|---------------------|--------------------------------------|
-| `Optic(optic)`      | Column name from `toDynamic`         |
-| `Literal(v, _)`     | SQL literal (`'text'`, `42`, `TRUE`) |
-| `Relational(_, _, op)` | `=`, `<>`, `<`, `>`, `<=`, `>=`   |
-| `Logical(_, _, op)` | `AND`, `OR`                          |
-| `Not(expr)`         | `NOT (...)`                          |
-| `Arithmetic(_, _, op, _)` | `+`, `-`, `*`                  |
-| `StringConcat`      | `CONCAT(a, b)`                       |
-| `StringRegexMatch`  | `LIKE` (pattern matching)            |
-| `StringLength`      | `LENGTH(col)`                        |
+| DynamicSchemaExpr Case | SQL Output                           |
+|------------------------|--------------------------------------|
+| `Select(path)`         | Column name from `DynamicOptic`      |
+| `Literal(value)`       | SQL literal (`'text'`, `42`, `TRUE`) |
+| `Relational(_, _, op)` | `=`, `<>`, `<`, `>`, `<=`, `>=`      |
+| `Logical(_, _, op)`    | `AND`, `OR`                          |
+| `Not(expr)`            | `NOT (...)`                          |
+| `Arithmetic(_, _, op, _)` | `+`, `-`, `*`                     |
+| `StringConcat`         | `CONCAT(a, b)`                       |
+| `StringRegexMatch`     | `LIKE` (pattern matching)            |
+| `StringLength`         | `LENGTH(col)`                        |
 
 ## Generating SQL from Queries
 
@@ -349,63 +365,80 @@ The `toSql` function above inlines literal values directly into the SQL string. 
 ```scala mdoc:silent
 case class SqlQuery(sql: String, params: List[Any])
 
-def toParameterized[A, B](expr: SchemaExpr[A, B]): SqlQuery = expr match {
+def toParameterized[A, B](expr: SchemaExpr[A, B]): SqlQuery = toParameterizedDynamic(expr.dynamic)
 
-  case SchemaExpr.Optic(optic) =>
-    SqlQuery(columnName(optic), Nil)
+private def toParameterizedDynamic(expr: DynamicSchemaExpr): SqlQuery = expr match {
 
-  case SchemaExpr.Literal(value, _) =>
-    SqlQuery("?", List(value))
+  case DynamicSchemaExpr.Select(path) =>
+    SqlQuery(columnName(path), Nil)
 
-  case SchemaExpr.Relational(left, right, op) =>
-    val l = toParameterized(left)
-    val r = toParameterized(right)
+  case DynamicSchemaExpr.Literal(value) =>
+    val param = value match {
+      case DynamicValue.Primitive(pv) => pv match {
+        case PrimitiveValue.String(s)     => s
+        case PrimitiveValue.Boolean(b)    => b
+        case PrimitiveValue.Int(n)        => n
+        case PrimitiveValue.Long(n)       => n
+        case PrimitiveValue.Double(n)     => n
+        case PrimitiveValue.Float(n)      => n
+        case PrimitiveValue.Short(n)      => n
+        case PrimitiveValue.Byte(n)       => n
+        case PrimitiveValue.BigInt(n)     => n
+        case PrimitiveValue.BigDecimal(n) => n
+        case PrimitiveValue.Char(c)       => c
+        case other                        => other.toString
+      }
+      case other => other.toString
+    }
+    SqlQuery("?", List(param))
+
+  case DynamicSchemaExpr.Relational(left, right, op) =>
+    val l = toParameterizedDynamic(left); val r = toParameterizedDynamic(right)
     val sqlOp = op match {
-      case SchemaExpr.RelationalOperator.Equal              => "="
-      case SchemaExpr.RelationalOperator.NotEqual           => "<>"
-      case SchemaExpr.RelationalOperator.LessThan           => "<"
-      case SchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
-      case SchemaExpr.RelationalOperator.GreaterThan        => ">"
-      case SchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
+      case DynamicSchemaExpr.RelationalOperator.Equal              => "="
+      case DynamicSchemaExpr.RelationalOperator.NotEqual           => "<>"
+      case DynamicSchemaExpr.RelationalOperator.LessThan           => "<"
+      case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
+      case DynamicSchemaExpr.RelationalOperator.GreaterThan        => ">"
+      case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
     }
     SqlQuery(s"(${l.sql} $sqlOp ${r.sql})", l.params ++ r.params)
 
-  case SchemaExpr.Logical(left, right, op) =>
-    val l = toParameterized(left)
-    val r = toParameterized(right)
+  case DynamicSchemaExpr.Logical(left, right, op) =>
+    val l = toParameterizedDynamic(left); val r = toParameterizedDynamic(right)
     val sqlOp = op match {
-      case SchemaExpr.LogicalOperator.And => "AND"
-      case SchemaExpr.LogicalOperator.Or  => "OR"
+      case DynamicSchemaExpr.LogicalOperator.And => "AND"
+      case DynamicSchemaExpr.LogicalOperator.Or  => "OR"
     }
     SqlQuery(s"(${l.sql} $sqlOp ${r.sql})", l.params ++ r.params)
 
-  case SchemaExpr.Not(inner) =>
-    val i = toParameterized(inner)
+  case DynamicSchemaExpr.Not(inner) =>
+    val i = toParameterizedDynamic(inner)
     SqlQuery(s"NOT (${i.sql})", i.params)
 
-  case SchemaExpr.Arithmetic(left, right, op, _) =>
-    val l = toParameterized(left)
-    val r = toParameterized(right)
+  case DynamicSchemaExpr.Arithmetic(left, right, op, _) =>
+    val l = toParameterizedDynamic(left); val r = toParameterizedDynamic(right)
     val sqlOp = op match {
-      case SchemaExpr.ArithmeticOperator.Add      => "+"
-      case SchemaExpr.ArithmeticOperator.Subtract => "-"
-      case SchemaExpr.ArithmeticOperator.Multiply => "*"
+      case DynamicSchemaExpr.ArithmeticOperator.Add      => "+"
+      case DynamicSchemaExpr.ArithmeticOperator.Subtract => "-"
+      case DynamicSchemaExpr.ArithmeticOperator.Multiply => "*"
+      case _                                             => "?"
     }
     SqlQuery(s"(${l.sql} $sqlOp ${r.sql})", l.params ++ r.params)
 
-  case SchemaExpr.StringConcat(left, right) =>
-    val l = toParameterized(left)
-    val r = toParameterized(right)
+  case DynamicSchemaExpr.StringConcat(left, right) =>
+    val l = toParameterizedDynamic(left); val r = toParameterizedDynamic(right)
     SqlQuery(s"CONCAT(${l.sql}, ${r.sql})", l.params ++ r.params)
 
-  case SchemaExpr.StringRegexMatch(regex, string) =>
-    val s = toParameterized(string)
-    val r = toParameterized(regex)
+  case DynamicSchemaExpr.StringRegexMatch(regex, string) =>
+    val s = toParameterizedDynamic(string); val r = toParameterizedDynamic(regex)
     SqlQuery(s"(${s.sql} LIKE ${r.sql})", s.params ++ r.params)
 
-  case SchemaExpr.StringLength(string) =>
-    val s = toParameterized(string)
+  case DynamicSchemaExpr.StringLength(string) =>
+    val s = toParameterizedDynamic(string)
     SqlQuery(s"LENGTH(${s.sql})", s.params)
+
+  case _ => SqlQuery("?", Nil)
 }
 ```
 
@@ -526,90 +559,128 @@ object Product extends CompanionOptics[Product] {
 def columnName(optic: zio.blocks.schema.Optic[?, ?]): String =
   optic.toDynamic.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
 
-def sqlLiteral(value: Any): String = value match {
-  case s: String  => s"'${s.replace("'", "''")}'"
-  case b: Boolean => if (b) "TRUE" else "FALSE"
-  case n: Number  => n.toString
-  case other      => other.toString
+def columnName(path: DynamicOptic): String =
+  path.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
+
+def sqlLiteralDV(dv: DynamicValue): String = dv match {
+  case DynamicValue.Primitive(pv) =>
+    pv match {
+      case PrimitiveValue.String(s)  => s"'${s.replace("'", "''")}'"
+      case PrimitiveValue.Boolean(b) => if (b) "TRUE" else "FALSE"
+      case PrimitiveValue.Int(n)     => n.toString
+      case PrimitiveValue.Long(n)    => n.toString
+      case PrimitiveValue.Double(n)  => n.toString
+      case PrimitiveValue.Float(n)   => n.toString
+      case PrimitiveValue.Short(n)   => n.toString
+      case PrimitiveValue.Byte(n)    => n.toString
+      case other                     => other.toString
+    }
+  case other => other.toString
 }
 
-def toSql[A, B](expr: SchemaExpr[A, B]): String = expr match {
-  case SchemaExpr.Optic(optic)                    => columnName(optic)
-  case SchemaExpr.Literal(value, _)               => sqlLiteral(value)
-  case SchemaExpr.Relational(left, right, op) =>
+def toSql[A, B](expr: SchemaExpr[A, B]): String = toSqlDynamic(expr.dynamic)
+
+private def toSqlDynamic(expr: DynamicSchemaExpr): String = expr match {
+  case DynamicSchemaExpr.Select(path)              => columnName(path)
+  case DynamicSchemaExpr.Literal(value)            => sqlLiteralDV(value)
+  case DynamicSchemaExpr.Relational(left, right, op) =>
     val sqlOp = op match {
-      case SchemaExpr.RelationalOperator.Equal              => "="
-      case SchemaExpr.RelationalOperator.NotEqual           => "<>"
-      case SchemaExpr.RelationalOperator.LessThan           => "<"
-      case SchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
-      case SchemaExpr.RelationalOperator.GreaterThan        => ">"
-      case SchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
+      case DynamicSchemaExpr.RelationalOperator.Equal              => "="
+      case DynamicSchemaExpr.RelationalOperator.NotEqual           => "<>"
+      case DynamicSchemaExpr.RelationalOperator.LessThan           => "<"
+      case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
+      case DynamicSchemaExpr.RelationalOperator.GreaterThan        => ">"
+      case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
     }
-    s"(${toSql(left)} $sqlOp ${toSql(right)})"
-  case SchemaExpr.Logical(left, right, op) =>
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.Logical(left, right, op) =>
     val sqlOp = op match {
-      case SchemaExpr.LogicalOperator.And => "AND"
-      case SchemaExpr.LogicalOperator.Or  => "OR"
+      case DynamicSchemaExpr.LogicalOperator.And => "AND"
+      case DynamicSchemaExpr.LogicalOperator.Or  => "OR"
     }
-    s"(${toSql(left)} $sqlOp ${toSql(right)})"
-  case SchemaExpr.Not(inner)                      => s"NOT (${toSql(inner)})"
-  case SchemaExpr.Arithmetic(left, right, op, _) =>
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.Not(inner)                      => s"NOT (${toSqlDynamic(inner)})"
+  case DynamicSchemaExpr.Arithmetic(left, right, op, _) =>
     val sqlOp = op match {
-      case SchemaExpr.ArithmeticOperator.Add      => "+"
-      case SchemaExpr.ArithmeticOperator.Subtract => "-"
-      case SchemaExpr.ArithmeticOperator.Multiply => "*"
+      case DynamicSchemaExpr.ArithmeticOperator.Add      => "+"
+      case DynamicSchemaExpr.ArithmeticOperator.Subtract => "-"
+      case DynamicSchemaExpr.ArithmeticOperator.Multiply => "*"
+      case _                                             => "?"
     }
-    s"(${toSql(left)} $sqlOp ${toSql(right)})"
-  case SchemaExpr.StringConcat(left, right)       => s"CONCAT(${toSql(left)}, ${toSql(right)})"
-  case SchemaExpr.StringRegexMatch(regex, string) => s"(${toSql(string)} LIKE ${toSql(regex)})"
-  case SchemaExpr.StringLength(string)            => s"LENGTH(${toSql(string)})"
+    s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.StringConcat(left, right)       => s"CONCAT(${toSqlDynamic(left)}, ${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.StringRegexMatch(regex, string) => s"(${toSqlDynamic(string)} LIKE ${toSqlDynamic(regex)})"
+  case DynamicSchemaExpr.StringLength(string)            => s"LENGTH(${toSqlDynamic(string)})"
+  case _                                                 => "?"
 }
 
 // --- Parameterized queries ---
 
 case class SqlQuery(sql: String, params: List[Any])
 
-def toParameterized[A, B](expr: SchemaExpr[A, B]): SqlQuery = expr match {
-  case SchemaExpr.Optic(optic)      => SqlQuery(columnName(optic), Nil)
-  case SchemaExpr.Literal(value, _) => SqlQuery("?", List(value))
-  case SchemaExpr.Relational(left, right, op) =>
-    val l = toParameterized(left); val r = toParameterized(right)
+def toParameterized[A, B](expr: SchemaExpr[A, B]): SqlQuery = toParameterizedDynamic(expr.dynamic)
+
+private def toParameterizedDynamic(expr: DynamicSchemaExpr): SqlQuery = expr match {
+  case DynamicSchemaExpr.Select(path)   => SqlQuery(columnName(path), Nil)
+  case DynamicSchemaExpr.Literal(value) =>
+    val param = value match {
+      case DynamicValue.Primitive(pv) => pv match {
+        case PrimitiveValue.String(s)     => s
+        case PrimitiveValue.Boolean(b)    => b
+        case PrimitiveValue.Int(n)        => n
+        case PrimitiveValue.Long(n)       => n
+        case PrimitiveValue.Double(n)     => n
+        case PrimitiveValue.Float(n)      => n
+        case PrimitiveValue.Short(n)      => n
+        case PrimitiveValue.Byte(n)       => n
+        case PrimitiveValue.BigInt(n)     => n
+        case PrimitiveValue.BigDecimal(n) => n
+        case PrimitiveValue.Char(c)       => c
+        case other                        => other.toString
+      }
+      case other => other.toString
+    }
+    SqlQuery("?", List(param))
+  case DynamicSchemaExpr.Relational(left, right, op) =>
+    val l = toParameterizedDynamic(left); val r = toParameterizedDynamic(right)
     val sqlOp = op match {
-      case SchemaExpr.RelationalOperator.Equal              => "="
-      case SchemaExpr.RelationalOperator.NotEqual           => "<>"
-      case SchemaExpr.RelationalOperator.LessThan           => "<"
-      case SchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
-      case SchemaExpr.RelationalOperator.GreaterThan        => ">"
-      case SchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
+      case DynamicSchemaExpr.RelationalOperator.Equal              => "="
+      case DynamicSchemaExpr.RelationalOperator.NotEqual           => "<>"
+      case DynamicSchemaExpr.RelationalOperator.LessThan           => "<"
+      case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
+      case DynamicSchemaExpr.RelationalOperator.GreaterThan        => ">"
+      case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
     }
     SqlQuery(s"(${l.sql} $sqlOp ${r.sql})", l.params ++ r.params)
-  case SchemaExpr.Logical(left, right, op) =>
-    val l = toParameterized(left); val r = toParameterized(right)
+  case DynamicSchemaExpr.Logical(left, right, op) =>
+    val l = toParameterizedDynamic(left); val r = toParameterizedDynamic(right)
     val sqlOp = op match {
-      case SchemaExpr.LogicalOperator.And => "AND"
-      case SchemaExpr.LogicalOperator.Or  => "OR"
+      case DynamicSchemaExpr.LogicalOperator.And => "AND"
+      case DynamicSchemaExpr.LogicalOperator.Or  => "OR"
     }
     SqlQuery(s"(${l.sql} $sqlOp ${r.sql})", l.params ++ r.params)
-  case SchemaExpr.Not(inner) =>
-    val i = toParameterized(inner)
+  case DynamicSchemaExpr.Not(inner) =>
+    val i = toParameterizedDynamic(inner)
     SqlQuery(s"NOT (${i.sql})", i.params)
-  case SchemaExpr.Arithmetic(left, right, op, _) =>
-    val l = toParameterized(left); val r = toParameterized(right)
+  case DynamicSchemaExpr.Arithmetic(left, right, op, _) =>
+    val l = toParameterizedDynamic(left); val r = toParameterizedDynamic(right)
     val sqlOp = op match {
-      case SchemaExpr.ArithmeticOperator.Add      => "+"
-      case SchemaExpr.ArithmeticOperator.Subtract => "-"
-      case SchemaExpr.ArithmeticOperator.Multiply => "*"
+      case DynamicSchemaExpr.ArithmeticOperator.Add      => "+"
+      case DynamicSchemaExpr.ArithmeticOperator.Subtract => "-"
+      case DynamicSchemaExpr.ArithmeticOperator.Multiply => "*"
+      case _                                             => "?"
     }
     SqlQuery(s"(${l.sql} $sqlOp ${r.sql})", l.params ++ r.params)
-  case SchemaExpr.StringConcat(left, right) =>
-    val l = toParameterized(left); val r = toParameterized(right)
+  case DynamicSchemaExpr.StringConcat(left, right) =>
+    val l = toParameterizedDynamic(left); val r = toParameterizedDynamic(right)
     SqlQuery(s"CONCAT(${l.sql}, ${r.sql})", l.params ++ r.params)
-  case SchemaExpr.StringRegexMatch(regex, string) =>
-    val s = toParameterized(string); val r = toParameterized(regex)
+  case DynamicSchemaExpr.StringRegexMatch(regex, string) =>
+    val s = toParameterizedDynamic(string); val r = toParameterizedDynamic(regex)
     SqlQuery(s"(${s.sql} LIKE ${r.sql})", s.params ++ r.params)
-  case SchemaExpr.StringLength(string) =>
-    val s = toParameterized(string)
+  case DynamicSchemaExpr.StringLength(string) =>
+    val s = toParameterizedDynamic(string)
     SqlQuery(s"LENGTH(${s.sql})", s.params)
+  case _ => SqlQuery("?", Nil)
 }
 
 // --- Complete SELECT builder ---
@@ -654,4 +725,4 @@ println(toSql(Product.price * 0.9))
 - **[Optics Reference](../reference/schema/optics.md)** -- Lens, Prism, Optional, and Traversal
 - **[DynamicOptic Reference](../reference/schema/dynamic-optic.md)** -- Runtime optic paths for programmatic field extraction
 
-The interpreter pattern shown here extends naturally to other query targets. Because `SchemaExpr` is a sealed trait and `DynamicOptic` carries full path metadata, you can write interpreters for MongoDB filters, Elasticsearch queries, GraphQL filters, or any other query language using the same approach: pattern match on the AST, map operators, and extract field names from optic paths.
+The interpreter pattern shown here extends naturally to other query targets. Because `SchemaExpr` wraps a `DynamicSchemaExpr` sealed trait and `DynamicOptic` carries full path metadata, you can write interpreters for MongoDB filters, Elasticsearch queries, GraphQL filters, or any other query language using the same approach: access `.dynamic`, pattern match on the AST, map operators, and extract field names from optic paths.

--- a/docs/guides/query-dsl-sql.md
+++ b/docs/guides/query-dsl-sql.md
@@ -9,7 +9,7 @@ This is Part 2 of the Query DSL series. [Part 1](./query-dsl-reified-optics.md) 
 
 **What we'll cover:**
 
-- Interpreting `SchemaExpr` via its `DynamicSchemaExpr` representation using pattern matching
+- Interpreting `SchemaExpr` while keeping the typed API at the boundary
 - Extracting column names from optic paths using `DynamicOptic`
 - Translating relational, logical, arithmetic, and string operations to SQL
 - Building complete `SELECT ... FROM ... WHERE ...` statements
@@ -36,7 +36,7 @@ def findProducts(category: Option[String], maxPrice: Option[Double], inStock: Op
 
 This is fragile, repetitive, and vulnerable to SQL injection. Every new query shape requires new string-building code. The query logic is duplicated -- once as a `SchemaExpr` for in-memory filtering, and again as hand-written SQL for the database.
 
-`SchemaExpr` wraps a `DynamicSchemaExpr` — a sealed trait whose cases represent the full expression AST. We can write a single interpreter that pattern-matches on this AST to translate *any* query expression into SQL. Write the interpreter once, and every query you build with the Part 1 DSL automatically gets a SQL translation.
+`SchemaExpr` is the user-facing query API. Internally it wraps a `DynamicSchemaExpr` — a sealed trait whose cases represent the full expression AST. That means we can write a single interpreter that accepts `SchemaExpr`, then crosses into the dynamic AST internally to translate *any* query expression into SQL. Write the interpreter once, and every query you build with the Part 1 DSL automatically gets a SQL translation.
 
 ## Prerequisites
 
@@ -74,23 +74,33 @@ object Product extends CompanionOptics[Product] {
 }
 ```
 
-## The SchemaExpr Structure
+## The SchemaExpr API
 
-Before we build the interpreter, let's understand the structure we are interpreting. `SchemaExpr[A, B]` is a case class that wraps a `DynamicSchemaExpr` — a sealed trait with cases representing the expression AST:
+Before we build the interpreter, keep the API boundary in mind: application code builds `SchemaExpr[A, B]` values, while interpreter code may inspect the underlying `DynamicSchemaExpr` through `.dynamic`.
 
 ```
-SchemaExpr[A, B]
-└── .dynamic: DynamicSchemaExpr
-    ├── Select(path: DynamicOptic)                         -- a field reference
-    ├── Literal(value: DynamicValue)                       -- a constant value
-    ├── Relational(left, right, op: RelationalOperator)    -- comparison operations
-    ├── Logical(left, right, op: LogicalOperator)          -- boolean operations
-    ├── Not(expr)                                          -- boolean negation
-    ├── Arithmetic(left, right, op, numericTag)            -- numeric operations
-    ├── StringConcat(left, right)                          -- string concatenation
-    ├── StringRegexMatch(regex, string)                    -- regex pattern matching
-    └── StringLength(string)                               -- string length calculation
+SchemaExpr[A, B]                        -- user-facing, typed API
+└── .dynamic: DynamicSchemaExpr         -- interpreter/runtime boundary
+    ├── Select(path: DynamicOptic)      -- field reference
+    ├── Literal(value: DynamicValue)    -- constant value
+    ├── Relational(left, right, op)     -- comparisons
+    ├── Logical(left, right, op)        -- boolean operators
+    ├── Not(expr)                       -- negation
+    ├── Arithmetic(left, right, op, _)  -- numeric operators
+    ├── StringConcat(left, right)       -- string concatenation
+    ├── StringRegexMatch(regex, string) -- pattern matching
+    └── StringLength(string)            -- string length
+```
 
+Most users never need to construct `DynamicSchemaExpr` directly. The normal workflow is:
+
+1. Build a typed `SchemaExpr` with optics and operators.
+2. Pass that `SchemaExpr` to your interpreter.
+3. Let the interpreter read `.dynamic` internally.
+
+The dynamic cases are still worth understanding because they are what your interpreter will pattern-match on:
+
+```
 RelationalOperator
 ├── LessThan
 ├── GreaterThan
@@ -109,7 +119,7 @@ ArithmeticOperator
 └── Multiply
 ```
 
-Each case carries enough information to produce SQL: `Select` nodes carry field paths, `Literal` nodes carry values, and operator nodes carry the operation type. Our interpreter walks this tree and emits SQL fragments.
+Each dynamic case carries enough information to produce SQL: `Select` nodes carry field paths, `Literal` nodes carry values, and operator nodes carry the operation type. Our interpreter walks this tree and emits SQL fragments.
 
 ## Extracting Column Names from Optics
 
@@ -135,7 +145,7 @@ columnName(Product.category)
 
 ## Translating Literals to SQL
 
-Literal values in `DynamicSchemaExpr` are stored as `DynamicValue`. We need a function to format them as SQL:
+Once we cross the interpreter boundary, literal values appear as `DynamicValue`. We need a function to format them as SQL:
 
 ```scala mdoc:silent
 def sqlLiteralDV(dv: DynamicValue): String = dv match {
@@ -157,7 +167,7 @@ def sqlLiteralDV(dv: DynamicValue): String = dv match {
 
 ## Building the SQL Interpreter
 
-Now we build the core interpreter. `SchemaExpr` wraps a `DynamicSchemaExpr`, so we access it via `.dynamic` and pattern-match on each case:
+Now we build the core interpreter. The public entry point accepts `SchemaExpr`; the internal helper does the `DynamicSchemaExpr` pattern matching:
 
 ```scala mdoc:silent
 def toSql[A, B](expr: SchemaExpr[A, B]): String = toSqlDynamic(expr.dynamic)
@@ -222,7 +232,7 @@ private def toSqlDynamic(expr: DynamicSchemaExpr): String = expr match {
 }
 ```
 
-The mapping from `DynamicSchemaExpr` to SQL is direct:
+The mapping from `DynamicSchemaExpr` to SQL is direct, but that dynamic matching stays inside the interpreter implementation:
 
 | DynamicSchemaExpr Case | SQL Output                           |
 |------------------------|--------------------------------------|

--- a/docs/guides/zio-schema-migration.md
+++ b/docs/guides/zio-schema-migration.md
@@ -735,11 +735,15 @@ dynSchema.conforms(value)         // true
 dynSchema.check(value)            // None (no error)
 ```
 
-:::warning
-ZIO Schema's `Migration` system for schema-to-schema migration (i.e., automatically migrating values from one version of a type to another) is **not yet available** in ZIO Blocks Schema. The `schema.migrate[B](newSchema)` and `schema.coerce[B](newSchema)` methods do not exist. If your application relies on schema migration, you have two options:
+:::info
+ZIO Blocks Schema now includes an explicit migration API for evolving values between schema versions. The entry point is [`Migration.newBuilder[A, B]`](../reference/schema/migration), which builds a typed `Migration[A, B]` backed by a serializable `DynamicMigration`.
 
-1. Implement migration logic manually using `DynamicValue` transformations and `DynamicSchema` for validation.
-2. Wait for schema migration support to be added to ZIO Blocks Schema (it is on the roadmap).
+This is a different model from ZIO Schema's `schema.migrate[B](newSchema)` / `schema.coerce[B](newSchema)` APIs:
+
+1. Build a migration explicitly with operations like `addField`, `dropField`, `renameField`, `changeFieldType`, and `migrateField`.
+2. Apply the resulting `Migration[A, B]` to typed values, or inspect/transport the underlying `DynamicMigration`.
+
+Use this when you want structural schema evolution as first-class data rather than implicit derivation.
 :::
 
 ### Schema Serialization
@@ -1127,7 +1131,7 @@ The following ZIO Schema features do not yet have equivalents in ZIO Blocks Sche
 | Feature | Status |
 |---|---|
 | `Schema.fail` / fail schemas | Not available |
-| `Schema.migrate[B]` / `Schema.coerce[B]` | Not available — schema migration is planned |
+| `Schema.migrate[B]` / `Schema.coerce[B]` | Replaced by explicit [`Migration.newBuilder[A, B]`](../reference/schema/migration) |
 | `MetaSchema` / schema serialization | Partial — `DynamicSchema` covers structural inspection; full schema round-trip is not available |
 | `Fallback[A, B]` schema | Not available |
 | `NonEmptyChunk` / `NonEmptyMap` schemas | Not available — use wrapper types |

--- a/docs/reference/schema/migration.md
+++ b/docs/reference/schema/migration.md
@@ -143,7 +143,7 @@ val combined: Migration[PersonV1, PersonV3] = migration ++ addCity
 - `transformField(_.from, _.to, expr)`
 - `mandateField(_.optionalSource, _.target, default)`
 - `optionalizeField(_.source, _.optionalTarget)`
-- `changeFieldType(_.source, _.target, expr)`
+- `changeFieldType(_.source, expr)`
 
 ```scala mdoc:compile-only
 import zio.blocks.schema._
@@ -164,7 +164,7 @@ val userMigration = Migration
   .newBuilder[UserV1, UserV2]
   .renameField(_.firstName, _.fullName)
   .mandateField(_.nickname, _.nickname, SchemaExpr.literal("anonymous"))
-  .changeFieldType(_.age, _.age, SchemaExpr.literal("30"))
+  .changeFieldType(_.age, SchemaExpr.literal("30"))
   .build
 ```
 

--- a/docs/reference/schema/migration.md
+++ b/docs/reference/schema/migration.md
@@ -1,0 +1,297 @@
+---
+id: migration
+title: "Migration"
+---
+
+`Migration[A, B]` is ZIO Blocks Schema's typed API for evolving data from one schema version to another. It wraps a fully serializable [`DynamicMigration`](#dynamicmigration) core with typed source and target schemas, giving you a builder-based workflow for adding fields, dropping fields, renaming fields, changing types, migrating nested values, transforming collections and maps, and composing migrations.
+
+## Overview
+
+The migration system is split into three layers:
+
+- **`Migration[A, B]`** — typed migration between source type `A` and target type `B`
+- **`DynamicMigration`** — pure runtime representation built from serializable actions
+- **`MigrationBuilder[A, B, Changeset]`** — macro-validated builder that accumulates actions and checks that the target shape is fully handled before `build`
+
+```
+Migration[A, B]
+  ├── sourceSchema: Schema[A]
+  ├── targetSchema: Schema[B]
+  └── dynamicMigration: DynamicMigration
+         └── actions: Chunk[MigrationAction]
+                ├── AddField / DropField / RenameField
+                ├── TransformField / ChangeFieldType
+                ├── MandateField / OptionalizeField
+                ├── RenameCase / TransformCase
+                ├── MigrateField
+                ├── TransformElements / TransformKeys / TransformValues
+                └── Irreversible
+```
+
+`Migration` is the user-facing entry point. `DynamicMigration` is the transport-friendly representation you can inspect, serialize, or apply dynamically.
+
+## Creating a Migration
+
+The normal entry point is `Migration.newBuilder[A, B]`:
+
+```scala mdoc:compile-only
+import zio.blocks.schema._
+import zio.blocks.schema.migration._
+
+case class PersonV1(name: String)
+case class PersonV2(name: String, age: Int)
+
+object PersonV1 {
+  implicit val schema: Schema[PersonV1] = Schema.derived
+}
+
+object PersonV2 {
+  implicit val schema: Schema[PersonV2] = Schema.derived
+}
+
+val migration: Migration[PersonV1, PersonV2] =
+  Migration
+    .newBuilder[PersonV1, PersonV2]
+    .addField(_.age, SchemaExpr.literal(0))
+    .build
+```
+
+Applying the migration converts the source value to [`DynamicValue`](./dynamic-value.md), applies the dynamic actions, then converts the result back into the target type:
+
+```scala mdoc:compile-only
+import zio.blocks.schema._
+import zio.blocks.schema.migration._
+
+case class PersonV1(name: String)
+case class PersonV2(name: String, age: Int)
+
+object PersonV1 {
+  implicit val schema: Schema[PersonV1] = Schema.derived
+}
+
+object PersonV2 {
+  implicit val schema: Schema[PersonV2] = Schema.derived
+}
+
+val migration = Migration
+  .newBuilder[PersonV1, PersonV2]
+  .addField(_.age, SchemaExpr.literal(0))
+  .build
+
+val result = migration(PersonV1("Alice"))
+// Right(PersonV2("Alice", 0))
+```
+
+## Core Operations
+
+### `Migration#apply`
+
+Transforms a typed value:
+
+```scala
+def apply(value: A): Either[SchemaError, B]
+```
+
+### `Migration#reverse`
+
+Returns the **structural reverse** of the migration:
+
+```scala
+def reverse: Migration[B, A]
+```
+
+This is best-effort at runtime. Actions that lose information (for example `TransformField`, `ChangeFieldType`, `OptionalizeField`, or collection-wide transforms) reverse to `Irreversible`, which causes reverse execution to fail with a descriptive error instead of silently fabricating data.
+
+### Composition
+
+Migrations compose with `++` or `andThen`:
+
+```scala mdoc:compile-only
+import zio.blocks.schema._
+import zio.blocks.schema.migration._
+
+case class PersonV1(name: String)
+case class PersonV2(name: String, age: Int)
+case class PersonV3(name: String, age: Int, city: String)
+
+object PersonV1 { implicit val schema: Schema[PersonV1] = Schema.derived }
+object PersonV2 { implicit val schema: Schema[PersonV2] = Schema.derived }
+object PersonV3 { implicit val schema: Schema[PersonV3] = Schema.derived }
+
+val migration = Migration
+  .newBuilder[PersonV1, PersonV2]
+  .addField(_.age, SchemaExpr.literal(0))
+  .build
+
+val addCity = Migration
+  .newBuilder[PersonV2, PersonV3]
+  .addField(_.city, SchemaExpr.literal(""))
+  .build
+
+val combined: Migration[PersonV1, PersonV3] = migration ++ addCity
+```
+
+## Builder Operations
+
+`MigrationBuilder` uses selector expressions such as `_.field`, `_.nested.field`, `_.items.each`, and `_.data.eachValue`. The builder's third type parameter, `Changeset`, tracks which operations have already been applied so `build` can validate completeness.
+
+### Record operations
+
+- `addField(_.target, default)`
+- `dropField(_.source, defaultForReverse)`
+- `renameField(_.from, _.to)`
+- `transformField(_.from, _.to, expr)`
+- `mandateField(_.optionalSource, _.target, default)`
+- `optionalizeField(_.source, _.optionalTarget)`
+- `changeFieldType(_.source, _.target, expr)`
+
+```scala mdoc:compile-only
+import zio.blocks.schema._
+import zio.blocks.schema.migration._
+
+case class UserV1(firstName: String, nickname: Option[String], age: Int)
+case class UserV2(fullName: String, nickname: String, age: String)
+
+object UserV1 {
+  implicit val schema: Schema[UserV1] = Schema.derived
+}
+
+object UserV2 {
+  implicit val schema: Schema[UserV2] = Schema.derived
+}
+
+val userMigration = Migration
+  .newBuilder[UserV1, UserV2]
+  .renameField(_.firstName, _.fullName)
+  .mandateField(_.nickname, _.nickname, SchemaExpr.literal("anonymous"))
+  .changeFieldType(_.age, _.age, SchemaExpr.literal("30"))
+  .build
+```
+
+`transformField` and `changeFieldType` evaluate their `SchemaExpr` against the currently focused field value, not the entire root record. In practice, that means the expression should be written in terms of the value being replaced.
+
+### Nested migration with `migrateField`
+
+When a nested value has its own migration, use `migrateField`:
+
+```scala mdoc:compile-only
+import zio.blocks.schema._
+import zio.blocks.schema.migration._
+
+case class AddressV1(street: String, city: String)
+case class AddressV2(street: String, city: String, zip: String)
+case class PersonWithAddressV1(name: String, address: AddressV1)
+case class PersonWithAddressV2(name: String, address: AddressV2)
+
+object AddressV1 { implicit val schema: Schema[AddressV1] = Schema.derived }
+object AddressV2 { implicit val schema: Schema[AddressV2] = Schema.derived }
+object PersonWithAddressV1 { implicit val schema: Schema[PersonWithAddressV1] = Schema.derived }
+object PersonWithAddressV2 { implicit val schema: Schema[PersonWithAddressV2] = Schema.derived }
+
+val addressMigration = Migration
+  .newBuilder[AddressV1, AddressV2]
+  .addField(_.zip, SchemaExpr.literal("00000"))
+  .build
+
+val personMigration = Migration
+  .newBuilder[PersonWithAddressV1, PersonWithAddressV2]
+  .migrateField(_.address, addressMigration)
+  .build
+```
+
+There is no `transformNested` builder method in the current API. Nested structural changes are expressed by building a migration for the nested type and applying it with `migrateField`.
+
+### Enum and collection operations
+
+- `renameCase(from, to)`
+- `transformCase(caseName)(...)`
+- `transformElements(_.items, expr)`
+- `transformKeys(_.data, expr)`
+- `transformValues(_.data, expr)`
+
+Collection and map transforms are map-like operations. The `SchemaExpr` is evaluated once per matched value:
+
+- `transformElements` evaluates against each collection element
+- `transformKeys` evaluates against each map key
+- `transformValues` evaluates against each map value
+
+For example, `transformElements(_.scores, expr)` runs `expr` separately for every element in `scores`, and `transformValues(_.metadata, expr)` runs it separately for every map value.
+
+## `build`
+
+```scala
+def build(using ev: MigrationComplete[A, B, Changeset]): Migration[A, B]
+```
+
+`build` runs macro validation. It checks that every field needed to transform `A` into `B` is either:
+
+- auto-mapped by identical source/target structure, or
+- explicitly handled by one of the builder operations
+
+If the migration is incomplete, the code fails to compile.
+
+This validated `build` step is the public completion path for `MigrationBuilder`. If you need unvalidated or dynamically assembled migrations, work at the `DynamicMigration` layer and wrap it with `Migration.fromDynamic`.
+
+## `DynamicMigration`
+
+`DynamicMigration` is the untyped runtime representation:
+
+```scala
+final case class DynamicMigration(actions: Chunk[MigrationAction]) {
+  def apply(value: DynamicValue): Either[SchemaError, DynamicValue]
+  def ++(that: DynamicMigration): DynamicMigration
+  def andThen(that: DynamicMigration): DynamicMigration
+  def reverse: DynamicMigration
+  def isEmpty: Boolean
+  def size: Int
+}
+```
+
+Use it when you need to inspect, serialize, or apply migrations without keeping the original Scala types around.
+
+## `MigrationAction`
+
+`MigrationAction` is the serializable ADT used by `DynamicMigration`.
+
+| Action | Purpose | Reverse behavior |
+|---|---|---|
+| `AddField` | add a field with a default expression | `DropField` |
+| `DropField` | remove a field | `AddField` using stored reverse default |
+| `RenameField` | rename a record field | structural inverse rename |
+| `TransformField` | replace a field by evaluating an expression against the current field value | `Irreversible` |
+| `MandateField` | convert `Option[A]` to `A` with default for `None` | `OptionalizeField` |
+| `OptionalizeField` | wrap a value in `Some` | `Irreversible` |
+| `ChangeFieldType` | replace a field with a converted value computed from the current field value | `Irreversible` |
+| `RenameCase` | rename enum case | inverse rename |
+| `TransformCase` | run actions inside a specific case | reverse inner actions in reverse order |
+| `MigrateField` | apply a nested `DynamicMigration` to a field | reverse nested migration |
+| `TransformElements` | replace each collection element by evaluating the expression on that element | `Irreversible` |
+| `TransformKeys` | replace each map key by evaluating the expression on that key | `Irreversible` |
+| `TransformValues` | replace each map value by evaluating the expression on that value | `Irreversible` |
+| `Irreversible` | explicit non-invertible sentinel | itself |
+
+## Errors
+
+Migration execution returns [`SchemaError`](./schema-error.md), with migration-specific kinds including:
+
+- path not found
+- type mismatch
+- missing default
+- transform failure
+- field/case not found
+- invalid value
+- mandate failure
+
+Errors carry a [`DynamicOptic`](./dynamic-optic.md) path so failures can be traced to the precise field or nested location that failed.
+
+## Relationship to Other Schema-Evolution APIs
+
+`Into` and `As` derive structural conversions automatically. `Migration` is lower-level and more explicit:
+
+- use [`Into`](./schema-evolution/into.md) for one-way derived schema evolution
+- use [`As`](./schema-evolution/as.md) for bidirectional derived evolution
+- use `Migration` when you need explicit, inspectable, serializable transformation steps
+
+:::tip
+If you want a practical migration walkthrough rather than a reference, start with [`MigrationSpec`](https://github.com/zio/zio-blocks/blob/main/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala) and [`DynamicMigrationSpec`](https://github.com/zio/zio-blocks/blob/main/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala) in the repository until a dedicated migration guide lands.
+:::

--- a/docs/reference/schema/optics.md
+++ b/docs/reference/schema/optics.md
@@ -148,7 +148,7 @@ val updatedAddress: Address = Address.street.replace(address, "456 Elm St")
 
 While manual lens construction gives you fine-grained control, ZIO Blocks provides macro-based derivation as the **preferred approach** for creating lenses.
 
-The `optic` macro inside the `CompanionOptics` trait creates a lens using intuitive selector syntax that mirrors standard Scala field access:
+The `optic` macro inside the `CompanionOptics` trait creates a lens using intuitive selector syntax that mirrors standard Scala field access. In the rest of the schema docs you may also see the symbolic `$(_.field)` form; it is the same optic-construction API presented with symbolic syntax instead of the named `optic(_.field)` helper.
 
 ```scala
 import zio.blocks.schema.optic

--- a/docs/reference/schema/schema-expr.md
+++ b/docs/reference/schema/schema-expr.md
@@ -3,7 +3,7 @@ id: schema-expr
 title: "SchemaExpr"
 ---
 
-`SchemaExpr[A, +B]` is a **schema-aware expression** that computes a result of type `B` from an input value of type `A`. The input type `A` must be fully described by a [`Schema`](./schema.md), and the expression is built from [optics](./optics.md), literal values, and operators. The fundamental operations are `eval` and `evalDynamic`.
+`SchemaExpr[A, B]` is a **schema-aware expression** that computes a result of type `B` from an input value of type `A`. The input type `A` must be fully described by a [`Schema`](./schema.md), and the expression is built from [optics](./optics.md), literal values, and operators. The fundamental operations are `eval` and `evalDynamic`.
 
 At runtime, `SchemaExpr` is a typed wrapper around `DynamicSchemaExpr`. The typed layer carries the input and output schemas, while the dynamic layer stores the serializable AST. This split is why you will sometimes see both `.dynamic` and `DynamicSchemaExpr` in advanced examples: `SchemaExpr` is the public typed API, and `DynamicSchemaExpr` is the untyped transport/runtime form underneath it.
 
@@ -11,10 +11,14 @@ At runtime, `SchemaExpr` is a typed wrapper around `DynamicSchemaExpr`. The type
 - represents expressions as a reified AST, enabling introspection and serialization
 - supports relational (`===`, `>`, `<`, `>=`, `<=`, `!=`), logical (`&&`, `||`, `!`), arithmetic (`+`, `-`, `*`), and string (`concat`, `matches`, `length`) operations
 - evaluates to `Either[OpticCheck, Seq[B]]`, handling failures and multi-valued results from traversals
-- is covariant in `B`, the output type
+- preserves both input and output schemas at the type level
 
 ```scala
-sealed trait SchemaExpr[A, +B] {
+final case class SchemaExpr[A, B](
+  dynamic: DynamicSchemaExpr,
+  inputSchema: Schema[A],
+  outputSchema: Schema[B]
+) {
   def eval(input: A): Either[OpticCheck, Seq[B]]
   def evalDynamic(input: A): Either[OpticCheck, Seq[DynamicValue]]
 }
@@ -248,7 +252,7 @@ If you need the raw dynamic form for serialization, transport, or custom interpr
 Evaluates the expression against an input value, returning the typed result. The result is a `Seq[B]` because traversal-based expressions can produce multiple values.
 
 ```scala
-trait SchemaExpr[A, +B] {
+trait SchemaExprLike[A, B] {
   def eval(input: A): Either[OpticCheck, Seq[B]]
 }
 ```
@@ -284,7 +288,7 @@ When an expression wraps a `Traversal` optic, `eval` returns multiple values —
 Like `eval`, but converts the result to [`DynamicValue`](./dynamic-value.md) instances. This is useful for serialization or when working with schema-agnostic code.
 
 ```scala
-trait SchemaExpr[A, +B] {
+trait SchemaExprLike[A, B] {
   def evalDynamic(input: A): Either[OpticCheck, Seq[DynamicValue]]
 }
 ```
@@ -314,7 +318,7 @@ val result = nameExpr.evalDynamic(Person("Alice", 30))
 Combines two boolean-typed expressions with logical AND. Both operands must produce `Boolean` results.
 
 ```scala
-trait SchemaExpr[A, +B] {
+trait SchemaExprLike[A, B] {
   def &&[B2](that: SchemaExpr[A, B2])(implicit ev: B <:< Boolean, ev2: B2 =:= Boolean): SchemaExpr[A, Boolean]
 }
 ```
@@ -343,7 +347,7 @@ val result = isAdultAlice.eval(Person("Alice", 30))
 Combines two boolean-typed expressions with logical OR.
 
 ```scala
-trait SchemaExpr[A, +B] {
+trait SchemaExprLike[A, B] {
   def ||[B2](that: SchemaExpr[A, B2])(implicit ev: B <:< Boolean, ev2: B2 =:= Boolean): SchemaExpr[A, Boolean]
 }
 ```

--- a/docs/reference/schema/schema-expr.md
+++ b/docs/reference/schema/schema-expr.md
@@ -5,6 +5,8 @@ title: "SchemaExpr"
 
 `SchemaExpr[A, +B]` is a **schema-aware expression** that computes a result of type `B` from an input value of type `A`. The input type `A` must be fully described by a [`Schema`](./schema.md), and the expression is built from [optics](./optics.md), literal values, and operators. The fundamental operations are `eval` and `evalDynamic`.
 
+At runtime, `SchemaExpr` is a typed wrapper around `DynamicSchemaExpr`. The typed layer carries the input and output schemas, while the dynamic layer stores the serializable AST. This split is why you will sometimes see both `.dynamic` and `DynamicSchemaExpr` in advanced examples: `SchemaExpr` is the public typed API, and `DynamicSchemaExpr` is the untyped transport/runtime form underneath it.
+
 `SchemaExpr`:
 - represents expressions as a reified AST, enabling introspection and serialization
 - supports relational (`===`, `>`, `<`, `>=`, `<=`, `!=`), logical (`&&`, `||`, `!`), arithmetic (`+`, `-`, `*`), and string (`concat`, `matches`, `length`) operations
@@ -84,6 +86,12 @@ Supported Scala versions: 2.13.x and 3.x.
 ## Creating Instances
 
 `SchemaExpr` instances are typically created through **operator syntax on optics** rather than by constructing AST nodes directly. Each operator on `Optic[S, A]` returns a `SchemaExpr[S, B]`.
+
+There are three common construction styles:
+
+- optic/operator syntax such as `Person.age >= 18`
+- literal expressions such as `SchemaExpr.literal[Person, Int](18)`
+- advanced direct construction when you intentionally need to work with the underlying dynamic AST
 
 ### Via Relational Operators on Optics
 
@@ -204,7 +212,7 @@ val adultOrAlice: SchemaExpr[Person, Boolean] = isAdult || isAlice
 
 ### Via Direct AST Construction
 
-For advanced use cases, we can construct `SchemaExpr` nodes directly:
+For advanced use cases, you can construct `SchemaExpr` values directly. In most application code, prefer optic/operator syntax or `SchemaExpr.literal` because they preserve the typed surface and are easier to read.
 
 ```scala mdoc:compile-only
 import zio.blocks.schema._
@@ -226,6 +234,10 @@ val comparison: SchemaExpr[Item, Boolean] = SchemaExpr.relational(
   SchemaExpr.RelationalOperator.GreaterThan
 )
 ```
+
+`SchemaExpr.literal` is the normal way to inject constants into an expression tree. It produces a typed `SchemaExpr[S, A]`, while storing the value internally as a `DynamicSchemaExpr.Literal`. That is usually what you want in user code, including migration builders.
+
+If you need the raw dynamic form for serialization, transport, or custom interpreters, use `.dynamic` on an existing `SchemaExpr` rather than constructing `DynamicSchemaExpr` directly unless you are working on expression internals.
 
 ## Core Operations
 
@@ -355,50 +367,43 @@ val result = isAdultOrAlice.eval(Person("Alice", 12))
 // Right(List(true)) — Alice, even though not adult
 ```
 
-## Subtypes
+## Structure
 
-`SchemaExpr` is a sealed trait with a rich set of case classes representing different expression nodes. These form an **expression AST** that can be inspected, serialized, or translated to other query languages.
+`SchemaExpr` is a typed wrapper. The actual expression AST lives in `DynamicSchemaExpr`, which is a sealed trait of serializable expression nodes. `SchemaExpr` adds the input and output schemas needed to convert between typed values and [`DynamicValue`](./dynamic-value.md).
 
-### Leaf Nodes
+### `DynamicSchemaExpr` leaf nodes
 
-#### `SchemaExpr.Literal`
+#### `DynamicSchemaExpr.Literal`
 
-A constant value that ignores the input and always produces the same result.
+A constant value represented directly as a `DynamicValue`.
 
 ```scala
-object SchemaExpr {
-  case class Literal[S, A](value: A, schema: Schema[A]) extends SchemaExpr[S, A]
+object DynamicSchemaExpr {
+  final case class Literal(value: DynamicValue) extends DynamicSchemaExpr
 }
 ```
 
-The `Literal#eval` always returns `Right(Seq(value))` regardless of the input. The `Literal#schema` parameter enables conversion to `DynamicValue` via `evalDynamic`.
+#### `DynamicSchemaExpr.Select`
 
-#### `SchemaExpr.Optic`
-
-Wraps an [`Optic[A, B]`](./optics.md) to extract values from the input. The behavior depends on the optic type:
+Selects values from the input using a [`DynamicOptic`](./dynamic-optic.md).
 
 ```scala
-object SchemaExpr {
-  case class Optic[A, B](optic: zio.blocks.schema.Optic[A, B]) extends SchemaExpr[A, B]
+object DynamicSchemaExpr {
+  final case class Select(path: DynamicOptic) extends DynamicSchemaExpr
 }
 ```
 
-| Optic Type  | `SchemaExpr.Optic#eval` Behavior                                                      |
-|-------------|---------------------------------------------------------------------------------------|
-| `Lens`      | Always succeeds with a single value                                                   |
-| `Prism`     | Succeeds if the input matches the expected case; otherwise returns `Left(OpticCheck)` |
-| `Optional`  | Succeeds if the value is present; otherwise returns `Left(OpticCheck)`                |
-| `Traversal` | Returns all elements; returns `Left(OpticCheck)` if the collection is empty           |
+`SchemaExpr.optic(...)` and optic operator syntax eventually produce `DynamicSchemaExpr.Select` nodes.
 
-### Unary Operations
+### Unary operations
 
-#### `SchemaExpr.Not`
+#### `DynamicSchemaExpr.Not`
 
 Negates a boolean expression.
 
 ```scala
-object SchemaExpr {
-  case class Not[A](expr: SchemaExpr[A, Boolean]) extends UnaryOp[A, Boolean](expr)
+object DynamicSchemaExpr {
+  final case class Not(expr: DynamicSchemaExpr) extends DynamicSchemaExpr
 }
 ```
 
@@ -421,21 +426,21 @@ val result = inactive.eval(User(active = true))
 // Right(List(false))
 ```
 
-### Binary Operations
+### Binary operations
 
-`Relational`, `Logical`, `Arithmetic`, and `StringConcat` extend `BinaryOp[A, B, C]`, which provides `left` and `right` sub-expressions. `StringRegexMatch` and `StringLength` extend `SchemaExpr` directly — see [Other Operations](#other-operations) below.
+`Relational`, `Logical`, `Arithmetic`, `Bitwise`, and the string binary operations are all represented as `DynamicSchemaExpr` nodes holding child expressions.
 
-#### `SchemaExpr.Relational`
+#### `DynamicSchemaExpr.Relational`
 
 Compares two expressions using a `RelationalOperator`. Returns a boolean result.
 
 ```scala
-object SchemaExpr {
-  case class Relational[A, B](
-    left: SchemaExpr[A, B],
-    right: SchemaExpr[A, B],
+object DynamicSchemaExpr {
+  final case class Relational(
+    left: DynamicSchemaExpr,
+    right: DynamicSchemaExpr,
     operator: RelationalOperator
-  ) extends SchemaExpr[A, Boolean]
+  ) extends DynamicSchemaExpr
 }
 ```
 
@@ -454,17 +459,17 @@ The available `RelationalOperator` values are:
 Equality and inequality (`===`, `!=`) compare values directly. Ordering operators (`<`, `<=`, `>`, `>=`) compare via `DynamicValue` ordering internally.
 :::
 
-#### `SchemaExpr.Logical`
+#### `DynamicSchemaExpr.Logical`
 
 Combines two boolean expressions with a `LogicalOperator`.
 
 ```scala
-object SchemaExpr {
-  case class Logical[A](
-    left: SchemaExpr[A, Boolean],
-    right: SchemaExpr[A, Boolean],
+object DynamicSchemaExpr {
+  final case class Logical(
+    left: DynamicSchemaExpr,
+    right: DynamicSchemaExpr,
     operator: LogicalOperator
-  ) extends SchemaExpr[A, Boolean]
+  ) extends DynamicSchemaExpr
 }
 ```
 
@@ -475,18 +480,18 @@ The available `LogicalOperator` values are:
 | `And`    | `&&`   | Logical conjunction |
 | `Or`     | `\|\|` | Logical disjunction |
 
-#### `SchemaExpr.Arithmetic`
+#### `DynamicSchemaExpr.Arithmetic`
 
 Performs arithmetic on two numeric expressions using an `ArithmeticOperator`. Requires an `IsNumeric[A]` type class instance.
 
 ```scala
-object SchemaExpr {
-  case class Arithmetic[S, A](
-    left: SchemaExpr[S, A],
-    right: SchemaExpr[S, A],
+object DynamicSchemaExpr {
+  final case class Arithmetic(
+    left: DynamicSchemaExpr,
+    right: DynamicSchemaExpr,
     operator: ArithmeticOperator,
-    isNumeric: IsNumeric[A]
-  ) extends SchemaExpr[S, A]
+    numericType: NumericTypeTag
+  ) extends DynamicSchemaExpr
 }
 ```
 
@@ -498,112 +503,29 @@ The available `ArithmeticOperator` values are:
 | `Subtract` | `-`          | Subtraction    |
 | `Multiply` | `*`          | Multiplication |
 
-Supported numeric types via `IsNumeric`: `Byte`, `Short`, `Int`, `Long`, `Float`, `Double`, `BigInt`, `BigDecimal`.
+Supported numeric types include `Byte`, `Short`, `Int`, `Long`, `Float`, `Double`, `BigInt`, and `BigDecimal`.
 
-#### `SchemaExpr.StringConcat`
+#### Other string and bitwise operations
 
-Concatenates two string expressions.
+`DynamicSchemaExpr` also includes:
 
-```scala
-object SchemaExpr {
-  case class StringConcat[A](
-    left: SchemaExpr[A, String],
-    right: SchemaExpr[A, String]
-  ) extends SchemaExpr[A, String]
-}
-```
+- `StringConcat`
+- `StringRegexMatch`
+- `StringLength`
+- `StringSubstring`
+- `StringTrim`
+- `StringToUpperCase`
+- `StringToLowerCase`
+- `StringReplace`
+- `StringStartsWith`
+- `StringEndsWith`
+- `StringContains`
+- `StringIndexOf`
+- `PrimitiveConversion`
+- `Bitwise`
+- `BitwiseNot`
 
-Created via the `concat` method on string optics:
-
-```scala mdoc:compile-only
-import zio.blocks.schema._
-
-case class Greeting(prefix: String)
-
-object Greeting extends CompanionOptics[Greeting] {
-  implicit val schema: Schema[Greeting] = Schema.derived
-
-  val prefix: Lens[Greeting, String] = $(_.prefix)
-}
-
-val withName = Greeting.prefix.concat(", World!")
-val result = withName.eval(Greeting("Hello"))
-// Right(List("Hello, World!"))
-```
-
-### Other Operations
-
-`StringRegexMatch` and `StringLength` extend `SchemaExpr` directly rather than through `UnaryOp` or `BinaryOp`.
-
-#### `SchemaExpr.StringRegexMatch`
-
-Tests whether a string matches a regular expression pattern. Despite having two operands (`regex` and `string`), it extends `SchemaExpr[A, Boolean]` directly.
-
-```scala
-object SchemaExpr {
-  case class StringRegexMatch[A](
-    regex: SchemaExpr[A, String],
-    string: SchemaExpr[A, String]
-  ) extends SchemaExpr[A, Boolean]
-}
-```
-
-Created via the `matches` method on string optics:
-
-```scala mdoc:compile-only
-import zio.blocks.schema._
-
-case class Email(address: String)
-
-object Email extends CompanionOptics[Email] {
-  implicit val schema: Schema[Email] = Schema.derived
-
-  val address: Lens[Email, String] = $(_.address)
-}
-
-val isValid = Email.address.matches("^[^@]+@[^@]+\\.[^@]+$")
-val result = isValid.eval(Email("alice@example.com"))
-// Right(List(true))
-```
-
-#### `SchemaExpr.StringLength`
-
-Computes the length of a string expression. This is a unary operation but extends `SchemaExpr[A, Int]` directly rather than `UnaryOp`.
-
-```scala
-object SchemaExpr {
-  case class StringLength[A](
-    string: SchemaExpr[A, String]
-  ) extends SchemaExpr[A, Int]
-}
-```
-
-Created via the `length` method on string optics:
-
-```scala mdoc:compile-only
-import zio.blocks.schema._
-
-case class Message(body: String)
-
-object Message extends CompanionOptics[Message] {
-  implicit val schema: Schema[Message] = Schema.derived
-
-  val body: Lens[Message, String] = $(_.body)
-}
-
-val bodyLength = Message.body.length
-val result = bodyLength.eval(Message("Hello!"))
-// Right(List(6))
-```
-
-### Abstract Intermediate Traits
-
-Two sealed traits categorize some expressions by arity:
-
-- **`UnaryOp[A, B]`** — has a single `expr: SchemaExpr[A, B]`. Extended by `Not`.
-- **`BinaryOp[A, B, C]`** — has `left: SchemaExpr[A, B]` and `right: SchemaExpr[A, B]`. Extended by `Relational`, `Logical`, `Arithmetic`, and `StringConcat`.
-
-Not all expression nodes use these traits — `StringRegexMatch` and `StringLength` extend `SchemaExpr` directly. These intermediate traits are useful for pattern matching when you need to generically process the expression tree.
+These are the cases downstream interpreters should consider when translating `SchemaExpr.dynamic` into SQL, filters, or other query languages.
 
 ## Error Handling
 
@@ -631,19 +553,22 @@ result match {
 
 ## Advanced Usage: Building Query DSLs
 
-Because `SchemaExpr` is a sealed, inspectable AST, third-party libraries can pattern-match on the expression tree to translate it into other languages. For example, a database library could translate `SchemaExpr` into SQL:
+Because `SchemaExpr.dynamic` is a sealed, inspectable AST, third-party libraries can translate expressions into other languages. The public entry point should still accept `SchemaExpr`; only the interpreter internals need to cross into `DynamicSchemaExpr`.
 
 ```scala
-// Pseudocode — illustrates the concept
-def toSql[A](expr: SchemaExpr[A, Boolean]): String = expr match {
-  case SchemaExpr.Relational(left, right, op) =>
+// Pseudocode — keeps SchemaExpr as the public API
+def toSql[A, B](expr: SchemaExpr[A, B]): String =
+  toSqlDynamic(expr.dynamic)
+
+def toSqlDynamic(expr: DynamicSchemaExpr): String = expr match {
+  case DynamicSchemaExpr.Relational(left, right, op) =>
     s"${toSqlValue(left)} ${opToSql(op)} ${toSqlValue(right)}"
-  case SchemaExpr.Logical(left, right, SchemaExpr.LogicalOperator.And) =>
-    s"(${toSql(left)}) AND (${toSql(right)})"
-  case SchemaExpr.Logical(left, right, SchemaExpr.LogicalOperator.Or) =>
-    s"(${toSql(left)}) OR (${toSql(right)})"
-  case SchemaExpr.Not(inner) =>
-    s"NOT (${toSql(inner)})"
+  case DynamicSchemaExpr.Logical(left, right, DynamicSchemaExpr.LogicalOperator.And) =>
+    s"(${toSqlDynamic(left)}) AND (${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.Logical(left, right, DynamicSchemaExpr.LogicalOperator.Or) =>
+    s"(${toSqlDynamic(left)}) OR (${toSqlDynamic(right)})"
+  case DynamicSchemaExpr.Not(inner) =>
+    s"NOT (${toSqlDynamic(inner)})"
   // ...
 }
 ```
@@ -658,7 +583,7 @@ This is the key advantage of reified expressions over plain functions — the sa
 
 ### Schema
 
-[Schema](./schema.md) provides the type information needed by `SchemaExpr.Literal` to convert values to `DynamicValue` via `Literal#evalDynamic`. The `IsNumeric` type class (used by `Arithmetic`) also derives from `Schema`.
+[Schema](./schema.md) provides the type information needed to construct typed `SchemaExpr` values and to convert typed results to and from `DynamicValue` during evaluation.
 
 ### DynamicValue
 

--- a/docs/reference/schema/schema-expr.md
+++ b/docs/reference/schema/schema-expr.md
@@ -3,7 +3,7 @@ id: schema-expr
 title: "SchemaExpr"
 ---
 
-`SchemaExpr[A, B]` is a **schema-aware expression** that computes a result of type `B` from an input value of type `A`. The input type `A` must be fully described by a [`Schema`](./schema.md), and the expression is built from [optics](./optics.md), literal values, and operators. The fundamental operations are `eval` and `evalDynamic`.
+`SchemaExpr[A, B]` is a **schema-aware expression** that computes a result of type `B` from an input value of type `A`. It is invariant in both type parameters. The input type `A` must be fully described by a [`Schema`](./schema.md), and the expression is built from [optics](./optics.md), literal values, and operators. The fundamental operations are `eval` and `evalDynamic`.
 
 At runtime, `SchemaExpr` is a typed wrapper around `DynamicSchemaExpr`. The typed layer carries the input and output schemas, while the dynamic layer stores the serializable AST. This split is why you will sometimes see both `.dynamic` and `DynamicSchemaExpr` in advanced examples: `SchemaExpr` is the public typed API, and `DynamicSchemaExpr` is the untyped transport/runtime form underneath it.
 

--- a/docs/reference/schema/schema-expr.md
+++ b/docs/reference/schema/schema-expr.md
@@ -217,10 +217,10 @@ object Item extends CompanionOptics[Item] {
   val price: Lens[Item, Int] = $(_.price)
 }
 
-// Construct AST nodes directly
-val lit: SchemaExpr[Item, Int] = new SchemaExpr.Literal(42, Schema[Int])
-val opticExpr: SchemaExpr[Item, Int] = new SchemaExpr.Optic(Item.price)
-val comparison: SchemaExpr[Item, Boolean] = new SchemaExpr.Relational(
+// Construct via factory methods
+val lit: SchemaExpr[Item, Int] = SchemaExpr.literal[Item, Int](42)
+val opticExpr: SchemaExpr[Item, Int] = SchemaExpr.optic[Item, Int](Item.price.toDynamic, Item.schema)
+val comparison: SchemaExpr[Item, Boolean] = SchemaExpr.relational(
   opticExpr,
   lit,
   SchemaExpr.RelationalOperator.GreaterThan
@@ -290,7 +290,7 @@ object Person extends CompanionOptics[Person] {
   val name: Lens[Person, String] = $(_.name)
 }
 
-val nameExpr = new SchemaExpr.Optic(Person.name)
+val nameExpr = SchemaExpr.optic[Person, String](Person.name.toDynamic, Person.schema)
 val result = nameExpr.evalDynamic(Person("Alice", 30))
 // Right(List(DynamicValue.Primitive(PrimitiveValue.String("Alice"))))
 ```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -86,15 +86,16 @@ const sidebars = {
                  "reference/schema/allows",
                ]
              },
-             {
-               type: "category",
-               label: "Schema Evolution",
-               link: { type: "doc", id: "reference/schema/schema-evolution/index" },
-               items: [
-                 "reference/schema/schema-evolution/into",
-                 "reference/schema/schema-evolution/as",
-               ]
-             },
+              {
+                type: "category",
+                label: "Schema Evolution",
+                link: { type: "doc", id: "reference/schema/schema-evolution/index" },
+                items: [
+                  "reference/schema/schema-evolution/into",
+                  "reference/schema/schema-evolution/as",
+                  "reference/schema/migration",
+                ]
+              },
              "reference/schema/syntax",
            ]
          },

--- a/schema-examples/src/main/scala/querydslbuilder/Common.scala
+++ b/schema-examples/src/main/scala/querydslbuilder/Common.scala
@@ -71,8 +71,8 @@ sealed trait Expr[S, A]
 object Expr {
 
   // --- Core nodes (superset of SchemaExpr's nodes) ---
-  final case class Column[S, A](optic: Optic[S, A])       extends Expr[S, A]
-  final case class Lit[S, A](value: A, schema: Schema[A]) extends Expr[S, A]
+  final case class Column[S, A](path: DynamicOptic) extends Expr[S, A]
+  final case class Lit[S, A](value: DynamicValue)   extends Expr[S, A]
 
   // Relational
   final case class Relational[S, A](left: Expr[S, A], right: Expr[S, A], op: RelOp) extends Expr[S, Boolean]
@@ -97,47 +97,58 @@ object Expr {
   final case class Like[S](expr: Expr[S, String], pattern: String)                     extends Expr[S, Boolean]
 
   // --- Factory methods ---
-  def col[S, A](optic: Optic[S, A]): Expr[S, A]                   = Column(optic)
-  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(value, schema)
+  def col[S, A](optic: Optic[S, A]): Expr[S, A]                   = Column(optic.toDynamic)
+  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(schema.toDynamicValue(value))
 
   // --- Translation from SchemaExpr (one-way, not embedding) ---
   def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = {
-    val result = se match {
-      case SchemaExpr.Optic(optic)     => Column(optic)
-      case l: SchemaExpr.Literal[_, _] => Lit(l.value, l.schema)
-
-      case SchemaExpr.Relational(l, r, op) =>
-        val relOp = op match {
-          case SchemaExpr.RelationalOperator.Equal              => RelOp.Equal
-          case SchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
-          case SchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
-          case SchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
-          case SchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
-          case SchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
-        }
-        Relational(fromSchemaExpr(l), fromSchemaExpr(r), relOp)
-
-      case SchemaExpr.Logical(l, r, op) =>
-        op match {
-          case SchemaExpr.LogicalOperator.And => And(fromSchemaExpr(l), fromSchemaExpr(r))
-          case SchemaExpr.LogicalOperator.Or  => Or(fromSchemaExpr(l), fromSchemaExpr(r))
-        }
-
-      case SchemaExpr.Not(inner) => Not(fromSchemaExpr(inner))
-
-      case SchemaExpr.Arithmetic(l, r, op, _) =>
-        val arithOp = op match {
-          case SchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
-          case SchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
-          case SchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
-        }
-        Arithmetic(fromSchemaExpr(l), fromSchemaExpr(r), arithOp)
-
-      case SchemaExpr.StringConcat(l, r)              => StringConcat(fromSchemaExpr(l), fromSchemaExpr(r))
-      case SchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromSchemaExpr(regex), fromSchemaExpr(string))
-      case SchemaExpr.StringLength(string)            => StringLength(fromSchemaExpr(string))
-    }
+    val result = fromDynamic[S](se.dynamic)
     result.asInstanceOf[Expr[S, A]]
+  }
+
+  private def fromDynamic[S](dse: DynamicSchemaExpr): Expr[S, ?] = dse match {
+    case DynamicSchemaExpr.Select(path)   => Column[S, Any](path)
+    case DynamicSchemaExpr.Literal(value) => Lit[S, Any](value)
+
+    case DynamicSchemaExpr.Relational(l, r, op) =>
+      val relOp = op match {
+        case DynamicSchemaExpr.RelationalOperator.Equal              => RelOp.Equal
+        case DynamicSchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
+        case DynamicSchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
+        case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
+        case DynamicSchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
+        case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
+      }
+      Relational(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], relOp)
+
+    case DynamicSchemaExpr.Logical(l, r, op) =>
+      op match {
+        case DynamicSchemaExpr.LogicalOperator.And =>
+          And(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
+        case DynamicSchemaExpr.LogicalOperator.Or =>
+          Or(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
+      }
+
+    case DynamicSchemaExpr.Not(inner) => Not(fromDynamic[S](inner).asInstanceOf[Expr[S, Boolean]])
+
+    case DynamicSchemaExpr.Arithmetic(l, r, op, _) =>
+      val arithOp = op match {
+        case DynamicSchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
+        case DynamicSchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
+        case DynamicSchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
+        case _                                             => ArithOp.Add
+      }
+      Arithmetic(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], arithOp)
+
+    case DynamicSchemaExpr.StringConcat(l, r) =>
+      StringConcat(fromDynamic[S](l).asInstanceOf[Expr[S, String]], fromDynamic[S](r).asInstanceOf[Expr[S, String]])
+    case DynamicSchemaExpr.StringRegexMatch(regex, string) =>
+      StringRegexMatch(
+        fromDynamic[S](regex).asInstanceOf[Expr[S, String]],
+        fromDynamic[S](string).asInstanceOf[Expr[S, String]]
+      )
+    case DynamicSchemaExpr.StringLength(string) => StringLength(fromDynamic[S](string).asInstanceOf[Expr[S, String]])
+    case _                                      => Lit[S, Any](DynamicValue.Null)
   }
 }
 

--- a/schema-examples/src/main/scala/querydslbuilder/Common.scala
+++ b/schema-examples/src/main/scala/querydslbuilder/Common.scala
@@ -70,6 +70,9 @@ sealed trait Expr[S, A]
 
 object Expr {
 
+  private def unsupportedDynamicExpr(op: String): Nothing =
+    throw new IllegalArgumentException(s"Unsupported DynamicSchemaExpr in example SQL DSL: $op")
+
   // --- Core nodes (superset of SchemaExpr's nodes) ---
   final case class Column[S, A](path: DynamicOptic) extends Expr[S, A]
   final case class Lit[S, A](value: DynamicValue)   extends Expr[S, A]
@@ -136,7 +139,7 @@ object Expr {
         case DynamicSchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
         case DynamicSchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
         case DynamicSchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
-        case _                                             => ArithOp.Add
+        case other                                         => unsupportedDynamicExpr(s"arithmetic operator $other")
       }
       Arithmetic(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], arithOp)
 
@@ -148,7 +151,7 @@ object Expr {
         fromDynamic[S](string).asInstanceOf[Expr[S, String]]
       )
     case DynamicSchemaExpr.StringLength(string) => StringLength(fromDynamic[S](string).asInstanceOf[Expr[S, String]])
-    case _                                      => Lit[S, Any](DynamicValue.Null)
+    case other                                  => unsupportedDynamicExpr(other.getClass.getSimpleName)
   }
 }
 

--- a/schema-examples/src/main/scala/querydslbuilder/package.scala
+++ b/schema-examples/src/main/scala/querydslbuilder/package.scala
@@ -57,6 +57,9 @@ package object querydslbuilder {
   def columnName(optic: zio.blocks.schema.Optic[_, _]): String =
     optic.toDynamic.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
 
+  def columnName(optic: DynamicOptic): String =
+    optic.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
+
   def tableName[S](schema: Schema[S]): String =
     schema.reflect.modifiers.collectFirst {
       case Modifier.config(key, value) if key == "sql.table_name" => value
@@ -86,13 +89,29 @@ package object querydslbuilder {
     }
   }
 
+  def sqlLiteralDV(dv: DynamicValue): String = dv match {
+    case DynamicValue.Primitive(pv) =>
+      pv match {
+        case PrimitiveValue.String(s)  => s"'${s.replace("'", "''")}'"
+        case PrimitiveValue.Boolean(b) => if (b) "TRUE" else "FALSE"
+        case PrimitiveValue.Int(n)     => n.toString
+        case PrimitiveValue.Long(n)    => n.toString
+        case PrimitiveValue.Double(n)  => n.toString
+        case PrimitiveValue.Float(n)   => n.toString
+        case PrimitiveValue.Short(n)   => n.toString
+        case PrimitiveValue.Byte(n)    => n.toString
+        case other                     => other.toString
+      }
+    case other => other.toString
+  }
+
   // ---------------------------------------------------------------------------
   // Single unified SQL interpreter
   // ---------------------------------------------------------------------------
 
   def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
-    case Expr.Column(optic)      => columnName(optic)
-    case Expr.Lit(value, schema) => sqlLiteral(value, schema)
+    case Expr.Column(path) => columnName(path)
+    case Expr.Lit(value)   => sqlLiteralDV(value)
 
     case Expr.Relational(left, right, op) =>
       val sqlOp = op match {

--- a/schema-examples/src/main/scala/querydslextended/Common.scala
+++ b/schema-examples/src/main/scala/querydslextended/Common.scala
@@ -49,8 +49,8 @@ sealed trait Expr[S, A]
 object Expr {
 
   // --- Core nodes (superset of SchemaExpr's nodes) ---
-  final case class Column[S, A](optic: Optic[S, A])       extends Expr[S, A]
-  final case class Lit[S, A](value: A, schema: Schema[A]) extends Expr[S, A]
+  final case class Column[S, A](path: DynamicOptic) extends Expr[S, A]
+  final case class Lit[S, A](value: DynamicValue)   extends Expr[S, A]
 
   // Relational
   final case class Relational[S, A](left: Expr[S, A], right: Expr[S, A], op: RelOp) extends Expr[S, Boolean]
@@ -84,8 +84,8 @@ object Expr {
   ) extends Expr[S, A]
 
   // --- Factory methods ---
-  def col[S, A](optic: Optic[S, A]): Expr[S, A]                   = Column(optic)
-  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(value, schema)
+  def col[S, A](optic: Optic[S, A]): Expr[S, A]                   = Column(optic.toDynamic)
+  def lit[S, A](value: A)(implicit schema: Schema[A]): Expr[S, A] = Lit(schema.toDynamicValue(value))
 
   def count[S, A](expr: Expr[S, A]): Expr[S, Long]   = Agg(AggFunction.Count(), expr)
   def sum[S](expr: Expr[S, Double]): Expr[S, Double] = Agg(AggFunction.Sum, expr)
@@ -103,42 +103,53 @@ object Expr {
 
   // --- Translation from SchemaExpr ---
   def fromSchemaExpr[S, A](se: SchemaExpr[S, A]): Expr[S, A] = {
-    val result = se match {
-      case SchemaExpr.Optic(optic)     => Column(optic)
-      case l: SchemaExpr.Literal[_, _] => Lit(l.value, l.schema)
-
-      case SchemaExpr.Relational(l, r, op) =>
-        val relOp = op match {
-          case SchemaExpr.RelationalOperator.Equal              => RelOp.Equal
-          case SchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
-          case SchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
-          case SchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
-          case SchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
-          case SchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
-        }
-        Relational(fromSchemaExpr(l), fromSchemaExpr(r), relOp)
-
-      case SchemaExpr.Logical(l, r, op) =>
-        op match {
-          case SchemaExpr.LogicalOperator.And => And(fromSchemaExpr(l), fromSchemaExpr(r))
-          case SchemaExpr.LogicalOperator.Or  => Or(fromSchemaExpr(l), fromSchemaExpr(r))
-        }
-
-      case SchemaExpr.Not(inner) => Not(fromSchemaExpr(inner))
-
-      case SchemaExpr.Arithmetic(l, r, op, _) =>
-        val arithOp = op match {
-          case SchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
-          case SchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
-          case SchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
-        }
-        Arithmetic(fromSchemaExpr(l), fromSchemaExpr(r), arithOp)
-
-      case SchemaExpr.StringConcat(l, r)              => StringConcat(fromSchemaExpr(l), fromSchemaExpr(r))
-      case SchemaExpr.StringRegexMatch(regex, string) => StringRegexMatch(fromSchemaExpr(regex), fromSchemaExpr(string))
-      case SchemaExpr.StringLength(string)            => StringLength(fromSchemaExpr(string))
-    }
+    val result = fromDynamic[S](se.dynamic)
     result.asInstanceOf[Expr[S, A]]
+  }
+
+  private def fromDynamic[S](dse: DynamicSchemaExpr): Expr[S, ?] = dse match {
+    case DynamicSchemaExpr.Select(path)   => Column[S, Any](path)
+    case DynamicSchemaExpr.Literal(value) => Lit[S, Any](value)
+
+    case DynamicSchemaExpr.Relational(l, r, op) =>
+      val relOp = op match {
+        case DynamicSchemaExpr.RelationalOperator.Equal              => RelOp.Equal
+        case DynamicSchemaExpr.RelationalOperator.NotEqual           => RelOp.NotEqual
+        case DynamicSchemaExpr.RelationalOperator.LessThan           => RelOp.LessThan
+        case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => RelOp.LessThanOrEqual
+        case DynamicSchemaExpr.RelationalOperator.GreaterThan        => RelOp.GreaterThan
+        case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => RelOp.GreaterThanOrEqual
+      }
+      Relational(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], relOp)
+
+    case DynamicSchemaExpr.Logical(l, r, op) =>
+      op match {
+        case DynamicSchemaExpr.LogicalOperator.And =>
+          And(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
+        case DynamicSchemaExpr.LogicalOperator.Or =>
+          Or(fromDynamic[S](l).asInstanceOf[Expr[S, Boolean]], fromDynamic[S](r).asInstanceOf[Expr[S, Boolean]])
+      }
+
+    case DynamicSchemaExpr.Not(inner) => Not(fromDynamic[S](inner).asInstanceOf[Expr[S, Boolean]])
+
+    case DynamicSchemaExpr.Arithmetic(l, r, op, _) =>
+      val arithOp = op match {
+        case DynamicSchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
+        case DynamicSchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
+        case DynamicSchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
+        case _                                             => ArithOp.Add
+      }
+      Arithmetic(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], arithOp)
+
+    case DynamicSchemaExpr.StringConcat(l, r) =>
+      StringConcat(fromDynamic[S](l).asInstanceOf[Expr[S, String]], fromDynamic[S](r).asInstanceOf[Expr[S, String]])
+    case DynamicSchemaExpr.StringRegexMatch(regex, string) =>
+      StringRegexMatch(
+        fromDynamic[S](regex).asInstanceOf[Expr[S, String]],
+        fromDynamic[S](string).asInstanceOf[Expr[S, String]]
+      )
+    case DynamicSchemaExpr.StringLength(string) => StringLength(fromDynamic[S](string).asInstanceOf[Expr[S, String]])
+    case _                                      => Lit[S, Any](DynamicValue.Null)
   }
 }
 

--- a/schema-examples/src/main/scala/querydslextended/Common.scala
+++ b/schema-examples/src/main/scala/querydslextended/Common.scala
@@ -48,6 +48,9 @@ sealed trait Expr[S, A]
 
 object Expr {
 
+  private def unsupportedDynamicExpr(op: String): Nothing =
+    throw new IllegalArgumentException(s"Unsupported DynamicSchemaExpr in example SQL DSL: $op")
+
   // --- Core nodes (superset of SchemaExpr's nodes) ---
   final case class Column[S, A](path: DynamicOptic) extends Expr[S, A]
   final case class Lit[S, A](value: DynamicValue)   extends Expr[S, A]
@@ -137,7 +140,7 @@ object Expr {
         case DynamicSchemaExpr.ArithmeticOperator.Add      => ArithOp.Add
         case DynamicSchemaExpr.ArithmeticOperator.Subtract => ArithOp.Subtract
         case DynamicSchemaExpr.ArithmeticOperator.Multiply => ArithOp.Multiply
-        case _                                             => ArithOp.Add
+        case other                                         => unsupportedDynamicExpr(s"arithmetic operator $other")
       }
       Arithmetic(fromDynamic[S](l).asInstanceOf[Expr[S, Any]], fromDynamic[S](r).asInstanceOf[Expr[S, Any]], arithOp)
 
@@ -149,7 +152,7 @@ object Expr {
         fromDynamic[S](string).asInstanceOf[Expr[S, String]]
       )
     case DynamicSchemaExpr.StringLength(string) => StringLength(fromDynamic[S](string).asInstanceOf[Expr[S, String]])
-    case _                                      => Lit[S, Any](DynamicValue.Null)
+    case other                                  => unsupportedDynamicExpr(other.getClass.getSimpleName)
   }
 }
 

--- a/schema-examples/src/main/scala/querydslextended/package.scala
+++ b/schema-examples/src/main/scala/querydslextended/package.scala
@@ -57,6 +57,9 @@ package object querydslextended {
   def columnName(optic: zio.blocks.schema.Optic[_, _]): String =
     optic.toDynamic.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
 
+  def columnName(optic: DynamicOptic): String =
+    optic.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
+
   def sqlLiteral[A](value: A, schema: Schema[A]): String = {
     val dv = schema.toDynamicValue(value)
     dv match {
@@ -70,13 +73,29 @@ package object querydslextended {
     }
   }
 
+  def sqlLiteralDV(dv: DynamicValue): String = dv match {
+    case DynamicValue.Primitive(pv) =>
+      pv match {
+        case PrimitiveValue.String(s)  => s"'${s.replace("'", "''")}'"
+        case PrimitiveValue.Boolean(b) => if (b) "TRUE" else "FALSE"
+        case PrimitiveValue.Int(n)     => n.toString
+        case PrimitiveValue.Long(n)    => n.toString
+        case PrimitiveValue.Double(n)  => n.toString
+        case PrimitiveValue.Float(n)   => n.toString
+        case PrimitiveValue.Short(n)   => n.toString
+        case PrimitiveValue.Byte(n)    => n.toString
+        case other                     => other.toString
+      }
+    case other => other.toString
+  }
+
   // ---------------------------------------------------------------------------
   // Single unified SQL interpreter
   // ---------------------------------------------------------------------------
 
   def exprToSql[S, A](expr: Expr[S, A]): String = expr match {
-    case Expr.Column(optic)      => columnName(optic)
-    case Expr.Lit(value, schema) => sqlLiteral(value, schema)
+    case Expr.Column(path) => columnName(path)
+    case Expr.Lit(value)   => sqlLiteralDV(value)
 
     case Expr.Relational(left, right, op) =>
       val sqlOp = op match {

--- a/schema-examples/src/main/scala/querydslsql/Step4NestedSql.scala
+++ b/schema-examples/src/main/scala/querydslsql/Step4NestedSql.scala
@@ -51,8 +51,11 @@ object Step4NestedSql extends App {
 
   // --- Table-Qualified Column Names ---
 
-  def qualifiedColumnName(optic: zio.blocks.schema.Optic[?, ?]): String = {
-    val fields = optic.toDynamic.nodes.collect { case f: DynamicOptic.Node.Field =>
+  def qualifiedColumnName(optic: zio.blocks.schema.Optic[?, ?]): String =
+    qualifiedColumnNameDynamic(optic.toDynamic)
+
+  def qualifiedColumnNameDynamic(optic: DynamicOptic): String = {
+    val fields = optic.nodes.collect { case f: DynamicOptic.Node.Field =>
       f.name
     }
     if (fields.length <= 1) fields.mkString
@@ -67,38 +70,43 @@ object Step4NestedSql extends App {
   println()
 
   // --- SQL Generation with Qualified Names ---
-  // Override columnName locally to produce table-qualified names
 
-  def toSqlQualified[A, B](expr: SchemaExpr[A, B]): String = expr match {
-    case SchemaExpr.Optic(optic)                => qualifiedColumnName(optic)
-    case SchemaExpr.Literal(value, _)           => sqlLiteral(value)
-    case SchemaExpr.Relational(left, right, op) =>
+  def toSqlQualified[A, B](expr: SchemaExpr[A, B]): String = toSqlQualifiedDynamic(expr.dynamic)
+
+  private def toSqlQualifiedDynamic(expr: DynamicSchemaExpr): String = expr match {
+    case DynamicSchemaExpr.Select(path)                => qualifiedColumnNameDynamic(path)
+    case DynamicSchemaExpr.Literal(value)              => sqlLiteralDV(value)
+    case DynamicSchemaExpr.Relational(left, right, op) =>
       val sqlOp = op match {
-        case SchemaExpr.RelationalOperator.Equal              => "="
-        case SchemaExpr.RelationalOperator.NotEqual           => "<>"
-        case SchemaExpr.RelationalOperator.LessThan           => "<"
-        case SchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
-        case SchemaExpr.RelationalOperator.GreaterThan        => ">"
-        case SchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
+        case DynamicSchemaExpr.RelationalOperator.Equal              => "="
+        case DynamicSchemaExpr.RelationalOperator.NotEqual           => "<>"
+        case DynamicSchemaExpr.RelationalOperator.LessThan           => "<"
+        case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
+        case DynamicSchemaExpr.RelationalOperator.GreaterThan        => ">"
+        case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
       }
-      s"(${toSqlQualified(left)} $sqlOp ${toSqlQualified(right)})"
-    case SchemaExpr.Logical(left, right, op) =>
+      s"(${toSqlQualifiedDynamic(left)} $sqlOp ${toSqlQualifiedDynamic(right)})"
+    case DynamicSchemaExpr.Logical(left, right, op) =>
       val sqlOp = op match {
-        case SchemaExpr.LogicalOperator.And => "AND"
-        case SchemaExpr.LogicalOperator.Or  => "OR"
+        case DynamicSchemaExpr.LogicalOperator.And => "AND"
+        case DynamicSchemaExpr.LogicalOperator.Or  => "OR"
       }
-      s"(${toSqlQualified(left)} $sqlOp ${toSqlQualified(right)})"
-    case SchemaExpr.Not(inner)                     => s"NOT (${toSqlQualified(inner)})"
-    case SchemaExpr.Arithmetic(left, right, op, _) =>
+      s"(${toSqlQualifiedDynamic(left)} $sqlOp ${toSqlQualifiedDynamic(right)})"
+    case DynamicSchemaExpr.Not(inner)                     => s"NOT (${toSqlQualifiedDynamic(inner)})"
+    case DynamicSchemaExpr.Arithmetic(left, right, op, _) =>
       val sqlOp = op match {
-        case SchemaExpr.ArithmeticOperator.Add      => "+"
-        case SchemaExpr.ArithmeticOperator.Subtract => "-"
-        case SchemaExpr.ArithmeticOperator.Multiply => "*"
+        case DynamicSchemaExpr.ArithmeticOperator.Add      => "+"
+        case DynamicSchemaExpr.ArithmeticOperator.Subtract => "-"
+        case DynamicSchemaExpr.ArithmeticOperator.Multiply => "*"
+        case _                                             => "?"
       }
-      s"(${toSqlQualified(left)} $sqlOp ${toSqlQualified(right)})"
-    case SchemaExpr.StringConcat(left, right)       => s"CONCAT(${toSqlQualified(left)}, ${toSqlQualified(right)})"
-    case SchemaExpr.StringRegexMatch(regex, string) => s"(${toSqlQualified(string)} LIKE ${toSqlQualified(regex)})"
-    case SchemaExpr.StringLength(string)            => s"LENGTH(${toSqlQualified(string)})"
+      s"(${toSqlQualifiedDynamic(left)} $sqlOp ${toSqlQualifiedDynamic(right)})"
+    case DynamicSchemaExpr.StringConcat(left, right) =>
+      s"CONCAT(${toSqlQualifiedDynamic(left)}, ${toSqlQualifiedDynamic(right)})"
+    case DynamicSchemaExpr.StringRegexMatch(regex, string) =>
+      s"(${toSqlQualifiedDynamic(string)} LIKE ${toSqlQualifiedDynamic(regex)})"
+    case DynamicSchemaExpr.StringLength(string) => s"LENGTH(${toSqlQualifiedDynamic(string)})"
+    case _                                      => "?"
   }
 
   def selectQualified(table: String, predicate: SchemaExpr[?, Boolean]): String =

--- a/schema-examples/src/main/scala/querydslsql/package.scala
+++ b/schema-examples/src/main/scala/querydslsql/package.scala
@@ -25,6 +25,9 @@ package object querydslsql {
   def columnName(optic: Optic[_, _]): String =
     optic.toDynamic.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
 
+  def columnName(optic: DynamicOptic): String =
+    optic.nodes.collect { case f: DynamicOptic.Node.Field => f.name }.mkString("_")
+
   def sqlLiteral(value: Any): String = value match {
     case s: String  => s"'${s.replace("'", "''")}'"
     case b: Boolean => if (b) "TRUE" else "FALSE"
@@ -32,40 +35,60 @@ package object querydslsql {
     case other      => other.toString
   }
 
+  def sqlLiteralDV(dv: DynamicValue): String = dv match {
+    case DynamicValue.Primitive(pv) =>
+      pv match {
+        case PrimitiveValue.String(s)  => s"'${s.replace("'", "''")}'"
+        case PrimitiveValue.Boolean(b) => if (b) "TRUE" else "FALSE"
+        case PrimitiveValue.Int(n)     => n.toString
+        case PrimitiveValue.Long(n)    => n.toString
+        case PrimitiveValue.Double(n)  => n.toString
+        case PrimitiveValue.Float(n)   => n.toString
+        case PrimitiveValue.Short(n)   => n.toString
+        case PrimitiveValue.Byte(n)    => n.toString
+        case other                     => other.toString
+      }
+    case other => other.toString
+  }
+
   // ---------------------------------------------------------------------------
   // Core SQL interpreter — translates SchemaExpr to inline SQL
   // ---------------------------------------------------------------------------
 
-  def toSql[A, B](expr: SchemaExpr[A, B]): String = expr match {
-    case SchemaExpr.Optic(optic)                => columnName(optic)
-    case SchemaExpr.Literal(value, _)           => sqlLiteral(value)
-    case SchemaExpr.Relational(left, right, op) =>
+  def toSql[A, B](expr: SchemaExpr[A, B]): String = toSqlDynamic(expr.dynamic)
+
+  private def toSqlDynamic(expr: DynamicSchemaExpr): String = expr match {
+    case DynamicSchemaExpr.Select(path)                => columnName(path)
+    case DynamicSchemaExpr.Literal(value)              => sqlLiteralDV(value)
+    case DynamicSchemaExpr.Relational(left, right, op) =>
       val sqlOp = op match {
-        case SchemaExpr.RelationalOperator.Equal              => "="
-        case SchemaExpr.RelationalOperator.NotEqual           => "<>"
-        case SchemaExpr.RelationalOperator.LessThan           => "<"
-        case SchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
-        case SchemaExpr.RelationalOperator.GreaterThan        => ">"
-        case SchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
+        case DynamicSchemaExpr.RelationalOperator.Equal              => "="
+        case DynamicSchemaExpr.RelationalOperator.NotEqual           => "<>"
+        case DynamicSchemaExpr.RelationalOperator.LessThan           => "<"
+        case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
+        case DynamicSchemaExpr.RelationalOperator.GreaterThan        => ">"
+        case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
       }
-      s"(${toSql(left)} $sqlOp ${toSql(right)})"
-    case SchemaExpr.Logical(left, right, op) =>
+      s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+    case DynamicSchemaExpr.Logical(left, right, op) =>
       val sqlOp = op match {
-        case SchemaExpr.LogicalOperator.And => "AND"
-        case SchemaExpr.LogicalOperator.Or  => "OR"
+        case DynamicSchemaExpr.LogicalOperator.And => "AND"
+        case DynamicSchemaExpr.LogicalOperator.Or  => "OR"
       }
-      s"(${toSql(left)} $sqlOp ${toSql(right)})"
-    case SchemaExpr.Not(inner)                     => s"NOT (${toSql(inner)})"
-    case SchemaExpr.Arithmetic(left, right, op, _) =>
+      s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+    case DynamicSchemaExpr.Not(inner)                     => s"NOT (${toSqlDynamic(inner)})"
+    case DynamicSchemaExpr.Arithmetic(left, right, op, _) =>
       val sqlOp = op match {
-        case SchemaExpr.ArithmeticOperator.Add      => "+"
-        case SchemaExpr.ArithmeticOperator.Subtract => "-"
-        case SchemaExpr.ArithmeticOperator.Multiply => "*"
+        case DynamicSchemaExpr.ArithmeticOperator.Add      => "+"
+        case DynamicSchemaExpr.ArithmeticOperator.Subtract => "-"
+        case DynamicSchemaExpr.ArithmeticOperator.Multiply => "*"
+        case _                                             => "?"
       }
-      s"(${toSql(left)} $sqlOp ${toSql(right)})"
-    case SchemaExpr.StringConcat(left, right)       => s"CONCAT(${toSql(left)}, ${toSql(right)})"
-    case SchemaExpr.StringRegexMatch(regex, string) => s"(${toSql(string)} LIKE ${toSql(regex)})"
-    case SchemaExpr.StringLength(string)            => s"LENGTH(${toSql(string)})"
+      s"(${toSqlDynamic(left)} $sqlOp ${toSqlDynamic(right)})"
+    case DynamicSchemaExpr.StringConcat(left, right)       => s"CONCAT(${toSqlDynamic(left)}, ${toSqlDynamic(right)})"
+    case DynamicSchemaExpr.StringRegexMatch(regex, string) => s"(${toSqlDynamic(string)} LIKE ${toSqlDynamic(regex)})"
+    case DynamicSchemaExpr.StringLength(string)            => s"LENGTH(${toSqlDynamic(string)})"
+    case _                                                 => "?"
   }
 
   // ---------------------------------------------------------------------------
@@ -74,47 +97,70 @@ package object querydslsql {
 
   case class SqlQuery(sql: String, params: List[Any])
 
-  def toParameterized[A, B](expr: SchemaExpr[A, B]): SqlQuery = expr match {
-    case SchemaExpr.Optic(optic)                => SqlQuery(columnName(optic), Nil)
-    case SchemaExpr.Literal(value, _)           => SqlQuery("?", List(value))
-    case SchemaExpr.Relational(left, right, op) =>
-      val l     = toParameterized(left); val r = toParameterized(right)
+  def toParameterized[A, B](expr: SchemaExpr[A, B]): SqlQuery = toParameterizedDynamic(expr.dynamic)
+
+  private def toParameterizedDynamic(expr: DynamicSchemaExpr): SqlQuery = expr match {
+    case DynamicSchemaExpr.Select(path)   => SqlQuery(columnName(path), Nil)
+    case DynamicSchemaExpr.Literal(value) =>
+      val param = value match {
+        case DynamicValue.Primitive(pv) =>
+          pv match {
+            case PrimitiveValue.String(s)     => s
+            case PrimitiveValue.Boolean(b)    => b
+            case PrimitiveValue.Int(n)        => n
+            case PrimitiveValue.Long(n)       => n
+            case PrimitiveValue.Double(n)     => n
+            case PrimitiveValue.Float(n)      => n
+            case PrimitiveValue.Short(n)      => n
+            case PrimitiveValue.Byte(n)       => n
+            case PrimitiveValue.BigInt(n)     => n
+            case PrimitiveValue.BigDecimal(n) => n
+            case PrimitiveValue.Char(c)       => c
+            case other                        => other.toString
+          }
+        case other => other.toString
+      }
+      SqlQuery("?", List(param))
+    case DynamicSchemaExpr.Relational(left, right, op) =>
+      val l     = toParameterizedDynamic(left); val r = toParameterizedDynamic(right)
       val sqlOp = op match {
-        case SchemaExpr.RelationalOperator.Equal              => "="
-        case SchemaExpr.RelationalOperator.NotEqual           => "<>"
-        case SchemaExpr.RelationalOperator.LessThan           => "<"
-        case SchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
-        case SchemaExpr.RelationalOperator.GreaterThan        => ">"
-        case SchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
+        case DynamicSchemaExpr.RelationalOperator.Equal              => "="
+        case DynamicSchemaExpr.RelationalOperator.NotEqual           => "<>"
+        case DynamicSchemaExpr.RelationalOperator.LessThan           => "<"
+        case DynamicSchemaExpr.RelationalOperator.LessThanOrEqual    => "<="
+        case DynamicSchemaExpr.RelationalOperator.GreaterThan        => ">"
+        case DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual => ">="
       }
       SqlQuery(s"(${l.sql} $sqlOp ${r.sql})", l.params ++ r.params)
-    case SchemaExpr.Logical(left, right, op) =>
-      val l     = toParameterized(left); val r = toParameterized(right)
+    case DynamicSchemaExpr.Logical(left, right, op) =>
+      val l     = toParameterizedDynamic(left); val r = toParameterizedDynamic(right)
       val sqlOp = op match {
-        case SchemaExpr.LogicalOperator.And => "AND"
-        case SchemaExpr.LogicalOperator.Or  => "OR"
+        case DynamicSchemaExpr.LogicalOperator.And => "AND"
+        case DynamicSchemaExpr.LogicalOperator.Or  => "OR"
       }
       SqlQuery(s"(${l.sql} $sqlOp ${r.sql})", l.params ++ r.params)
-    case SchemaExpr.Not(inner) =>
-      val i = toParameterized(inner)
+    case DynamicSchemaExpr.Not(inner) =>
+      val i = toParameterizedDynamic(inner)
       SqlQuery(s"NOT (${i.sql})", i.params)
-    case SchemaExpr.Arithmetic(left, right, op, _) =>
-      val l     = toParameterized(left); val r = toParameterized(right)
+    case DynamicSchemaExpr.Arithmetic(left, right, op, _) =>
+      val l     = toParameterizedDynamic(left); val r = toParameterizedDynamic(right)
       val sqlOp = op match {
-        case SchemaExpr.ArithmeticOperator.Add      => "+"
-        case SchemaExpr.ArithmeticOperator.Subtract => "-"
-        case SchemaExpr.ArithmeticOperator.Multiply => "*"
+        case DynamicSchemaExpr.ArithmeticOperator.Add      => "+"
+        case DynamicSchemaExpr.ArithmeticOperator.Subtract => "-"
+        case DynamicSchemaExpr.ArithmeticOperator.Multiply => "*"
+        case _                                             => "?"
       }
       SqlQuery(s"(${l.sql} $sqlOp ${r.sql})", l.params ++ r.params)
-    case SchemaExpr.StringConcat(left, right) =>
-      val l = toParameterized(left); val r = toParameterized(right)
+    case DynamicSchemaExpr.StringConcat(left, right) =>
+      val l = toParameterizedDynamic(left); val r = toParameterizedDynamic(right)
       SqlQuery(s"CONCAT(${l.sql}, ${r.sql})", l.params ++ r.params)
-    case SchemaExpr.StringRegexMatch(regex, string) =>
-      val s = toParameterized(string); val r = toParameterized(regex)
+    case DynamicSchemaExpr.StringRegexMatch(regex, string) =>
+      val s = toParameterizedDynamic(string); val r = toParameterizedDynamic(regex)
       SqlQuery(s"(${s.sql} LIKE ${r.sql})", s.params ++ r.params)
-    case SchemaExpr.StringLength(string) =>
-      val s = toParameterized(string)
+    case DynamicSchemaExpr.StringLength(string) =>
+      val s = toParameterizedDynamic(string)
       SqlQuery(s"LENGTH(${s.sql})", s.params)
+    case _ => SqlQuery("?", Nil)
   }
 
   // ---------------------------------------------------------------------------

--- a/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/StructuralMigrationSpec.scala
+++ b/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/StructuralMigrationSpec.scala
@@ -1,0 +1,460 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import scala.language.reflectiveCalls
+import zio.test.*
+import zio.blocks.schema.*
+
+/**
+ * Tests for migrating from PURE STRUCTURAL TYPES to case classes.
+ *
+ * This demonstrates the killer feature: migrating from old data formats
+ * (represented as structural types) to current case classes WITHOUT keeping the
+ * old case class definitions around.
+ *
+ * Use case: You have serialized data from version 1 of your app, but the case
+ * class no longer exists. Represent the old schema as a structural type and
+ * migrate to your current case class.
+ *
+ * NOTE: We use Migration.fromActions with string-based field paths because the
+ * MigrationBuilder's selector syntax (_.fieldName) doesn't work with structural
+ * types (it uses macros that can't introspect selectDynamic calls).
+ */
+object StructuralMigrationSpec extends ZIOSpecDefault {
+
+  private def literal(dv: DynamicValue): DynamicSchemaExpr =
+    DynamicSchemaExpr.Literal(dv)
+
+  def spec: Spec[TestEnvironment, Any] = suite("StructuralMigrationSpec")(
+    suite("Structural → Case Class (PRIMARY USE CASE: migrating from old versions)")(
+      test("pure structural to case class with addField") {
+        type PersonV0 = { def name: String }
+        def makePersonV0(n: String): PersonV0 = new { def name: String = n }
+        given Schema[PersonV0]                = Schema.derived[PersonV0]
+
+        case class PersonV2(name: String, age: Int)
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV0, PersonV2](
+          MigrationAction.AddField(
+            DynamicOptic.root.field("age"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
+          )
+        )
+
+        val input: PersonV0 = makePersonV0("Alice")
+        val result          = migration(input)
+
+        assertTrue(result == Right(PersonV2("Alice", 0)))
+      },
+      test("pure structural to case class with dropField") {
+        type PersonV0 = { def name: String; def age: Int }
+        def makePersonV0(n: String, a: Int): PersonV0 = new {
+          def name: String = n
+          def age: Int     = a
+        }
+        given Schema[PersonV0] = Schema.derived[PersonV0]
+
+        case class PersonV2(name: String)
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV0, PersonV2](
+          MigrationAction.DropField(
+            DynamicOptic.root.field("age"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
+          )
+        )
+
+        val input: PersonV0 = makePersonV0("Bob", 30)
+        val result          = migration(input)
+
+        assertTrue(result == Right(PersonV2("Bob")))
+      },
+      test("pure structural to case class with renameField") {
+        type PersonV0 = { def firstName: String }
+        def makePersonV0(fn: String): PersonV0 = new { def firstName: String = fn }
+        given Schema[PersonV0]                 = Schema.derived[PersonV0]
+
+        case class PersonV2(fullName: String)
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV0, PersonV2](
+          MigrationAction.RenameField(
+            DynamicOptic.root.field("firstName"),
+            "fullName"
+          )
+        )
+
+        val input: PersonV0 = makePersonV0("Charlie")
+        val result          = migration(input)
+
+        assertTrue(result == Right(PersonV2("Charlie")))
+      },
+      test("pure structural to case class with transformField") {
+        type PersonV0 = { def age: Int }
+        def makePersonV0(a: Int): PersonV0 = new { def age: Int = a }
+        given Schema[PersonV0]             = Schema.derived[PersonV0]
+
+        case class PersonV2(age: Long)
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV0, PersonV2](
+          MigrationAction.TransformField(
+            DynamicOptic.root.field("age"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Long(30L)))
+          )
+        )
+
+        val input: PersonV0 = makePersonV0(30)
+        val result          = migration(input)
+
+        assertTrue(result == Right(PersonV2(30L)))
+      },
+      test("complex pure structural to case class with multiple operations") {
+        type PersonV0 = { def firstName: String; def age: Int; def city: String }
+        def makePersonV0(fn: String, a: Int, c: String): PersonV0 = new {
+          def firstName: String = fn
+          def age: Int          = a
+          def city: String      = c
+        }
+        given Schema[PersonV0] = Schema.derived[PersonV0]
+
+        case class PersonV2(fullName: String, age: Long, country: String)
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV0, PersonV2](
+          MigrationAction.RenameField(DynamicOptic.root.field("firstName"), "fullName"),
+          MigrationAction.TransformField(
+            DynamicOptic.root.field("age"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Long(25L)))
+          ),
+          MigrationAction.DropField(
+            DynamicOptic.root.field("city"),
+            literal(DynamicValue.Primitive(PrimitiveValue.String("Unknown")))
+          ),
+          MigrationAction.AddField(
+            DynamicOptic.root.field("country"),
+            literal(DynamicValue.Primitive(PrimitiveValue.String("USA")))
+          )
+        )
+
+        val input: PersonV0 = makePersonV0("David", 25, "NYC")
+        val result          = migration(input)
+
+        assertTrue(result == Right(PersonV2("David", 25L, "USA")))
+      }
+    ),
+    suite("Case Class → Structural (reverse migration for validation)")(
+      test("case class to structural with addField") {
+        case class PersonV1(name: String)
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+
+        type PersonV2 = { def name: String; def age: Int }
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV1, PersonV2](
+          MigrationAction.AddField(
+            DynamicOptic.root.field("age"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
+          )
+        )
+
+        val input  = PersonV1("Emma")
+        val result = migration(input)
+
+        assertTrue(result.isRight)
+      },
+      test("case class to structural with dropField") {
+        case class PersonV1(name: String, age: Int)
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+
+        type PersonV2 = { def name: String }
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV1, PersonV2](
+          MigrationAction.DropField(
+            DynamicOptic.root.field("age"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
+          )
+        )
+
+        val input  = PersonV1("Frank", 40)
+        val result = migration(input)
+
+        assertTrue(result.isRight)
+      },
+      test("case class to structural with renameField") {
+        case class PersonV1(firstName: String)
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+
+        type PersonV2 = { def fullName: String }
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV1, PersonV2](
+          MigrationAction.RenameField(
+            DynamicOptic.root.field("firstName"),
+            "fullName"
+          )
+        )
+
+        val input  = PersonV1("Grace")
+        val result = migration(input)
+
+        assertTrue(result.isRight)
+      },
+      test("case class to structural with transformField") {
+        case class PersonV1(age: Int)
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+
+        type PersonV2 = { def age: Long }
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV1, PersonV2](
+          MigrationAction.TransformField(
+            DynamicOptic.root.field("age"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Long(35L)))
+          )
+        )
+
+        val input  = PersonV1(35)
+        val result = migration(input)
+
+        assertTrue(result.isRight)
+      }
+    ),
+    suite("Structural → Structural (version-to-version migration without runtime types)")(
+      test("pure structural to pure structural with addField") {
+        type PersonV0 = { def name: String }
+        def makePersonV0(n: String): PersonV0 = new { def name: String = n }
+        given Schema[PersonV0]                = Schema.derived[PersonV0]
+
+        type PersonV2 = { def name: String; def age: Int }
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV0, PersonV2](
+          MigrationAction.AddField(
+            DynamicOptic.root.field("age"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
+          )
+        )
+
+        val input: PersonV0 = makePersonV0("Helen")
+        val result          = migration(input)
+
+        assertTrue(result.isRight)
+      },
+      test("pure structural to pure structural with dropField") {
+        type PersonV0 = { def name: String; def age: Int }
+        def makePersonV0(n: String, a: Int): PersonV0 = new {
+          def name: String = n
+          def age: Int     = a
+        }
+        given Schema[PersonV0] = Schema.derived[PersonV0]
+
+        type PersonV2 = { def name: String }
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV0, PersonV2](
+          MigrationAction.DropField(
+            DynamicOptic.root.field("age"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
+          )
+        )
+
+        val input: PersonV0 = makePersonV0("Ivan", 45)
+        val result          = migration(input)
+
+        assertTrue(result.isRight)
+      },
+      test("pure structural to pure structural with renameField") {
+        type PersonV0 = { def firstName: String }
+        def makePersonV0(fn: String): PersonV0 = new { def firstName: String = fn }
+        given Schema[PersonV0]                 = Schema.derived[PersonV0]
+
+        type PersonV2 = { def fullName: String }
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV0, PersonV2](
+          MigrationAction.RenameField(
+            DynamicOptic.root.field("firstName"),
+            "fullName"
+          )
+        )
+
+        val input: PersonV0 = makePersonV0("Julia")
+        val result          = migration(input)
+
+        assertTrue(result.isRight)
+      },
+      test("pure structural to pure structural with transformField") {
+        type PersonV0 = { def age: Int }
+        def makePersonV0(a: Int): PersonV0 = new { def age: Int = a }
+        given Schema[PersonV0]             = Schema.derived[PersonV0]
+
+        type PersonV2 = { def age: Long }
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV0, PersonV2](
+          MigrationAction.TransformField(
+            DynamicOptic.root.field("age"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Long(50L)))
+          )
+        )
+
+        val input: PersonV0 = makePersonV0(50)
+        val result          = migration(input)
+
+        assertTrue(result.isRight)
+      },
+      test("complex pure structural to pure structural migration") {
+        type PersonV0 = { def firstName: String; def lastName: String; def age: Int; def active: Boolean }
+        def makePersonV0(fn: String, ln: String, a: Int, ac: Boolean): PersonV0 = new {
+          def firstName: String = fn
+          def lastName: String  = ln
+          def age: Int          = a
+          def active: Boolean   = ac
+        }
+        given Schema[PersonV0] = Schema.derived[PersonV0]
+
+        type PersonV2 = { def fullName: String; def age: Long; def status: String }
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV0, PersonV2](
+          MigrationAction.DropField(
+            DynamicOptic.root.field("firstName"),
+            literal(DynamicValue.Primitive(PrimitiveValue.String("")))
+          ),
+          MigrationAction.DropField(
+            DynamicOptic.root.field("lastName"),
+            literal(DynamicValue.Primitive(PrimitiveValue.String("")))
+          ),
+          MigrationAction.DropField(
+            DynamicOptic.root.field("active"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Boolean(true)))
+          ),
+          MigrationAction.AddField(
+            DynamicOptic.root.field("fullName"),
+            literal(DynamicValue.Primitive(PrimitiveValue.String("Unknown")))
+          ),
+          MigrationAction.TransformField(
+            DynamicOptic.root.field("age"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Long(0L)))
+          ),
+          MigrationAction.AddField(
+            DynamicOptic.root.field("status"),
+            literal(DynamicValue.Primitive(PrimitiveValue.String("active")))
+          )
+        )
+
+        val input: PersonV0 = makePersonV0("Kate", "Smith", 28, true)
+        val result          = migration(input)
+
+        assertTrue(result.isRight)
+      }
+    ),
+    suite("Nested structural types")(
+      test("pure structural with nested structural field") {
+        type AddressV0 = { def street: String; def city: String }
+        def makeAddressV0(s: String, c: String): AddressV0 = new {
+          def street: String = s
+          def city: String   = c
+        }
+        given Schema[AddressV0] = Schema.derived[AddressV0]
+
+        type PersonV0 = { def name: String; def address: AddressV0 }
+        def makePersonV0(n: String, addr: AddressV0): PersonV0 = new {
+          def name: String       = n
+          def address: AddressV0 = addr
+        }
+        given Schema[PersonV0] = Schema.derived[PersonV0]
+
+        case class Address(street: String, city: String)
+        case class PersonV2(name: String, address: Address, age: Int)
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV0, PersonV2](
+          MigrationAction.AddField(
+            DynamicOptic.root.field("age"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
+          )
+        )
+
+        val input: PersonV0 = makePersonV0("Leo", makeAddressV0("123 Main St", "NYC"))
+        val result          = migration(input)
+
+        assertTrue(result.isRight && migration.actions.size == 1)
+      }
+    ),
+    suite("Edge cases")(
+      test("empty structural type migration") {
+        type EmptyV0 = {}
+        def makeEmptyV0(): EmptyV0 = new {}
+        given Schema[EmptyV0]      = Schema.derived[EmptyV0]
+
+        case class PersonV2(name: String, age: Int)
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[EmptyV0, PersonV2](
+          MigrationAction.AddField(
+            DynamicOptic.root.field("name"),
+            literal(DynamicValue.Primitive(PrimitiveValue.String("Unknown")))
+          ),
+          MigrationAction.AddField(
+            DynamicOptic.root.field("age"),
+            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
+          )
+        )
+
+        val input: EmptyV0 = makeEmptyV0()
+        val result         = migration(input)
+
+        assertTrue(result == Right(PersonV2("Unknown", 0)))
+      },
+      test("identity migration with pure structural type") {
+        type PersonV0 = { def name: String; def age: Int }
+        def makePersonV0(n: String, a: Int): PersonV0 = new {
+          def name: String = n
+          def age: Int     = a
+        }
+        given Schema[PersonV0] = Schema.derived[PersonV0]
+
+        val migration = Migration.fromActions[PersonV0, PersonV0]()
+
+        val input: PersonV0 = makePersonV0("Mia", 32)
+        val result          = migration(input)
+
+        assertTrue(result.isRight && migration.isEmpty)
+      },
+      test("pure structural migration preserves DynamicValue structure") {
+        type PersonV0 = { def name: String }
+        def makePersonV0(n: String): PersonV0 = new { def name: String = n }
+        given schemaV0: Schema[PersonV0]      = Schema.derived[PersonV0]
+
+        val input: PersonV0 = makePersonV0("Nora")
+        val dynamicValue    = schemaV0.toDynamicValue(input)
+
+        assertTrue(
+          dynamicValue match {
+            case DynamicValue.Record(_) => true
+            case _                      => false
+          }
+        )
+      }
+    )
+  )
+}

--- a/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/StructuralMigrationSpec.scala
+++ b/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/StructuralMigrationSpec.scala
@@ -17,442 +17,215 @@
 package zio.blocks.schema.migration
 
 import scala.language.reflectiveCalls
-import zio.test.*
+import scala.reflect.Selectable.reflectiveSelectable
 import zio.blocks.schema.*
+import zio.test.*
 
-/**
- * Tests for migrating from PURE STRUCTURAL TYPES to case classes.
- *
- * This demonstrates the killer feature: migrating from old data formats
- * (represented as structural types) to current case classes WITHOUT keeping the
- * old case class definitions around.
- *
- * Use case: You have serialized data from version 1 of your app, but the case
- * class no longer exists. Represent the old schema as a structural type and
- * migrate to your current case class.
- *
- * NOTE: We use Migration.fromActions with string-based field paths because the
- * MigrationBuilder's selector syntax (_.fieldName) doesn't work with structural
- * types (it uses macros that can't introspect selectDynamic calls).
- */
 object StructuralMigrationSpec extends ZIOSpecDefault {
 
-  private def literal(dv: DynamicValue): DynamicSchemaExpr =
-    DynamicSchemaExpr.Literal(dv)
+  private def literal[A: Schema](value: A): SchemaExpr[Any, A] =
+    SchemaExpr.literal(value)
+
+  private def identityExpr[A: Schema]: SchemaExpr[A, A] =
+    SchemaExpr.optic(DynamicOptic.root, Schema[A])
 
   def spec: Spec[TestEnvironment, Any] = suite("StructuralMigrationSpec")(
-    suite("Structural → Case Class (PRIMARY USE CASE: migrating from old versions)")(
-      test("pure structural to case class with addField") {
-        type PersonV0 = { def name: String }
-        def makePersonV0(n: String): PersonV0 = new { def name: String = n }
-        given Schema[PersonV0]                = Schema.derived[PersonV0]
-
-        case class PersonV2(name: String, age: Int)
-        given Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration.fromActions[PersonV0, PersonV2](
-          MigrationAction.AddField(
-            DynamicOptic.root.field("age"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
-          )
-        )
-
-        val input: PersonV0 = makePersonV0("Alice")
-        val result          = migration(input)
-
-        assertTrue(result == Right(PersonV2("Alice", 0)))
-      },
-      test("pure structural to case class with dropField") {
-        type PersonV0 = { def name: String; def age: Int }
-        def makePersonV0(n: String, a: Int): PersonV0 = new {
-          def name: String = n
-          def age: Int     = a
-        }
-        given Schema[PersonV0] = Schema.derived[PersonV0]
-
-        case class PersonV2(name: String)
-        given Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration.fromActions[PersonV0, PersonV2](
-          MigrationAction.DropField(
-            DynamicOptic.root.field("age"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
-          )
-        )
-
-        val input: PersonV0 = makePersonV0("Bob", 30)
-        val result          = migration(input)
-
-        assertTrue(result == Right(PersonV2("Bob")))
-      },
-      test("pure structural to case class with renameField") {
-        type PersonV0 = { def firstName: String }
-        def makePersonV0(fn: String): PersonV0 = new { def firstName: String = fn }
-        given Schema[PersonV0]                 = Schema.derived[PersonV0]
-
-        case class PersonV2(fullName: String)
-        given Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration.fromActions[PersonV0, PersonV2](
-          MigrationAction.RenameField(
-            DynamicOptic.root.field("firstName"),
-            "fullName"
-          )
-        )
-
-        val input: PersonV0 = makePersonV0("Charlie")
-        val result          = migration(input)
-
-        assertTrue(result == Right(PersonV2("Charlie")))
-      },
-      test("pure structural to case class with transformField") {
-        type PersonV0 = { def age: Int }
-        def makePersonV0(a: Int): PersonV0 = new { def age: Int = a }
-        given Schema[PersonV0]             = Schema.derived[PersonV0]
-
-        case class PersonV2(age: Long)
-        given Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration.fromActions[PersonV0, PersonV2](
-          MigrationAction.TransformField(
-            DynamicOptic.root.field("age"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Long(30L)))
-          )
-        )
-
-        val input: PersonV0 = makePersonV0(30)
-        val result          = migration(input)
-
-        assertTrue(result == Right(PersonV2(30L)))
-      },
-      test("complex pure structural to case class with multiple operations") {
-        type PersonV0 = { def firstName: String; def age: Int; def city: String }
-        def makePersonV0(fn: String, a: Int, c: String): PersonV0 = new {
-          def firstName: String = fn
-          def age: Int          = a
-          def city: String      = c
-        }
-        given Schema[PersonV0] = Schema.derived[PersonV0]
-
-        case class PersonV2(fullName: String, age: Long, country: String)
-        given Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration.fromActions[PersonV0, PersonV2](
-          MigrationAction.RenameField(DynamicOptic.root.field("firstName"), "fullName"),
-          MigrationAction.TransformField(
-            DynamicOptic.root.field("age"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Long(25L)))
-          ),
-          MigrationAction.DropField(
-            DynamicOptic.root.field("city"),
-            literal(DynamicValue.Primitive(PrimitiveValue.String("Unknown")))
-          ),
-          MigrationAction.AddField(
-            DynamicOptic.root.field("country"),
-            literal(DynamicValue.Primitive(PrimitiveValue.String("USA")))
-          )
-        )
-
-        val input: PersonV0 = makePersonV0("David", 25, "NYC")
-        val result          = migration(input)
-
-        assertTrue(result == Right(PersonV2("David", 25L, "USA")))
-      }
-    ),
-    suite("Case Class → Structural (reverse migration for validation)")(
-      test("case class to structural with addField") {
+    suite("Structural → Case Class")(
+      test("addField works with structural target selectors") {
         case class PersonV1(name: String)
         given Schema[PersonV1] = Schema.derived[PersonV1]
 
         type PersonV2 = { def name: String; def age: Int }
         given Schema[PersonV2] = Schema.derived[PersonV2]
 
-        val migration = Migration.fromActions[PersonV1, PersonV2](
-          MigrationAction.AddField(
-            DynamicOptic.root.field("age"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
-          )
-        )
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .transformField(_.name, _.name, identityExpr[String])
+          .addField(_.age, literal(0))
+          .build
 
-        val input  = PersonV1("Emma")
-        val result = migration(input)
-
-        assertTrue(result.isRight)
+        assertTrue(migration(PersonV1("Alice")).isRight)
       },
-      test("case class to structural with dropField") {
-        case class PersonV1(name: String, age: Int)
-        given Schema[PersonV1] = Schema.derived[PersonV1]
+      test("renameField works with structural source selectors") {
+        type PersonV0 = { def firstName: String }
+        def makePersonV0(name: String): PersonV0 = new { def firstName: String = name }
+        given Schema[PersonV0]                   = Schema.derived[PersonV0]
 
-        type PersonV2 = { def name: String }
+        case class PersonV2(fullName: String)
         given Schema[PersonV2] = Schema.derived[PersonV2]
 
-        val migration = Migration.fromActions[PersonV1, PersonV2](
-          MigrationAction.DropField(
-            DynamicOptic.root.field("age"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
-          )
-        )
+        val migration = Migration
+          .newBuilder[PersonV0, PersonV2]
+          .renameField(_.firstName, _.fullName)
+          .build
 
-        val input  = PersonV1("Frank", 40)
-        val result = migration(input)
-
-        assertTrue(result.isRight)
+        assertTrue(migration(makePersonV0("Charlie")) == Right(PersonV2("Charlie")))
       },
-      test("case class to structural with renameField") {
+      test("transformField works with structural source selectors") {
+        type PersonV0 = { def age: Int }
+        def makePersonV0(value: Int): PersonV0 = new { def age: Int = value }
+        given Schema[PersonV0]                 = Schema.derived[PersonV0]
+
+        case class PersonV2(age: Long)
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV0, PersonV2]
+          .transformField(_.age, _.age, literal(30L))
+          .build
+
+        assertTrue(migration(makePersonV0(30)) == Right(PersonV2(30L)))
+      }
+    ),
+    suite("Case Class → Structural")(
+      test("addField works with structural target selectors") {
+        case class PersonV1(name: String)
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+
+        type PersonV2 = { def name: String; def age: Int }
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .transformField(_.name, _.name, identityExpr[String])
+          .addField(_.age, literal(0))
+          .build
+
+        assertTrue(migration(PersonV1("Emma")).isRight)
+      },
+      test("renameField works with structural target selectors") {
         case class PersonV1(firstName: String)
         given Schema[PersonV1] = Schema.derived[PersonV1]
 
         type PersonV2 = { def fullName: String }
         given Schema[PersonV2] = Schema.derived[PersonV2]
 
-        val migration = Migration.fromActions[PersonV1, PersonV2](
-          MigrationAction.RenameField(
-            DynamicOptic.root.field("firstName"),
-            "fullName"
-          )
-        )
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .renameField(_.firstName, _.fullName)
+          .build
 
-        val input  = PersonV1("Grace")
-        val result = migration(input)
+        assertTrue(migration(PersonV1("Grace")).isRight)
+      }
+    ),
+    suite("Structural → Structural")(
+      test("renameField works with structural selectors on both sides") {
+        type PersonV1 = { def firstName: String }
+        type PersonV2 = { def fullName: String }
 
-        assertTrue(result.isRight)
+        def makePersonV1(name: String): PersonV1 = new { def firstName: String = name }
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .renameField(_.firstName, _.fullName)
+          .build
+
+        assertTrue(migration(makePersonV1("Julia")).isRight)
       },
-      test("case class to structural with transformField") {
-        case class PersonV1(age: Int)
+      test("identity migration works for structural types") {
+        type PersonV0 = { def name: String; def age: Int }
+        def makePersonV0(n: String, a: Int): PersonV0 = new {
+          def name: String = n
+          def age: Int     = a
+        }
+        given Schema[PersonV0] = Schema.derived[PersonV0]
+
+        val migration = Migration.newBuilder[PersonV0, PersonV0].build
+
+        assertTrue(migration(makePersonV0("Mia", 32)).isRight && migration.isEmpty)
+      }
+    ),
+    suite("Structural selector validation")(
+      test("build fails to compile when structural target field is missing") {
+        typeCheck {
+          """
+          import scala.language.reflectiveCalls
+          import scala.reflect.Selectable.reflectiveSelectable
+          import zio.blocks.schema.Schema
+          import zio.blocks.schema.migration.Migration
+
+          type PersonV1 = { def name: String }
+          type PersonV2 = { def name: String; def age: Int }
+
+          given Schema[PersonV1] = Schema.derived[PersonV1]
+          given Schema[PersonV2] = Schema.derived[PersonV2]
+
+          Migration.newBuilder[PersonV1, PersonV2].build
+          """
+        }.map(result => assertTrue(result.isLeft))
+      },
+      test("build succeeds for nested structural fields without structural selectors") {
+        case class Address(street: String, city: String)
+        case class PersonV1(name: String, address: Address)
+        given Schema[Address]  = Schema.derived[Address]
         given Schema[PersonV1] = Schema.derived[PersonV1]
 
-        type PersonV2 = { def age: Long }
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        type AddressV2 = { def street: String; def city: String }
+        type PersonV2  = { def name: String; def address: AddressV2; def age: Int }
+        given Schema[AddressV2] = Schema.derived[AddressV2]
+        given Schema[PersonV2]  = Schema.derived[PersonV2]
 
-        val migration = Migration.fromActions[PersonV1, PersonV2](
-          MigrationAction.TransformField(
-            DynamicOptic.root.field("age"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Long(35L)))
-          )
-        )
+        val addressMigration = Migration
+          .newBuilder[Address, AddressV2]
+          .transformField(_.street, _.street, identityExpr[String])
+          .transformField(_.city, _.city, identityExpr[String])
+          .build
 
-        val input  = PersonV1(35)
-        val result = migration(input)
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .transformField(_.name, _.name, identityExpr[String])
+          .migrateField(_.address, addressMigration)
+          .addField(_.age, literal(0))
+          .build
 
-        assertTrue(result.isRight)
-      }
-    ),
-    suite("Structural → Structural (version-to-version migration without runtime types)")(
-      test("pure structural to pure structural with addField") {
-        type PersonV0 = { def name: String }
-        def makePersonV0(n: String): PersonV0 = new { def name: String = n }
-        given Schema[PersonV0]                = Schema.derived[PersonV0]
-
-        type PersonV2 = { def name: String; def age: Int }
-        given Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration.fromActions[PersonV0, PersonV2](
-          MigrationAction.AddField(
-            DynamicOptic.root.field("age"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
-          )
-        )
-
-        val input: PersonV0 = makePersonV0("Helen")
-        val result          = migration(input)
-
-        assertTrue(result.isRight)
+        assertTrue(migration(PersonV1("Leo", Address("123 Main St", "NYC"))).isRight)
       },
-      test("pure structural to pure structural with dropField") {
-        type PersonV0 = { def name: String; def age: Int }
-        def makePersonV0(n: String, a: Int): PersonV0 = new {
-          def name: String = n
-          def age: Int     = a
+      test("nested structural migrateField tracks deep structural fields") {
+        type StreetV1  = { def name: String }
+        type AddressV1 = { def street: StreetV1; def city: String }
+        type PersonV1  = { def name: String; def address: AddressV1 }
+
+        type StreetV2  = { def name: String; def number: Int }
+        type AddressV2 = { def street: StreetV2; def city: String }
+        type PersonV2  = { def name: String; def address: AddressV2 }
+
+        def makeStreetV1(streetName: String): StreetV1                         = new { def name: String = streetName }
+        def makeAddressV1(streetValue: StreetV1, cityValue: String): AddressV1 = new {
+          def street: StreetV1 = streetValue
+          def city: String     = cityValue
         }
-        given Schema[PersonV0] = Schema.derived[PersonV0]
-
-        type PersonV2 = { def name: String }
-        given Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration.fromActions[PersonV0, PersonV2](
-          MigrationAction.DropField(
-            DynamicOptic.root.field("age"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
-          )
-        )
-
-        val input: PersonV0 = makePersonV0("Ivan", 45)
-        val result          = migration(input)
-
-        assertTrue(result.isRight)
-      },
-      test("pure structural to pure structural with renameField") {
-        type PersonV0 = { def firstName: String }
-        def makePersonV0(fn: String): PersonV0 = new { def firstName: String = fn }
-        given Schema[PersonV0]                 = Schema.derived[PersonV0]
-
-        type PersonV2 = { def fullName: String }
-        given Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration.fromActions[PersonV0, PersonV2](
-          MigrationAction.RenameField(
-            DynamicOptic.root.field("firstName"),
-            "fullName"
-          )
-        )
-
-        val input: PersonV0 = makePersonV0("Julia")
-        val result          = migration(input)
-
-        assertTrue(result.isRight)
-      },
-      test("pure structural to pure structural with transformField") {
-        type PersonV0 = { def age: Int }
-        def makePersonV0(a: Int): PersonV0 = new { def age: Int = a }
-        given Schema[PersonV0]             = Schema.derived[PersonV0]
-
-        type PersonV2 = { def age: Long }
-        given Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration.fromActions[PersonV0, PersonV2](
-          MigrationAction.TransformField(
-            DynamicOptic.root.field("age"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Long(50L)))
-          )
-        )
-
-        val input: PersonV0 = makePersonV0(50)
-        val result          = migration(input)
-
-        assertTrue(result.isRight)
-      },
-      test("complex pure structural to pure structural migration") {
-        type PersonV0 = { def firstName: String; def lastName: String; def age: Int; def active: Boolean }
-        def makePersonV0(fn: String, ln: String, a: Int, ac: Boolean): PersonV0 = new {
-          def firstName: String = fn
-          def lastName: String  = ln
-          def age: Int          = a
-          def active: Boolean   = ac
+        def makePersonV1(personName: String, addressValue: AddressV1): PersonV1 = new {
+          def name: String       = personName
+          def address: AddressV1 = addressValue
         }
-        given Schema[PersonV0] = Schema.derived[PersonV0]
 
-        type PersonV2 = { def fullName: String; def age: Long; def status: String }
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        given Schema[StreetV1]  = Schema.derived[StreetV1]
+        given Schema[AddressV1] = Schema.derived[AddressV1]
+        given Schema[PersonV1]  = Schema.derived[PersonV1]
+        given Schema[StreetV2]  = Schema.derived[StreetV2]
+        given Schema[AddressV2] = Schema.derived[AddressV2]
+        given Schema[PersonV2]  = Schema.derived[PersonV2]
 
-        val migration = Migration.fromActions[PersonV0, PersonV2](
-          MigrationAction.DropField(
-            DynamicOptic.root.field("firstName"),
-            literal(DynamicValue.Primitive(PrimitiveValue.String("")))
-          ),
-          MigrationAction.DropField(
-            DynamicOptic.root.field("lastName"),
-            literal(DynamicValue.Primitive(PrimitiveValue.String("")))
-          ),
-          MigrationAction.DropField(
-            DynamicOptic.root.field("active"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Boolean(true)))
-          ),
-          MigrationAction.AddField(
-            DynamicOptic.root.field("fullName"),
-            literal(DynamicValue.Primitive(PrimitiveValue.String("Unknown")))
-          ),
-          MigrationAction.TransformField(
-            DynamicOptic.root.field("age"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Long(0L)))
-          ),
-          MigrationAction.AddField(
-            DynamicOptic.root.field("status"),
-            literal(DynamicValue.Primitive(PrimitiveValue.String("active")))
-          )
-        )
+        val streetMigration = Migration
+          .newBuilder[StreetV1, StreetV2]
+          .addField(_.number, literal(0))
+          .build
 
-        val input: PersonV0 = makePersonV0("Kate", "Smith", 28, true)
-        val result          = migration(input)
+        val addressMigration = Migration
+          .newBuilder[AddressV1, AddressV2]
+          .migrateField(_.street, streetMigration)
+          .build
 
-        assertTrue(result.isRight)
-      }
-    ),
-    suite("Nested structural types")(
-      test("pure structural with nested structural field") {
-        type AddressV0 = { def street: String; def city: String }
-        def makeAddressV0(s: String, c: String): AddressV0 = new {
-          def street: String = s
-          def city: String   = c
-        }
-        given Schema[AddressV0] = Schema.derived[AddressV0]
-
-        type PersonV0 = { def name: String; def address: AddressV0 }
-        def makePersonV0(n: String, addr: AddressV0): PersonV0 = new {
-          def name: String       = n
-          def address: AddressV0 = addr
-        }
-        given Schema[PersonV0] = Schema.derived[PersonV0]
-
-        case class Address(street: String, city: String)
-        case class PersonV2(name: String, address: Address, age: Int)
-        given Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration.fromActions[PersonV0, PersonV2](
-          MigrationAction.AddField(
-            DynamicOptic.root.field("age"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
-          )
-        )
-
-        val input: PersonV0 = makePersonV0("Leo", makeAddressV0("123 Main St", "NYC"))
-        val result          = migration(input)
-
-        assertTrue(result.isRight && migration.actions.size == 1)
-      }
-    ),
-    suite("Edge cases")(
-      test("empty structural type migration") {
-        type EmptyV0 = {}
-        def makeEmptyV0(): EmptyV0 = new {}
-        given Schema[EmptyV0]      = Schema.derived[EmptyV0]
-
-        case class PersonV2(name: String, age: Int)
-        given Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration.fromActions[EmptyV0, PersonV2](
-          MigrationAction.AddField(
-            DynamicOptic.root.field("name"),
-            literal(DynamicValue.Primitive(PrimitiveValue.String("Unknown")))
-          ),
-          MigrationAction.AddField(
-            DynamicOptic.root.field("age"),
-            literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
-          )
-        )
-
-        val input: EmptyV0 = makeEmptyV0()
-        val result         = migration(input)
-
-        assertTrue(result == Right(PersonV2("Unknown", 0)))
-      },
-      test("identity migration with pure structural type") {
-        type PersonV0 = { def name: String; def age: Int }
-        def makePersonV0(n: String, a: Int): PersonV0 = new {
-          def name: String = n
-          def age: Int     = a
-        }
-        given Schema[PersonV0] = Schema.derived[PersonV0]
-
-        val migration = Migration.fromActions[PersonV0, PersonV0]()
-
-        val input: PersonV0 = makePersonV0("Mia", 32)
-        val result          = migration(input)
-
-        assertTrue(result.isRight && migration.isEmpty)
-      },
-      test("pure structural migration preserves DynamicValue structure") {
-        type PersonV0 = { def name: String }
-        def makePersonV0(n: String): PersonV0 = new { def name: String = n }
-        given schemaV0: Schema[PersonV0]      = Schema.derived[PersonV0]
-
-        val input: PersonV0 = makePersonV0("Nora")
-        val dynamicValue    = schemaV0.toDynamicValue(input)
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .migrateField(_.address, addressMigration)
+          .build
 
         assertTrue(
-          dynamicValue match {
-            case DynamicValue.Record(_) => true
-            case _                      => false
-          }
+          migration(makePersonV1("Nina", makeAddressV1(makeStreetV1("Main"), "Berlin"))).isRight
         )
       }
     )

--- a/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/StructuralMigrationSpec.scala
+++ b/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/StructuralMigrationSpec.scala
@@ -75,6 +75,34 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
           .build
 
         assertTrue(migration(makePersonV0(30)) == Right(PersonV2(30L)))
+      },
+      test("dropField works with structural source selectors") {
+        type PersonV1 = { def name: String; def age: Int }
+        case class PersonV2(name: String)
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .dropField(_.age, literal(0))
+          .buildPartial
+
+        assertTrue(migration.size == 1)
+      },
+      test("changeFieldType works with structural source selectors") {
+        type PersonV1 = { def score: Int }
+        case class PersonV2(score: String)
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .changeFieldType(_.score, literal("0"))
+          .build
+
+        assertTrue(migration.size == 1)
       }
     ),
     suite("Case Class → Structural")(
@@ -106,6 +134,34 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
           .build
 
         assertTrue(migration(PersonV1("Grace")).isRight)
+      },
+      test("dropField works with structural target selectors") {
+        case class PersonV1(name: String, age: Int)
+        type PersonV2 = { def name: String }
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .dropField(_.age, literal(0))
+          .buildPartial
+
+        assertTrue(migration.size == 1)
+      },
+      test("changeFieldType works with structural target selectors") {
+        case class PersonV1(score: Int)
+        type PersonV2 = { def score: String }
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .changeFieldType(_.score, literal("0"))
+          .build
+
+        assertTrue(migration.size == 1)
       }
     ),
     suite("Structural → Structural")(
@@ -136,6 +192,34 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
         val migration = Migration.newBuilder[PersonV0, PersonV0].build
 
         assertTrue(migration(makePersonV0("Mia", 32)).isRight && migration.isEmpty)
+      },
+      test("dropField works with structural selectors on both sides") {
+        type PersonV1 = { def name: String; def age: Int }
+        type PersonV2 = { def name: String }
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .dropField(_.age, literal(0))
+          .buildPartial
+
+        assertTrue(migration.size == 1)
+      },
+      test("changeFieldType works with structural selectors on both sides") {
+        type PersonV1 = { def score: Int }
+        type PersonV2 = { def score: String }
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .changeFieldType(_.score, literal("0"))
+          .build
+
+        assertTrue(migration.size == 1)
       }
     ),
     suite("Structural selector validation")(

--- a/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/StructuralMigrationTypeCheckSpec.scala
+++ b/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/StructuralMigrationTypeCheckSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import scala.language.reflectiveCalls
+import scala.reflect.Selectable.reflectiveSelectable
+import zio.blocks.schema._
+import zio.test._
+
+object StructuralMigrationTypeCheckSpec extends ZIOSpecDefault {
+  def spec: Spec[TestEnvironment, Any] = suite("StructuralMigrationTypeCheckSpec")(
+    test("build fails to compile when structural target field is missing") {
+      typeCheck {
+        """
+        import scala.language.reflectiveCalls
+        import scala.reflect.Selectable.reflectiveSelectable
+        import zio.blocks.schema.Schema
+        import zio.blocks.schema.migration.Migration
+
+        type PersonV1 = { def name: String }
+        type PersonV2 = { def name: String; def age: Int }
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        Migration.newBuilder[PersonV1, PersonV2].build
+        """
+      }.map(result => assertTrue(result.isLeft))
+    }
+  )
+}

--- a/schema/jvm/src/test/scala/zio/blocks/schema/migration/StructuralMigrationSpec.scala
+++ b/schema/jvm/src/test/scala/zio/blocks/schema/migration/StructuralMigrationSpec.scala
@@ -17,9 +17,8 @@
 package zio.blocks.schema.migration
 
 import scala.language.reflectiveCalls
-import scala.reflect.Selectable.reflectiveSelectable
-import zio.blocks.schema.*
-import zio.test.*
+import zio.blocks.schema._
+import zio.test._
 
 object StructuralMigrationSpec extends ZIOSpecDefault {
 
@@ -33,10 +32,10 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
     suite("Structural → Case Class")(
       test("addField works with structural target selectors") {
         case class PersonV1(name: String)
-        given Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
 
         type PersonV2 = { def name: String; def age: Int }
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
@@ -48,11 +47,11 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
       },
       test("renameField works with structural source selectors") {
         type PersonV0 = { def firstName: String }
-        def makePersonV0(name: String): PersonV0 = new { def firstName: String = name }
-        given Schema[PersonV0]                   = Schema.derived[PersonV0]
+        def makePersonV0(name: String): PersonV0      = new { def firstName: String = name }
+        implicit val personV0Schema: Schema[PersonV0] = Schema.derived[PersonV0]
 
         case class PersonV2(fullName: String)
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV0, PersonV2]
@@ -63,11 +62,11 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
       },
       test("transformField works with structural source selectors") {
         type PersonV0 = { def age: Int }
-        def makePersonV0(value: Int): PersonV0 = new { def age: Int = value }
-        given Schema[PersonV0]                 = Schema.derived[PersonV0]
+        def makePersonV0(value: Int): PersonV0        = new { def age: Int = value }
+        implicit val personV0Schema: Schema[PersonV0] = Schema.derived[PersonV0]
 
         case class PersonV2(age: Long)
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV0, PersonV2]
@@ -78,40 +77,46 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
       },
       test("dropField works with structural source selectors") {
         type PersonV1 = { def name: String; def age: Int }
+        def makePersonV1(n: String, a: Int): PersonV1 = new {
+          def name: String = n
+          def age: Int     = a
+        }
         case class PersonV2(name: String)
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
           .dropField(_.age, literal(0))
-          .buildPartial
+          .transformField(_.name, _.name, identityExpr[String])
+          .build
 
-        assertTrue(migration.size == 1)
+        assertTrue(migration(makePersonV1("Alice", 30)).isRight)
       },
       test("changeFieldType works with structural source selectors") {
         type PersonV1 = { def score: Int }
+        def makePersonV1(s: Int): PersonV1 = new { def score: Int = s }
         case class PersonV2(score: String)
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
           .changeFieldType(_.score, literal("0"))
           .build
 
-        assertTrue(migration.size == 1)
+        assertTrue(migration(makePersonV1(42)) == Right(PersonV2("0")))
       }
     ),
     suite("Case Class → Structural")(
       test("addField works with structural target selectors") {
         case class PersonV1(name: String)
-        given Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
 
         type PersonV2 = { def name: String; def age: Int }
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
@@ -123,10 +128,10 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
       },
       test("renameField works with structural target selectors") {
         case class PersonV1(firstName: String)
-        given Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
 
         type PersonV2 = { def fullName: String }
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
@@ -139,29 +144,30 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
         case class PersonV1(name: String, age: Int)
         type PersonV2 = { def name: String }
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
           .dropField(_.age, literal(0))
-          .buildPartial
+          .transformField(_.name, _.name, identityExpr[String])
+          .build
 
-        assertTrue(migration.size == 1)
+        assertTrue(migration(PersonV1("Alice", 30)).isRight)
       },
       test("changeFieldType works with structural target selectors") {
         case class PersonV1(score: Int)
         type PersonV2 = { def score: String }
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
           .changeFieldType(_.score, literal("0"))
           .build
 
-        assertTrue(migration.size == 1)
+        assertTrue(migration(PersonV1(42)).isRight)
       }
     ),
     suite("Structural → Structural")(
@@ -171,8 +177,8 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
 
         def makePersonV1(name: String): PersonV1 = new { def firstName: String = name }
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
@@ -187,7 +193,7 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
           def name: String = n
           def age: Int     = a
         }
-        given Schema[PersonV0] = Schema.derived[PersonV0]
+        implicit val personV0Schema: Schema[PersonV0] = Schema.derived[PersonV0]
 
         val migration = Migration.newBuilder[PersonV0, PersonV0].build
 
@@ -196,61 +202,49 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
       test("dropField works with structural selectors on both sides") {
         type PersonV1 = { def name: String; def age: Int }
         type PersonV2 = { def name: String }
+        def makePersonV1(n: String, a: Int): PersonV1 = new {
+          def name: String = n
+          def age: Int     = a
+        }
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
           .dropField(_.age, literal(0))
-          .buildPartial
+          .transformField(_.name, _.name, identityExpr[String])
+          .build
 
-        assertTrue(migration.size == 1)
+        assertTrue(migration(makePersonV1("Alice", 30)).isRight)
       },
       test("changeFieldType works with structural selectors on both sides") {
         type PersonV1 = { def score: Int }
         type PersonV2 = { def score: String }
+        def makePersonV1(s: Int): PersonV1 = new { def score: Int = s }
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
           .changeFieldType(_.score, literal("0"))
           .build
 
-        assertTrue(migration.size == 1)
+        assertTrue(migration(makePersonV1(42)).isRight)
       }
     ),
     suite("Structural selector validation")(
-      test("build fails to compile when structural target field is missing") {
-        typeCheck {
-          """
-          import scala.language.reflectiveCalls
-          import scala.reflect.Selectable.reflectiveSelectable
-          import zio.blocks.schema.Schema
-          import zio.blocks.schema.migration.Migration
-
-          type PersonV1 = { def name: String }
-          type PersonV2 = { def name: String; def age: Int }
-
-          given Schema[PersonV1] = Schema.derived[PersonV1]
-          given Schema[PersonV2] = Schema.derived[PersonV2]
-
-          Migration.newBuilder[PersonV1, PersonV2].build
-          """
-        }.map(result => assertTrue(result.isLeft))
-      },
       test("build succeeds for nested structural fields without structural selectors") {
         case class Address(street: String, city: String)
         case class PersonV1(name: String, address: Address)
-        given Schema[Address]  = Schema.derived[Address]
-        given Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val addressSchema: Schema[Address]   = Schema.derived[Address]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
 
         type AddressV2 = { def street: String; def city: String }
         type PersonV2  = { def name: String; def address: AddressV2; def age: Int }
-        given Schema[AddressV2] = Schema.derived[AddressV2]
-        given Schema[PersonV2]  = Schema.derived[PersonV2]
+        implicit val addressV2Schema: Schema[AddressV2] = Schema.derived[AddressV2]
+        implicit val personV2Schema: Schema[PersonV2]   = Schema.derived[PersonV2]
 
         val addressMigration = Migration
           .newBuilder[Address, AddressV2]
@@ -266,6 +260,88 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
           .build
 
         assertTrue(migration(PersonV1("Leo", Address("123 Main St", "NYC"))).isRight)
+      },
+      test("deep nested structural renameField via migrateField") {
+        type Inner  = { def firstName: String }
+        type Outer  = { def data: Inner }
+        type Inner2 = { def fullName: String }
+        type Outer2 = { def data: Inner2 }
+
+        def makeInner(n: String): Inner = new { def firstName: String = n }
+        def makeOuter(d: Inner): Outer  = new { def data: Inner = d }
+
+        implicit val innerSchema: Schema[Inner]   = Schema.derived[Inner]
+        implicit val outerSchema: Schema[Outer]   = Schema.derived[Outer]
+        implicit val inner2Schema: Schema[Inner2] = Schema.derived[Inner2]
+        implicit val outer2Schema: Schema[Outer2] = Schema.derived[Outer2]
+
+        val innerMigration = Migration
+          .newBuilder[Inner, Inner2]
+          .renameField(_.firstName, _.fullName)
+          .build
+
+        val migration = Migration
+          .newBuilder[Outer, Outer2]
+          .migrateField(_.data, innerMigration)
+          .build
+
+        assertTrue(migration(makeOuter(makeInner("Alice"))).isRight)
+      },
+      test("deep nested structural dropField via migrateField") {
+        type Inner  = { def name: String; def age: Int }
+        type Outer  = { def data: Inner }
+        type Inner2 = { def name: String }
+        type Outer2 = { def data: Inner2 }
+
+        def makeInner(n: String, a: Int): Inner = new {
+          def name: String = n
+          def age: Int     = a
+        }
+        def makeOuter(d: Inner): Outer = new { def data: Inner = d }
+
+        implicit val innerSchema: Schema[Inner]   = Schema.derived[Inner]
+        implicit val outerSchema: Schema[Outer]   = Schema.derived[Outer]
+        implicit val inner2Schema: Schema[Inner2] = Schema.derived[Inner2]
+        implicit val outer2Schema: Schema[Outer2] = Schema.derived[Outer2]
+
+        val innerMigration = Migration
+          .newBuilder[Inner, Inner2]
+          .dropField(_.age, literal(0))
+          .transformField(_.name, _.name, identityExpr[String])
+          .build
+
+        val outerMigration = Migration
+          .newBuilder[Outer, Outer2]
+          .migrateField(_.data, innerMigration)
+          .build
+
+        assertTrue(outerMigration(makeOuter(makeInner("Bob", 25))).isRight)
+      },
+      test("deep nested structural changeFieldType via migrateField") {
+        type Inner  = { def score: Int }
+        type Outer  = { def data: Inner }
+        type Inner2 = { def score: String }
+        type Outer2 = { def data: Inner2 }
+
+        def makeInner(s: Int): Inner   = new { def score: Int = s }
+        def makeOuter(d: Inner): Outer = new { def data: Inner = d }
+
+        implicit val innerSchema: Schema[Inner]   = Schema.derived[Inner]
+        implicit val outerSchema: Schema[Outer]   = Schema.derived[Outer]
+        implicit val inner2Schema: Schema[Inner2] = Schema.derived[Inner2]
+        implicit val outer2Schema: Schema[Outer2] = Schema.derived[Outer2]
+
+        val innerMigration = Migration
+          .newBuilder[Inner, Inner2]
+          .changeFieldType(_.score, literal("0"))
+          .build
+
+        val migration = Migration
+          .newBuilder[Outer, Outer2]
+          .migrateField(_.data, innerMigration)
+          .build
+
+        assertTrue(migration(makeOuter(makeInner(42))).isRight)
       },
       test("nested structural migrateField tracks deep structural fields") {
         type StreetV1  = { def name: String }
@@ -286,12 +362,12 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
           def address: AddressV1 = addressValue
         }
 
-        given Schema[StreetV1]  = Schema.derived[StreetV1]
-        given Schema[AddressV1] = Schema.derived[AddressV1]
-        given Schema[PersonV1]  = Schema.derived[PersonV1]
-        given Schema[StreetV2]  = Schema.derived[StreetV2]
-        given Schema[AddressV2] = Schema.derived[AddressV2]
-        given Schema[PersonV2]  = Schema.derived[PersonV2]
+        implicit val streetV1Schema: Schema[StreetV1]   = Schema.derived[StreetV1]
+        implicit val addressV1Schema: Schema[AddressV1] = Schema.derived[AddressV1]
+        implicit val personV1Schema: Schema[PersonV1]   = Schema.derived[PersonV1]
+        implicit val streetV2Schema: Schema[StreetV2]   = Schema.derived[StreetV2]
+        implicit val addressV2Schema: Schema[AddressV2] = Schema.derived[AddressV2]
+        implicit val personV2Schema: Schema[PersonV2]   = Schema.derived[PersonV2]
 
         val streetMigration = Migration
           .newBuilder[StreetV1, StreetV2]

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -197,9 +197,10 @@ final class MigrationBuilder[A, B, Changeset](
     caseSourceSchema: Schema[CaseA],
     caseTargetSchema: Schema[CaseB]
   ): MigrationBuilder[A, B, Changeset] = {
-    val innerBuilder = new MigrationBuilder[CaseA, CaseB, Any](caseSourceSchema, caseTargetSchema, Chunk.empty)
-    val builtInner   = caseMigration(innerBuilder)
-    appendAction(MigrationAction.TransformCase(DynamicOptic.root.caseOf(caseName), builtInner.actions))
+    val innerBuilder   = new MigrationBuilder[CaseA, CaseB, Any](caseSourceSchema, caseTargetSchema, Chunk.empty)
+    val builtInner     = caseMigration(innerBuilder)
+    val targetCaseName = caseTargetSchema.reflect.typeId.name
+    appendAction(MigrationAction.TransformCase(DynamicOptic.root.caseOf(caseName), targetCaseName, builtInner.actions))
   }
 
   // ----- Collections -----
@@ -253,14 +254,6 @@ final class MigrationBuilder[A, B, Changeset](
    */
   def build(implicit ev: MigrationComplete[A, B, Changeset]): Migration[A, B] =
     new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
-
-  /**
-   * Build migration without full validation.
-   */
-  private[migration] def buildPartial: Migration[A, B] =
-    new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
-
-  // ----- Internal -----
 
   private[migration] def appendAction(action: MigrationAction): MigrationBuilder[A, B, Changeset] =
     new MigrationBuilder(sourceSchema, targetSchema, actions :+ action)

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import scala.language.experimental.macros
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{DynamicOptic, Schema, SchemaExpr}
+
+object Changeset {
+
+  /**
+   * Phantom type wrapper to preserve literal string types through macro
+   * expansion. Direct use of ConstantType causes literal types to widen to
+   * String. By wrapping in FieldName[N], the type argument is preserved when
+   * using appliedType.
+   */
+  sealed trait FieldName[N]
+
+  // Field operations (tracked for validation)
+  sealed trait AddField[N]
+  sealed trait DropField[N]
+  sealed trait RenameField[From, To]
+  sealed trait TransformField[From, To]
+  sealed trait MandateField[Source, Target]
+  sealed trait OptionalizeField[Source, Target]
+  sealed trait ChangeFieldType[Source, Target]
+  sealed trait MigrateField[Name]
+
+  // Case operations (tracked but not field-validated)
+  sealed trait RenameCase[From, To]
+  sealed trait TransformCase[CaseName]
+
+  // Collection operations (tracked but not field-validated)
+  sealed trait TransformElements[FieldName]
+  sealed trait TransformKeys[FieldName]
+  sealed trait TransformValues[FieldName]
+}
+
+/**
+ * A builder for constructing migrations from type `A` to type `B`.
+ *
+ * All selector-accepting methods are implemented via macros that:
+ *   1. Inspect the selector expression
+ *   2. Validate it is a supported projection
+ *   3. Convert it into a `DynamicOptic`
+ *   4. Store that optic in the migration action
+ *
+ * `DynamicOptic` is never exposed publicly in the builder API.
+ *
+ * @tparam A
+ *   The source type
+ * @tparam B
+ *   The target type
+ * @tparam Changeset
+ *   Intersection type tracking which operations have been performed
+ */
+final class MigrationBuilder[A, B, Changeset](
+  val sourceSchema: Schema[A],
+  val targetSchema: Schema[B],
+  private[migration] val actions: Chunk[MigrationAction]
+) {
+
+  // ----- Record operations -----
+
+  /**
+   * Add a new field to the target with a default value.
+   *
+   * @param target
+   *   Selector for the field to add
+   * @param default
+   *   Expression providing the default value
+   */
+  // format: off
+  def addField(target: B => Any, default: SchemaExpr[_, _]): MigrationBuilder[A, B, _] =
+    macro MigrationBuilderMacros.addFieldImpl[A, B, Changeset]
+  // format: on
+
+  /**
+   * Drop a field from the source.
+   *
+   * @param source
+   *   Selector for the field to drop
+   * @param defaultForReverse
+   *   Default value to use when reversing the migration (for re-adding the
+   *   field)
+   */
+  // format: off
+  def dropField(source: A => Any, defaultForReverse: SchemaExpr[_, _]): MigrationBuilder[A, B, _] =
+    macro MigrationBuilderMacros.dropFieldImpl[A, B, Changeset]
+  // format: on
+
+  /**
+   * Rename a field from source to target.
+   */
+  def renameField(
+    from: A => Any,
+    to: B => Any
+  ): MigrationBuilder[A, B, _] = macro MigrationBuilderMacros.renameFieldImpl[A, B, Changeset]
+
+  /**
+   * Transform a field value.
+   *
+   * @param from
+   *   Selector for the source field
+   * @param to
+   *   Selector for the target field (used for validation)
+   * @param transform
+   *   Expression that computes the new value
+   */
+  def transformField(
+    from: A => Any,
+    to: B => Any,
+    transform: SchemaExpr[_, _]
+  ): MigrationBuilder[A, B, _] = macro MigrationBuilderMacros.transformFieldImpl[A, B, Changeset]
+
+  /**
+   * Convert an optional field in source to a required field in target.
+   *
+   * @param source
+   *   Selector for the optional source field
+   * @param target
+   *   Selector for the required target field (used for validation)
+   * @param default
+   *   Expression providing the default value when source is None
+   */
+  def mandateField(
+    source: A => Option[_],
+    target: B => Any,
+    default: SchemaExpr[_, _]
+  ): MigrationBuilder[A, B, _] = macro MigrationBuilderMacros.mandateFieldImpl[A, B, Changeset]
+
+  /**
+   * Convert a required field in source to an optional field in target.
+   */
+  // format: off
+  def optionalizeField(source: A => Any, target: B => Option[_]): MigrationBuilder[A, B, _] =
+    macro MigrationBuilderMacros.optionalizeFieldImpl[A, B, Changeset]
+  // format: on
+
+  /**
+   * Change the type of a field (primitive-to-primitive only).
+   *
+   * @param source
+   *   Selector for the source field
+   * @param target
+   *   Selector for the target field (used for validation)
+   * @param converter
+   *   Expression that converts between types
+   */
+  // format: off
+  def changeFieldType(source: A => Any, target: B => Any, converter: SchemaExpr[_, _]): MigrationBuilder[A, B, _] =
+    macro MigrationBuilderMacros.changeFieldTypeImpl[A, B, Changeset]
+  // format: on
+
+
+  // format: off
+  def migrateField[F1, F2](selector: A => F1, migration: Migration[F1, F2]): MigrationBuilder[A, B, _] =
+    macro MigrationBuilderMacros.migrateFieldExplicitImpl[A, B, F1, F2, Changeset]
+  // format: on
+
+  // format: off
+  def migrateField[F1, F2](selector: A => F1)(implicit migration: Migration[F1, F2]): MigrationBuilder[A, B, _] =
+    macro MigrationBuilderMacros.migrateFieldImplicitImpl[A, B, F1, F2, Changeset]
+  // format: on
+
+  // ----- Enum operations -----
+
+  /**
+   * Rename an enum case.
+   */
+  def renameCase(
+    from: String,
+    to: String
+  ): MigrationBuilder[A, B, Changeset] =
+    appendAction(MigrationAction.RenameCase(DynamicOptic.root, from, to))
+
+  /**
+   * Transform the fields within an enum case.
+   */
+  def transformCase[CaseA, CaseB](
+    caseName: String
+  )(
+    caseMigration: MigrationBuilder[CaseA, CaseB, Any] => MigrationBuilder[CaseA, CaseB, _]
+  )(implicit
+    caseSourceSchema: Schema[CaseA],
+    caseTargetSchema: Schema[CaseB]
+  ): MigrationBuilder[A, B, Changeset] = {
+    val innerBuilder = new MigrationBuilder[CaseA, CaseB, Any](caseSourceSchema, caseTargetSchema, Chunk.empty)
+    val builtInner   = caseMigration(innerBuilder)
+    appendAction(MigrationAction.TransformCase(DynamicOptic.root.caseOf(caseName), builtInner.actions))
+  }
+
+  // ----- Collections -----
+
+  /**
+   * Transform each element in a collection.
+   *
+   * @param at
+   *   Selector for the collection field
+   * @param transform
+   *   Expression that transforms each element
+   */
+  // format: off
+  def transformElements(at: A => Iterable[_], transform: SchemaExpr[_, _]): MigrationBuilder[A, B, Changeset] =
+    macro MigrationBuilderMacros.transformElementsImpl[A, B, Changeset]
+  // format: on
+
+  // ----- Maps -----
+
+  /**
+   * Transform each key in a map.
+   *
+   * @param at
+   *   Selector for the map field
+   * @param transform
+   *   Expression that transforms each key
+   */
+  // format: off
+  def transformKeys(at: A => Map[_, _], transform: SchemaExpr[_, _]): MigrationBuilder[A, B, Changeset] =
+    macro MigrationBuilderMacros.transformKeysImpl[A, B, Changeset]
+  // format: on
+
+  /**
+   * Transform each value in a map.
+   *
+   * @param at
+   *   Selector for the map field
+   * @param transform
+   *   Expression that transforms each value
+   */
+  // format: off
+  def transformValues(at: A => Map[_, _], transform: SchemaExpr[_, _]): MigrationBuilder[A, B, Changeset] =
+    macro MigrationBuilderMacros.transformValuesImpl[A, B, Changeset]
+  // format: on
+
+  // ----- Build -----
+
+  /**
+   * Build migration with full macro validation. Requires implicit evidence that
+   * all source fields are handled and all target fields are provided.
+   */
+  def build(implicit ev: MigrationComplete[A, B, Changeset]): Migration[A, B] =
+    new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
+
+  /**
+   * Build migration without full validation.
+   */
+  def buildPartial: Migration[A, B] =
+    new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
+
+  // ----- Internal -----
+
+  private[migration] def appendAction(action: MigrationAction): MigrationBuilder[A, B, Changeset] =
+    new MigrationBuilder(sourceSchema, targetSchema, actions :+ action)
+}
+
+object MigrationBuilder {
+  def apply[A, B](implicit
+    sourceSchema: Schema[A],
+    targetSchema: Schema[B]
+  ): MigrationBuilder[A, B, Any] =
+    new MigrationBuilder(sourceSchema, targetSchema, Chunk.empty)
+}
+
+/**
+ * Evidence that a migration is complete. All source fields must be handled and
+ * all target fields must be provided.
+ */
+trait MigrationComplete[-A, -B, -Changeset]
+
+object MigrationComplete {
+  private[migration] def unsafeCreate[A, B, CS]: MigrationComplete[A, B, CS] =
+    instance.asInstanceOf[MigrationComplete[A, B, CS]]
+
+  private val instance: MigrationComplete[Any, Any, Any] =
+    new MigrationComplete[Any, Any, Any] {}
+
+  // format: off
+  implicit def derive[A, B, CS]: MigrationComplete[A, B, CS] =
+    macro MigrationValidationMacros.validateMigrationImpl[A, B, CS]
+  // format: on
+}

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -259,7 +259,7 @@ final class MigrationBuilder[A, B, Changeset](
   /**
    * Build migration without full validation.
    */
-  def buildPartial: Migration[A, B] =
+  private[migration] def buildPartial: Migration[A, B] =
     new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
 
   // ----- Internal -----

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -37,7 +37,7 @@ object Changeset {
   sealed trait TransformField[From, To]
   sealed trait MandateField[Source, Target]
   sealed trait OptionalizeField[Source, Target]
-  sealed trait ChangeFieldType[Source, Target]
+  sealed trait ChangeFieldType[Name]
   sealed trait MigrateField[Name]
 
   // Case operations (tracked but not field-validated)
@@ -156,13 +156,11 @@ final class MigrationBuilder[A, B, Changeset](
    *
    * @param source
    *   Selector for the source field
-   * @param target
-   *   Selector for the target field (used for validation)
    * @param converter
    *   Expression that converts between types
    */
   // format: off
-  def changeFieldType(source: A => Any, target: B => Any, converter: SchemaExpr[_, _]): MigrationBuilder[A, B, _] =
+  def changeFieldType(source: A => Any, converter: SchemaExpr[_, _]): MigrationBuilder[A, B, _] =
     macro MigrationBuilderMacros.changeFieldTypeImpl[A, B, Changeset]
   // format: on
 

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
@@ -1,0 +1,833 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import scala.reflect.macros.whitebox
+import zio.blocks.schema.SchemaExpr
+
+object MigrationBuilderMacros {
+
+  private def extractFieldNameFromSelector(c: whitebox.Context)(selector: c.Tree): String = {
+    import c.universe._
+
+    def extractFromBody(body: c.Tree): String = body match {
+      case Select(_, fieldName) => fieldName.decodedName.toString
+      case _                    => c.abort(c.enclosingPosition, s"Cannot extract field name from selector: ${showRaw(body)}")
+    }
+
+    selector match {
+      case q"($_) => $body" => extractFromBody(body)
+      case _                => c.abort(c.enclosingPosition, s"Expected a lambda expression, got: ${showRaw(selector)}")
+    }
+  }
+
+  private def createRefinedType(c: whitebox.Context)(currentType: c.Type, fieldName: String): c.Type = {
+    import c.universe._
+
+    val fieldNameLiteral = c.internal.constantType(Constant(fieldName))
+    val fieldNameTpe     = appliedType(typeOf[Changeset.FieldName[_]].typeConstructor, fieldNameLiteral)
+    c.internal.refinedType(List(currentType, fieldNameTpe), c.internal.newScopeWith())
+  }
+
+  private def addToChangeset(c: whitebox.Context)(currentType: c.Type, opType: c.Type): c.Type =
+    c.internal.refinedType(List(currentType, opType), c.internal.newScopeWith())
+
+  private def createAddFieldType(c: whitebox.Context)(fieldName: String): c.Type = {
+    import c.universe._
+    val fieldNameLiteral = c.internal.constantType(Constant(fieldName))
+    appliedType(typeOf[Changeset.AddField[_]].typeConstructor, fieldNameLiteral)
+  }
+
+  private def createDropFieldType(c: whitebox.Context)(fieldName: String): c.Type = {
+    import c.universe._
+    val fieldNameLiteral = c.internal.constantType(Constant(fieldName))
+    appliedType(typeOf[Changeset.DropField[_]].typeConstructor, fieldNameLiteral)
+  }
+
+  private def createRenameFieldType(c: whitebox.Context)(from: String, to: String): c.Type = {
+    import c.universe._
+    val fromLiteral = c.internal.constantType(Constant(from))
+    val toLiteral   = c.internal.constantType(Constant(to))
+    appliedType(typeOf[Changeset.RenameField[_, _]].typeConstructor, fromLiteral, toLiteral)
+  }
+
+  private def createTransformFieldType(c: whitebox.Context)(from: String, to: String): c.Type = {
+    import c.universe._
+    val fromLiteral = c.internal.constantType(Constant(from))
+    val toLiteral   = c.internal.constantType(Constant(to))
+    appliedType(typeOf[Changeset.TransformField[_, _]].typeConstructor, fromLiteral, toLiteral)
+  }
+
+  private def createMandateFieldType(c: whitebox.Context)(source: String, target: String): c.Type = {
+    import c.universe._
+    val sourceLiteral = c.internal.constantType(Constant(source))
+    val targetLiteral = c.internal.constantType(Constant(target))
+    appliedType(typeOf[Changeset.MandateField[_, _]].typeConstructor, sourceLiteral, targetLiteral)
+  }
+
+  private def createOptionalizeFieldType(c: whitebox.Context)(source: String, target: String): c.Type = {
+    import c.universe._
+    val sourceLiteral = c.internal.constantType(Constant(source))
+    val targetLiteral = c.internal.constantType(Constant(target))
+    appliedType(typeOf[Changeset.OptionalizeField[_, _]].typeConstructor, sourceLiteral, targetLiteral)
+  }
+
+  private def createChangeFieldTypeType(c: whitebox.Context)(source: String, target: String): c.Type = {
+    import c.universe._
+    val sourceLiteral = c.internal.constantType(Constant(source))
+    val targetLiteral = c.internal.constantType(Constant(target))
+    appliedType(typeOf[Changeset.ChangeFieldType[_, _]].typeConstructor, sourceLiteral, targetLiteral)
+  }
+
+  private def createMigrateFieldType(c: whitebox.Context)(name: String): c.Type = {
+    import c.universe._
+    val nameLiteral = c.internal.constantType(Constant(name))
+    appliedType(typeOf[Changeset.MigrateField[_]].typeConstructor, nameLiteral)
+  }
+
+  def addFieldImpl[A: c.WeakTypeTag, B: c.WeakTypeTag, CS: c.WeakTypeTag](c: whitebox.Context)(
+    target: c.Expr[B => Any],
+    default: c.Expr[SchemaExpr[_, _]]
+  ): c.Tree = {
+    import c.universe._
+
+    val aType  = weakTypeOf[A]
+    val bType  = weakTypeOf[B]
+    val csType = weakTypeOf[CS]
+
+    val fieldName    = extractFieldNameFromSelector(c)(target.tree)
+    val addFieldType = createAddFieldType(c)(fieldName)
+    val newCSType    = addToChangeset(c)(csType, addFieldType)
+
+    val targetPath = SelectorMacros.toPathImpl[B, Any](c)(target.asInstanceOf[c.Expr[B => Any]])
+
+    q"""{
+      val targetPath = $targetPath
+      new _root_.zio.blocks.schema.migration.MigrationBuilder[$aType, $bType, $newCSType](
+        ${c.prefix}.sourceSchema,
+        ${c.prefix}.targetSchema,
+        ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.AddField(
+          targetPath,
+          $default.toDynamic
+        )
+      )
+    }"""
+  }
+
+  def dropFieldImpl[A: c.WeakTypeTag, B: c.WeakTypeTag, CS: c.WeakTypeTag](c: whitebox.Context)(
+    source: c.Expr[A => Any],
+    defaultForReverse: c.Expr[SchemaExpr[_, _]]
+  ): c.Tree = {
+    import c.universe._
+
+    val aType  = weakTypeOf[A]
+    val bType  = weakTypeOf[B]
+    val csType = weakTypeOf[CS]
+
+    val fieldName     = extractFieldNameFromSelector(c)(source.tree)
+    val dropFieldType = createDropFieldType(c)(fieldName)
+    val newCSType     = addToChangeset(c)(csType, dropFieldType)
+
+    val sourcePath = SelectorMacros.toPathImpl[A, Any](c)(source.asInstanceOf[c.Expr[A => Any]])
+
+    q"""{
+      val sourcePath = $sourcePath
+      new _root_.zio.blocks.schema.migration.MigrationBuilder[$aType, $bType, $newCSType](
+        ${c.prefix}.sourceSchema,
+        ${c.prefix}.targetSchema,
+        ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.DropField(
+          sourcePath,
+          $defaultForReverse.toDynamic
+        )
+      )
+    }"""
+  }
+
+  def renameFieldImpl[A: c.WeakTypeTag, B: c.WeakTypeTag, CS: c.WeakTypeTag](c: whitebox.Context)(
+    from: c.Expr[A => Any],
+    to: c.Expr[B => Any]
+  ): c.Tree = {
+    import c.universe._
+
+    val aType  = weakTypeOf[A]
+    val bType  = weakTypeOf[B]
+    val csType = weakTypeOf[CS]
+
+    val fromFieldName   = extractFieldNameFromSelector(c)(from.tree)
+    val toFieldName     = extractFieldNameFromSelector(c)(to.tree)
+    val renameFieldType = createRenameFieldType(c)(fromFieldName, toFieldName)
+    val newCSType       = addToChangeset(c)(csType, renameFieldType)
+
+    val fromPath = SelectorMacros.toPathImpl[A, Any](c)(from.asInstanceOf[c.Expr[A => Any]])
+    val toPath   = SelectorMacros.toPathImpl[B, Any](c)(to.asInstanceOf[c.Expr[B => Any]])
+
+    q"""{
+      val fromPath = $fromPath
+      val toPath = $toPath
+      val toName = toPath.nodes.lastOption match {
+        case _root_.scala.Some(_root_.zio.blocks.schema.DynamicOptic.Node.Field(name)) => name
+        case _ => throw new IllegalArgumentException("Target selector must end with a field access")
+      }
+      new _root_.zio.blocks.schema.migration.MigrationBuilder[$aType, $bType, $newCSType](
+        ${c.prefix}.sourceSchema,
+        ${c.prefix}.targetSchema,
+        ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.RenameField(fromPath, toName)
+      )
+    }"""
+  }
+
+  def transformFieldImpl[A: c.WeakTypeTag, B: c.WeakTypeTag, CS: c.WeakTypeTag](c: whitebox.Context)(
+    from: c.Expr[A => Any],
+    to: c.Expr[B => Any],
+    transform: c.Expr[SchemaExpr[_, _]]
+  ): c.Tree = {
+    import c.universe._
+
+    val aType  = weakTypeOf[A]
+    val bType  = weakTypeOf[B]
+    val csType = weakTypeOf[CS]
+
+    val fromFieldName      = extractFieldNameFromSelector(c)(from.tree)
+    val toFieldName        = extractFieldNameFromSelector(c)(to.tree)
+    val transformFieldType = createTransformFieldType(c)(fromFieldName, toFieldName)
+    val newCSType          = addToChangeset(c)(csType, transformFieldType)
+
+    val fromPath = SelectorMacros.toPathImpl[A, Any](c)(from.asInstanceOf[c.Expr[A => Any]])
+    val toPath   = SelectorMacros.toPathImpl[B, Any](c)(to.asInstanceOf[c.Expr[B => Any]])
+
+    q"""{
+      val fromPath = $fromPath
+      val toPath = $toPath
+      locally(toPath)
+      new _root_.zio.blocks.schema.migration.MigrationBuilder[$aType, $bType, $newCSType](
+        ${c.prefix}.sourceSchema,
+        ${c.prefix}.targetSchema,
+        ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.TransformField(
+          fromPath,
+          $transform.toDynamic
+        )
+      )
+    }"""
+  }
+
+  def mandateFieldImpl[A: c.WeakTypeTag, B: c.WeakTypeTag, CS: c.WeakTypeTag](c: whitebox.Context)(
+    source: c.Expr[A => Option[_]],
+    target: c.Expr[B => Any],
+    default: c.Expr[SchemaExpr[_, _]]
+  ): c.Tree = {
+    import c.universe._
+
+    val aType  = weakTypeOf[A]
+    val bType  = weakTypeOf[B]
+    val csType = weakTypeOf[CS]
+
+    val sourceFieldName  = extractFieldNameFromSelector(c)(source.tree)
+    val targetFieldName  = extractFieldNameFromSelector(c)(target.tree)
+    val mandateFieldType = createMandateFieldType(c)(sourceFieldName, targetFieldName)
+    val newCSType        = addToChangeset(c)(csType, mandateFieldType)
+
+    val sourcePath = SelectorMacros.toPathImpl[A, Option[_]](c)(source.asInstanceOf[c.Expr[A => Option[_]]])
+    val targetPath = SelectorMacros.toPathImpl[B, Any](c)(target.asInstanceOf[c.Expr[B => Any]])
+
+    q"""{
+      val sourcePath = $sourcePath
+      val targetPath = $targetPath
+      locally(targetPath)
+      new _root_.zio.blocks.schema.migration.MigrationBuilder[$aType, $bType, $newCSType](
+        ${c.prefix}.sourceSchema,
+        ${c.prefix}.targetSchema,
+        ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.MandateField(
+          sourcePath,
+          $default.toDynamic
+        )
+      )
+    }"""
+  }
+
+  def optionalizeFieldImpl[A: c.WeakTypeTag, B: c.WeakTypeTag, CS: c.WeakTypeTag](
+    c: whitebox.Context
+  )(
+    source: c.Expr[A => Any],
+    target: c.Expr[B => Option[_]]
+  ): c.Tree = {
+    import c.universe._
+
+    val aType  = weakTypeOf[A]
+    val bType  = weakTypeOf[B]
+    val csType = weakTypeOf[CS]
+
+    val sourceFieldName      = extractFieldNameFromSelector(c)(source.tree)
+    val targetFieldName      = extractFieldNameFromSelector(c)(target.tree)
+    val optionalizeFieldType = createOptionalizeFieldType(c)(sourceFieldName, targetFieldName)
+    val newCSType            = addToChangeset(c)(csType, optionalizeFieldType)
+
+    val sourcePath = SelectorMacros.toPathImpl[A, Any](c)(source.asInstanceOf[c.Expr[A => Any]])
+    val targetPath = SelectorMacros.toPathImpl[B, Option[_]](c)(target.asInstanceOf[c.Expr[B => Option[_]]])
+
+    q"""{
+      val sourcePath = $sourcePath
+      val targetPath = $targetPath
+      locally(targetPath)
+      new _root_.zio.blocks.schema.migration.MigrationBuilder[$aType, $bType, $newCSType](
+        ${c.prefix}.sourceSchema,
+        ${c.prefix}.targetSchema,
+        ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.OptionalizeField(sourcePath)
+      )
+    }"""
+  }
+
+  def changeFieldTypeImpl[A: c.WeakTypeTag, B: c.WeakTypeTag, CS: c.WeakTypeTag](
+    c: whitebox.Context
+  )(
+    source: c.Expr[A => Any],
+    target: c.Expr[B => Any],
+    converter: c.Expr[SchemaExpr[_, _]]
+  ): c.Tree = {
+    import c.universe._
+
+    val aType  = weakTypeOf[A]
+    val bType  = weakTypeOf[B]
+    val csType = weakTypeOf[CS]
+
+    val sourceFieldName     = extractFieldNameFromSelector(c)(source.tree)
+    val targetFieldName     = extractFieldNameFromSelector(c)(target.tree)
+    val changeFieldTypeType = createChangeFieldTypeType(c)(sourceFieldName, targetFieldName)
+    val newCSType           = addToChangeset(c)(csType, changeFieldTypeType)
+
+    val sourcePath = SelectorMacros.toPathImpl[A, Any](c)(source.asInstanceOf[c.Expr[A => Any]])
+    val targetPath = SelectorMacros.toPathImpl[B, Any](c)(target.asInstanceOf[c.Expr[B => Any]])
+
+    q"""{
+      val sourcePath = $sourcePath
+      val targetPath = $targetPath
+      locally(targetPath)
+      new _root_.zio.blocks.schema.migration.MigrationBuilder[$aType, $bType, $newCSType](
+        ${c.prefix}.sourceSchema,
+        ${c.prefix}.targetSchema,
+        ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.ChangeFieldType(
+          sourcePath,
+          $converter.toDynamic
+        )
+      )
+    }"""
+  }
+
+  def transformElementsImpl[A: c.WeakTypeTag, B: c.WeakTypeTag, CS: c.WeakTypeTag](
+    c: whitebox.Context
+  )(
+    at: c.Expr[A => Iterable[_]],
+    transform: c.Expr[SchemaExpr[_, _]]
+  ): c.Tree = {
+    import c.universe._
+
+    val aType  = weakTypeOf[A]
+    val bType  = weakTypeOf[B]
+    val csType = weakTypeOf[CS]
+
+    val path = SelectorMacros.toPathImpl[A, Iterable[_]](c)(at.asInstanceOf[c.Expr[A => Iterable[_]]])
+
+    q"""{
+      val path = $path
+      new _root_.zio.blocks.schema.migration.MigrationBuilder[$aType, $bType, $csType](
+        ${c.prefix}.sourceSchema,
+        ${c.prefix}.targetSchema,
+        ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.TransformElements(
+          path,
+          $transform.toDynamic
+        )
+      )
+    }"""
+  }
+
+  def transformKeysImpl[A: c.WeakTypeTag, B: c.WeakTypeTag, CS: c.WeakTypeTag](c: whitebox.Context)(
+    at: c.Expr[A => Map[_, _]],
+    transform: c.Expr[SchemaExpr[_, _]]
+  ): c.Tree = {
+    import c.universe._
+
+    val aType  = weakTypeOf[A]
+    val bType  = weakTypeOf[B]
+    val csType = weakTypeOf[CS]
+
+    val path = SelectorMacros.toPathImpl[A, Map[_, _]](c)(at.asInstanceOf[c.Expr[A => Map[_, _]]])
+
+    q"""{
+      val path = $path
+      new _root_.zio.blocks.schema.migration.MigrationBuilder[$aType, $bType, $csType](
+        ${c.prefix}.sourceSchema,
+        ${c.prefix}.targetSchema,
+        ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.TransformKeys(
+          path,
+          $transform.toDynamic
+        )
+      )
+    }"""
+  }
+
+  def transformValuesImpl[A: c.WeakTypeTag, B: c.WeakTypeTag, CS: c.WeakTypeTag](
+    c: whitebox.Context
+  )(
+    at: c.Expr[A => Map[_, _]],
+    transform: c.Expr[SchemaExpr[_, _]]
+  ): c.Tree = {
+    import c.universe._
+
+    val aType  = weakTypeOf[A]
+    val bType  = weakTypeOf[B]
+    val csType = weakTypeOf[CS]
+
+    val path = SelectorMacros.toPathImpl[A, Map[_, _]](c)(at.asInstanceOf[c.Expr[A => Map[_, _]]])
+
+    q"""{
+      val path = $path
+      new _root_.zio.blocks.schema.migration.MigrationBuilder[$aType, $bType, $csType](
+        ${c.prefix}.sourceSchema,
+        ${c.prefix}.targetSchema,
+        ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.TransformValues(
+          path,
+          $transform.toDynamic
+        )
+      )
+    }"""
+  }
+
+  def migrateFieldExplicitImpl[
+    A: c.WeakTypeTag,
+    B: c.WeakTypeTag,
+    F1: c.WeakTypeTag,
+    F2: c.WeakTypeTag,
+    CS: c.WeakTypeTag
+  ](c: whitebox.Context)(
+    selector: c.Expr[A => F1],
+    migration: c.Expr[Migration[F1, F2]]
+  ): c.Tree = {
+    import c.universe._
+
+    val aType  = weakTypeOf[A]
+    val bType  = weakTypeOf[B]
+    val f1Type = weakTypeOf[F1]
+    val f2Type = weakTypeOf[F2]
+    val csType = weakTypeOf[CS]
+
+    val sourceFieldName = extractFieldNameFromSelector(c)(selector.tree)
+
+    val nestedSourceFields = extractCaseClassFields(c)(f1Type)
+    val nestedTargetFields = extractCaseClassFields(c)(f2Type)
+
+    val migrateFieldType = createMigrateFieldType(c)(sourceFieldName)
+    var newCSType        = addToChangeset(c)(csType, migrateFieldType)
+
+    for (nestedField <- nestedSourceFields) {
+      val dotPath = s"$sourceFieldName.$nestedField"
+      newCSType = createRefinedType(c)(newCSType, dotPath)
+    }
+
+    for (nestedField <- nestedTargetFields) {
+      val dotPath = s"$sourceFieldName.$nestedField"
+      newCSType = createRefinedType(c)(newCSType, dotPath)
+    }
+
+    val sourcePath = SelectorMacros.toPathImpl[A, F1](c)(selector.asInstanceOf[c.Expr[A => F1]])
+
+    q"""{
+      val sourcePath = $sourcePath
+      new _root_.zio.blocks.schema.migration.MigrationBuilder[$aType, $bType, $newCSType](
+        ${c.prefix}.sourceSchema,
+        ${c.prefix}.targetSchema,
+        ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.MigrateField(
+          sourcePath,
+          $migration.dynamicMigration
+        )
+      )
+    }"""
+  }
+
+  def migrateFieldImplicitImpl[
+    A: c.WeakTypeTag,
+    B: c.WeakTypeTag,
+    F1: c.WeakTypeTag,
+    F2: c.WeakTypeTag,
+    CS: c.WeakTypeTag
+  ](c: whitebox.Context)(
+    selector: c.Expr[A => F1]
+  )(
+    migration: c.Expr[Migration[F1, F2]]
+  ): c.Tree =
+    migrateFieldExplicitImpl[A, B, F1, F2, CS](c)(selector, migration)
+
+  private def extractCaseClassFields(c: whitebox.Context)(tpe: c.universe.Type): List[String] = {
+    import c.universe._
+
+    val sym = tpe.typeSymbol
+    if (sym.isClass && sym.asClass.isCaseClass) {
+      val ctor = tpe.decl(termNames.CONSTRUCTOR).asMethod
+      ctor.paramLists.headOption.getOrElse(Nil).map(_.name.decodedName.toString)
+    } else {
+      Nil
+    }
+  }
+}
+
+object MigrationValidationMacros {
+
+  def validateMigrationImpl[A: c.WeakTypeTag, B: c.WeakTypeTag, CS: c.WeakTypeTag](
+    c: whitebox.Context
+  ): c.Tree = {
+    import c.universe._
+
+    val sourceType = weakTypeOf[A]
+    val targetType = weakTypeOf[B]
+    val csType     = weakTypeOf[CS]
+
+    val sourceFields = extractCaseClassFieldsWithNested(c)(sourceType, "")
+    val targetFields = extractCaseClassFieldsWithNested(c)(targetType, "")
+
+    val (handledFields, providedFields) = extractHandledAndProvided(c)(csType)
+
+    val autoMapped = computeAutoMappedWithNested(c)(sourceType, targetType, "")
+
+    val allExplicitlyHandled = handledFields ++ providedFields
+    val crossTypeAutoMapped  = computeCrossTypeAutoMapped(c)(sourceType, targetType, allExplicitlyHandled, "")
+
+    var coveredSource = handledFields ++ autoMapped ++ crossTypeAutoMapped
+    var coveredTarget = providedFields ++ autoMapped ++ crossTypeAutoMapped
+
+    coveredSource = inferParentCoverage(sourceFields, coveredSource)
+    coveredTarget = inferParentCoverage(targetFields, coveredTarget)
+
+    val missingTarget   = targetFields -- coveredTarget
+    val unhandledSource = sourceFields -- coveredSource
+
+    if (missingTarget.nonEmpty || unhandledSource.nonEmpty) {
+      val errors = new StringBuilder("Migration incomplete:\n")
+
+      if (missingTarget.nonEmpty) {
+        errors.append(s"\n  Target fields not provided: ${missingTarget.mkString(", ")}\n")
+        errors.append("  Use addField, renameField, transformField, or migrateField to provide these fields.\n")
+      }
+
+      if (unhandledSource.nonEmpty) {
+        errors.append(s"\n  Source fields not handled: ${unhandledSource.mkString(", ")}\n")
+        errors.append("  Use dropField, renameField, transformField, or migrateField to handle these fields.\n")
+      }
+
+      errors.append("\n  Alternatively, use .buildPartial to skip validation.")
+
+      c.abort(c.enclosingPosition, errors.toString)
+    }
+
+    q"_root_.zio.blocks.schema.migration.MigrationComplete.unsafeCreate[$sourceType, $targetType, $csType]"
+  }
+
+  private def extractHandledAndProvided(c: whitebox.Context)(tpe: c.universe.Type): (Set[String], Set[String]) = {
+    import c.universe._
+
+    var handled  = Set.empty[String]
+    var provided = Set.empty[String]
+
+    def extractString(t: Type): Option[String] = t.dealias match {
+      case ConstantType(Constant(s: String)) => Some(s)
+      case _                                 => None
+    }
+
+    def extract(t: Type): Unit = t.dealias match {
+      case RefinedType(parents, _) =>
+        parents.foreach(extract)
+      case t if t =:= typeOf[Any] => ()
+      case TypeRef(_, sym, args)  =>
+        sym.name.toString match {
+          case "AddField" =>
+            args.headOption.flatMap(extractString).foreach(n => provided += n)
+          case "DropField" =>
+            args.headOption.flatMap(extractString).foreach(n => handled += n)
+          case "RenameField" =>
+            args.headOption.flatMap(extractString).foreach(n => handled += n)
+            args.lift(1).flatMap(extractString).foreach(n => provided += n)
+          case "TransformField" =>
+            args.headOption.flatMap(extractString).foreach(n => handled += n)
+            args.lift(1).flatMap(extractString).foreach(n => provided += n)
+          case "MandateField" =>
+            args.headOption.flatMap(extractString).foreach(n => handled += n)
+            args.lift(1).flatMap(extractString).foreach(n => provided += n)
+          case "OptionalizeField" =>
+            args.headOption.flatMap(extractString).foreach(n => handled += n)
+            args.lift(1).flatMap(extractString).foreach(n => provided += n)
+          case "ChangeFieldType" =>
+            args.headOption.flatMap(extractString).foreach(n => handled += n)
+            args.lift(1).flatMap(extractString).foreach(n => provided += n)
+          case "MigrateField" =>
+            args.headOption.flatMap(extractString).foreach { n =>
+              handled += n
+              provided += n
+            }
+          case "FieldName" =>
+            args.headOption.flatMap(extractString).foreach { n =>
+              handled += n
+              provided += n
+            }
+          case "RenameCase" | "TransformCase" | "TransformElements" | "TransformKeys" | "TransformValues" =>
+            ()
+          case _ => ()
+        }
+      case _ => ()
+    }
+
+    extract(tpe)
+    (handled, provided)
+  }
+
+  private def extractCaseClassFieldsWithNested(
+    c: whitebox.Context
+  )(tpe: c.universe.Type, prefix: String): Set[String] = {
+    import c.universe._
+
+    val sym = tpe.typeSymbol
+    if (sym.isClass && sym.asClass.isCaseClass) {
+      val ctor = tpe.decl(termNames.CONSTRUCTOR).asMethod
+      ctor.paramLists.headOption
+        .getOrElse(Nil)
+        .flatMap { param =>
+          val fieldName =
+            if (prefix.isEmpty) param.name.decodedName.toString else s"$prefix.${param.name.decodedName.toString}"
+          val fieldType = param.typeSignature.asSeenFrom(tpe, sym)
+          val fieldSym  = fieldType.typeSymbol
+
+          if (fieldSym.isClass && fieldSym.asClass.isCaseClass) {
+            Set(fieldName) ++ extractNestedFieldNames(c)(fieldType, fieldName)
+          } else {
+            Set(fieldName)
+          }
+        }
+        .toSet
+    } else {
+      Set.empty
+    }
+  }
+
+  private def extractNestedFieldNames(c: whitebox.Context)(tpe: c.universe.Type, prefix: String): Set[String] = {
+    import c.universe._
+
+    val sym = tpe.typeSymbol
+    if (sym.isClass && sym.asClass.isCaseClass) {
+      val ctor = tpe.decl(termNames.CONSTRUCTOR).asMethod
+      ctor.paramLists.headOption
+        .getOrElse(Nil)
+        .flatMap { param =>
+          val fieldName = s"$prefix.${param.name.decodedName.toString}"
+          val fieldType = param.typeSignature.asSeenFrom(tpe, sym)
+          val fieldSym  = fieldType.typeSymbol
+
+          if (fieldSym.isClass && fieldSym.asClass.isCaseClass) {
+            Set(fieldName) ++ extractNestedFieldNames(c)(fieldType, fieldName)
+          } else {
+            Set(fieldName)
+          }
+        }
+        .toSet
+    } else {
+      Set.empty
+    }
+  }
+
+  private def computeAutoMappedWithNested(
+    c: whitebox.Context
+  )(sourceType: c.universe.Type, targetType: c.universe.Type, prefix: String): Set[String] = {
+    import c.universe._
+
+    val sourceSym = sourceType.typeSymbol
+    val targetSym = targetType.typeSymbol
+
+    if (sourceSym.isClass && sourceSym.asClass.isCaseClass && targetSym.isClass && targetSym.asClass.isCaseClass) {
+      val sourceCtor = sourceType.decl(termNames.CONSTRUCTOR).asMethod
+      val targetCtor = targetType.decl(termNames.CONSTRUCTOR).asMethod
+
+      val sourceFieldTypes: Map[String, Type] = sourceCtor.paramLists.headOption
+        .getOrElse(Nil)
+        .map(p => p.name.decodedName.toString -> p.typeSignature.asSeenFrom(sourceType, sourceSym))
+        .toMap
+
+      val targetFieldTypes: Map[String, Type] = targetCtor.paramLists.headOption
+        .getOrElse(Nil)
+        .map(p => p.name.decodedName.toString -> p.typeSignature.asSeenFrom(targetType, targetSym))
+        .toMap
+
+      val commonFields = sourceFieldTypes.keySet.intersect(targetFieldTypes.keySet)
+
+      commonFields.flatMap { fieldName =>
+        val fullFieldName = if (prefix.isEmpty) fieldName else s"$prefix.$fieldName"
+        (sourceFieldTypes.get(fieldName), targetFieldTypes.get(fieldName)) match {
+          case (Some(srcType), Some(tgtType)) if srcType =:= tgtType =>
+            Set(fullFieldName) ++ computeAutoMappedNested(c)(srcType, tgtType, fullFieldName)
+          case (Some(srcType), Some(tgtType)) if srcType <:< tgtType || tgtType <:< srcType =>
+            Set(fullFieldName)
+          case _ => Set.empty[String]
+        }
+      }
+    } else {
+      Set.empty
+    }
+  }
+
+  private def computeAutoMappedNested(
+    c: whitebox.Context
+  )(srcType: c.universe.Type, tgtType: c.universe.Type, prefix: String): Set[String] = {
+    import c.universe._
+
+    val srcSym = srcType.typeSymbol
+    val tgtSym = tgtType.typeSymbol
+
+    if (srcSym.isClass && srcSym.asClass.isCaseClass && tgtSym.isClass && tgtSym.asClass.isCaseClass) {
+      val srcCtor = srcType.decl(termNames.CONSTRUCTOR).asMethod
+      val tgtCtor = tgtType.decl(termNames.CONSTRUCTOR).asMethod
+
+      val srcFields: Map[String, Type] = srcCtor.paramLists.headOption
+        .getOrElse(Nil)
+        .map(p => p.name.decodedName.toString -> p.typeSignature.asSeenFrom(srcType, srcSym))
+        .toMap
+
+      val tgtFields: Map[String, Type] = tgtCtor.paramLists.headOption
+        .getOrElse(Nil)
+        .map(p => p.name.decodedName.toString -> p.typeSignature.asSeenFrom(tgtType, tgtSym))
+        .toMap
+
+      val commonFields = srcFields.keySet.intersect(tgtFields.keySet)
+
+      commonFields.flatMap { fieldName =>
+        val fullFieldName = s"$prefix.$fieldName"
+        (srcFields.get(fieldName), tgtFields.get(fieldName)) match {
+          case (Some(srcFieldType), Some(tgtFieldType)) if srcFieldType =:= tgtFieldType =>
+            Set(fullFieldName) ++ computeAutoMappedNested(c)(srcFieldType, tgtFieldType, fullFieldName)
+          case (Some(srcFieldType), Some(tgtFieldType))
+              if srcFieldType <:< tgtFieldType || tgtFieldType <:< srcFieldType =>
+            Set(fullFieldName)
+          case _ => Set.empty[String]
+        }
+      }
+    } else {
+      Set.empty
+    }
+  }
+
+  private def computeCrossTypeAutoMapped(
+    c: whitebox.Context
+  )(
+    sourceType: c.universe.Type,
+    targetType: c.universe.Type,
+    explicitlyHandled: Set[String],
+    prefix: String
+  ): Set[String] = {
+    import c.universe._
+
+    val sourceSym = sourceType.typeSymbol
+    val targetSym = targetType.typeSymbol
+
+    val sourceFieldTypes: Map[String, Type] =
+      if (sourceSym.isClass && sourceSym.asClass.isCaseClass) {
+        val ctor = sourceType.decl(termNames.CONSTRUCTOR).asMethod
+        ctor.paramLists.headOption
+          .getOrElse(Nil)
+          .map(p => p.name.decodedName.toString -> p.typeSignature.asSeenFrom(sourceType, sourceSym))
+          .toMap
+      } else Map.empty
+
+    val targetFieldTypes: Map[String, Type] =
+      if (targetSym.isClass && targetSym.asClass.isCaseClass) {
+        val ctor = targetType.decl(termNames.CONSTRUCTOR).asMethod
+        ctor.paramLists.headOption
+          .getOrElse(Nil)
+          .map(p => p.name.decodedName.toString -> p.typeSignature.asSeenFrom(targetType, targetSym))
+          .toMap
+      } else Map.empty
+
+    val commonFields = sourceFieldTypes.keySet.intersect(targetFieldTypes.keySet)
+
+    commonFields.flatMap { fieldName =>
+      val fullFieldName = if (prefix.isEmpty) fieldName else s"$prefix.$fieldName"
+      (sourceFieldTypes.get(fieldName), targetFieldTypes.get(fieldName)) match {
+        case (Some(srcType), Some(tgtType)) if !(srcType =:= tgtType) =>
+          val hasExplicitChild = explicitlyHandled.exists(_.startsWith(s"$fullFieldName."))
+          if (hasExplicitChild)
+            crossTypeAutoMapLeaves(c)(srcType, tgtType, explicitlyHandled, fullFieldName)
+          else Set.empty[String]
+        case _ => Set.empty[String]
+      }
+    }
+  }
+
+  private def crossTypeAutoMapLeaves(
+    c: whitebox.Context
+  )(srcType: c.universe.Type, tgtType: c.universe.Type, explicitlyHandled: Set[String], prefix: String): Set[String] = {
+    import c.universe._
+
+    val srcSym = srcType.typeSymbol
+    val tgtSym = tgtType.typeSymbol
+
+    val srcFields: Map[String, Type] =
+      if (srcSym.isClass && srcSym.asClass.isCaseClass) {
+        val ctor = srcType.decl(termNames.CONSTRUCTOR).asMethod
+        ctor.paramLists.headOption
+          .getOrElse(Nil)
+          .map(p => p.name.decodedName.toString -> p.typeSignature.asSeenFrom(srcType, srcSym))
+          .toMap
+      } else Map.empty
+
+    val tgtFields: Map[String, Type] =
+      if (tgtSym.isClass && tgtSym.asClass.isCaseClass) {
+        val ctor = tgtType.decl(termNames.CONSTRUCTOR).asMethod
+        ctor.paramLists.headOption
+          .getOrElse(Nil)
+          .map(p => p.name.decodedName.toString -> p.typeSignature.asSeenFrom(tgtType, tgtSym))
+          .toMap
+      } else Map.empty
+
+    val common = srcFields.keySet.intersect(tgtFields.keySet)
+
+    common.flatMap { fieldName =>
+      val fullName = s"$prefix.$fieldName"
+      (srcFields(fieldName), tgtFields(fieldName)) match {
+        case (s, t) if s =:= t => Set(fullName)
+        case (s, t)            =>
+          val hasExplicitChild = explicitlyHandled.exists(_.startsWith(s"$fullName."))
+          if (hasExplicitChild)
+            crossTypeAutoMapLeaves(c)(s, t, explicitlyHandled, fullName)
+          else Set.empty[String]
+      }
+    }
+  }
+
+  private def inferParentCoverage(allFields: Set[String], covered: Set[String]): Set[String] = {
+    val parents = allFields.flatMap { f =>
+      val parts = f.split('.')
+      if (parts.length > 1) Some(parts.init.mkString(".")) else None
+    }
+    var result  = covered
+    var changed = true
+    while (changed) {
+      changed = false
+      for (parent <- parents) {
+        if (!result.contains(parent)) {
+          val children = allFields.filter(_.startsWith(s"$parent."))
+          if (children.nonEmpty && children.forall(result.contains)) {
+            result = result + parent
+            changed = true
+          }
+        }
+      }
+    }
+    result
+  }
+}

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
@@ -92,11 +92,10 @@ object MigrationBuilderMacros {
     appliedType(typeOf[Changeset.OptionalizeField[_, _]].typeConstructor, sourceLiteral, targetLiteral)
   }
 
-  private def createChangeFieldTypeType(c: whitebox.Context)(source: String, target: String): c.Type = {
+  private def createChangeFieldTypeType(c: whitebox.Context)(name: String): c.Type = {
     import c.universe._
-    val sourceLiteral = c.internal.constantType(Constant(source))
-    val targetLiteral = c.internal.constantType(Constant(target))
-    appliedType(typeOf[Changeset.ChangeFieldType[_, _]].typeConstructor, sourceLiteral, targetLiteral)
+    val nameLiteral = c.internal.constantType(Constant(name))
+    appliedType(typeOf[Changeset.ChangeFieldType[_]].typeConstructor, nameLiteral)
   }
 
   private def createMigrateFieldType(c: whitebox.Context)(name: String): c.Type = {
@@ -300,7 +299,6 @@ object MigrationBuilderMacros {
     c: whitebox.Context
   )(
     source: c.Expr[A => Any],
-    target: c.Expr[B => Any],
     converter: c.Expr[SchemaExpr[_, _]]
   ): c.Tree = {
     import c.universe._
@@ -310,17 +308,13 @@ object MigrationBuilderMacros {
     val csType = weakTypeOf[CS]
 
     val sourceFieldName     = extractFieldPathFromSelector(c)(source.tree)
-    val targetFieldName     = extractFieldPathFromSelector(c)(target.tree)
-    val changeFieldTypeType = createChangeFieldTypeType(c)(sourceFieldName, targetFieldName)
+    val changeFieldTypeType = createChangeFieldTypeType(c)(sourceFieldName)
     val newCSType           = addToChangeset(c)(csType, changeFieldTypeType)
 
     val sourcePath = SelectorMacros.toPathImpl[A, Any](c)(source.asInstanceOf[c.Expr[A => Any]])
-    val targetPath = SelectorMacros.toPathImpl[B, Any](c)(target.asInstanceOf[c.Expr[B => Any]])
 
     q"""{
       val sourcePath = $sourcePath
-      val targetPath = $targetPath
-      locally(targetPath)
       new _root_.zio.blocks.schema.migration.MigrationBuilder[$aType, $bType, $newCSType](
         ${c.prefix}.sourceSchema,
         ${c.prefix}.targetSchema,
@@ -571,8 +565,10 @@ object MigrationValidationMacros {
             args.headOption.flatMap(extractString).foreach(n => handled += n)
             args.lift(1).flatMap(extractString).foreach(n => provided += n)
           case "ChangeFieldType" =>
-            args.headOption.flatMap(extractString).foreach(n => handled += n)
-            args.lift(1).flatMap(extractString).foreach(n => provided += n)
+            args.headOption.flatMap(extractString).foreach { n =>
+              handled += n
+              provided += n
+            }
           case "MigrateField" =>
             args.headOption.flatMap(extractString).foreach { n =>
               handled += n

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
@@ -37,7 +37,7 @@ object MigrationBuilderMacros {
           c.abort(c.enclosingPosition, "Selector must access at least one field")
         else
           segments.mkString(".")
-      case _                => c.abort(c.enclosingPosition, s"Expected a lambda expression, got: ${showRaw(selector)}")
+      case _ => c.abort(c.enclosingPosition, s"Expected a lambda expression, got: ${showRaw(selector)}")
     }
   }
 

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
@@ -206,8 +206,15 @@ object MigrationBuilderMacros {
     val bType  = weakTypeOf[B]
     val csType = weakTypeOf[CS]
 
-    val fromFieldName      = extractFieldPathFromSelector(c)(from.tree)
-    val toFieldName        = extractFieldPathFromSelector(c)(to.tree)
+    val fromFieldName = extractFieldPathFromSelector(c)(from.tree)
+    val toFieldName   = extractFieldPathFromSelector(c)(to.tree)
+    if (fromFieldName != toFieldName)
+      c.abort(
+        c.enclosingPosition,
+        s"transformField requires the same field name in source and target, " +
+          s"got '$fromFieldName' and '$toFieldName'. " +
+          s"Use renameField followed by transformField for rename-and-transform."
+      )
     val transformFieldType = createTransformFieldType(c)(fromFieldName, toFieldName)
     val newCSType          = addToChangeset(c)(csType, transformFieldType)
 
@@ -240,8 +247,15 @@ object MigrationBuilderMacros {
     val bType  = weakTypeOf[B]
     val csType = weakTypeOf[CS]
 
-    val sourceFieldName  = extractFieldPathFromSelector(c)(source.tree)
-    val targetFieldName  = extractFieldPathFromSelector(c)(target.tree)
+    val sourceFieldName = extractFieldPathFromSelector(c)(source.tree)
+    val targetFieldName = extractFieldPathFromSelector(c)(target.tree)
+    if (sourceFieldName != targetFieldName)
+      c.abort(
+        c.enclosingPosition,
+        s"mandateField requires the same field name in source and target, " +
+          s"got '$sourceFieldName' and '$targetFieldName'. " +
+          s"Use renameField followed by mandateField for rename-and-mandate."
+      )
     val mandateFieldType = createMandateFieldType(c)(sourceFieldName, targetFieldName)
     val newCSType        = addToChangeset(c)(csType, mandateFieldType)
 
@@ -275,8 +289,15 @@ object MigrationBuilderMacros {
     val bType  = weakTypeOf[B]
     val csType = weakTypeOf[CS]
 
-    val sourceFieldName      = extractFieldPathFromSelector(c)(source.tree)
-    val targetFieldName      = extractFieldPathFromSelector(c)(target.tree)
+    val sourceFieldName = extractFieldPathFromSelector(c)(source.tree)
+    val targetFieldName = extractFieldPathFromSelector(c)(target.tree)
+    if (sourceFieldName != targetFieldName)
+      c.abort(
+        c.enclosingPosition,
+        s"optionalizeField requires the same field name in source and target, " +
+          s"got '$sourceFieldName' and '$targetFieldName'. " +
+          s"Use renameField followed by optionalizeField for rename-and-optionalize."
+      )
     val optionalizeFieldType = createOptionalizeFieldType(c)(sourceFieldName, targetFieldName)
     val newCSType            = addToChangeset(c)(csType, optionalizeFieldType)
 

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
@@ -21,16 +21,22 @@ import zio.blocks.schema.SchemaExpr
 
 object MigrationBuilderMacros {
 
-  private def extractFieldNameFromSelector(c: whitebox.Context)(selector: c.Tree): String = {
+  private def extractFieldPathFromSelector(c: whitebox.Context)(selector: c.Tree): String = {
     import c.universe._
 
-    def extractFromBody(body: c.Tree): String = body match {
-      case Select(_, fieldName) => fieldName.decodedName.toString
-      case _                    => c.abort(c.enclosingPosition, s"Cannot extract field name from selector: ${showRaw(body)}")
+    def extractFromBody(body: c.Tree): List[String] = body match {
+      case Select(parent, fieldName) => extractFromBody(parent) :+ fieldName.decodedName.toString
+      case Ident(_)                  => Nil
+      case _                         => c.abort(c.enclosingPosition, s"Cannot extract field path from selector: ${showRaw(body)}")
     }
 
     selector match {
-      case q"($_) => $body" => extractFromBody(body)
+      case q"($_) => $body" =>
+        val segments = extractFromBody(body)
+        if (segments.isEmpty)
+          c.abort(c.enclosingPosition, "Selector must access at least one field")
+        else
+          segments.mkString(".")
       case _                => c.abort(c.enclosingPosition, s"Expected a lambda expression, got: ${showRaw(selector)}")
     }
   }
@@ -109,7 +115,7 @@ object MigrationBuilderMacros {
     val bType  = weakTypeOf[B]
     val csType = weakTypeOf[CS]
 
-    val fieldName    = extractFieldNameFromSelector(c)(target.tree)
+    val fieldName    = extractFieldPathFromSelector(c)(target.tree)
     val addFieldType = createAddFieldType(c)(fieldName)
     val newCSType    = addToChangeset(c)(csType, addFieldType)
 
@@ -138,7 +144,7 @@ object MigrationBuilderMacros {
     val bType  = weakTypeOf[B]
     val csType = weakTypeOf[CS]
 
-    val fieldName     = extractFieldNameFromSelector(c)(source.tree)
+    val fieldName     = extractFieldPathFromSelector(c)(source.tree)
     val dropFieldType = createDropFieldType(c)(fieldName)
     val newCSType     = addToChangeset(c)(csType, dropFieldType)
 
@@ -167,8 +173,8 @@ object MigrationBuilderMacros {
     val bType  = weakTypeOf[B]
     val csType = weakTypeOf[CS]
 
-    val fromFieldName   = extractFieldNameFromSelector(c)(from.tree)
-    val toFieldName     = extractFieldNameFromSelector(c)(to.tree)
+    val fromFieldName   = extractFieldPathFromSelector(c)(from.tree)
+    val toFieldName     = extractFieldPathFromSelector(c)(to.tree)
     val renameFieldType = createRenameFieldType(c)(fromFieldName, toFieldName)
     val newCSType       = addToChangeset(c)(csType, renameFieldType)
 
@@ -201,8 +207,8 @@ object MigrationBuilderMacros {
     val bType  = weakTypeOf[B]
     val csType = weakTypeOf[CS]
 
-    val fromFieldName      = extractFieldNameFromSelector(c)(from.tree)
-    val toFieldName        = extractFieldNameFromSelector(c)(to.tree)
+    val fromFieldName      = extractFieldPathFromSelector(c)(from.tree)
+    val toFieldName        = extractFieldPathFromSelector(c)(to.tree)
     val transformFieldType = createTransformFieldType(c)(fromFieldName, toFieldName)
     val newCSType          = addToChangeset(c)(csType, transformFieldType)
 
@@ -235,8 +241,8 @@ object MigrationBuilderMacros {
     val bType  = weakTypeOf[B]
     val csType = weakTypeOf[CS]
 
-    val sourceFieldName  = extractFieldNameFromSelector(c)(source.tree)
-    val targetFieldName  = extractFieldNameFromSelector(c)(target.tree)
+    val sourceFieldName  = extractFieldPathFromSelector(c)(source.tree)
+    val targetFieldName  = extractFieldPathFromSelector(c)(target.tree)
     val mandateFieldType = createMandateFieldType(c)(sourceFieldName, targetFieldName)
     val newCSType        = addToChangeset(c)(csType, mandateFieldType)
 
@@ -270,8 +276,8 @@ object MigrationBuilderMacros {
     val bType  = weakTypeOf[B]
     val csType = weakTypeOf[CS]
 
-    val sourceFieldName      = extractFieldNameFromSelector(c)(source.tree)
-    val targetFieldName      = extractFieldNameFromSelector(c)(target.tree)
+    val sourceFieldName      = extractFieldPathFromSelector(c)(source.tree)
+    val targetFieldName      = extractFieldPathFromSelector(c)(target.tree)
     val optionalizeFieldType = createOptionalizeFieldType(c)(sourceFieldName, targetFieldName)
     val newCSType            = addToChangeset(c)(csType, optionalizeFieldType)
 
@@ -303,8 +309,8 @@ object MigrationBuilderMacros {
     val bType  = weakTypeOf[B]
     val csType = weakTypeOf[CS]
 
-    val sourceFieldName     = extractFieldNameFromSelector(c)(source.tree)
-    val targetFieldName     = extractFieldNameFromSelector(c)(target.tree)
+    val sourceFieldName     = extractFieldPathFromSelector(c)(source.tree)
+    val targetFieldName     = extractFieldPathFromSelector(c)(target.tree)
     val changeFieldTypeType = createChangeFieldTypeType(c)(sourceFieldName, targetFieldName)
     val newCSType           = addToChangeset(c)(csType, changeFieldTypeType)
 
@@ -423,7 +429,7 @@ object MigrationBuilderMacros {
     val f2Type = weakTypeOf[F2]
     val csType = weakTypeOf[CS]
 
-    val sourceFieldName = extractFieldNameFromSelector(c)(selector.tree)
+    val sourceFieldName = extractFieldPathFromSelector(c)(selector.tree)
 
     val nestedSourceFields = extractCaseClassFields(c)(f1Type)
     val nestedTargetFields = extractCaseClassFields(c)(f2Type)
@@ -524,8 +530,6 @@ object MigrationValidationMacros {
         errors.append(s"\n  Source fields not handled: ${unhandledSource.mkString(", ")}\n")
         errors.append("  Use dropField, renameField, transformField, or migrateField to handle these fields.\n")
       }
-
-      errors.append("\n  Alternatively, use .buildPartial to skip validation.")
 
       c.abort(c.enclosingPosition, errors.toString)
     }

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationCompanionVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationCompanionVersionSpecific.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.Schema
+
+trait MigrationCompanionVersionSpecific {
+  def newBuilder[A, B](implicit
+    sourceSchema: Schema[A],
+    targetSchema: Schema[B]
+  ): MigrationBuilder[A, B, Any] =
+    new MigrationBuilder(sourceSchema, targetSchema, Chunk.empty)
+}

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationSelectorSyntax.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationSelectorSyntax.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import scala.annotation.compileTimeOnly
+
+/**
+ * Scala 2 extension methods for selector syntax in migrations. These are
+ * compile-time-only placeholders that get transformed by the macros.
+ *
+ * Provides syntax sugar for selector expressions like:
+ *   - `_.field.each` for collection traversal
+ *   - `_.variant.when[Type]` for case selection
+ *   - `_.wrapper.wrapped[Inner]` for wrapper unwrapping
+ *   - `_.seq.at(0)` for index access
+ *   - `_.map.atKey(key)` for map key access
+ */
+trait MigrationSelectorSyntax {
+
+  implicit class ValueExtension[A](a: A) {
+    @compileTimeOnly("Can only be used inside migration selector macros")
+    def when[B <: A]: B = ???
+
+    @compileTimeOnly("Can only be used inside migration selector macros")
+    def wrapped[B]: B = ???
+  }
+
+  implicit class SequenceExtension[C[_], A](c: C[A]) {
+    @compileTimeOnly("Can only be used inside migration selector macros")
+    def at(index: Int): A = ???
+
+    @compileTimeOnly("Can only be used inside migration selector macros")
+    def each: A = ???
+  }
+
+  implicit class MapExtension[M[_, _], K, V](m: M[K, V]) {
+    @compileTimeOnly("Can only be used inside migration selector macros")
+    def atKey(key: K): V = ???
+
+    @compileTimeOnly("Can only be used inside migration selector macros")
+    def eachKey: K = ???
+
+    @compileTimeOnly("Can only be used inside migration selector macros")
+    def eachValue: V = ???
+  }
+}
+
+object MigrationSelectorSyntax extends MigrationSelectorSyntax

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/SelectorMacros.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/SelectorMacros.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+import zio.blocks.schema.DynamicOptic
+
+/**
+ * Scala 2 macros for converting selector expressions into DynamicOptic paths.
+ *
+ * These macros parse selector expressions like:
+ *   - `_.field` → `DynamicOptic.root.field("field")`
+ *   - `_.a.b.c` → `DynamicOptic.root.field("a").field("b").field("c")`
+ *   - `_.items.each` → `DynamicOptic.root.field("items").elements`
+ *   - `_.country.when[UK]` → `DynamicOptic.root.field("country").caseOf("UK")`
+ */
+object SelectorMacros {
+
+  /**
+   * Convert a selector expression to a DynamicOptic.
+   */
+  def toPath[S, A](selector: S => A): DynamicOptic = macro toPathImpl[S, A]
+
+  def toPathImpl[S: c.WeakTypeTag, A: c.WeakTypeTag](c: whitebox.Context)(selector: c.Expr[S => A]): c.Tree = {
+    import c.universe._
+
+    // Use type tags for better error messages
+    val sourceType = weakTypeOf[S]
+    val targetType = weakTypeOf[A]
+
+    def fail(msg: String): Nothing =
+      c.abort(c.enclosingPosition, s"$msg (selector: $sourceType => $targetType)")
+
+    def toPathBody(tree: c.Tree): c.Tree = tree match {
+      case q"($_) => $pathBody" => pathBody
+      case _                    => fail(s"Expected a lambda expression, got '$tree'")
+    }
+
+    def getTypeName(tpe: Type): String =
+      tpe.dealias.typeSymbol.name.toString
+
+    def toDynamicOptic(tree: c.Tree): c.Tree = tree match {
+      // Identity - just the parameter reference
+      case Ident(_) =>
+        q"_root_.zio.blocks.schema.DynamicOptic.root"
+
+      // Field access: _.field or _.a.b.c
+      case q"$parent.$fieldName" =>
+        val parentOptic = toDynamicOptic(parent)
+        val fieldStr    = fieldName.toString
+        q"$parentOptic.field($fieldStr)"
+
+      // Collection traversal: _.items.each
+      case q"$_[..$_]($parent).each" =>
+        val parentOptic = toDynamicOptic(parent)
+        q"$parentOptic.elements"
+
+      // Map key traversal: _.map.eachKey
+      case q"$_[..$_]($parent).eachKey" =>
+        val parentOptic = toDynamicOptic(parent)
+        q"$parentOptic.mapKeys"
+
+      // Map value traversal: _.map.eachValue
+      case q"$_[..$_]($parent).eachValue" =>
+        val parentOptic = toDynamicOptic(parent)
+        q"$parentOptic.mapValues"
+
+      // Case selection: _.variant.when[CaseType]
+      case q"$_[..$_]($parent).when[$caseType]" =>
+        val parentOptic = toDynamicOptic(parent)
+        val caseName    = getTypeName(caseType.tpe)
+        q"$parentOptic.caseOf($caseName)"
+
+      // Wrapper unwrap: _.wrapper.wrapped[Inner]
+      case q"$_[..$_]($parent).wrapped[$_]" =>
+        val parentOptic = toDynamicOptic(parent)
+        q"$parentOptic.wrapped"
+
+      // Index access: _.seq.at(0)
+      case q"$_[..$_]($parent).at($index)" =>
+        val parentOptic = toDynamicOptic(parent)
+        q"$parentOptic.at($index)"
+
+      // Map key access: _.map.atKey(key)
+      case q"$_[..$_]($parent).atKey($key)" =>
+        val parentOptic = toDynamicOptic(parent)
+        q"$parentOptic.atKey($key)"
+
+      case other =>
+        fail(s"Unsupported selector expression: ${showRaw(other)}")
+    }
+
+    val pathBody = toPathBody(selector.tree)
+    toDynamicOptic(pathBody)
+  }
+}

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/package.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/package.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema
+
+package object migration extends MigrationSelectorSyntax {
+  type &[+A, +B] = A with B
+}

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{DynamicOptic, Schema, SchemaExpr}
+
+object Changeset {
+
+  // Phantom type wrapper to preserve literal string types through macro expansion.
+  // Direct use of ConstantType with .asType causes literal types to widen to String.
+  // By wrapping in FieldName[N], the type argument is preserved when using appliedTo.
+  sealed trait FieldName[N <: String & Singleton]
+
+  // Field operations (tracked for validation)
+  sealed trait AddField[N <: String & Singleton]
+  sealed trait DropField[N <: String & Singleton]
+  sealed trait RenameField[From <: String & Singleton, To <: String & Singleton]
+  sealed trait TransformField[From <: String & Singleton, To <: String & Singleton]
+  sealed trait MandateField[Source <: String & Singleton, Target <: String & Singleton]
+  sealed trait OptionalizeField[Source <: String & Singleton, Target <: String & Singleton]
+  sealed trait ChangeFieldType[Source <: String & Singleton, Target <: String & Singleton]
+  sealed trait MigrateField[Name <: String & Singleton]
+
+  // Case operations (tracked but not field-validated)
+  sealed trait RenameCase[From <: String & Singleton, To <: String & Singleton]
+  sealed trait TransformCase[CaseName <: String & Singleton]
+
+  // Collection operations (tracked but not field-validated)
+  sealed trait TransformElements[FieldName <: String & Singleton]
+  sealed trait TransformKeys[FieldName <: String & Singleton]
+  sealed trait TransformValues[FieldName <: String & Singleton]
+}
+
+final class MigrationBuilder[A, B, Changeset](
+  val sourceSchema: Schema[A],
+  val targetSchema: Schema[B],
+  private[migration] val actions: Chunk[MigrationAction]
+) {
+
+  transparent inline def addField(
+    inline target: B => Any,
+    default: SchemaExpr[_, _]
+  ) = ${ MigrationBuilderMacros.addFieldImpl[A, B, Changeset]('this, 'target, 'default) }
+
+  transparent inline def dropField(
+    inline source: A => Any,
+    defaultForReverse: SchemaExpr[_, _]
+  ) = ${ MigrationBuilderMacros.dropFieldImpl[A, B, Changeset]('this, 'source, 'defaultForReverse) }
+
+  transparent inline def renameField(
+    inline from: A => Any,
+    inline to: B => Any
+  ) = ${ MigrationBuilderMacros.renameFieldImpl[A, B, Changeset]('this, 'from, 'to) }
+
+  transparent inline def transformField(
+    inline from: A => Any,
+    inline to: B => Any,
+    transform: SchemaExpr[_, _]
+  ) = ${ MigrationBuilderMacros.transformFieldImpl[A, B, Changeset]('this, 'from, 'to, 'transform) }
+
+  transparent inline def mandateField(
+    inline source: A => Option[?],
+    inline target: B => Any,
+    default: SchemaExpr[_, _]
+  ) = ${
+    MigrationBuilderMacros.mandateFieldImpl[A, B, Changeset]('this, 'source, 'target, 'default)
+  }
+
+  transparent inline def optionalizeField(
+    inline source: A => Any,
+    inline target: B => Option[?]
+  ) = ${ MigrationBuilderMacros.optionalizeFieldImpl[A, B, Changeset]('this, 'source, 'target) }
+
+  transparent inline def changeFieldType(
+    inline source: A => Any,
+    inline target: B => Any,
+    converter: SchemaExpr[_, _]
+  ) = ${
+    MigrationBuilderMacros.changeFieldTypeImpl[A, B, Changeset]('this, 'source, 'target, 'converter)
+  }
+
+  def renameCase(
+    from: String,
+    to: String
+  ): MigrationBuilder[A, B, Changeset] =
+    new MigrationBuilder(sourceSchema, targetSchema, actions :+ MigrationAction.RenameCase(DynamicOptic.root, from, to))
+
+  def transformCase[CaseA, CaseB](
+    caseName: String
+  )(
+    caseMigration: MigrationBuilder[CaseA, CaseB, Any] => MigrationBuilder[CaseA, CaseB, ?]
+  )(using
+    caseSourceSchema: Schema[CaseA],
+    caseTargetSchema: Schema[CaseB]
+  ): MigrationBuilder[A, B, Changeset] = {
+    val innerBuilder = new MigrationBuilder[CaseA, CaseB, Any](
+      caseSourceSchema,
+      caseTargetSchema,
+      Chunk.empty
+    )
+    val builtInner = caseMigration(innerBuilder)
+    new MigrationBuilder(
+      sourceSchema,
+      targetSchema,
+      actions :+ MigrationAction.TransformCase(DynamicOptic.root.caseOf(caseName), builtInner.actions)
+    )
+  }
+
+  inline def transformElements(
+    inline at: A => Iterable[?],
+    transform: SchemaExpr[_, _]
+  ): MigrationBuilder[A, B, Changeset] = {
+    val path = SelectorMacros.toPath[A, Iterable[?]](at)
+    new MigrationBuilder(
+      sourceSchema,
+      targetSchema,
+      actions :+ MigrationAction.TransformElements(path, transform.toDynamic)
+    )
+  }
+
+  inline def transformKeys(
+    inline at: A => Map[?, ?],
+    transform: SchemaExpr[_, _]
+  ): MigrationBuilder[A, B, Changeset] = {
+    val path = SelectorMacros.toPath[A, Map[?, ?]](at)
+    new MigrationBuilder(
+      sourceSchema,
+      targetSchema,
+      actions :+ MigrationAction.TransformKeys(path, transform.toDynamic)
+    )
+  }
+
+  inline def transformValues(
+    inline at: A => Map[?, ?],
+    transform: SchemaExpr[_, _]
+  ): MigrationBuilder[A, B, Changeset] = {
+    val path = SelectorMacros.toPath[A, Map[?, ?]](at)
+    new MigrationBuilder(
+      sourceSchema,
+      targetSchema,
+      actions :+ MigrationAction.TransformValues(path, transform.toDynamic)
+    )
+  }
+
+  transparent inline def migrateField[F1, F2](
+    inline selector: A => F1,
+    migration: Migration[F1, F2]
+  ) = ${
+    MigrationBuilderMacros.migrateFieldExplicitImpl[A, B, F1, F2, Changeset](
+      'this,
+      'selector,
+      'migration
+    )
+  }
+
+  @scala.annotation.targetName("migrateFieldImplicit")
+  transparent inline def migrateField[F1, F2](
+    inline selector: A => F1
+  )(using migration: Migration[F1, F2]) = ${
+    MigrationBuilderMacros.migrateFieldImplicitImpl[A, B, F1, F2, Changeset](
+      'this,
+      'selector,
+      'migration
+    )
+  }
+
+  inline def build(using
+    ev: MigrationComplete[A, B, Changeset]
+  ): Migration[A, B] =
+    new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
+
+  def buildPartial: Migration[A, B] =
+    new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
+}
+
+object MigrationBuilder {
+  def apply[A, B](using
+    sourceSchema: Schema[A],
+    targetSchema: Schema[B]
+  ): MigrationBuilder[A, B, Any] =
+    new MigrationBuilder(sourceSchema, targetSchema, Chunk.empty)
+}
+
+trait MigrationComplete[-A, -B, -Changeset]
+
+object MigrationComplete {
+  private[migration] def unsafeCreate[A, B, CS]: MigrationComplete[A, B, CS] =
+    instance.asInstanceOf[MigrationComplete[A, B, CS]]
+
+  private val instance: MigrationComplete[Any, Any, Any] =
+    new MigrationComplete[Any, Any, Any] {}
+
+  inline given derive[A, B, CS]: MigrationComplete[A, B, CS] =
+    ${ MigrationValidationMacros.validateMigration[A, B, CS] }
+}

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -112,11 +112,12 @@ final class MigrationBuilder[A, B, Changeset](
       caseTargetSchema,
       Chunk.empty
     )
-    val builtInner = caseMigration(innerBuilder)
+    val builtInner     = caseMigration(innerBuilder)
+    val targetCaseName = caseTargetSchema.reflect.typeId.name
     new MigrationBuilder(
       sourceSchema,
       targetSchema,
-      actions :+ MigrationAction.TransformCase(DynamicOptic.root.caseOf(caseName), builtInner.actions)
+      actions :+ MigrationAction.TransformCase(DynamicOptic.root.caseOf(caseName), targetCaseName, builtInner.actions)
     )
   }
 
@@ -183,8 +184,6 @@ final class MigrationBuilder[A, B, Changeset](
   ): Migration[A, B] =
     new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
 
-  private[migration] def buildPartial: Migration[A, B] =
-    new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
 }
 
 object MigrationBuilder {

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -33,7 +33,7 @@ object Changeset {
   sealed trait TransformField[From <: String & Singleton, To <: String & Singleton]
   sealed trait MandateField[Source <: String & Singleton, Target <: String & Singleton]
   sealed trait OptionalizeField[Source <: String & Singleton, Target <: String & Singleton]
-  sealed trait ChangeFieldType[Source <: String & Singleton, Target <: String & Singleton]
+  sealed trait ChangeFieldType[Name <: String & Singleton]
   sealed trait MigrateField[Name <: String & Singleton]
 
   // Case operations (tracked but not field-validated)
@@ -88,10 +88,9 @@ final class MigrationBuilder[A, B, Changeset](
 
   transparent inline def changeFieldType(
     inline source: A => Any,
-    inline target: B => Any,
     converter: SchemaExpr[_, _]
   ) = ${
-    MigrationBuilderMacros.changeFieldTypeImpl[A, B, Changeset]('this, 'source, 'target, 'converter)
+    MigrationBuilderMacros.changeFieldTypeImpl[A, B, Changeset]('this, 'source, 'converter)
   }
 
   def renameCase(

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -184,7 +184,7 @@ final class MigrationBuilder[A, B, Changeset](
   ): Migration[A, B] =
     new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
 
-  def buildPartial: Migration[A, B] =
+  private[migration] def buildPartial: Migration[A, B] =
     new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
 }
 

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import scala.annotation.tailrec
+import scala.quoted.*
+import zio.blocks.schema.SchemaExpr
+
+object MigrationBuilderMacros {
+
+  def addFieldImpl[A: Type, B: Type, CS: Type](
+    builder: Expr[MigrationBuilder[A, B, CS]],
+    target: Expr[B => Any],
+    default: Expr[SchemaExpr[_, _]]
+  )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] = {
+    import q.reflect.*
+
+    val fieldPath     = extractFieldPathFromTerm(target.asTerm)
+    val fieldNameType = ConstantType(StringConstant(fieldPath))
+    val addedWrapped  = TypeRepr.of[Changeset.AddField].appliedTo(fieldNameType)
+    val newCSType     = AndType(TypeRepr.of[CS], addedWrapped)
+
+    newCSType.asType match {
+      case '[newCs] =>
+        '{
+          val targetPath = SelectorMacros.toPath[B, Any]($target)
+          new MigrationBuilder[A, B, newCs](
+            $builder.sourceSchema,
+            $builder.targetSchema,
+            $builder.actions :+ MigrationAction.AddField(targetPath, $default.toDynamic)
+          )
+        }
+    }
+  }
+
+  def dropFieldImpl[A: Type, B: Type, CS: Type](
+    builder: Expr[MigrationBuilder[A, B, CS]],
+    source: Expr[A => Any],
+    defaultForReverse: Expr[SchemaExpr[_, _]]
+  )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] = {
+    import q.reflect.*
+
+    val fieldPath      = extractFieldPathFromTerm(source.asTerm)
+    val fieldNameType  = ConstantType(StringConstant(fieldPath))
+    val droppedWrapped = TypeRepr.of[Changeset.DropField].appliedTo(fieldNameType)
+    val newCSType      = AndType(TypeRepr.of[CS], droppedWrapped)
+
+    newCSType.asType match {
+      case '[newCs] =>
+        '{
+          val sourcePath = SelectorMacros.toPath[A, Any]($source)
+          new MigrationBuilder[A, B, newCs](
+            $builder.sourceSchema,
+            $builder.targetSchema,
+            $builder.actions :+ MigrationAction.DropField(sourcePath, $defaultForReverse.toDynamic)
+          )
+        }
+    }
+  }
+
+  def renameFieldImpl[A: Type, B: Type, CS: Type](
+    builder: Expr[MigrationBuilder[A, B, CS]],
+    from: Expr[A => Any],
+    to: Expr[B => Any]
+  )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] = {
+    import q.reflect.*
+
+    val fromFieldPath  = extractFieldPathFromTerm(from.asTerm)
+    val toFieldPath    = extractFieldPathFromTerm(to.asTerm)
+    val toLeafName     = extractLeafFieldName(to.asTerm)
+    val fromFieldType  = ConstantType(StringConstant(fromFieldPath))
+    val toFieldType    = ConstantType(StringConstant(toFieldPath))
+    val toNameExpr     = Expr(toLeafName)
+    val renamedWrapped = TypeRepr.of[Changeset.RenameField].appliedTo(List(fromFieldType, toFieldType))
+    val newCSType      = AndType(TypeRepr.of[CS], renamedWrapped)
+
+    newCSType.asType match {
+      case '[newCs] =>
+        '{
+          val fromPath = SelectorMacros.toPath[A, Any]($from)
+          new MigrationBuilder[A, B, newCs](
+            $builder.sourceSchema,
+            $builder.targetSchema,
+            $builder.actions :+ MigrationAction.RenameField(fromPath, $toNameExpr)
+          )
+        }
+    }
+  }
+
+  def transformFieldImpl[A: Type, B: Type, CS: Type](
+    builder: Expr[MigrationBuilder[A, B, CS]],
+    from: Expr[A => Any],
+    to: Expr[B => Any],
+    transform: Expr[SchemaExpr[_, _]]
+  )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] = {
+    import q.reflect.*
+
+    val fromFieldPath      = extractFieldPathFromTerm(from.asTerm)
+    val toFieldPath        = extractFieldPathFromTerm(to.asTerm)
+    val fromFieldType      = ConstantType(StringConstant(fromFieldPath))
+    val toFieldType        = ConstantType(StringConstant(toFieldPath))
+    val transformedWrapped = TypeRepr.of[Changeset.TransformField].appliedTo(List(fromFieldType, toFieldType))
+    val newCSType          = AndType(TypeRepr.of[CS], transformedWrapped)
+
+    newCSType.asType match {
+      case '[newCs] =>
+        '{
+          val fromPath = SelectorMacros.toPath[A, Any]($from)
+          new MigrationBuilder[A, B, newCs](
+            $builder.sourceSchema,
+            $builder.targetSchema,
+            $builder.actions :+ MigrationAction.TransformField(fromPath, $transform.toDynamic)
+          )
+        }
+    }
+  }
+
+  def mandateFieldImpl[A: Type, B: Type, CS: Type](
+    builder: Expr[MigrationBuilder[A, B, CS]],
+    source: Expr[A => Option[?]],
+    target: Expr[B => Any],
+    default: Expr[SchemaExpr[_, _]]
+  )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] = {
+    import q.reflect.*
+
+    val sourceFieldPath = extractFieldPathFromTerm(source.asTerm)
+    val targetFieldPath = extractFieldPathFromTerm(target.asTerm)
+    val sourceFieldType = ConstantType(StringConstant(sourceFieldPath))
+    val targetFieldType = ConstantType(StringConstant(targetFieldPath))
+    val mandatedWrapped = TypeRepr.of[Changeset.MandateField].appliedTo(List(sourceFieldType, targetFieldType))
+    val newCSType       = AndType(TypeRepr.of[CS], mandatedWrapped)
+
+    newCSType.asType match {
+      case '[newCs] =>
+        '{
+          val sourcePath = SelectorMacros.toPath[A, Option[?]]($source)
+          new MigrationBuilder[A, B, newCs](
+            $builder.sourceSchema,
+            $builder.targetSchema,
+            $builder.actions :+ MigrationAction.MandateField(sourcePath, $default.toDynamic)
+          )
+        }
+    }
+  }
+
+  def optionalizeFieldImpl[A: Type, B: Type, CS: Type](
+    builder: Expr[MigrationBuilder[A, B, CS]],
+    source: Expr[A => Any],
+    target: Expr[B => Option[?]]
+  )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] = {
+    import q.reflect.*
+
+    val sourceFieldPath     = extractFieldPathFromTerm(source.asTerm)
+    val targetFieldPath     = extractFieldPathFromTerm(target.asTerm)
+    val sourceFieldType     = ConstantType(StringConstant(sourceFieldPath))
+    val targetFieldType     = ConstantType(StringConstant(targetFieldPath))
+    val optionalizedWrapped = TypeRepr.of[Changeset.OptionalizeField].appliedTo(List(sourceFieldType, targetFieldType))
+    val newCSType           = AndType(TypeRepr.of[CS], optionalizedWrapped)
+
+    newCSType.asType match {
+      case '[newCs] =>
+        '{
+          val sourcePath = SelectorMacros.toPath[A, Any]($source)
+          new MigrationBuilder[A, B, newCs](
+            $builder.sourceSchema,
+            $builder.targetSchema,
+            $builder.actions :+ MigrationAction.OptionalizeField(sourcePath)
+          )
+        }
+    }
+  }
+
+  def changeFieldTypeImpl[A: Type, B: Type, CS: Type](
+    builder: Expr[MigrationBuilder[A, B, CS]],
+    source: Expr[A => Any],
+    target: Expr[B => Any],
+    converter: Expr[SchemaExpr[_, _]]
+  )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] = {
+    import q.reflect.*
+
+    val sourceFieldPath    = extractFieldPathFromTerm(source.asTerm)
+    val targetFieldPath    = extractFieldPathFromTerm(target.asTerm)
+    val sourceFieldType    = ConstantType(StringConstant(sourceFieldPath))
+    val targetFieldType    = ConstantType(StringConstant(targetFieldPath))
+    val typeChangedWrapped = TypeRepr.of[Changeset.ChangeFieldType].appliedTo(List(sourceFieldType, targetFieldType))
+    val newCSType          = AndType(TypeRepr.of[CS], typeChangedWrapped)
+
+    newCSType.asType match {
+      case '[newCs] =>
+        '{
+          val sourcePath = SelectorMacros.toPath[A, Any]($source)
+          new MigrationBuilder[A, B, newCs](
+            $builder.sourceSchema,
+            $builder.targetSchema,
+            $builder.actions :+ MigrationAction.ChangeFieldType(sourcePath, $converter.toDynamic)
+          )
+        }
+    }
+  }
+
+  def migrateFieldExplicitImpl[A: Type, B: Type, F1: Type, F2: Type, CS: Type](
+    builder: Expr[MigrationBuilder[A, B, CS]],
+    source: Expr[A => F1],
+    migration: Expr[Migration[F1, F2]]
+  )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] = {
+    import q.reflect.*
+
+    val sourceFieldPath = extractFieldPathFromTerm(source.asTerm)
+
+    val nestedSourceFields = extractCaseClassFieldNames[F1]
+    val nestedTargetFields = extractCaseClassFieldNames[F2]
+
+    var newCSType           = TypeRepr.of[CS]
+    val sourceFieldNameType = ConstantType(StringConstant(sourceFieldPath))
+    val migratedWrapped     = TypeRepr.of[Changeset.MigrateField].appliedTo(sourceFieldNameType)
+    newCSType = AndType(newCSType, migratedWrapped)
+
+    for (nestedField <- nestedSourceFields) {
+      val dotPath             = s"$sourceFieldPath.$nestedField"
+      val dotPathType         = ConstantType(StringConstant(dotPath))
+      val dotPathFieldWrapped = TypeRepr.of[Changeset.FieldName].appliedTo(dotPathType)
+      newCSType = AndType(newCSType, dotPathFieldWrapped)
+    }
+
+    for (nestedField <- nestedTargetFields) {
+      val dotPath             = s"$sourceFieldPath.$nestedField"
+      val dotPathType         = ConstantType(StringConstant(dotPath))
+      val dotPathFieldWrapped = TypeRepr.of[Changeset.FieldName].appliedTo(dotPathType)
+      newCSType = AndType(newCSType, dotPathFieldWrapped)
+    }
+
+    newCSType.asType match {
+      case '[newCs] =>
+        '{
+          val sourcePath = SelectorMacros.toPath[A, F1]($source)
+          new MigrationBuilder[A, B, newCs](
+            $builder.sourceSchema,
+            $builder.targetSchema,
+            $builder.actions :+ MigrationAction.MigrateField(sourcePath, $migration.dynamicMigration)
+          )
+        }
+    }
+  }
+
+  def migrateFieldImplicitImpl[A: Type, B: Type, F1: Type, F2: Type, CS: Type](
+    builder: Expr[MigrationBuilder[A, B, CS]],
+    source: Expr[A => F1],
+    migration: Expr[Migration[F1, F2]]
+  )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] =
+    migrateFieldExplicitImpl[A, B, F1, F2, CS](builder, source, migration)
+
+  private def extractCaseClassFieldNames[T: Type](using q: Quotes): List[String] = {
+    import q.reflect.*
+
+    val tpe = TypeRepr.of[T]
+    val sym = tpe.typeSymbol
+
+    if (sym.flags.is(Flags.Case) && sym.caseFields.nonEmpty) {
+      sym.caseFields.map(_.name)
+    } else {
+      Nil
+    }
+  }
+
+  private def extractFieldPathFromTerm(term: Any)(using q: Quotes): String = {
+    import q.reflect.*
+
+    @tailrec
+    def toPathBody(t: Term): Term = t match {
+      case Inlined(_, _, inlinedBlock)                     => toPathBody(inlinedBlock)
+      case Block(List(DefDef(_, _, _, Some(pathBody))), _) => pathBody
+      case _                                               => report.errorAndAbort(s"Expected a lambda expression, got '${t.show}'")
+    }
+
+    def extractPath(t: Term): List[String] = t match {
+      case Select(parent, fieldName) => extractPath(parent) :+ fieldName
+      case Ident(_)                  => Nil
+      case _                         => report.errorAndAbort(s"Cannot extract field path from: ${t.show}")
+    }
+
+    val pathBody = toPathBody(term.asInstanceOf[Term])
+    val segments = extractPath(pathBody)
+    if (segments.isEmpty) {
+      report.errorAndAbort("Selector must access at least one field")
+    }
+    segments.mkString(".")
+  }
+
+  private def extractLeafFieldName(term: Any)(using q: Quotes): String = {
+    import q.reflect.*
+
+    @tailrec
+    def toPathBody(t: Term): Term = t match {
+      case Inlined(_, _, inlinedBlock)                     => toPathBody(inlinedBlock)
+      case Block(List(DefDef(_, _, _, Some(pathBody))), _) => pathBody
+      case _                                               => report.errorAndAbort(s"Expected a lambda expression, got '${t.show}'")
+    }
+
+    @tailrec
+    def extractLastFieldName(t: Term): String = t match {
+      case Select(_, fieldName)                        => fieldName
+      case Inlined(_, _, inner)                        => extractLastFieldName(inner)
+      case Block(List(DefDef(_, _, _, Some(body))), _) => extractLastFieldName(body)
+      case Ident(_)                                    => report.errorAndAbort("Selector must access at least one field")
+      case _                                           => report.errorAndAbort(s"Cannot extract field name from: ${t.show}")
+    }
+
+    val pathBody = toPathBody(term.asInstanceOf[Term])
+    extractLastFieldName(pathBody)
+  }
+}

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
@@ -22,6 +22,31 @@ import zio.blocks.schema.SchemaExpr
 
 object MigrationBuilderMacros {
 
+  private def refinementFieldTypes(using q: Quotes)(tpe: q.reflect.TypeRepr): Map[String, q.reflect.TypeRepr] = {
+    import q.reflect.*
+
+    def loop(current: TypeRepr, acc: List[(String, TypeRepr)]): List[(String, TypeRepr)] =
+      current.dealias match {
+        case Refinement(parent, fieldName, fieldInfo) if fieldName != "<none>" =>
+          loop(parent, (fieldName -> fieldInfo) :: acc)
+        case _ => acc
+      }
+
+    loop(tpe, Nil).reverse.toMap
+  }
+
+  private def fieldTypes(using q: Quotes)(tpe: q.reflect.TypeRepr): Map[String, q.reflect.TypeRepr] = {
+    import q.reflect.*
+
+    val dealiased = tpe.dealias
+    val sym       = dealiased.typeSymbol
+
+    if (sym.flags.is(Flags.Case) && sym.caseFields.nonEmpty)
+      sym.caseFields.map(field => field.name -> dealiased.memberType(field)).toMap
+    else
+      refinementFieldTypes(dealiased)
+  }
+
   def addFieldImpl[A: Type, B: Type, CS: Type](
     builder: Expr[MigrationBuilder[A, B, CS]],
     target: Expr[B => Any],
@@ -221,8 +246,8 @@ object MigrationBuilderMacros {
 
     val sourceFieldPath = extractFieldPathFromTerm(source.asTerm)
 
-    val nestedSourceFields = extractCaseClassFieldNames[F1]
-    val nestedTargetFields = extractCaseClassFieldNames[F2]
+    val nestedSourceFields = extractNestedFieldNames[F1]
+    val nestedTargetFields = extractNestedFieldNames[F2]
 
     var newCSType           = TypeRepr.of[CS]
     val sourceFieldNameType = ConstantType(StringConstant(sourceFieldPath))
@@ -263,21 +288,36 @@ object MigrationBuilderMacros {
   )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] =
     migrateFieldExplicitImpl[A, B, F1, F2, CS](builder, source, migration)
 
-  private def extractCaseClassFieldNames[T: Type](using q: Quotes): List[String] = {
+  private def extractNestedFieldNames[T: Type](using q: Quotes): List[String] = {
     import q.reflect.*
 
-    val tpe = TypeRepr.of[T]
-    val sym = tpe.typeSymbol
+    def loop(tpe: TypeRepr, prefix: String): List[String] =
+      fieldTypes(tpe).toList.flatMap { case (name, fieldType) =>
+        val fieldName = if (prefix.isEmpty) name else s"$prefix.$name"
+        val nested    = loop(fieldType, fieldName)
+        fieldName :: nested
+      }
 
-    if (sym.flags.is(Flags.Case) && sym.caseFields.nonEmpty) {
-      sym.caseFields.map(_.name)
-    } else {
-      Nil
-    }
+    loop(TypeRepr.of[T], "")
   }
 
   private def extractFieldPathFromTerm(term: Any)(using q: Quotes): String = {
     import q.reflect.*
+
+    def structuralFieldAccess(t: Term): Option[(Term, String)] = t match {
+      case TypeApply(
+            Select(
+              Apply(
+                Select(Apply(Ident("reflectiveSelectable"), List(parent)), "selectDynamic"),
+                List(Literal(StringConstant(fieldName)))
+              ),
+              "$asInstanceOf$"
+            ),
+            _
+          ) =>
+        Some((parent, fieldName))
+      case _ => None
+    }
 
     @tailrec
     def toPathBody(t: Term): Term = t match {
@@ -287,9 +327,12 @@ object MigrationBuilderMacros {
     }
 
     def extractPath(t: Term): List[String] = t match {
-      case Select(parent, fieldName) => extractPath(parent) :+ fieldName
-      case Ident(_)                  => Nil
-      case _                         => report.errorAndAbort(s"Cannot extract field path from: ${t.show}")
+      case Select(parent, fieldName)                       => extractPath(parent) :+ fieldName
+      case other if structuralFieldAccess(other).isDefined =>
+        val (parent, fieldName) = structuralFieldAccess(other).get
+        extractPath(parent) :+ fieldName
+      case Ident(_) => Nil
+      case _        => report.errorAndAbort(s"Cannot extract field path from: ${t.show}")
     }
 
     val pathBody = toPathBody(term.asInstanceOf[Term])
@@ -303,6 +346,21 @@ object MigrationBuilderMacros {
   private def extractLeafFieldName(term: Any)(using q: Quotes): String = {
     import q.reflect.*
 
+    def structuralFieldAccess(t: Term): Option[(Term, String)] = t match {
+      case TypeApply(
+            Select(
+              Apply(
+                Select(Apply(Ident("reflectiveSelectable"), List(parent)), "selectDynamic"),
+                List(Literal(StringConstant(fieldName)))
+              ),
+              "$asInstanceOf$"
+            ),
+            _
+          ) =>
+        Some((parent, fieldName))
+      case _ => None
+    }
+
     @tailrec
     def toPathBody(t: Term): Term = t match {
       case Inlined(_, _, inlinedBlock)                     => toPathBody(inlinedBlock)
@@ -312,11 +370,12 @@ object MigrationBuilderMacros {
 
     @tailrec
     def extractLastFieldName(t: Term): String = t match {
-      case Select(_, fieldName)                        => fieldName
-      case Inlined(_, _, inner)                        => extractLastFieldName(inner)
-      case Block(List(DefDef(_, _, _, Some(body))), _) => extractLastFieldName(body)
-      case Ident(_)                                    => report.errorAndAbort("Selector must access at least one field")
-      case _                                           => report.errorAndAbort(s"Cannot extract field name from: ${t.show}")
+      case Select(_, fieldName)                            => fieldName
+      case other if structuralFieldAccess(other).isDefined => structuralFieldAccess(other).get._2
+      case Inlined(_, _, inner)                            => extractLastFieldName(inner)
+      case Block(List(DefDef(_, _, _, Some(body))), _)     => extractLastFieldName(body)
+      case Ident(_)                                        => report.errorAndAbort("Selector must access at least one field")
+      case _                                               => report.errorAndAbort(s"Cannot extract field name from: ${t.show}")
     }
 
     val pathBody = toPathBody(term.asInstanceOf[Term])

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
@@ -134,8 +134,14 @@ object MigrationBuilderMacros {
   )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] = {
     import q.reflect.*
 
-    val fromFieldPath      = extractFieldPathFromTerm(from.asTerm)
-    val toFieldPath        = extractFieldPathFromTerm(to.asTerm)
+    val fromFieldPath = extractFieldPathFromTerm(from.asTerm)
+    val toFieldPath   = extractFieldPathFromTerm(to.asTerm)
+    if (fromFieldPath != toFieldPath)
+      report.errorAndAbort(
+        s"transformField requires the same field name in source and target, " +
+          s"got '$fromFieldPath' and '$toFieldPath'. " +
+          s"Use renameField followed by transformField for rename-and-transform."
+      )
     val fromFieldType      = ConstantType(StringConstant(fromFieldPath))
     val toFieldType        = ConstantType(StringConstant(toFieldPath))
     val transformedWrapped = TypeRepr.of[Changeset.TransformField].appliedTo(List(fromFieldType, toFieldType))
@@ -164,6 +170,12 @@ object MigrationBuilderMacros {
 
     val sourceFieldPath = extractFieldPathFromTerm(source.asTerm)
     val targetFieldPath = extractFieldPathFromTerm(target.asTerm)
+    if (sourceFieldPath != targetFieldPath)
+      report.errorAndAbort(
+        s"mandateField requires the same field name in source and target, " +
+          s"got '$sourceFieldPath' and '$targetFieldPath'. " +
+          s"Use renameField followed by mandateField for rename-and-mandate."
+      )
     val sourceFieldType = ConstantType(StringConstant(sourceFieldPath))
     val targetFieldType = ConstantType(StringConstant(targetFieldPath))
     val mandatedWrapped = TypeRepr.of[Changeset.MandateField].appliedTo(List(sourceFieldType, targetFieldType))
@@ -189,8 +201,14 @@ object MigrationBuilderMacros {
   )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] = {
     import q.reflect.*
 
-    val sourceFieldPath     = extractFieldPathFromTerm(source.asTerm)
-    val targetFieldPath     = extractFieldPathFromTerm(target.asTerm)
+    val sourceFieldPath = extractFieldPathFromTerm(source.asTerm)
+    val targetFieldPath = extractFieldPathFromTerm(target.asTerm)
+    if (sourceFieldPath != targetFieldPath)
+      report.errorAndAbort(
+        s"optionalizeField requires the same field name in source and target, " +
+          s"got '$sourceFieldPath' and '$targetFieldPath'. " +
+          s"Use renameField followed by optionalizeField for rename-and-optionalize."
+      )
     val sourceFieldType     = ConstantType(StringConstant(sourceFieldPath))
     val targetFieldType     = ConstantType(StringConstant(targetFieldPath))
     val optionalizedWrapped = TypeRepr.of[Changeset.OptionalizeField].appliedTo(List(sourceFieldType, targetFieldType))
@@ -301,20 +319,7 @@ object MigrationBuilderMacros {
   private def extractFieldPathFromTerm(term: Any)(using q: Quotes): String = {
     import q.reflect.*
 
-    def structuralFieldAccess(t: Term): Option[(Term, String)] = t match {
-      case TypeApply(
-            Select(
-              Apply(
-                Select(Apply(Ident("reflectiveSelectable"), List(parent)), "selectDynamic"),
-                List(Literal(StringConstant(fieldName)))
-              ),
-              "$asInstanceOf$"
-            ),
-            _
-          ) =>
-        Some((parent, fieldName))
-      case _ => None
-    }
+    def structuralFieldAccess(t: Term): Option[(Term, String)] = SelectorMacros.extractSelectDynamic(t)
 
     @tailrec
     def toPathBody(t: Term): Term = t match {
@@ -343,20 +348,7 @@ object MigrationBuilderMacros {
   private def extractLeafFieldName(term: Any)(using q: Quotes): String = {
     import q.reflect.*
 
-    def structuralFieldAccess(t: Term): Option[(Term, String)] = t match {
-      case TypeApply(
-            Select(
-              Apply(
-                Select(Apply(Ident("reflectiveSelectable"), List(parent)), "selectDynamic"),
-                List(Literal(StringConstant(fieldName)))
-              ),
-              "$asInstanceOf$"
-            ),
-            _
-          ) =>
-        Some((parent, fieldName))
-      case _ => None
-    }
+    def structuralFieldAccess(t: Term): Option[(Term, String)] = SelectorMacros.extractSelectDynamic(t)
 
     @tailrec
     def toPathBody(t: Term): Term = t match {

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
@@ -212,16 +212,13 @@ object MigrationBuilderMacros {
   def changeFieldTypeImpl[A: Type, B: Type, CS: Type](
     builder: Expr[MigrationBuilder[A, B, CS]],
     source: Expr[A => Any],
-    target: Expr[B => Any],
     converter: Expr[SchemaExpr[_, _]]
   )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] = {
     import q.reflect.*
 
     val sourceFieldPath    = extractFieldPathFromTerm(source.asTerm)
-    val targetFieldPath    = extractFieldPathFromTerm(target.asTerm)
     val sourceFieldType    = ConstantType(StringConstant(sourceFieldPath))
-    val targetFieldType    = ConstantType(StringConstant(targetFieldPath))
-    val typeChangedWrapped = TypeRepr.of[Changeset.ChangeFieldType].appliedTo(List(sourceFieldType, targetFieldType))
+    val typeChangedWrapped = TypeRepr.of[Changeset.ChangeFieldType].appliedTo(List(sourceFieldType))
     val newCSType          = AndType(TypeRepr.of[CS], typeChangedWrapped)
 
     newCSType.asType match {

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationCompanionVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationCompanionVersionSpecific.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.Schema
+
+trait MigrationCompanionVersionSpecific {
+  def newBuilder[A, B](using
+    sourceSchema: Schema[A],
+    targetSchema: Schema[B]
+  ): MigrationBuilder[A, B, Any] =
+    new MigrationBuilder(sourceSchema, targetSchema, Chunk.empty)
+}

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationSelectorSyntax.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationSelectorSyntax.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import scala.compiletime.error
+
+/**
+ * Scala 3 extension methods for selector syntax in migrations. These are
+ * compile-time-only placeholders that get transformed by the macros.
+ *
+ * Provides syntax sugar for selector expressions like:
+ *   - `_.field.each` for collection traversal
+ *   - `_.variant.when[Type]` for case selection
+ *   - `_.wrapper.wrapped[Inner]` for wrapper unwrapping
+ *   - `_.seq.at(0)` for index access
+ *   - `_.map.atKey(key)` for map key access
+ */
+transparent trait MigrationSelectorSyntax {
+
+  extension [A](a: A) {
+    inline def when[B <: A]: B = error("Can only be used inside migration selector macros")
+    inline def wrapped[B]: B   = error("Can only be used inside migration selector macros")
+  }
+
+  extension [C[_], A](c: C[A]) {
+    inline def at(index: Int): A = error("Can only be used inside migration selector macros")
+    inline def each: A           = error("Can only be used inside migration selector macros")
+  }
+
+  extension [M[_, _], K, V](m: M[K, V]) {
+    inline def atKey(key: K): V = error("Can only be used inside migration selector macros")
+    inline def eachKey: K       = error("Can only be used inside migration selector macros")
+    inline def eachValue: V     = error("Can only be used inside migration selector macros")
+  }
+}
+
+object MigrationSelectorSyntax extends MigrationSelectorSyntax

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationValidationMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationValidationMacros.scala
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import scala.quoted.*
+
+object MigrationValidationMacros {
+
+  def validateMigration[A: Type, B: Type, CS: Type](using
+    Quotes
+  ): Expr[MigrationComplete[A, B, CS]] = {
+    import quotes.reflect.*
+
+    val sourceFields = extractFieldNamesWithNested[A]("")
+    val targetFields = extractFieldNamesWithNested[B]("")
+
+    val (handledFields, providedFields) = extractHandledAndProvided[CS]
+
+    val autoMapped = computeAutoMappedWithNested[A, B]("")
+
+    val allExplicitlyHandled = handledFields ++ providedFields
+    val crossTypeAutoMapped  = computeCrossTypeAutoMapped[A, B](allExplicitlyHandled, "")
+
+    var coveredSource = handledFields ++ autoMapped ++ crossTypeAutoMapped
+    var coveredTarget = providedFields ++ autoMapped ++ crossTypeAutoMapped
+
+    coveredSource = inferParentCoverage(sourceFields, coveredSource)
+    coveredTarget = inferParentCoverage(targetFields, coveredTarget)
+
+    val missingTarget   = targetFields -- coveredTarget
+    val unhandledSource = sourceFields -- coveredSource
+
+    if (missingTarget.nonEmpty || unhandledSource.nonEmpty) {
+      val errors = new StringBuilder("Migration incomplete:\n")
+
+      if (missingTarget.nonEmpty) {
+        errors.append(s"\n  Target fields not provided: ${missingTarget.mkString(", ")}\n")
+        errors.append("  Use addField, renameField, transformField, or migrateField to provide these fields.\n")
+      }
+
+      if (unhandledSource.nonEmpty) {
+        errors.append(s"\n  Source fields not handled: ${unhandledSource.mkString(", ")}\n")
+        errors.append("  Use dropField, renameField, transformField, or migrateField to handle these fields.\n")
+      }
+
+      errors.append("\n  Alternatively, use .buildPartial to skip validation.")
+
+      report.errorAndAbort(errors.toString)
+    }
+
+    '{ MigrationComplete.unsafeCreate[A, B, CS] }
+  }
+
+  private def extractHandledAndProvided[CS: Type](using Quotes): (Set[String], Set[String]) = {
+    import quotes.reflect.*
+
+    var handled  = Set.empty[String]
+    var provided = Set.empty[String]
+
+    def extract(tpe: TypeRepr): Unit = {
+      val dealiased = tpe.dealias
+      dealiased match {
+        case AndType(left, right) =>
+          extract(left)
+          extract(right)
+        case t if t =:= TypeRepr.of[Any] => ()
+        case AppliedType(tycon, args)    =>
+          tycon.typeSymbol.name match {
+            case "AddField" =>
+              extractStringFromType(args.head).foreach(n => provided += n)
+            case "DropField" =>
+              extractStringFromType(args.head).foreach(n => handled += n)
+            case "RenameField" =>
+              extractStringFromType(args.head).foreach(n => handled += n)
+              extractStringFromType(args(1)).foreach(n => provided += n)
+            case "TransformField" =>
+              extractStringFromType(args.head).foreach(n => handled += n)
+              extractStringFromType(args(1)).foreach(n => provided += n)
+            case "MandateField" =>
+              extractStringFromType(args.head).foreach(n => handled += n)
+              extractStringFromType(args(1)).foreach(n => provided += n)
+            case "OptionalizeField" =>
+              extractStringFromType(args.head).foreach(n => handled += n)
+              extractStringFromType(args(1)).foreach(n => provided += n)
+            case "ChangeFieldType" =>
+              extractStringFromType(args.head).foreach(n => handled += n)
+              extractStringFromType(args(1)).foreach(n => provided += n)
+            case "MigrateField" =>
+              extractStringFromType(args.head).foreach { n =>
+                handled += n
+                provided += n
+              }
+            case "FieldName" =>
+              extractStringFromType(args.head).foreach { n =>
+                handled += n
+                provided += n
+              }
+            case "RenameCase" | "TransformCase" | "TransformElements" | "TransformKeys" | "TransformValues" =>
+              ()
+            case _ => ()
+          }
+        case _ => ()
+      }
+    }
+
+    extract(TypeRepr.of[CS])
+    (handled, provided)
+  }
+
+  private def extractStringFromType(using q: Quotes)(tpe: q.reflect.TypeRepr): Option[String] = {
+    import q.reflect.*
+    tpe.dealias match {
+      case ConstantType(StringConstant(s)) => Some(s)
+      case _                               => None
+    }
+  }
+
+  private def extractFieldNamesWithNested[T: Type](prefix: String)(using Quotes): Set[String] = {
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[T]
+
+    if (tpe.typeSymbol.flags.is(Flags.Case) && tpe.typeSymbol.caseFields.nonEmpty) {
+      tpe.typeSymbol.caseFields.flatMap { field =>
+        val fieldName = if (prefix.isEmpty) field.name else s"$prefix.${field.name}"
+        val fieldType = tpe.memberType(field)
+
+        if (fieldType.typeSymbol.flags.is(Flags.Case) && fieldType.typeSymbol.caseFields.nonEmpty) {
+          Set(fieldName) ++ extractNestedFieldNames(fieldType, fieldName)
+        } else {
+          Set(fieldName)
+        }
+      }.toSet
+    } else {
+      Set.empty
+    }
+  }
+
+  private def extractNestedFieldNames(using q: Quotes)(tpe: q.reflect.TypeRepr, prefix: String): Set[String] = {
+    import q.reflect.*
+
+    if (tpe.typeSymbol.flags.is(Flags.Case) && tpe.typeSymbol.caseFields.nonEmpty) {
+      tpe.typeSymbol.caseFields.flatMap { field =>
+        val fieldName = s"$prefix.${field.name}"
+        val fieldType = tpe.memberType(field)
+
+        if (fieldType.typeSymbol.flags.is(Flags.Case) && fieldType.typeSymbol.caseFields.nonEmpty) {
+          Set(fieldName) ++ extractNestedFieldNames(fieldType, fieldName)
+        } else {
+          Set(fieldName)
+        }
+      }.toSet
+    } else {
+      Set.empty
+    }
+  }
+
+  private def computeAutoMappedWithNested[A: Type, B: Type](prefix: String)(using Quotes): Set[String] = {
+    import quotes.reflect.*
+
+    val sourceType = TypeRepr.of[A]
+    val targetType = TypeRepr.of[B]
+
+    val sourceFieldTypes: Map[String, TypeRepr] =
+      if (sourceType.typeSymbol.flags.is(Flags.Case)) {
+        sourceType.typeSymbol.caseFields.map { field =>
+          field.name -> sourceType.memberType(field)
+        }.toMap
+      } else Map.empty
+
+    val targetFieldTypes: Map[String, TypeRepr] =
+      if (targetType.typeSymbol.flags.is(Flags.Case)) {
+        targetType.typeSymbol.caseFields.map { field =>
+          field.name -> targetType.memberType(field)
+        }.toMap
+      } else Map.empty
+
+    val sourceFields = sourceFieldTypes.keySet
+    val targetFields = targetFieldTypes.keySet
+    val commonFields = sourceFields.intersect(targetFields)
+
+    commonFields.flatMap { fieldName =>
+      val fullFieldName = if (prefix.isEmpty) fieldName else s"$prefix.$fieldName"
+      (sourceFieldTypes.get(fieldName), targetFieldTypes.get(fieldName)) match {
+        case (Some(srcType), Some(tgtType)) if srcType =:= tgtType =>
+          Set(fullFieldName) ++ computeAutoMappedNested(srcType, tgtType, fullFieldName)
+        case (Some(srcType), Some(tgtType)) if srcType <:< tgtType || tgtType <:< srcType =>
+          Set(fullFieldName)
+        case _ => Set.empty[String]
+      }
+    }
+  }
+
+  private def computeAutoMappedNested(using
+    q: Quotes
+  )(srcType: q.reflect.TypeRepr, tgtType: q.reflect.TypeRepr, prefix: String): Set[String] = {
+    import q.reflect.*
+
+    if (srcType.typeSymbol.flags.is(Flags.Case) && tgtType.typeSymbol.flags.is(Flags.Case)) {
+      val srcFields = srcType.typeSymbol.caseFields.map(f => f.name -> srcType.memberType(f)).toMap
+      val tgtFields = tgtType.typeSymbol.caseFields.map(f => f.name -> tgtType.memberType(f)).toMap
+
+      val commonFields = srcFields.keySet.intersect(tgtFields.keySet)
+
+      commonFields.flatMap { fieldName =>
+        val fullFieldName = s"$prefix.$fieldName"
+        (srcFields.get(fieldName), tgtFields.get(fieldName)) match {
+          case (Some(srcFieldType), Some(tgtFieldType)) if srcFieldType =:= tgtFieldType =>
+            Set(fullFieldName) ++ computeAutoMappedNested(srcFieldType, tgtFieldType, fullFieldName)
+          case (Some(srcFieldType), Some(tgtFieldType))
+              if srcFieldType <:< tgtFieldType || tgtFieldType <:< srcFieldType =>
+            Set(fullFieldName)
+          case _ => Set.empty[String]
+        }
+      }
+    } else {
+      Set.empty
+    }
+  }
+
+  private def computeCrossTypeAutoMapped[A: Type, B: Type](explicitlyHandled: Set[String], prefix: String)(using
+    Quotes
+  ): Set[String] =
+    computeCrossTypeAutoMappedImpl(
+      quotes.reflect.TypeRepr.of[A],
+      quotes.reflect.TypeRepr.of[B],
+      explicitlyHandled,
+      prefix
+    )
+
+  private def computeCrossTypeAutoMappedImpl(using
+    q: Quotes
+  )(
+    sourceType: q.reflect.TypeRepr,
+    targetType: q.reflect.TypeRepr,
+    explicitlyHandled: Set[String],
+    prefix: String
+  ): Set[String] = {
+    import q.reflect.*
+
+    val sourceFieldTypes: Map[String, TypeRepr] =
+      if (sourceType.typeSymbol.flags.is(Flags.Case) && sourceType.typeSymbol.caseFields.nonEmpty)
+        sourceType.typeSymbol.caseFields.map(f => f.name -> sourceType.memberType(f)).toMap
+      else Map.empty
+
+    val targetFieldTypes: Map[String, TypeRepr] =
+      if (targetType.typeSymbol.flags.is(Flags.Case) && targetType.typeSymbol.caseFields.nonEmpty)
+        targetType.typeSymbol.caseFields.map(f => f.name -> targetType.memberType(f)).toMap
+      else Map.empty
+
+    val commonFields = sourceFieldTypes.keySet.intersect(targetFieldTypes.keySet)
+
+    commonFields.flatMap { fieldName =>
+      val fullFieldName = if (prefix.isEmpty) fieldName else s"$prefix.$fieldName"
+      (sourceFieldTypes.get(fieldName), targetFieldTypes.get(fieldName)) match {
+        case (Some(srcType), Some(tgtType)) if !(srcType =:= tgtType) =>
+          val hasExplicitChild = explicitlyHandled.exists(_.startsWith(s"$fullFieldName."))
+          if (hasExplicitChild)
+            crossTypeAutoMapLeaves(srcType, tgtType, explicitlyHandled, fullFieldName)
+          else Set.empty[String]
+        case _ => Set.empty[String]
+      }
+    }
+  }
+
+  private def crossTypeAutoMapLeaves(using
+    q: Quotes
+  )(
+    srcType: q.reflect.TypeRepr,
+    tgtType: q.reflect.TypeRepr,
+    explicitlyHandled: Set[String],
+    prefix: String
+  ): Set[String] = {
+    import q.reflect.*
+
+    val srcFields =
+      if (srcType.typeSymbol.flags.is(Flags.Case) && srcType.typeSymbol.caseFields.nonEmpty)
+        srcType.typeSymbol.caseFields.map(f => f.name -> srcType.memberType(f)).toMap
+      else Map.empty
+
+    val tgtFields =
+      if (tgtType.typeSymbol.flags.is(Flags.Case) && tgtType.typeSymbol.caseFields.nonEmpty)
+        tgtType.typeSymbol.caseFields.map(f => f.name -> tgtType.memberType(f)).toMap
+      else Map.empty
+
+    val common = srcFields.keySet.intersect(tgtFields.keySet)
+
+    common.flatMap { fieldName =>
+      val fullName = s"$prefix.$fieldName"
+      (srcFields(fieldName), tgtFields(fieldName)) match {
+        case (s, t) if s =:= t => Set(fullName)
+        case (s, t)            =>
+          val hasExplicitChild = explicitlyHandled.exists(_.startsWith(s"$fullName."))
+          if (hasExplicitChild)
+            crossTypeAutoMapLeaves(s, t, explicitlyHandled, fullName)
+          else Set.empty[String]
+      }
+    }
+  }
+
+  private def inferParentCoverage(allFields: Set[String], covered: Set[String]): Set[String] = {
+    val parents = allFields.flatMap { f =>
+      val parts = f.split('.')
+      if (parts.length > 1) Some(parts.init.mkString(".")) else None
+    }
+    var result  = covered
+    var changed = true
+    while (changed) {
+      changed = false
+      for (parent <- parents) {
+        if (!result.contains(parent)) {
+          val children = allFields.filter(_.startsWith(s"$parent."))
+          if (children.nonEmpty && children.forall(result.contains)) {
+            result = result + parent
+            changed = true
+          }
+        }
+      }
+    }
+    result
+  }
+}

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationValidationMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationValidationMacros.scala
@@ -20,6 +20,31 @@ import scala.quoted.*
 
 object MigrationValidationMacros {
 
+  private def refinementFieldTypes(using q: Quotes)(tpe: q.reflect.TypeRepr): Map[String, q.reflect.TypeRepr] = {
+    import q.reflect.*
+
+    def loop(current: TypeRepr, acc: List[(String, TypeRepr)]): List[(String, TypeRepr)] =
+      current.dealias match {
+        case Refinement(parent, fieldName, fieldInfo) if fieldName != "<none>" =>
+          loop(parent, (fieldName -> fieldInfo) :: acc)
+        case _ => acc
+      }
+
+    loop(tpe, Nil).reverse.toMap
+  }
+
+  private def fieldTypes(using q: Quotes)(tpe: q.reflect.TypeRepr): Map[String, q.reflect.TypeRepr] = {
+    import q.reflect.*
+
+    val dealiased = tpe.dealias
+    val sym       = dealiased.typeSymbol
+
+    if (sym.flags.is(Flags.Case) && sym.caseFields.nonEmpty)
+      sym.caseFields.map(field => field.name -> dealiased.memberType(field)).toMap
+    else
+      refinementFieldTypes(dealiased)
+  }
+
   def validateMigration[A: Type, B: Type, CS: Type](using
     Quotes
   ): Expr[MigrationComplete[A, B, CS]] = {
@@ -56,8 +81,6 @@ object MigrationValidationMacros {
         errors.append(s"\n  Source fields not handled: ${unhandledSource.mkString(", ")}\n")
         errors.append("  Use dropField, renameField, transformField, or migrateField to handle these fields.\n")
       }
-
-      errors.append("\n  Alternatively, use .buildPartial to skip validation.")
 
       report.errorAndAbort(errors.toString)
     }
@@ -133,41 +156,23 @@ object MigrationValidationMacros {
     import quotes.reflect.*
 
     val tpe = TypeRepr.of[T]
-
-    if (tpe.typeSymbol.flags.is(Flags.Case) && tpe.typeSymbol.caseFields.nonEmpty) {
-      tpe.typeSymbol.caseFields.flatMap { field =>
-        val fieldName = if (prefix.isEmpty) field.name else s"$prefix.${field.name}"
-        val fieldType = tpe.memberType(field)
-
-        if (fieldType.typeSymbol.flags.is(Flags.Case) && fieldType.typeSymbol.caseFields.nonEmpty) {
-          Set(fieldName) ++ extractNestedFieldNames(fieldType, fieldName)
-        } else {
-          Set(fieldName)
-        }
-      }.toSet
-    } else {
-      Set.empty
-    }
+    fieldTypes(tpe).flatMap { case (name, fieldType) =>
+      val fieldName = if (prefix.isEmpty) name else s"$prefix.$name"
+      if (fieldTypes(fieldType).nonEmpty)
+        Set(fieldName) ++ extractNestedFieldNames(fieldType, fieldName)
+      else
+        Set(fieldName)
+    }.toSet
   }
 
-  private def extractNestedFieldNames(using q: Quotes)(tpe: q.reflect.TypeRepr, prefix: String): Set[String] = {
-    import q.reflect.*
-
-    if (tpe.typeSymbol.flags.is(Flags.Case) && tpe.typeSymbol.caseFields.nonEmpty) {
-      tpe.typeSymbol.caseFields.flatMap { field =>
-        val fieldName = s"$prefix.${field.name}"
-        val fieldType = tpe.memberType(field)
-
-        if (fieldType.typeSymbol.flags.is(Flags.Case) && fieldType.typeSymbol.caseFields.nonEmpty) {
-          Set(fieldName) ++ extractNestedFieldNames(fieldType, fieldName)
-        } else {
-          Set(fieldName)
-        }
-      }.toSet
-    } else {
-      Set.empty
-    }
-  }
+  private def extractNestedFieldNames(using q: Quotes)(tpe: q.reflect.TypeRepr, prefix: String): Set[String] =
+    fieldTypes(tpe).flatMap { case (name, fieldType) =>
+      val fieldName = s"$prefix.$name"
+      if (fieldTypes(fieldType).nonEmpty)
+        Set(fieldName) ++ extractNestedFieldNames(fieldType, fieldName)
+      else
+        Set(fieldName)
+    }.toSet
 
   private def computeAutoMappedWithNested[A: Type, B: Type](prefix: String)(using Quotes): Set[String] = {
     import quotes.reflect.*
@@ -175,19 +180,8 @@ object MigrationValidationMacros {
     val sourceType = TypeRepr.of[A]
     val targetType = TypeRepr.of[B]
 
-    val sourceFieldTypes: Map[String, TypeRepr] =
-      if (sourceType.typeSymbol.flags.is(Flags.Case)) {
-        sourceType.typeSymbol.caseFields.map { field =>
-          field.name -> sourceType.memberType(field)
-        }.toMap
-      } else Map.empty
-
-    val targetFieldTypes: Map[String, TypeRepr] =
-      if (targetType.typeSymbol.flags.is(Flags.Case)) {
-        targetType.typeSymbol.caseFields.map { field =>
-          field.name -> targetType.memberType(field)
-        }.toMap
-      } else Map.empty
+    val sourceFieldTypes: Map[String, TypeRepr] = fieldTypes(sourceType)
+    val targetFieldTypes: Map[String, TypeRepr] = fieldTypes(targetType)
 
     val sourceFields = sourceFieldTypes.keySet
     val targetFields = targetFieldTypes.keySet
@@ -208,12 +202,10 @@ object MigrationValidationMacros {
   private def computeAutoMappedNested(using
     q: Quotes
   )(srcType: q.reflect.TypeRepr, tgtType: q.reflect.TypeRepr, prefix: String): Set[String] = {
-    import q.reflect.*
+    val srcFields = fieldTypes(srcType)
+    val tgtFields = fieldTypes(tgtType)
 
-    if (srcType.typeSymbol.flags.is(Flags.Case) && tgtType.typeSymbol.flags.is(Flags.Case)) {
-      val srcFields = srcType.typeSymbol.caseFields.map(f => f.name -> srcType.memberType(f)).toMap
-      val tgtFields = tgtType.typeSymbol.caseFields.map(f => f.name -> tgtType.memberType(f)).toMap
-
+    if (srcFields.nonEmpty && tgtFields.nonEmpty) {
       val commonFields = srcFields.keySet.intersect(tgtFields.keySet)
 
       commonFields.flatMap { fieldName =>
@@ -252,15 +244,8 @@ object MigrationValidationMacros {
   ): Set[String] = {
     import q.reflect.*
 
-    val sourceFieldTypes: Map[String, TypeRepr] =
-      if (sourceType.typeSymbol.flags.is(Flags.Case) && sourceType.typeSymbol.caseFields.nonEmpty)
-        sourceType.typeSymbol.caseFields.map(f => f.name -> sourceType.memberType(f)).toMap
-      else Map.empty
-
-    val targetFieldTypes: Map[String, TypeRepr] =
-      if (targetType.typeSymbol.flags.is(Flags.Case) && targetType.typeSymbol.caseFields.nonEmpty)
-        targetType.typeSymbol.caseFields.map(f => f.name -> targetType.memberType(f)).toMap
-      else Map.empty
+    val sourceFieldTypes: Map[String, TypeRepr] = fieldTypes(sourceType)
+    val targetFieldTypes: Map[String, TypeRepr] = fieldTypes(targetType)
 
     val commonFields = sourceFieldTypes.keySet.intersect(targetFieldTypes.keySet)
 
@@ -285,17 +270,8 @@ object MigrationValidationMacros {
     explicitlyHandled: Set[String],
     prefix: String
   ): Set[String] = {
-    import q.reflect.*
-
-    val srcFields =
-      if (srcType.typeSymbol.flags.is(Flags.Case) && srcType.typeSymbol.caseFields.nonEmpty)
-        srcType.typeSymbol.caseFields.map(f => f.name -> srcType.memberType(f)).toMap
-      else Map.empty
-
-    val tgtFields =
-      if (tgtType.typeSymbol.flags.is(Flags.Case) && tgtType.typeSymbol.caseFields.nonEmpty)
-        tgtType.typeSymbol.caseFields.map(f => f.name -> tgtType.memberType(f)).toMap
-      else Map.empty
+    val srcFields = fieldTypes(srcType)
+    val tgtFields = fieldTypes(tgtType)
 
     val common = srcFields.keySet.intersect(tgtFields.keySet)
 

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationValidationMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationValidationMacros.scala
@@ -120,8 +120,10 @@ object MigrationValidationMacros {
               extractStringFromType(args.head).foreach(n => handled += n)
               extractStringFromType(args(1)).foreach(n => provided += n)
             case "ChangeFieldType" =>
-              extractStringFromType(args.head).foreach(n => handled += n)
-              extractStringFromType(args(1)).foreach(n => provided += n)
+              extractStringFromType(args.head).foreach { n =>
+                handled += n
+                provided += n
+              }
             case "MigrateField" =>
               extractStringFromType(args.head).foreach { n =>
                 handled += n

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/SelectorMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/SelectorMacros.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import scala.annotation.tailrec
+import scala.quoted._
+import zio.blocks.schema.{DynamicOptic, Schema}
+
+/**
+ * Scala 3 macros for converting selector expressions into DynamicOptic paths.
+ *
+ * These macros parse selector expressions like:
+ *   - `_.field` → `DynamicOptic.root.field("field")`
+ *   - `_.a.b.c` → `DynamicOptic.root.field("a").field("b").field("c")`
+ *   - `_.items.each` → `DynamicOptic.root.field("items").elements`
+ *   - `_.country.when[UK]` → `DynamicOptic.root.field("country").caseOf("UK")`
+ */
+object SelectorMacros {
+
+  inline def toPath[S, A](inline selector: S => A): DynamicOptic =
+    ${ toPathImpl[S, A]('selector) }
+
+  inline def extractFieldName[S, A](inline selector: S => A): String =
+    ${ extractFieldNameImpl[S, A]('selector) }
+
+  def extractFieldNameImpl[S: Type, A: Type](selector: Expr[S => A])(using q: Quotes): Expr[String] = {
+    import q.reflect.*
+
+    @scala.annotation.tailrec
+    def toPathBody(term: Term): Term = term match {
+      case Inlined(_, _, inlinedBlock)                     => toPathBody(inlinedBlock)
+      case Block(List(DefDef(_, _, _, Some(pathBody))), _) => pathBody
+      case _                                               => report.errorAndAbort(s"Expected a lambda expression, got '${term.show}'")
+    }
+
+    def extractLastFieldName(term: Term): String = term match {
+      case Select(_, fieldName) => fieldName
+      case Ident(_)             => report.errorAndAbort("Selector must access at least one field")
+      case _                    => report.errorAndAbort(s"Cannot extract field name from: ${term.show}")
+    }
+
+    val pathBody  = toPathBody(selector.asTerm)
+    val fieldName = extractLastFieldName(pathBody)
+    Expr(fieldName)
+  }
+
+  def toPathImpl[S: Type, A: Type](selector: Expr[S => A])(using q: Quotes): Expr[DynamicOptic] = {
+    import q.reflect._
+
+    def fail(msg: String): Nothing =
+      report.errorAndAbort(msg)
+
+    @tailrec
+    def toPathBody(term: Term): Term = term match {
+      case Inlined(_, _, inlinedBlock)                     => toPathBody(inlinedBlock)
+      case Block(List(DefDef(_, _, _, Some(pathBody))), _) => pathBody
+      case _                                               => fail(s"Expected a lambda expression, got '${term.show}'")
+    }
+
+    def hasName(term: Term, name: String): Boolean = term match {
+      case Ident(s)     => name == s
+      case Select(_, s) => name == s
+      case _            => false
+    }
+
+    def getTypeName(tpe: TypeRepr): String =
+      tpe.dealias match {
+        case tr: TypeRef => tr.name
+        case other       => other.show
+      }
+
+    def toDynamicOptic(term: Term): Expr[DynamicOptic] = term match {
+      // Identity - just the parameter reference
+      case Ident(_) =>
+        '{ DynamicOptic.root }
+
+      // Field access: _.field or _.a.b.c
+      case Select(parent, fieldName) =>
+        val parentOptic = toDynamicOptic(parent)
+        val fieldExpr   = Expr(fieldName)
+        '{ $parentOptic.field($fieldExpr) }
+
+      // Collection traversal: _.items.each
+      case Apply(TypeApply(elementTerm, _), List(parent)) if hasName(elementTerm, "each") =>
+        val parentOptic = toDynamicOptic(parent)
+        '{ $parentOptic.elements }
+
+      // Map key traversal: _.map.eachKey
+      case Apply(TypeApply(keyTerm, _), List(parent)) if hasName(keyTerm, "eachKey") =>
+        val parentOptic = toDynamicOptic(parent)
+        '{ $parentOptic.mapKeys }
+
+      // Map value traversal: _.map.eachValue
+      case Apply(TypeApply(valueTerm, _), List(parent)) if hasName(valueTerm, "eachValue") =>
+        val parentOptic = toDynamicOptic(parent)
+        '{ $parentOptic.mapValues }
+
+      // Case selection: _.variant.when[CaseType]
+      case TypeApply(Apply(TypeApply(caseTerm, _), List(parent)), List(typeTree)) if hasName(caseTerm, "when") =>
+        val parentOptic = toDynamicOptic(parent)
+        val caseName    = Expr(getTypeName(typeTree.tpe))
+        '{ $parentOptic.caseOf($caseName) }
+
+      // Wrapper unwrap: _.wrapper.wrapped[Inner]
+      case TypeApply(Apply(TypeApply(wrapperTerm, _), List(parent)), List(_)) if hasName(wrapperTerm, "wrapped") =>
+        val parentOptic = toDynamicOptic(parent)
+        '{ $parentOptic.wrapped }
+
+      // Index access: _.seq.at(0)
+      case Apply(Apply(TypeApply(atTerm, _), List(parent)), List(index)) if hasName(atTerm, "at") =>
+        val parentOptic = toDynamicOptic(parent)
+        val indexExpr   = index.asExprOf[Int]
+        '{ $parentOptic.at($indexExpr) }
+
+      // Map key access: _.map.atKey(key)
+      case Apply(Apply(TypeApply(atKeyTerm, keyTypes), List(parent)), List(key)) if hasName(atKeyTerm, "atKey") =>
+        val parentOptic = toDynamicOptic(parent)
+        val keyExpr     = key.asExpr
+        val keyTypeRepr = keyTypes.head.tpe
+        val schemaTpe   = TypeRepr.of[Schema].appliedTo(keyTypeRepr)
+        Implicits.search(schemaTpe) match {
+          case v: ImplicitSearchSuccess =>
+            val schemaExpr = v.tree.asExpr.asInstanceOf[Expr[Schema[Any]]]
+            '{ $parentOptic.atKey($keyExpr)(using $schemaExpr) }
+          case _ =>
+            fail(s"Cannot find Schema[${keyTypeRepr.show}] for atKey")
+        }
+
+      case other =>
+        fail(s"Unsupported selector expression: ${other.show}")
+    }
+
+    val pathBody = toPathBody(selector.asTerm)
+    toDynamicOptic(pathBody)
+  }
+}

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/SelectorMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/SelectorMacros.scala
@@ -37,23 +37,53 @@ object SelectorMacros {
   inline def extractFieldName[S, A](inline selector: S => A): String =
     ${ extractFieldNameImpl[S, A]('selector) }
 
-  def extractFieldNameImpl[S: Type, A: Type](selector: Expr[S => A])(using q: Quotes): Expr[String] = {
+  private[migration] def isReflectiveSelectable(name: String): Boolean =
+    name == "reflectiveSelectable" || name == "reflectiveSelectableFromLangReflectiveCalls"
+
+  private[migration] def extractSelectDynamic(using
+    q: Quotes
+  )(term: q.reflect.Term): Option[(q.reflect.Term, String)] = {
     import q.reflect.*
 
-    def structuralFieldAccess(term: Term): Option[(Term, String)] = term match {
+    def extractSelectableParent(t: Term): Option[Term] = t match {
+      case Apply(selectableRef, List(parent)) if isSelectableRef(selectableRef) =>
+        Some(parent)
+      case Apply(Apply(selectableRef, List(parent)), _) if isSelectableRef(selectableRef) =>
+        Some(parent)
+      case Apply(inner, _) =>
+        extractSelectableParent(inner)
+      case _ => None
+    }
+
+    term match {
       case TypeApply(
             Select(
               Apply(
-                Select(Apply(Ident("reflectiveSelectable"), List(parent)), "selectDynamic"),
+                Select(selectableApp, "selectDynamic"),
                 List(Literal(StringConstant(fieldName)))
               ),
               "$asInstanceOf$"
             ),
             _
           ) =>
-        Some((parent, fieldName))
+        extractSelectableParent(selectableApp).map(parent => (parent, fieldName))
       case _ => None
     }
+  }
+
+  private def isSelectableRef(using q: Quotes)(term: q.reflect.Term): Boolean = {
+    import q.reflect.*
+    term match {
+      case Ident(name)     => isReflectiveSelectable(name)
+      case Select(_, name) => isReflectiveSelectable(name)
+      case _               => false
+    }
+  }
+
+  def extractFieldNameImpl[S: Type, A: Type](selector: Expr[S => A])(using q: Quotes): Expr[String] = {
+    import q.reflect.*
+
+    def structuralFieldAccess(term: Term): Option[(Term, String)] = extractSelectDynamic(term)
 
     @scala.annotation.tailrec
     def toPathBody(term: Term): Term = term match {
@@ -99,20 +129,7 @@ object SelectorMacros {
         case other       => other.show
       }
 
-    def structuralFieldAccess(term: Term): Option[(Term, String)] = term match {
-      case TypeApply(
-            Select(
-              Apply(
-                Select(Apply(Ident("reflectiveSelectable"), List(parent)), "selectDynamic"),
-                List(Literal(StringConstant(fieldName)))
-              ),
-              "$asInstanceOf$"
-            ),
-            _
-          ) =>
-        Some((parent, fieldName))
-      case _ => None
-    }
+    def structuralFieldAccess(term: Term): Option[(Term, String)] = extractSelectDynamic(term)
 
     def toDynamicOptic(term: Term): Expr[DynamicOptic] = term match {
       // Identity - just the parameter reference

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/SelectorMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/SelectorMacros.scala
@@ -40,6 +40,21 @@ object SelectorMacros {
   def extractFieldNameImpl[S: Type, A: Type](selector: Expr[S => A])(using q: Quotes): Expr[String] = {
     import q.reflect.*
 
+    def structuralFieldAccess(term: Term): Option[(Term, String)] = term match {
+      case TypeApply(
+            Select(
+              Apply(
+                Select(Apply(Ident("reflectiveSelectable"), List(parent)), "selectDynamic"),
+                List(Literal(StringConstant(fieldName)))
+              ),
+              "$asInstanceOf$"
+            ),
+            _
+          ) =>
+        Some((parent, fieldName))
+      case _ => None
+    }
+
     @scala.annotation.tailrec
     def toPathBody(term: Term): Term = term match {
       case Inlined(_, _, inlinedBlock)                     => toPathBody(inlinedBlock)
@@ -48,9 +63,10 @@ object SelectorMacros {
     }
 
     def extractLastFieldName(term: Term): String = term match {
-      case Select(_, fieldName) => fieldName
-      case Ident(_)             => report.errorAndAbort("Selector must access at least one field")
-      case _                    => report.errorAndAbort(s"Cannot extract field name from: ${term.show}")
+      case Select(_, fieldName)                            => fieldName
+      case other if structuralFieldAccess(other).isDefined => structuralFieldAccess(other).get._2
+      case Ident(_)                                        => report.errorAndAbort("Selector must access at least one field")
+      case _                                               => report.errorAndAbort(s"Cannot extract field name from: ${term.show}")
     }
 
     val pathBody  = toPathBody(selector.asTerm)
@@ -83,6 +99,21 @@ object SelectorMacros {
         case other       => other.show
       }
 
+    def structuralFieldAccess(term: Term): Option[(Term, String)] = term match {
+      case TypeApply(
+            Select(
+              Apply(
+                Select(Apply(Ident("reflectiveSelectable"), List(parent)), "selectDynamic"),
+                List(Literal(StringConstant(fieldName)))
+              ),
+              "$asInstanceOf$"
+            ),
+            _
+          ) =>
+        Some((parent, fieldName))
+      case _ => None
+    }
+
     def toDynamicOptic(term: Term): Expr[DynamicOptic] = term match {
       // Identity - just the parameter reference
       case Ident(_) =>
@@ -92,6 +123,12 @@ object SelectorMacros {
       case Select(parent, fieldName) =>
         val parentOptic = toDynamicOptic(parent)
         val fieldExpr   = Expr(fieldName)
+        '{ $parentOptic.field($fieldExpr) }
+
+      case other if structuralFieldAccess(other).isDefined =>
+        val (parent, fieldName) = structuralFieldAccess(other).get
+        val parentOptic         = toDynamicOptic(parent)
+        val fieldExpr           = Expr(fieldName)
         '{ $parentOptic.field($fieldExpr) }
 
       // Collection traversal: _.items.each

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/package.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/package.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema
+
+package object migration extends MigrationSelectorSyntax

--- a/schema/shared/src/main/scala/zio/blocks/schema/DynamicSchemaExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/DynamicSchemaExpr.scala
@@ -1,0 +1,897 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema
+
+import zio.blocks.chunk.Chunk
+
+sealed trait DynamicSchemaExpr {
+  def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]]
+}
+
+object DynamicSchemaExpr {
+
+  private def extractBoolean(dv: DynamicValue): Either[SchemaError, Boolean] = dv match {
+    case DynamicValue.Primitive(PrimitiveValue.Boolean(b)) => Right(b)
+    case _                                                 => Left(SchemaError.conversionFailed(Nil, s"Expected Boolean, got: $dv"))
+  }
+
+  private def extractString(dv: DynamicValue): Either[SchemaError, String] = dv match {
+    case DynamicValue.Primitive(PrimitiveValue.String(s)) => Right(s)
+    case _                                                => Left(SchemaError.conversionFailed(Nil, s"Expected String, got: $dv"))
+  }
+
+  private def extractInt(dv: DynamicValue): Either[SchemaError, Int] = dv match {
+    case DynamicValue.Primitive(PrimitiveValue.Int(i)) => Right(i)
+    case _                                             => Left(SchemaError.conversionFailed(Nil, s"Expected Int, got: $dv"))
+  }
+
+  private def extractIntegral(dv: DynamicValue): Either[SchemaError, (Long, Boolean)] = dv match {
+    case DynamicValue.Primitive(PrimitiveValue.Byte(v))  => Right((v.toLong, false))
+    case DynamicValue.Primitive(PrimitiveValue.Short(v)) => Right((v.toLong, false))
+    case DynamicValue.Primitive(PrimitiveValue.Int(v))   => Right((v.toLong, false))
+    case DynamicValue.Primitive(PrimitiveValue.Long(v))  => Right((v, true))
+    case _                                               => Left(SchemaError.conversionFailed(Nil, s"Bitwise operation requires integral types, got: $dv"))
+  }
+
+  private def sequence(results: Seq[Either[SchemaError, DynamicValue]]): Either[SchemaError, Seq[DynamicValue]] = {
+    val errors = results.collect { case Left(e) => e }
+    if (errors.nonEmpty) Left(errors.head)
+    else Right(results.collect { case Right(v) => v })
+  }
+  // ==================== Leaf Expressions ====================
+
+  final case class Literal(value: DynamicValue) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      Right(Seq(value))
+  }
+
+  final case class Select(path: DynamicOptic) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] = {
+      val result = walkPath(Chunk(input), path.nodes, 0)
+      result
+    }
+
+    private def walkPath(
+      current: Chunk[DynamicValue],
+      nodes: IndexedSeq[DynamicOptic.Node],
+      idx: Int
+    ): Either[SchemaError, Seq[DynamicValue]] = {
+      if (idx >= nodes.length) return Right(current.toSeq)
+      if (current.isEmpty) return Right(Seq.empty)
+
+      val node   = nodes(idx)
+      val prefix = new DynamicOptic(nodes.take(idx + 1).toVector)
+
+      node match {
+        case DynamicOptic.Node.Field(name) =>
+          val next = current.flatMap {
+            case r: DynamicValue.Record => r.fields.collect { case (n, v) if n == name => v }
+            case _                      => Chunk.empty
+          }
+          walkPath(next, nodes, idx + 1)
+
+        case DynamicOptic.Node.Case(expectedCase) =>
+          var result: Chunk[DynamicValue] = Chunk.empty
+          var error: Option[SchemaError]  = None
+
+          current.foreach {
+            case v: DynamicValue.Variant if v.caseNameValue == expectedCase =>
+              result = result ++ Chunk(v.value)
+            case v: DynamicValue.Variant =>
+              val actualCase = v.caseNameValue match {
+                case "None" | "Some" => "Option"
+                case other           => other
+              }
+              error = Some(
+                SchemaError.message(
+                  s"UnexpectedCase: expected $expectedCase, got $actualCase",
+                  prefix
+                )
+              )
+            case _ =>
+          }
+
+          if (error.isDefined) Left(error.get)
+          else walkPath(result, nodes, idx + 1)
+
+        case DynamicOptic.Node.Elements =>
+          val hasSequence = current.exists(_.isInstanceOf[DynamicValue.Sequence])
+          val next        = current.flatMap {
+            case s: DynamicValue.Sequence => s.elements
+            case _                        => Chunk.empty
+          }
+          if (next.isEmpty && hasSequence) {
+            Left(SchemaError.message("EmptySequence", prefix))
+          } else {
+            walkPath(next, nodes, idx + 1)
+          }
+
+        case DynamicOptic.Node.AtIndex(i) =>
+          var outOfBoundsError: Option[SchemaError] = None
+          val next                                  = current.flatMap {
+            case s: DynamicValue.Sequence if i >= 0 && i < s.elements.length =>
+              Chunk(s.elements(i))
+            case s: DynamicValue.Sequence =>
+              outOfBoundsError = Some(
+                SchemaError.message(
+                  s"SequenceIndexOutOfBounds: index $i, size ${s.elements.length}",
+                  prefix
+                )
+              )
+              Chunk.empty
+            case _ => Chunk.empty
+          }
+          outOfBoundsError match {
+            case Some(err) => Left(err)
+            case None      => walkPath(next, nodes, idx + 1)
+          }
+
+        case DynamicOptic.Node.AtIndices(indices) =>
+          val next = current.flatMap {
+            case s: DynamicValue.Sequence =>
+              Chunk.from(indices.flatMap(i => if (i >= 0 && i < s.elements.length) Some(s.elements(i)) else None))
+            case _ => Chunk.empty
+          }
+          walkPath(next, nodes, idx + 1)
+
+        case DynamicOptic.Node.AtMapKey(key) =>
+          val next = current.flatMap {
+            case m: DynamicValue.Map => m.entries.collect { case (k, v) if k == key => v }
+            case _                   => Chunk.empty
+          }
+          if (next.isEmpty && current.exists(_.isInstanceOf[DynamicValue.Map])) {
+            Left(SchemaError.message(s"MissingKey:${key.toString}", prefix))
+          } else {
+            walkPath(next, nodes, idx + 1)
+          }
+
+        case DynamicOptic.Node.AtMapKeys(keys) =>
+          val next = current.flatMap {
+            case m: DynamicValue.Map =>
+              Chunk.from(keys.flatMap(key => m.entries.collect { case (k, v) if k == key => v }))
+            case _ => Chunk.empty
+          }
+          walkPath(next, nodes, idx + 1)
+
+        case DynamicOptic.Node.MapKeys =>
+          val next = current.flatMap {
+            case m: DynamicValue.Map => m.entries.map(_._1)
+            case _                   => Chunk.empty
+          }
+          if (next.isEmpty && current.exists(_.isInstanceOf[DynamicValue.Map])) {
+            Left(SchemaError.message("EmptyMap", prefix))
+          } else {
+            walkPath(next, nodes, idx + 1)
+          }
+
+        case DynamicOptic.Node.MapValues =>
+          val next = current.flatMap {
+            case m: DynamicValue.Map => m.entries.map(_._2)
+            case _                   => Chunk.empty
+          }
+          if (next.isEmpty && current.exists(_.isInstanceOf[DynamicValue.Map])) {
+            Left(SchemaError.message("EmptyMap", prefix))
+          } else {
+            walkPath(next, nodes, idx + 1)
+          }
+
+        case DynamicOptic.Node.Wrapped =>
+          walkPath(current, nodes, idx + 1)
+
+        case _: DynamicOptic.Node.TypeSearch =>
+          Left(SchemaError.conversionFailed(Nil, s"TypeSearch nodes are not supported in schema expressions"))
+
+        case _: DynamicOptic.Node.SchemaSearch =>
+          Left(SchemaError.conversionFailed(Nil, s"SchemaSearch nodes are not supported in schema expressions"))
+      }
+    }
+  }
+
+  final case class PrimitiveConversion(conversionType: SchemaExpr.ConversionType) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      conversionType.convert(input).map(Seq(_)).left.map(SchemaError.conversionFailed(Nil, _))
+  }
+
+  // ==================== Relational Operators ====================
+
+  final case class Relational(
+    left: DynamicSchemaExpr,
+    right: DynamicSchemaExpr,
+    operator: RelationalOperator
+  ) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        xs <- left.eval(input)
+        ys <- right.eval(input)
+      } yield for { x <- xs; y <- ys } yield operator.apply(x, y)
+  }
+
+  sealed trait RelationalOperator {
+    def apply(x: DynamicValue, y: DynamicValue): DynamicValue
+  }
+
+  object RelationalOperator {
+    case object LessThan extends RelationalOperator {
+      def apply(x: DynamicValue, y: DynamicValue): DynamicValue =
+        DynamicValue.Primitive(PrimitiveValue.Boolean(x < y))
+    }
+
+    case object LessThanOrEqual extends RelationalOperator {
+      def apply(x: DynamicValue, y: DynamicValue): DynamicValue =
+        DynamicValue.Primitive(PrimitiveValue.Boolean(x <= y))
+    }
+
+    case object GreaterThan extends RelationalOperator {
+      def apply(x: DynamicValue, y: DynamicValue): DynamicValue =
+        DynamicValue.Primitive(PrimitiveValue.Boolean(x > y))
+    }
+
+    case object GreaterThanOrEqual extends RelationalOperator {
+      def apply(x: DynamicValue, y: DynamicValue): DynamicValue =
+        DynamicValue.Primitive(PrimitiveValue.Boolean(x >= y))
+    }
+
+    case object Equal extends RelationalOperator {
+      def apply(x: DynamicValue, y: DynamicValue): DynamicValue =
+        DynamicValue.Primitive(PrimitiveValue.Boolean(x == y))
+    }
+
+    case object NotEqual extends RelationalOperator {
+      def apply(x: DynamicValue, y: DynamicValue): DynamicValue =
+        DynamicValue.Primitive(PrimitiveValue.Boolean(x != y))
+    }
+  }
+
+  // ==================== Logical Operators ====================
+
+  final case class Logical(
+    left: DynamicSchemaExpr,
+    right: DynamicSchemaExpr,
+    operator: LogicalOperator
+  ) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        xs     <- left.eval(input)
+        ys     <- right.eval(input)
+        result <- operator.apply(xs, ys)
+      } yield result
+  }
+
+  sealed trait LogicalOperator {
+    def apply(xs: Seq[DynamicValue], ys: Seq[DynamicValue]): Either[SchemaError, Seq[DynamicValue]]
+  }
+
+  object LogicalOperator {
+    case object And extends LogicalOperator {
+      def apply(xs: Seq[DynamicValue], ys: Seq[DynamicValue]): Either[SchemaError, Seq[DynamicValue]] = {
+        val results = for { x <- xs; y <- ys } yield {
+          for {
+            xBool <- extractBoolean(x)
+            yBool <- extractBoolean(y)
+          } yield DynamicValue.Primitive(PrimitiveValue.Boolean(xBool && yBool))
+        }
+        sequence(results)
+      }
+    }
+
+    case object Or extends LogicalOperator {
+      def apply(xs: Seq[DynamicValue], ys: Seq[DynamicValue]): Either[SchemaError, Seq[DynamicValue]] = {
+        val results = for { x <- xs; y <- ys } yield {
+          for {
+            xBool <- extractBoolean(x)
+            yBool <- extractBoolean(y)
+          } yield DynamicValue.Primitive(PrimitiveValue.Boolean(xBool || yBool))
+        }
+        sequence(results)
+      }
+    }
+  }
+
+  final case class Not(expr: DynamicSchemaExpr) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        xs     <- expr.eval(input)
+        result <- {
+          val mapped = xs.map { x =>
+            extractBoolean(x).map(b => DynamicValue.Primitive(PrimitiveValue.Boolean(!b)))
+          }
+          sequence(mapped)
+        }
+      } yield result
+  }
+
+  // ==================== Arithmetic Operators ====================
+
+  sealed trait NumericTypeTag {
+    def add(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue]
+    def subtract(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue]
+    def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue]
+    def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue]
+    def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue]
+    def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue]
+  }
+
+  object NumericTypeTag {
+    case object ByteTag extends NumericTypeTag {
+      def add(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Byte((a + b).toByte)) }
+      def subtract(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Byte((a - b).toByte)) }
+      def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Byte((a * b).toByte)) }
+      def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Byte((a / b).toByte)) }
+      def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) =>
+          DynamicValue.Primitive(PrimitiveValue.Byte(Math.pow(a.toDouble, b.toDouble).toByte))
+        }
+      def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Byte((a % b).toByte)) }
+
+      private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (Byte, Byte)] =
+        (x, y) match {
+          case (DynamicValue.Primitive(PrimitiveValue.Byte(a)), DynamicValue.Primitive(PrimitiveValue.Byte(b))) =>
+            Right((a, b))
+          case _ => Left(s"Expected Byte values, got: $x and $y")
+        }
+    }
+
+    case object ShortTag extends NumericTypeTag {
+      def add(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Short((a + b).toShort)) }
+      def subtract(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Short((a - b).toShort)) }
+      def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Short((a * b).toShort)) }
+      def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Short((a / b).toShort)) }
+      def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) =>
+          DynamicValue.Primitive(PrimitiveValue.Short(Math.pow(a.toDouble, b.toDouble).toShort))
+        }
+      def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Short((a % b).toShort)) }
+
+      private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (Short, Short)] =
+        (x, y) match {
+          case (DynamicValue.Primitive(PrimitiveValue.Short(a)), DynamicValue.Primitive(PrimitiveValue.Short(b))) =>
+            Right((a, b))
+          case _ => Left(s"Expected Short values, got: $x and $y")
+        }
+    }
+
+    case object IntTag extends NumericTypeTag {
+      def add(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Int(a + b)) }
+      def subtract(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Int(a - b)) }
+      def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Int(a * b)) }
+      def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Int(a / b)) }
+      def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) =>
+          DynamicValue.Primitive(PrimitiveValue.Int(Math.pow(a.toDouble, b.toDouble).toInt))
+        }
+      def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Int(a % b)) }
+
+      private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (Int, Int)] =
+        (x, y) match {
+          case (DynamicValue.Primitive(PrimitiveValue.Int(a)), DynamicValue.Primitive(PrimitiveValue.Int(b))) =>
+            Right((a, b))
+          case _ => Left(s"Expected Int values, got: $x and $y")
+        }
+    }
+
+    case object LongTag extends NumericTypeTag {
+      def add(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Long(a + b)) }
+      def subtract(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Long(a - b)) }
+      def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Long(a * b)) }
+      def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Long(a / b)) }
+      def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) =>
+          DynamicValue.Primitive(PrimitiveValue.Long(Math.pow(a.toDouble, b.toDouble).toLong))
+        }
+      def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Long(a % b)) }
+
+      private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (Long, Long)] =
+        (x, y) match {
+          case (DynamicValue.Primitive(PrimitiveValue.Long(a)), DynamicValue.Primitive(PrimitiveValue.Long(b))) =>
+            Right((a, b))
+          case _ => Left(s"Expected Long values, got: $x and $y")
+        }
+    }
+
+    case object FloatTag extends NumericTypeTag {
+      def add(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Float(a + b)) }
+      def subtract(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Float(a - b)) }
+      def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Float(a * b)) }
+      def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Float(a / b)) }
+      def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) =>
+          DynamicValue.Primitive(PrimitiveValue.Float(Math.pow(a.toDouble, b.toDouble).toFloat))
+        }
+      def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Float(a % b)) }
+
+      private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (Float, Float)] =
+        (x, y) match {
+          case (DynamicValue.Primitive(PrimitiveValue.Float(a)), DynamicValue.Primitive(PrimitiveValue.Float(b))) =>
+            Right((a, b))
+          case _ => Left(s"Expected Float values, got: $x and $y")
+        }
+    }
+
+    case object DoubleTag extends NumericTypeTag {
+      def add(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Double(a + b)) }
+      def subtract(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Double(a - b)) }
+      def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Double(a * b)) }
+      def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Double(a / b)) }
+      def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Double(Math.pow(a, b))) }
+      def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Double(a % b)) }
+
+      private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (Double, Double)] =
+        (x, y) match {
+          case (DynamicValue.Primitive(PrimitiveValue.Double(a)), DynamicValue.Primitive(PrimitiveValue.Double(b))) =>
+            Right((a, b))
+          case _ => Left(s"Expected Double values, got: $x and $y")
+        }
+    }
+
+    case object BigIntTag extends NumericTypeTag {
+      def add(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigInt(a + b)) }
+      def subtract(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigInt(a - b)) }
+      def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigInt(a * b)) }
+      def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigInt(a / b)) }
+      def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigInt(a.pow(b.toInt))) }
+      def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigInt(a % b)) }
+
+      private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (BigInt, BigInt)] =
+        (x, y) match {
+          case (DynamicValue.Primitive(PrimitiveValue.BigInt(a)), DynamicValue.Primitive(PrimitiveValue.BigInt(b))) =>
+            Right((a, b))
+          case _ => Left(s"Expected BigInt values, got: $x and $y")
+        }
+    }
+
+    case object BigDecimalTag extends NumericTypeTag {
+      def add(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigDecimal(a + b)) }
+      def subtract(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigDecimal(a - b)) }
+      def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigDecimal(a * b)) }
+      def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigDecimal(a / b)) }
+      def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigDecimal(a.pow(b.toInt))) }
+      def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
+        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigDecimal(a % b)) }
+
+      private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (BigDecimal, BigDecimal)] =
+        (x, y) match {
+          case (
+                DynamicValue.Primitive(PrimitiveValue.BigDecimal(a)),
+                DynamicValue.Primitive(PrimitiveValue.BigDecimal(b))
+              ) =>
+            Right((a, b))
+          case _ => Left(s"Expected BigDecimal values, got: $x and $y")
+        }
+    }
+  }
+
+  final case class Arithmetic(
+    left: DynamicSchemaExpr,
+    right: DynamicSchemaExpr,
+    operator: ArithmeticOperator,
+    numericType: NumericTypeTag
+  ) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        xs      <- left.eval(input)
+        ys      <- right.eval(input)
+        results <- {
+          val computed = for {
+            x <- xs
+            y <- ys
+          } yield operator.apply(x, y, numericType)
+
+          val errors = computed.collect { case Left(e) => e }
+          if (errors.nonEmpty) Left(SchemaError.conversionFailed(Nil, errors.head))
+          else Right(computed.collect { case Right(v) => v })
+        }
+      } yield results
+  }
+
+  sealed trait ArithmeticOperator {
+    def apply(x: DynamicValue, y: DynamicValue, numericType: NumericTypeTag): Either[String, DynamicValue]
+  }
+
+  object ArithmeticOperator {
+    case object Add extends ArithmeticOperator {
+      def apply(x: DynamicValue, y: DynamicValue, numericType: NumericTypeTag): Either[String, DynamicValue] =
+        numericType.add(x, y)
+    }
+
+    case object Subtract extends ArithmeticOperator {
+      def apply(x: DynamicValue, y: DynamicValue, numericType: NumericTypeTag): Either[String, DynamicValue] =
+        numericType.subtract(x, y)
+    }
+
+    case object Multiply extends ArithmeticOperator {
+      def apply(x: DynamicValue, y: DynamicValue, numericType: NumericTypeTag): Either[String, DynamicValue] =
+        numericType.multiply(x, y)
+    }
+
+    case object Divide extends ArithmeticOperator {
+      def apply(x: DynamicValue, y: DynamicValue, numericType: NumericTypeTag): Either[String, DynamicValue] =
+        numericType.divide(x, y)
+    }
+
+    case object Pow extends ArithmeticOperator {
+      def apply(x: DynamicValue, y: DynamicValue, numericType: NumericTypeTag): Either[String, DynamicValue] =
+        numericType.pow(x, y)
+    }
+
+    case object Modulo extends ArithmeticOperator {
+      def apply(x: DynamicValue, y: DynamicValue, numericType: NumericTypeTag): Either[String, DynamicValue] =
+        numericType.modulo(x, y)
+    }
+  }
+
+  // ==================== Bitwise Operators ====================
+
+  final case class Bitwise(
+    left: DynamicSchemaExpr,
+    right: DynamicSchemaExpr,
+    operator: BitwiseOperator
+  ) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        xs      <- left.eval(input)
+        ys      <- right.eval(input)
+        results <- {
+          val computed = for { x <- xs; y <- ys } yield operator.apply(x, y)
+          sequence(computed)
+        }
+      } yield results
+  }
+
+  sealed trait BitwiseOperator {
+    def apply(x: DynamicValue, y: DynamicValue): Either[SchemaError, DynamicValue]
+  }
+
+  object BitwiseOperator {
+    case object And extends BitwiseOperator {
+      def apply(x: DynamicValue, y: DynamicValue): Either[SchemaError, DynamicValue] = applyOp(x, y, _ & _)
+    }
+
+    case object Or extends BitwiseOperator {
+      def apply(x: DynamicValue, y: DynamicValue): Either[SchemaError, DynamicValue] = applyOp(x, y, _ | _)
+    }
+
+    case object Xor extends BitwiseOperator {
+      def apply(x: DynamicValue, y: DynamicValue): Either[SchemaError, DynamicValue] = applyOp(x, y, _ ^ _)
+    }
+
+    case object LeftShift extends BitwiseOperator {
+      def apply(x: DynamicValue, y: DynamicValue): Either[SchemaError, DynamicValue] =
+        applyShift(x, y, (a, b) => a << b)
+    }
+
+    case object RightShift extends BitwiseOperator {
+      def apply(x: DynamicValue, y: DynamicValue): Either[SchemaError, DynamicValue] =
+        applyShift(x, y, (a, b) => a >> b)
+    }
+
+    case object UnsignedRightShift extends BitwiseOperator {
+      def apply(x: DynamicValue, y: DynamicValue): Either[SchemaError, DynamicValue] =
+        applyShift(x, y, (a, b) => a >>> b)
+    }
+
+    private def applyOp(x: DynamicValue, y: DynamicValue, op: (Long, Long) => Long): Either[SchemaError, DynamicValue] =
+      for {
+        lPair <- extractIntegral(x)
+        rPair <- extractIntegral(y)
+      } yield {
+        val (lVal, lIsLong) = lPair
+        val (rVal, rIsLong) = rPair
+        val result          = op(lVal, rVal)
+        if (lIsLong || rIsLong) DynamicValue.Primitive(PrimitiveValue.Long(result))
+        else DynamicValue.Primitive(PrimitiveValue.Int(result.toInt))
+      }
+
+    private def applyShift(
+      x: DynamicValue,
+      y: DynamicValue,
+      op: (Long, Int) => Long
+    ): Either[SchemaError, DynamicValue] =
+      for {
+        lPair <- extractIntegral(x)
+        rPair <- extractIntegral(y)
+      } yield {
+        val (lVal, lIsLong) = lPair
+        val (rVal, _)       = rPair
+        val result          = op(lVal, rVal.toInt)
+        if (lIsLong) DynamicValue.Primitive(PrimitiveValue.Long(result))
+        else DynamicValue.Primitive(PrimitiveValue.Int(result.toInt))
+      }
+  }
+
+  final case class BitwiseNot(expr: DynamicSchemaExpr) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        xs     <- expr.eval(input)
+        result <- {
+          val mapped = xs.map(applyNot)
+          sequence(mapped)
+        }
+      } yield result
+
+    private def applyNot(x: DynamicValue): Either[SchemaError, DynamicValue] = x match {
+      case DynamicValue.Primitive(PrimitiveValue.Byte(v)) =>
+        Right(DynamicValue.Primitive(PrimitiveValue.Byte((~v).toByte)))
+      case DynamicValue.Primitive(PrimitiveValue.Short(v)) =>
+        Right(DynamicValue.Primitive(PrimitiveValue.Short((~v).toShort)))
+      case DynamicValue.Primitive(PrimitiveValue.Int(v))  => Right(DynamicValue.Primitive(PrimitiveValue.Int(~v)))
+      case DynamicValue.Primitive(PrimitiveValue.Long(v)) => Right(DynamicValue.Primitive(PrimitiveValue.Long(~v)))
+      case _                                              => Left(SchemaError.conversionFailed(Nil, s"Bitwise NOT requires integral type, got: $x"))
+    }
+  }
+
+  // ==================== String Operations ====================
+
+  final case class StringConcat(
+    left: DynamicSchemaExpr,
+    right: DynamicSchemaExpr
+  ) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        xs      <- left.eval(input)
+        ys      <- right.eval(input)
+        results <- {
+          val computed = for { x <- xs; y <- ys } yield {
+            for {
+              xStr <- extractString(x)
+              yStr <- extractString(y)
+            } yield DynamicValue.Primitive(PrimitiveValue.String(xStr + yStr))
+          }
+          sequence(computed)
+        }
+      } yield results
+  }
+
+  final case class StringRegexMatch(
+    regex: DynamicSchemaExpr,
+    string: DynamicSchemaExpr
+  ) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        xs      <- regex.eval(input)
+        ys      <- string.eval(input)
+        results <- {
+          val computed = for { x <- xs; y <- ys } yield {
+            for {
+              regexStr <- extractString(x)
+              str      <- extractString(y)
+            } yield DynamicValue.Primitive(PrimitiveValue.Boolean(str.matches(regexStr)))
+          }
+          sequence(computed)
+        }
+      } yield results
+  }
+
+  final case class StringLength(string: DynamicSchemaExpr) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        xs     <- string.eval(input)
+        result <- {
+          val mapped = xs.map { x =>
+            extractString(x).map(str => DynamicValue.Primitive(PrimitiveValue.Int(str.length)))
+          }
+          sequence(mapped)
+        }
+      } yield result
+  }
+
+  final case class StringSubstring(
+    string: DynamicSchemaExpr,
+    start: DynamicSchemaExpr,
+    end: DynamicSchemaExpr
+  ) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        strings <- string.eval(input)
+        starts  <- start.eval(input)
+        ends    <- end.eval(input)
+        results <- {
+          val computed = for { s <- strings; st <- starts; en <- ends } yield {
+            for {
+              str      <- extractString(s)
+              startInt <- extractInt(st)
+              endInt   <- extractInt(en)
+            } yield DynamicValue.Primitive(PrimitiveValue.String(str.substring(startInt, endInt)))
+          }
+          sequence(computed)
+        }
+      } yield results
+  }
+
+  final case class StringTrim(string: DynamicSchemaExpr) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        xs     <- string.eval(input)
+        result <- {
+          val mapped = xs.map { x =>
+            extractString(x).map(str => DynamicValue.Primitive(PrimitiveValue.String(str.trim)))
+          }
+          sequence(mapped)
+        }
+      } yield result
+  }
+
+  final case class StringToUpperCase(string: DynamicSchemaExpr) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        xs     <- string.eval(input)
+        result <- {
+          val mapped = xs.map { x =>
+            extractString(x).map(str => DynamicValue.Primitive(PrimitiveValue.String(str.toUpperCase)))
+          }
+          sequence(mapped)
+        }
+      } yield result
+  }
+
+  final case class StringToLowerCase(string: DynamicSchemaExpr) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        xs     <- string.eval(input)
+        result <- {
+          val mapped = xs.map { x =>
+            extractString(x).map(str => DynamicValue.Primitive(PrimitiveValue.String(str.toLowerCase)))
+          }
+          sequence(mapped)
+        }
+      } yield result
+  }
+
+  final case class StringReplace(
+    string: DynamicSchemaExpr,
+    target: DynamicSchemaExpr,
+    replacement: DynamicSchemaExpr
+  ) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        strings      <- string.eval(input)
+        targets      <- target.eval(input)
+        replacements <- replacement.eval(input)
+        results      <- {
+          val computed = for { s <- strings; t <- targets; r <- replacements } yield {
+            for {
+              str       <- extractString(s)
+              targetStr <- extractString(t)
+              replStr   <- extractString(r)
+            } yield DynamicValue.Primitive(PrimitiveValue.String(str.replace(targetStr, replStr)))
+          }
+          sequence(computed)
+        }
+      } yield results
+  }
+
+  final case class StringStartsWith(
+    string: DynamicSchemaExpr,
+    prefix: DynamicSchemaExpr
+  ) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        strings  <- string.eval(input)
+        prefixes <- prefix.eval(input)
+        results  <- {
+          val computed = for { s <- strings; p <- prefixes } yield {
+            for {
+              str       <- extractString(s)
+              prefixStr <- extractString(p)
+            } yield DynamicValue.Primitive(PrimitiveValue.Boolean(str.startsWith(prefixStr)))
+          }
+          sequence(computed)
+        }
+      } yield results
+  }
+
+  final case class StringEndsWith(
+    string: DynamicSchemaExpr,
+    suffix: DynamicSchemaExpr
+  ) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        strings  <- string.eval(input)
+        suffixes <- suffix.eval(input)
+        results  <- {
+          val computed = for { s <- strings; sx <- suffixes } yield {
+            for {
+              str       <- extractString(s)
+              suffixStr <- extractString(sx)
+            } yield DynamicValue.Primitive(PrimitiveValue.Boolean(str.endsWith(suffixStr)))
+          }
+          sequence(computed)
+        }
+      } yield results
+  }
+
+  final case class StringContains(
+    string: DynamicSchemaExpr,
+    substring: DynamicSchemaExpr
+  ) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        strings    <- string.eval(input)
+        substrings <- substring.eval(input)
+        results    <- {
+          val computed = for { s <- strings; sub <- substrings } yield {
+            for {
+              str    <- extractString(s)
+              subStr <- extractString(sub)
+            } yield DynamicValue.Primitive(PrimitiveValue.Boolean(str.contains(subStr)))
+          }
+          sequence(computed)
+        }
+      } yield results
+  }
+
+  final case class StringIndexOf(
+    string: DynamicSchemaExpr,
+    substring: DynamicSchemaExpr
+  ) extends DynamicSchemaExpr {
+    def eval(input: DynamicValue): Either[SchemaError, Seq[DynamicValue]] =
+      for {
+        strings    <- string.eval(input)
+        substrings <- substring.eval(input)
+        results    <- {
+          val computed = for { s <- strings; sub <- substrings } yield {
+            for {
+              str    <- extractString(s)
+              subStr <- extractString(sub)
+            } yield DynamicValue.Primitive(PrimitiveValue.Int(str.indexOf(subStr)))
+          }
+          sequence(computed)
+        }
+      } yield results
+  }
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/DynamicSchemaExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/DynamicSchemaExpr.scala
@@ -16,6 +16,9 @@
 
 package zio.blocks.schema
 
+import java.util.regex.Pattern
+import java.util.regex.PatternSyntaxException
+
 import zio.blocks.chunk.Chunk
 
 sealed trait DynamicSchemaExpr {
@@ -23,6 +26,8 @@ sealed trait DynamicSchemaExpr {
 }
 
 object DynamicSchemaExpr {
+
+  private val MaxSafeExponent: Int = 10000
 
   private def extractBoolean(dv: DynamicValue): Either[SchemaError, Boolean] = dv match {
     case DynamicValue.Primitive(PrimitiveValue.Boolean(b)) => Right(b)
@@ -52,6 +57,44 @@ object DynamicSchemaExpr {
     if (errors.nonEmpty) Left(errors.head)
     else Right(results.collect { case Right(v) => v })
   }
+
+  private def invalidOperation[A](message: String): Either[String, A] =
+    Left(message)
+
+  private def dynamicResult(value: DynamicValue): Either[String, DynamicValue] =
+    Right(value)
+
+  private def ensureNonZero[A](value: A, render: A => String = (_: A).toString)(
+    isZero: A => Boolean
+  ): Either[String, Unit] =
+    if (isZero(value)) Left(s"Division by zero: divisor ${render(value)}") else Right(())
+
+  private def checkedPowExponent(value: BigInt): Either[String, Int] =
+    if (!value.isValidInt) invalidOperation[Int](s"Exponent out of range: $value")
+    else {
+      val exponent = value.toInt
+      if (exponent < 0) invalidOperation[Int](s"Negative exponent not supported: $exponent")
+      else if (exponent > MaxSafeExponent)
+        invalidOperation[Int](s"Exponent exceeds safe limit ($MaxSafeExponent): $exponent")
+      else Right(exponent)
+    }
+
+  private def safeRegexMatch(regex: String, value: String): Either[SchemaError, Boolean] =
+    try Right(Pattern.matches(regex, value))
+    catch {
+      case e: PatternSyntaxException =>
+        Left(SchemaError.conversionFailed(Nil, s"Invalid regex pattern: ${e.getDescription}"))
+    }
+
+  private def safeSubstring(value: String, start: Int, end: Int): Either[SchemaError, String] =
+    if (start < 0 || end < 0)
+      Left(SchemaError.conversionFailed(Nil, s"Substring indices must be non-negative: start=$start, end=$end"))
+    else if (start > end)
+      Left(SchemaError.conversionFailed(Nil, s"Substring start index $start exceeds end index $end"))
+    else if (end > value.length)
+      Left(SchemaError.conversionFailed(Nil, s"Substring end index $end exceeds string length ${value.length}"))
+    else Right(value.substring(start, end))
+
   // ==================== Leaf Expressions ====================
 
   final case class Literal(value: DynamicValue) extends DynamicSchemaExpr {
@@ -334,13 +377,21 @@ object DynamicSchemaExpr {
       def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Byte((a * b).toByte)) }
       def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Byte((a / b).toByte)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[Byte](b)(_ == 0).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.Byte((a / b).toByte)))
+          )
+        }
       def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) =>
           DynamicValue.Primitive(PrimitiveValue.Byte(Math.pow(a.toDouble, b.toDouble).toByte))
         }
       def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Byte((a % b).toByte)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[Byte](b)(_ == 0).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.Byte((a % b).toByte)))
+          )
+        }
 
       private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (Byte, Byte)] =
         (x, y) match {
@@ -358,13 +409,21 @@ object DynamicSchemaExpr {
       def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Short((a * b).toShort)) }
       def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Short((a / b).toShort)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[Short](b)(_ == 0).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.Short((a / b).toShort)))
+          )
+        }
       def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) =>
           DynamicValue.Primitive(PrimitiveValue.Short(Math.pow(a.toDouble, b.toDouble).toShort))
         }
       def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Short((a % b).toShort)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[Short](b)(_ == 0).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.Short((a % b).toShort)))
+          )
+        }
 
       private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (Short, Short)] =
         (x, y) match {
@@ -382,13 +441,17 @@ object DynamicSchemaExpr {
       def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Int(a * b)) }
       def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Int(a / b)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[Int](b)(_ == 0).flatMap(_ => dynamicResult(DynamicValue.Primitive(PrimitiveValue.Int(a / b))))
+        }
       def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) =>
           DynamicValue.Primitive(PrimitiveValue.Int(Math.pow(a.toDouble, b.toDouble).toInt))
         }
       def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Int(a % b)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[Int](b)(_ == 0).flatMap(_ => dynamicResult(DynamicValue.Primitive(PrimitiveValue.Int(a % b))))
+        }
 
       private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (Int, Int)] =
         (x, y) match {
@@ -406,13 +469,21 @@ object DynamicSchemaExpr {
       def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Long(a * b)) }
       def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Long(a / b)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[Long](b)(_ == 0L).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.Long(a / b)))
+          )
+        }
       def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) =>
           DynamicValue.Primitive(PrimitiveValue.Long(Math.pow(a.toDouble, b.toDouble).toLong))
         }
       def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Long(a % b)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[Long](b)(_ == 0L).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.Long(a % b)))
+          )
+        }
 
       private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (Long, Long)] =
         (x, y) match {
@@ -430,13 +501,21 @@ object DynamicSchemaExpr {
       def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Float(a * b)) }
       def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Float(a / b)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[Float](b)(_.compare(0.0f) == 0).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.Float(a / b)))
+          )
+        }
       def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) =>
           DynamicValue.Primitive(PrimitiveValue.Float(Math.pow(a.toDouble, b.toDouble).toFloat))
         }
       def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Float(a % b)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[Float](b)(_.compare(0.0f) == 0).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.Float(a % b)))
+          )
+        }
 
       private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (Float, Float)] =
         (x, y) match {
@@ -454,11 +533,19 @@ object DynamicSchemaExpr {
       def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Double(a * b)) }
       def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Double(a / b)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[Double](b)(_.compare(0.0d) == 0).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.Double(a / b)))
+          )
+        }
       def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Double(Math.pow(a, b))) }
       def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.Double(a % b)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[Double](b)(_.compare(0.0d) == 0).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.Double(a % b)))
+          )
+        }
 
       private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (Double, Double)] =
         (x, y) match {
@@ -476,11 +563,23 @@ object DynamicSchemaExpr {
       def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigInt(a * b)) }
       def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigInt(a / b)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[BigInt](b)(_ == BigInt(0)).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.BigInt(a / b)))
+          )
+        }
       def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigInt(a.pow(b.toInt))) }
+        extract2(x, y).flatMap { case (a, b) =>
+          checkedPowExponent(b).flatMap(exponent =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.BigInt(a.pow(exponent))))
+          )
+        }
       def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigInt(a % b)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[BigInt](b)(_ == BigInt(0)).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.BigInt(a % b)))
+          )
+        }
 
       private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (BigInt, BigInt)] =
         (x, y) match {
@@ -498,11 +597,23 @@ object DynamicSchemaExpr {
       def multiply(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
         extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigDecimal(a * b)) }
       def divide(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigDecimal(a / b)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[BigDecimal](b)(_ == BigDecimal(0)).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.BigDecimal(a / b)))
+          )
+        }
       def pow(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigDecimal(a.pow(b.toInt))) }
+        extract2(x, y).flatMap { case (a, b) =>
+          checkedPowExponent(b.toBigIntExact.getOrElse(BigInt(Int.MaxValue))).flatMap { exponent =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.BigDecimal(a.pow(exponent))))
+          }
+        }
       def modulo(x: DynamicValue, y: DynamicValue): Either[String, DynamicValue] =
-        extract2(x, y).map { case (a, b) => DynamicValue.Primitive(PrimitiveValue.BigDecimal(a % b)) }
+        extract2(x, y).flatMap { case (a, b) =>
+          ensureNonZero[BigDecimal](b)(_ == BigDecimal(0)).flatMap(_ =>
+            dynamicResult(DynamicValue.Primitive(PrimitiveValue.BigDecimal(a % b)))
+          )
+        }
 
       private def extract2(x: DynamicValue, y: DynamicValue): Either[String, (BigDecimal, BigDecimal)] =
         (x, y) match {
@@ -710,7 +821,8 @@ object DynamicSchemaExpr {
             for {
               regexStr <- extractString(x)
               str      <- extractString(y)
-            } yield DynamicValue.Primitive(PrimitiveValue.Boolean(str.matches(regexStr)))
+              matches  <- safeRegexMatch(regexStr, str)
+            } yield DynamicValue.Primitive(PrimitiveValue.Boolean(matches))
           }
           sequence(computed)
         }
@@ -746,7 +858,8 @@ object DynamicSchemaExpr {
               str      <- extractString(s)
               startInt <- extractInt(st)
               endInt   <- extractInt(en)
-            } yield DynamicValue.Primitive(PrimitiveValue.String(str.substring(startInt, endInt)))
+              slice    <- safeSubstring(str, startInt, endInt)
+            } yield DynamicValue.Primitive(PrimitiveValue.String(slice))
           }
           sequence(computed)
         }

--- a/schema/shared/src/main/scala/zio/blocks/schema/IsIntegral.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/IsIntegral.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema
+
+/**
+ * Type class for integral types that support bitwise operations. Only Byte,
+ * Short, Int, and Long are supported.
+ */
+sealed trait IsIntegral[A] {
+  def schema: Schema[A]
+}
+
+object IsIntegral {
+  implicit val IsByte: IsIntegral[Byte] = new IsIntegral[Byte] {
+    def schema: Schema[Byte] = Schema[Byte]
+  }
+
+  implicit val IsShort: IsIntegral[Short] = new IsIntegral[Short] {
+    def schema: Schema[Short] = Schema[Short]
+  }
+
+  implicit val IsInt: IsIntegral[Int] = new IsIntegral[Int] {
+    def schema: Schema[Int] = Schema[Int]
+  }
+
+  implicit val IsLong: IsIntegral[Long] = new IsIntegral[Long] {
+    def schema: Schema[Long] = Schema[Long]
+  }
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/IsNumeric.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/IsNumeric.scala
@@ -16,59 +16,67 @@
 
 package zio.blocks.schema
 
+/**
+ * Type class for numeric types that support arithmetic operations.
+ *
+ * Note: Consider using NumericPrimitiveType directly for new code, which is
+ * part of the sealed PrimitiveType hierarchy and fully serializable.
+ */
 sealed trait IsNumeric[A] {
-  val primitiveType: PrimitiveType[A] = schema.reflect.asPrimitive.get.primitiveType
+  def numericPrimitiveType: NumericPrimitiveType[A]
 
-  def numeric: Numeric[A]
+  def primitiveType: PrimitiveType[A] = numericPrimitiveType
+
+  def numeric: Numeric[A] = numericPrimitiveType.numeric
 
   def schema: Schema[A]
 }
 
 object IsNumeric {
   implicit val IsByte: IsNumeric[Byte] = new IsNumeric[Byte] {
-    def numeric: Numeric[Byte] = implicitly[Numeric[Byte]]
+    def numericPrimitiveType: NumericPrimitiveType[Byte] = PrimitiveType.Byte(Validation.None)
 
     def schema: Schema[Byte] = Schema[Byte]
   }
 
   implicit val IsShort: IsNumeric[Short] = new IsNumeric[Short] {
-    def numeric: Numeric[Short] = implicitly[Numeric[Short]]
+    def numericPrimitiveType: NumericPrimitiveType[Short] = PrimitiveType.Short(Validation.None)
 
     def schema: Schema[Short] = Schema[Short]
   }
 
   implicit val IsInt: IsNumeric[Int] = new IsNumeric[Int] {
-    def numeric: Numeric[Int] = implicitly[Numeric[Int]]
+    def numericPrimitiveType: NumericPrimitiveType[Int] = PrimitiveType.Int(Validation.None)
 
     def schema: Schema[Int] = Schema[Int]
   }
 
   implicit val IsLong: IsNumeric[Long] = new IsNumeric[Long] {
-    def numeric: Numeric[Long] = implicitly[Numeric[Long]]
+    def numericPrimitiveType: NumericPrimitiveType[Long] = PrimitiveType.Long(Validation.None)
 
     def schema: Schema[Long] = Schema[Long]
   }
 
   implicit val IsFloat: IsNumeric[Float] = new IsNumeric[Float] {
-    def numeric: Numeric[Float] = implicitly[Numeric[Float]]
+    def numericPrimitiveType: NumericPrimitiveType[Float] = PrimitiveType.Float(Validation.None)
 
     def schema: Schema[Float] = Schema[Float]
   }
 
   implicit val IsDouble: IsNumeric[Double] = new IsNumeric[Double] {
-    def numeric: Numeric[Double] = implicitly[Numeric[Double]]
+    def numericPrimitiveType: NumericPrimitiveType[Double] = PrimitiveType.Double(Validation.None)
 
     def schema: Schema[Double] = Schema[Double]
   }
 
   implicit val IsBigInt: IsNumeric[BigInt] = new IsNumeric[BigInt] {
-    def numeric: Numeric[BigInt] = implicitly[Numeric[BigInt]]
+    def numericPrimitiveType: NumericPrimitiveType[BigInt] = PrimitiveType.BigInt(Validation.None)
 
     def schema: Schema[BigInt] = Schema[BigInt]
   }
 
   implicit val IsBigDecimal: IsNumeric[BigDecimal] = new IsNumeric[BigDecimal] {
-    def numeric: Numeric[BigDecimal] = implicitly[Numeric[BigDecimal]]
+    def numericPrimitiveType: NumericPrimitiveType[BigDecimal] = PrimitiveType.BigDecimal(Validation.None)
 
     def schema: Schema[BigDecimal] = Schema[BigDecimal]
   }

--- a/schema/shared/src/main/scala/zio/blocks/schema/Optic.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Optic.scala
@@ -16,7 +16,7 @@
 
 package zio.blocks.schema
 
-import zio.blocks.chunk.Chunk
+import zio.blocks.chunk.ChunkBuilder
 import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
 import zio.blocks.schema.binding._
 import scala.collection.immutable.ArraySeq
@@ -93,148 +93,205 @@ sealed trait Optic[S, A] { self =>
   }
 
   final def ===(that: A)(implicit schema: Schema[A]): SchemaExpr[S, Boolean] =
-    new SchemaExpr.Relational(
-      new SchemaExpr.Optic(this),
-      new SchemaExpr.Literal(that, schema),
+    SchemaExpr.relational(
+      SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+      SchemaExpr.literal(that),
       SchemaExpr.RelationalOperator.Equal
     )
 
   final def ===(that: Optic[S, A]): SchemaExpr[S, Boolean] =
-    new SchemaExpr.Relational(
-      new SchemaExpr.Optic(this),
-      new SchemaExpr.Optic(that),
+    SchemaExpr.relational(
+      SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+      SchemaExpr.optic(that.toDynamic, new Schema(that.source)),
       SchemaExpr.RelationalOperator.Equal
     )
 
   final def >(that: Optic[S, A]): SchemaExpr[S, Boolean] =
-    new SchemaExpr.Relational(
-      new SchemaExpr.Optic(this),
-      new SchemaExpr.Optic(that),
+    SchemaExpr.relational(
+      SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+      SchemaExpr.optic(that.toDynamic, new Schema(that.source)),
       SchemaExpr.RelationalOperator.GreaterThan
     )
 
-  final def >(that: A)(implicit schema: Schema[A]): SchemaExpr[S, Boolean] = new SchemaExpr.Relational(
-    new SchemaExpr.Optic(this),
-    new SchemaExpr.Literal(that, schema),
+  final def >(that: A)(implicit schema: Schema[A]): SchemaExpr[S, Boolean] = SchemaExpr.relational(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that),
     SchemaExpr.RelationalOperator.GreaterThan
   )
 
-  final def >=(that: Optic[S, A]): SchemaExpr[S, Boolean] = new SchemaExpr.Relational(
-    new SchemaExpr.Optic(this),
-    new SchemaExpr.Optic(that),
+  final def >=(that: Optic[S, A]): SchemaExpr[S, Boolean] = SchemaExpr.relational(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.optic(that.toDynamic, new Schema(that.source)),
     SchemaExpr.RelationalOperator.GreaterThanOrEqual
   )
 
-  final def >=(that: A)(implicit schema: Schema[A]): SchemaExpr[S, Boolean] = new SchemaExpr.Relational(
-    new SchemaExpr.Optic(this),
-    new SchemaExpr.Literal(that, schema),
+  final def >=(that: A)(implicit schema: Schema[A]): SchemaExpr[S, Boolean] = SchemaExpr.relational(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that),
     SchemaExpr.RelationalOperator.GreaterThanOrEqual
   )
 
   final def <(that: Optic[S, A]): SchemaExpr[S, Boolean] =
-    new SchemaExpr.Relational(
-      new SchemaExpr.Optic(this),
-      new SchemaExpr.Optic(that),
+    SchemaExpr.relational(
+      SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+      SchemaExpr.optic(that.toDynamic, new Schema(that.source)),
       SchemaExpr.RelationalOperator.LessThan
     )
 
-  final def <(that: A)(implicit schema: Schema[A]): SchemaExpr[S, Boolean] = new SchemaExpr.Relational(
-    new SchemaExpr.Optic(this),
-    new SchemaExpr.Literal(that, schema),
+  final def <(that: A)(implicit schema: Schema[A]): SchemaExpr[S, Boolean] = SchemaExpr.relational(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that),
     SchemaExpr.RelationalOperator.LessThan
   )
 
   final def <=(that: Optic[S, A]): SchemaExpr[S, Boolean] =
-    new SchemaExpr.Relational(
-      new SchemaExpr.Optic(this),
-      new SchemaExpr.Optic(that),
+    SchemaExpr.relational(
+      SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+      SchemaExpr.optic(that.toDynamic, new Schema(that.source)),
       SchemaExpr.RelationalOperator.LessThanOrEqual
     )
 
-  final def <=(that: A)(implicit schema: Schema[A]): SchemaExpr[S, Boolean] = new SchemaExpr.Relational(
-    new SchemaExpr.Optic(this),
-    new SchemaExpr.Literal(that, schema),
+  final def <=(that: A)(implicit schema: Schema[A]): SchemaExpr[S, Boolean] = SchemaExpr.relational(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that),
     SchemaExpr.RelationalOperator.LessThanOrEqual
   )
 
   final def !=(that: Optic[S, A]): SchemaExpr[S, Boolean] =
-    new SchemaExpr.Relational(
-      new SchemaExpr.Optic(this),
-      new SchemaExpr.Optic(that),
+    SchemaExpr.relational(
+      SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+      SchemaExpr.optic(that.toDynamic, new Schema(that.source)),
       SchemaExpr.RelationalOperator.NotEqual
     )
 
   final def !=(that: A)(implicit schema: Schema[A]): SchemaExpr[S, Boolean] =
-    new SchemaExpr.Relational(
-      new SchemaExpr.Optic(this),
-      new SchemaExpr.Literal(that, schema),
+    SchemaExpr.relational(
+      SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+      SchemaExpr.literal(that),
       SchemaExpr.RelationalOperator.NotEqual
     )
 
-  final def &&(that: Optic[S, A])(implicit ev: A =:= Boolean): SchemaExpr[S, Boolean] = new SchemaExpr.Logical(
-    new SchemaExpr.Optic(this.asEquivalent[Boolean]),
-    new SchemaExpr.Optic(that.asEquivalent[Boolean]),
+  final def &&(that: Optic[S, A])(implicit ev: A =:= Boolean): SchemaExpr[S, Boolean] = SchemaExpr.logical(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.optic(that.toDynamic, new Schema(that.source)),
     SchemaExpr.LogicalOperator.And
   )
 
   final def &&(that: Boolean)(implicit ev: A =:= Boolean): SchemaExpr[S, Boolean] =
-    new SchemaExpr.Logical(
-      new SchemaExpr.Optic(this.asEquivalent[Boolean]),
-      new SchemaExpr.Literal(that, Schema[Boolean]),
+    SchemaExpr.logical(
+      SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+      SchemaExpr.literal(that),
       SchemaExpr.LogicalOperator.And
     )
 
-  final def ||(that: Optic[S, A])(implicit ev: A =:= Boolean): SchemaExpr[S, Boolean] = new SchemaExpr.Logical(
-    new SchemaExpr.Optic(this.asEquivalent[Boolean]),
-    new SchemaExpr.Optic(that.asEquivalent[Boolean]),
+  final def ||(that: Optic[S, A])(implicit ev: A =:= Boolean): SchemaExpr[S, Boolean] = SchemaExpr.logical(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.optic(that.toDynamic, new Schema(that.source)),
     SchemaExpr.LogicalOperator.Or
   )
 
   final def ||(that: Boolean)(implicit ev: A =:= Boolean): SchemaExpr[S, Boolean] =
-    new SchemaExpr.Logical(
-      new SchemaExpr.Optic(this.asEquivalent[Boolean]),
-      new SchemaExpr.Literal(that, Schema[Boolean]),
+    SchemaExpr.logical(
+      SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+      SchemaExpr.literal(that),
       SchemaExpr.LogicalOperator.Or
     )
 
   final def unary_!(implicit ev: A =:= Boolean): SchemaExpr[S, Boolean] =
-    new SchemaExpr.Not(new SchemaExpr.Optic(this.asEquivalent[Boolean]))
+    SchemaExpr.not(SchemaExpr.optic(this.toDynamic, new Schema(this.source)))
 
   final def concat(that: String)(implicit ev: A =:= String): SchemaExpr[S, String] =
-    new SchemaExpr.StringConcat(
-      new SchemaExpr.Optic(this.asEquivalent[String]),
-      new SchemaExpr.Literal(that, Schema[String])
-    )
+    SchemaExpr.stringConcat(SchemaExpr.optic(this.toDynamic, new Schema(this.source)), SchemaExpr.literal(that))
 
   final def matches(that: String)(implicit ev: A =:= String): SchemaExpr[S, Boolean] =
-    new SchemaExpr.StringRegexMatch(
-      new SchemaExpr.Literal(that, Schema[String]),
-      new SchemaExpr.Optic(this.asEquivalent[String])
-    )
+    SchemaExpr.stringRegexMatch(SchemaExpr.literal(that), SchemaExpr.optic(this.toDynamic, new Schema(this.source)))
 
-  final def +(that: A)(implicit isNumeric: IsNumeric[A]): SchemaExpr[S, A] = new SchemaExpr.Arithmetic(
-    new SchemaExpr.Optic(this),
-    new SchemaExpr.Literal(that, isNumeric.schema),
+  final def +(that: A)(implicit isNumeric: IsNumeric[A]): SchemaExpr[S, A] = SchemaExpr.arithmetic(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that)(isNumeric.schema),
     SchemaExpr.ArithmeticOperator.Add,
-    isNumeric
+    isNumeric.primitiveType.asInstanceOf[NumericPrimitiveType[A]]
   )
 
-  final def -(that: A)(implicit isNumeric: IsNumeric[A]): SchemaExpr[S, A] = new SchemaExpr.Arithmetic(
-    new SchemaExpr.Optic(this),
-    new SchemaExpr.Literal(that, isNumeric.schema),
+  final def -(that: A)(implicit isNumeric: IsNumeric[A]): SchemaExpr[S, A] = SchemaExpr.arithmetic(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that)(isNumeric.schema),
     SchemaExpr.ArithmeticOperator.Subtract,
-    isNumeric
+    isNumeric.primitiveType.asInstanceOf[NumericPrimitiveType[A]]
   )
 
-  final def *(that: A)(implicit isNumeric: IsNumeric[A]): SchemaExpr[S, A] = new SchemaExpr.Arithmetic(
-    new SchemaExpr.Optic(this),
-    new SchemaExpr.Literal(that, isNumeric.schema),
+  final def *(that: A)(implicit isNumeric: IsNumeric[A]): SchemaExpr[S, A] = SchemaExpr.arithmetic(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that)(isNumeric.schema),
     SchemaExpr.ArithmeticOperator.Multiply,
-    isNumeric
+    isNumeric.primitiveType.asInstanceOf[NumericPrimitiveType[A]]
   )
+
+  final def /(that: A)(implicit isNumeric: IsNumeric[A]): SchemaExpr[S, A] = SchemaExpr.arithmetic(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that)(isNumeric.schema),
+    SchemaExpr.ArithmeticOperator.Divide,
+    isNumeric.primitiveType.asInstanceOf[NumericPrimitiveType[A]]
+  )
+
+  final def %(that: A)(implicit isNumeric: IsNumeric[A]): SchemaExpr[S, A] = SchemaExpr.arithmetic(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that)(isNumeric.schema),
+    SchemaExpr.ArithmeticOperator.Modulo,
+    isNumeric.primitiveType.asInstanceOf[NumericPrimitiveType[A]]
+  )
+
+  final def pow(that: A)(implicit isNumeric: IsNumeric[A]): SchemaExpr[S, A] = SchemaExpr.arithmetic(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that)(isNumeric.schema),
+    SchemaExpr.ArithmeticOperator.Pow,
+    isNumeric.primitiveType.asInstanceOf[NumericPrimitiveType[A]]
+  )
+
+  // Bitwise operations
+  final def &(that: A)(implicit ev: IsIntegral[A]): SchemaExpr[S, A] = SchemaExpr.bitwise(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that)(ev.schema),
+    SchemaExpr.BitwiseOperator.And
+  )
+
+  final def |(that: A)(implicit ev: IsIntegral[A]): SchemaExpr[S, A] = SchemaExpr.bitwise(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that)(ev.schema),
+    SchemaExpr.BitwiseOperator.Or
+  )
+
+  final def ^(that: A)(implicit ev: IsIntegral[A]): SchemaExpr[S, A] = SchemaExpr.bitwise(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that)(ev.schema),
+    SchemaExpr.BitwiseOperator.Xor
+  )
+
+  final def <<(that: A)(implicit ev: IsIntegral[A]): SchemaExpr[S, A] = SchemaExpr.bitwise(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that)(ev.schema),
+    SchemaExpr.BitwiseOperator.LeftShift
+  )
+
+  final def >>(that: A)(implicit ev: IsIntegral[A]): SchemaExpr[S, A] = SchemaExpr.bitwise(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that)(ev.schema),
+    SchemaExpr.BitwiseOperator.RightShift
+  )
+
+  final def >>>(that: A)(implicit ev: IsIntegral[A]): SchemaExpr[S, A] = SchemaExpr.bitwise(
+    SchemaExpr.optic(this.toDynamic, new Schema(this.source)),
+    SchemaExpr.literal(that)(ev.schema),
+    SchemaExpr.BitwiseOperator.UnsignedRightShift
+  )
+
+  final def unary_~(implicit ev: IsIntegral[A]): SchemaExpr[S, A] = {
+    val _ = ev
+    SchemaExpr.bitwiseNot(SchemaExpr.optic(this.toDynamic, new Schema(this.source)))
+  }
 
   final def length(implicit ev: A =:= String): SchemaExpr[S, Int] =
-    new SchemaExpr.StringLength(new SchemaExpr.Optic(this.asEquivalent[String]))
+    SchemaExpr.stringLength(SchemaExpr.optic(this.toDynamic, new Schema(this.source)))
 
   final def asEquivalent[B](implicit ev: A =:= B): Optic[S, B] = self.asInstanceOf[Optic[S, B]]
 }
@@ -369,12 +426,11 @@ object Lens {
     def modifyOrFail(s: S, f: A => A): Either[OpticCheck, S] = new Right(modify(s, f))
 
     lazy val toDynamic: DynamicOptic =
-      new DynamicOptic(Chunk.fromArray(focusTerms.map(term => new DynamicOptic.Node.Field(term.name))))
+      new DynamicOptic(ArraySeq.unsafeWrapArray(focusTerms.map(term => new DynamicOptic.Node.Field(term.name))))
 
     override def toString: String = {
-      val sb = new java.lang.StringBuilder("Lens(_")
-      focusTerms.foreach(term => sb.append('.').append(term.name))
-      sb.append(')').toString
+      val path = focusTerms.map(term => s".${term.name}").mkString
+      s"Lens(_$path)"
     }
 
     override def hashCode: Int = java.util.Arrays.hashCode(sources.asInstanceOf[Array[AnyRef]]) ^
@@ -556,12 +612,11 @@ object Prism {
     }
 
     lazy val toDynamic: DynamicOptic =
-      new DynamicOptic(Chunk.fromArray(focusTerms.map(term => new DynamicOptic.Node.Case(term.name))))
+      new DynamicOptic(ArraySeq.unsafeWrapArray(focusTerms.map(term => new DynamicOptic.Node.Case(term.name))))
 
     override def toString: String = {
-      val sb = new java.lang.StringBuilder("Prism(_")
-      focusTerms.foreach(term => sb.append(".when[").append(term.name).append(']'))
-      sb.append(')').toString
+      val path = focusTerms.map(term => s".when[${term.name}]").mkString
+      s"Prism(_$path)"
     }
 
     override def hashCode: Int = java.util.Arrays.hashCode(sources.asInstanceOf[Array[AnyRef]]) ^
@@ -796,11 +851,11 @@ object Optional {
             val col           = x.asInstanceOf[Col[A]]
             deconstructor match {
               case indexed: SeqDeconstructor.SpecializedIndexed[Col] =>
-                val len    = indexed.size(col)
-                val colIdx = atBinding.index
-                if (len <= colIdx) {
+                val colSize = indexed.size(col)
+                val colIdx  = atBinding.index
+                if (colSize <= colIdx) {
                   val sequenceIndexOutOfBounds =
-                    new OpticCheck.SequenceIndexOutOfBounds(toDynamic, toDynamic(idx), colIdx, len)
+                    new OpticCheck.SequenceIndexOutOfBounds(toDynamic, toDynamic(idx), colIdx, colSize)
                   return new Some(new OpticCheck(new ::(sequenceIndexOutOfBounds, Nil)))
                 }
                 indexed.elementType(col) match {
@@ -871,9 +926,9 @@ object Optional {
             val col           = x.asInstanceOf[Col[A]]
             deconstructor match {
               case indexed: SeqDeconstructor.SpecializedIndexed[Col] =>
-                val len    = indexed.size(col)
-                val colIdx = atBinding.index
-                if (len <= colIdx) return None
+                val colSize = indexed.size(col)
+                val colIdx  = atBinding.index
+                if (colSize <= colIdx) return None
                 indexed.elementType(col) match {
                   case _: RegisterType.Boolean.type => x = indexed.booleanAt(x.asInstanceOf[Col[Boolean]], colIdx)
                   case _: RegisterType.Byte.type    => x = indexed.byteAt(x.asInstanceOf[Col[Byte]], colIdx)
@@ -1002,8 +1057,13 @@ object Optional {
           if (idx + 1 == bindings.length)
             modifySeqAt(deconstructor, constructor, col, f, colIdx, atBinding.elemClassTag)
           else {
+            val sizeHint =
+              deconstructor match {
+                case indexed: SeqDeconstructor.SpecializedIndexed[Col] => indexed.size(col)
+                case _                                                 => 8
+              }
             implicit val classTag: ClassTag[Any] = atBinding.elemClassTag.asInstanceOf[ClassTag[Any]]
-            val builder                          = constructor.newBuilder[Any](deconstructor.size(col))
+            val builder                          = constructor.newBuilder[Any](sizeHint)
             val it                               = deconstructor.deconstruct(col)
             var currIdx                          = 0
             while (it.hasNext) {
@@ -1045,12 +1105,12 @@ object Optional {
       elemClassTag: ClassTag[?]
     ): Col[A] = {
       implicit val classTag: ClassTag[A] = elemClassTag.asInstanceOf[ClassTag[A]]
-      val len                            = deconstructor.size(s)
-      val builder                        = constructor.newBuilder[A](len)
       deconstructor match {
         case indexed: SeqDeconstructor.SpecializedIndexed[Col] =>
-          var idx = 0
-          while (idx < len) {
+          val size    = indexed.size(s)
+          val builder = constructor.newBuilder[A](size)
+          var idx     = 0
+          while (idx < size) {
             constructor.add(
               builder, {
                 val value = indexed.objectAt(s, idx)
@@ -1060,7 +1120,9 @@ object Optional {
             )
             idx += 1
           }
+          constructor.result(builder)
         case _ =>
+          val builder = constructor.newBuilder[A]()
           val it      = deconstructor.deconstruct(s)
           var currIdx = -1
           while (it.hasNext)
@@ -1072,8 +1134,8 @@ object Optional {
                 else f(value)
               }
             )
+          constructor.result(builder)
       }
-      constructor.result(builder)
     }
 
     def modifyOption(s: S, f: A => A): Option[S] = {
@@ -1123,27 +1185,33 @@ object Optional {
 
     lazy val toDynamic: DynamicOptic = new DynamicOptic({
       if (bindings eq null) init()
+      val nodes = ChunkBuilder.make[DynamicOptic.Node]()
       val len   = bindings.length
-      val nodes = new Array[DynamicOptic.Node](len)
       var idx   = 0
       while (idx < len) {
-        nodes(idx) = bindings(idx) match {
-          case _: LensBinding                                        => new DynamicOptic.Node.Field(focusTerms(idx).name)
-          case _: PrismBinding                                       => new DynamicOptic.Node.Case(focusTerms(idx).name)
-          case _: WrappedBinding[Wrapping, Wrapped] @scala.unchecked => DynamicOptic.Node.Wrapped
-          case at: AtBinding[Col] @scala.unchecked                   => new DynamicOptic.Node.AtIndex(at.index)
-          case binding                                               =>
-            val atKeyBinding = binding.asInstanceOf[AtKeyBinding[Key, Map]]
-            new DynamicOptic.Node.AtMapKey(atKeyBinding.keySchema.toDynamicValue(atKeyBinding.key))
+        nodes.addOne {
+          bindings(idx) match {
+            case _: LensBinding =>
+              new DynamicOptic.Node.Field(focusTerms(idx).name)
+            case _: PrismBinding =>
+              new DynamicOptic.Node.Case(focusTerms(idx).name)
+            case _: WrappedBinding[Wrapping, Wrapped] @scala.unchecked =>
+              DynamicOptic.Node.Wrapped
+            case at: AtBinding[Col] @scala.unchecked =>
+              new DynamicOptic.Node.AtIndex(at.index)
+            case binding =>
+              val atKeyBinding = binding.asInstanceOf[AtKeyBinding[Key, Map]]
+              new DynamicOptic.Node.AtMapKey(atKeyBinding.keySchema.toDynamicValue(atKeyBinding.key))
+          }
         }
         idx += 1
       }
-      Chunk.fromArray(nodes)
+      nodes.result()
     })
 
     override def toString: String = {
       if (bindings eq null) init()
-      val sb  = new java.lang.StringBuilder("Optional(_")
+      val sb  = new java.lang.StringBuilder
       val len = bindings.length
       var idx = 0
       while (idx < len) {
@@ -1161,7 +1229,7 @@ object Optional {
         }
         idx += 1
       }
-      sb.append(')').toString
+      s"Optional(_${sb.toString})"
     }
 
     override def hashCode: Int = java.util.Arrays.hashCode(sources.asInstanceOf[Array[AnyRef]]) ^
@@ -1553,10 +1621,10 @@ object Traversal {
           val col           = x.asInstanceOf[Col[A]]
           deconstructor match {
             case indexed: SeqDeconstructor.SpecializedIndexed[Col] =>
-              val len    = indexed.size(col)
-              val colIdx = atBinding.index
-              if (len <= colIdx) {
-                errors.addOne(new OpticCheck.SequenceIndexOutOfBounds(toDynamic, toDynamic(idx), colIdx, len))
+              val colSize = indexed.size(col)
+              val colIdx  = atBinding.index
+              if (colSize <= colIdx) {
+                errors.addOne(new OpticCheck.SequenceIndexOutOfBounds(toDynamic, toDynamic(idx), colIdx, colSize))
               } else if (idx + 1 != bindings.length) {
                 checkRecursive(registers, idx + 1, indexed.objectAt(col, colIdx), errors)
               }
@@ -1584,13 +1652,13 @@ object Traversal {
           val col           = x.asInstanceOf[Col[A]]
           deconstructor match {
             case indexed: SeqDeconstructor.SpecializedIndexed[Col] =>
-              val len        = indexed.size(col)
+              val colSize    = indexed.size(col)
               val indices    = atIndicesBinding.indices
               var indicesIdx = 0
               while (indicesIdx < indices.length) {
                 val colIdx = indices(indicesIdx)
-                if (len <= colIdx) {
-                  errors.addOne(new OpticCheck.SequenceIndexOutOfBounds(toDynamic, toDynamic(idx), colIdx, len))
+                if (colSize <= colIdx) {
+                  errors.addOne(new OpticCheck.SequenceIndexOutOfBounds(toDynamic, toDynamic(idx), colIdx, colSize))
                 } else if (idx + 1 != bindings.length) {
                   checkRecursive(registers, idx + 1, indexed.objectAt(col, colIdx), errors)
                 }
@@ -1676,9 +1744,9 @@ object Traversal {
           val col           = x.asInstanceOf[Col[A]]
           deconstructor match {
             case indexed: SeqDeconstructor.SpecializedIndexed[Col] =>
-              val len    = indexed.size(col)
-              val colIdx = atBinding.index
-              if (len <= colIdx) zero
+              val colSize = indexed.size(col)
+              val colIdx  = atBinding.index
+              if (colSize <= colIdx) zero
               else if (idx + 1 == bindings.length) {
                 f(
                   zero,
@@ -1732,10 +1800,10 @@ object Traversal {
             var indicesIdx = 0
             deconstructor match {
               case indexed: SeqDeconstructor.SpecializedIndexed[Col] =>
-                val len = indexed.size(col)
+                val colSize = indexed.size(col)
                 while (indicesIdx < indices.length) {
                   val colIdx = indices(indicesIdx)
-                  if (len > colIdx) z = foldRecursive(registers, idx + 1, indexed.objectAt(col, colIdx), z, f)
+                  if (colSize > colIdx) z = foldRecursive(registers, idx + 1, indexed.objectAt(col, colIdx), z, f)
                   indicesIdx += 1
                 }
               case _ =>
@@ -1818,7 +1886,7 @@ object Traversal {
     ): Z =
       deconstructor match {
         case indexed: SeqDeconstructor.SpecializedIndexed[Col] =>
-          val len        = indexed.size(x)
+          val colSize    = indexed.size(x)
           var indicesIdx = 0
           indexed.elementType(x) match {
             case _: RegisterType.Int.type =>
@@ -1829,7 +1897,7 @@ object Traversal {
                   val sf     = f.asInstanceOf[(Int, Int) => Int]
                   while (indicesIdx < indices.length) {
                     val colIdx = indices(indicesIdx)
-                    if (len > colIdx) z = sf(z, indexed.intAt(col, colIdx))
+                    if (colSize > colIdx) z = sf(z, indexed.intAt(col, colIdx))
                     indicesIdx += 1
                   }
                   z.asInstanceOf[Z]
@@ -1838,7 +1906,7 @@ object Traversal {
                   val sf      = f.asInstanceOf[(Long, Int) => Long]
                   while (indicesIdx < indices.length) {
                     val colIdx = indices(indicesIdx)
-                    if (len > colIdx) z = sf(z, indexed.intAt(col, colIdx))
+                    if (colSize > colIdx) z = sf(z, indexed.intAt(col, colIdx))
                     indicesIdx += 1
                   }
                   z.asInstanceOf[Z]
@@ -1847,7 +1915,7 @@ object Traversal {
                   val sf        = f.asInstanceOf[(Double, Int) => Double]
                   while (indicesIdx < indices.length) {
                     val colIdx = indices(indicesIdx)
-                    if (len > colIdx) z = sf(z, indexed.intAt(col, colIdx))
+                    if (colSize > colIdx) z = sf(z, indexed.intAt(col, colIdx))
                     indicesIdx += 1
                   }
                   z.asInstanceOf[Z]
@@ -1856,7 +1924,7 @@ object Traversal {
                   val sf = f.asInstanceOf[(Z, Int) => Z]
                   while (indicesIdx < indices.length) {
                     val colIdx = indices(indicesIdx)
-                    if (len > colIdx) z = sf(z, indexed.intAt(col, colIdx))
+                    if (colSize > colIdx) z = sf(z, indexed.intAt(col, colIdx))
                     indicesIdx += 1
                   }
                   z
@@ -1869,7 +1937,7 @@ object Traversal {
                   val sf     = f.asInstanceOf[(Int, Long) => Int]
                   while (indicesIdx < indices.length) {
                     val colIdx = indices(indicesIdx)
-                    if (len > colIdx) z = sf(z, indexed.longAt(col, colIdx))
+                    if (colSize > colIdx) z = sf(z, indexed.longAt(col, colIdx))
                     indicesIdx += 1
                   }
                   z.asInstanceOf[Z]
@@ -1878,7 +1946,7 @@ object Traversal {
                   val sf      = f.asInstanceOf[(Long, Long) => Long]
                   while (indicesIdx < indices.length) {
                     val colIdx = indices(indicesIdx)
-                    if (len > colIdx) z = sf(z, indexed.longAt(col, colIdx))
+                    if (colSize > colIdx) z = sf(z, indexed.longAt(col, colIdx))
                     indicesIdx += 1
                   }
                   z.asInstanceOf[Z]
@@ -1887,7 +1955,7 @@ object Traversal {
                   val sf        = f.asInstanceOf[(Double, Long) => Double]
                   while (indicesIdx < indices.length) {
                     val colIdx = indices(indicesIdx)
-                    if (len > colIdx) z = sf(z, indexed.longAt(col, colIdx))
+                    if (colSize > colIdx) z = sf(z, indexed.longAt(col, colIdx))
                     indicesIdx += 1
                   }
                   z.asInstanceOf[Z]
@@ -1896,7 +1964,7 @@ object Traversal {
                   val sf = f.asInstanceOf[(Z, Long) => Z]
                   while (indicesIdx < indices.length) {
                     val colIdx = indices(indicesIdx)
-                    if (len > colIdx) z = sf(z, indexed.longAt(col, colIdx))
+                    if (colSize > colIdx) z = sf(z, indexed.longAt(col, colIdx))
                     indicesIdx += 1
                   }
                   z
@@ -1909,7 +1977,7 @@ object Traversal {
                   val sf     = f.asInstanceOf[(Int, Double) => Int]
                   while (indicesIdx < indices.length) {
                     val colIdx = indices(indicesIdx)
-                    if (len > colIdx) z = sf(z, indexed.doubleAt(col, colIdx))
+                    if (colSize > colIdx) z = sf(z, indexed.doubleAt(col, colIdx))
                     indicesIdx += 1
                   }
                   z.asInstanceOf[Z]
@@ -1918,7 +1986,7 @@ object Traversal {
                   val sf      = f.asInstanceOf[(Long, Double) => Long]
                   while (indicesIdx < indices.length) {
                     val colIdx = indices(indicesIdx)
-                    if (len > colIdx) z = sf(z, indexed.doubleAt(col, colIdx))
+                    if (colSize > colIdx) z = sf(z, indexed.doubleAt(col, colIdx))
                     indicesIdx += 1
                   }
                   z.asInstanceOf[Z]
@@ -1927,7 +1995,7 @@ object Traversal {
                   val sf        = f.asInstanceOf[(Double, Double) => Double]
                   while (indicesIdx < indices.length) {
                     val colIdx = indices(indicesIdx)
-                    if (len > colIdx) z = sf(z, indexed.doubleAt(col, colIdx))
+                    if (colSize > colIdx) z = sf(z, indexed.doubleAt(col, colIdx))
                     indicesIdx += 1
                   }
                   z.asInstanceOf[Z]
@@ -1936,7 +2004,7 @@ object Traversal {
                   val sf = f.asInstanceOf[(Z, Double) => Z]
                   while (indicesIdx < indices.length) {
                     val colIdx = indices(indicesIdx)
-                    if (len > colIdx) z = sf(z, indexed.doubleAt(col, colIdx))
+                    if (colSize > colIdx) z = sf(z, indexed.doubleAt(col, colIdx))
                     indicesIdx += 1
                   }
                   z
@@ -1947,7 +2015,7 @@ object Traversal {
               var z   = zero
               while (indicesIdx < indices.length) {
                 val colIdx = indices(indicesIdx)
-                if (len > colIdx) z = sf(z, indexed.booleanAt(col, colIdx))
+                if (colSize > colIdx) z = sf(z, indexed.booleanAt(col, colIdx))
                 indicesIdx += 1
               }
               z
@@ -1957,7 +2025,7 @@ object Traversal {
               var z   = zero
               while (indicesIdx < indices.length) {
                 val colIdx = indices(indicesIdx)
-                if (len > colIdx) z = sf(z, indexed.byteAt(col, colIdx))
+                if (colSize > colIdx) z = sf(z, indexed.byteAt(col, colIdx))
                 indicesIdx += 1
               }
               z
@@ -1967,7 +2035,7 @@ object Traversal {
               val sf  = f.asInstanceOf[(Z, Short) => Z]
               while (indicesIdx < indices.length) {
                 val colIdx = indices(indicesIdx)
-                if (len > colIdx) z = sf(z, indexed.shortAt(col, colIdx))
+                if (colSize > colIdx) z = sf(z, indexed.shortAt(col, colIdx))
                 indicesIdx += 1
               }
               z
@@ -1977,7 +2045,7 @@ object Traversal {
               val sf  = f.asInstanceOf[(Z, Float) => Z]
               while (indicesIdx < indices.length) {
                 val colIdx = indices(indicesIdx)
-                if (len > colIdx) z = sf(z, indexed.floatAt(col, colIdx))
+                if (colSize > colIdx) z = sf(z, indexed.floatAt(col, colIdx))
                 indicesIdx += 1
               }
               z
@@ -1987,7 +2055,7 @@ object Traversal {
               val sf  = f.asInstanceOf[(Z, Char) => Z]
               while (indicesIdx < indices.length) {
                 val colIdx = indices(indicesIdx)
-                if (len > colIdx) z = sf(z, indexed.charAt(col, colIdx))
+                if (colSize > colIdx) z = sf(z, indexed.charAt(col, colIdx))
                 indicesIdx += 1
               }
               z
@@ -1995,7 +2063,7 @@ object Traversal {
               var z = zero
               while (indicesIdx < indices.length) {
                 val colIdx = indices(indicesIdx)
-                if (len > colIdx) z = f(z, indexed.objectAt(x, colIdx))
+                if (colSize > colIdx) z = f(z, indexed.objectAt(x, colIdx))
                 indicesIdx += 1
               }
               z
@@ -2022,7 +2090,7 @@ object Traversal {
     private[this] def foldSeq[Z](deconstructor: SeqDeconstructor[Col], x: Col[A], zero: Z, f: (Z, A) => Z): Z =
       deconstructor match {
         case indexed: SeqDeconstructor.SpecializedIndexed[Col] =>
-          val len     = indexed.size(x)
+          val size    = indexed.size(x)
           var currIdx = 0
           indexed.elementType(x) match {
             case _: RegisterType.Int.type =>
@@ -2031,7 +2099,7 @@ object Traversal {
                 case zi: Int =>
                   val sf     = f.asInstanceOf[(Int, Int) => Int]
                   var z: Int = zi
-                  while (currIdx < len) {
+                  while (currIdx < size) {
                     z = sf(z, indexed.intAt(col, currIdx))
                     currIdx += 1
                   }
@@ -2039,7 +2107,7 @@ object Traversal {
                 case zl: Long =>
                   val sf      = f.asInstanceOf[(Long, Int) => Long]
                   var z: Long = zl
-                  while (currIdx < len) {
+                  while (currIdx < size) {
                     z = sf(z, indexed.intAt(col, currIdx))
                     currIdx += 1
                   }
@@ -2047,7 +2115,7 @@ object Traversal {
                 case zd: Double =>
                   val sf        = f.asInstanceOf[(Double, Int) => Double]
                   var z: Double = zd
-                  while (currIdx < len) {
+                  while (currIdx < size) {
                     z = sf(z, indexed.intAt(col, currIdx))
                     currIdx += 1
                   }
@@ -2055,7 +2123,7 @@ object Traversal {
                 case _ =>
                   val sf = f.asInstanceOf[(Z, Int) => Z]
                   var z  = zero
-                  while (currIdx < len) {
+                  while (currIdx < size) {
                     z = sf(z, indexed.intAt(col, currIdx))
                     currIdx += 1
                   }
@@ -2067,7 +2135,7 @@ object Traversal {
                 case zi: Int =>
                   val sf     = f.asInstanceOf[(Int, Long) => Int]
                   var z: Int = zi
-                  while (currIdx < len) {
+                  while (currIdx < size) {
                     z = sf(z, indexed.longAt(col, currIdx))
                     currIdx += 1
                   }
@@ -2075,7 +2143,7 @@ object Traversal {
                 case zl: Long =>
                   val sf      = f.asInstanceOf[(Long, Long) => Long]
                   var z: Long = zl
-                  while (currIdx < len) {
+                  while (currIdx < size) {
                     z = sf(z, indexed.longAt(col, currIdx))
                     currIdx += 1
                   }
@@ -2083,7 +2151,7 @@ object Traversal {
                 case zd: Double =>
                   val sf        = f.asInstanceOf[(Double, Long) => Double]
                   var z: Double = zd
-                  while (currIdx < len) {
+                  while (currIdx < size) {
                     z = sf(z, indexed.longAt(col, currIdx))
                     currIdx += 1
                   }
@@ -2091,7 +2159,7 @@ object Traversal {
                 case _ =>
                   val sf = f.asInstanceOf[(Z, Long) => Z]
                   var z  = zero
-                  while (currIdx < len) {
+                  while (currIdx < size) {
                     z = sf(z, indexed.longAt(col, currIdx))
                     currIdx += 1
                   }
@@ -2103,7 +2171,7 @@ object Traversal {
                 case zi: Int =>
                   val sf     = f.asInstanceOf[(Int, Double) => Int]
                   var z: Int = zi
-                  while (currIdx < len) {
+                  while (currIdx < size) {
                     z = sf(z, indexed.doubleAt(col, currIdx))
                     currIdx += 1
                   }
@@ -2111,7 +2179,7 @@ object Traversal {
                 case zl: Long =>
                   val sf      = f.asInstanceOf[(Long, Double) => Long]
                   var z: Long = zl
-                  while (currIdx < len) {
+                  while (currIdx < size) {
                     z = sf(z, indexed.doubleAt(col, currIdx))
                     currIdx += 1
                   }
@@ -2119,7 +2187,7 @@ object Traversal {
                 case zd: Double =>
                   val sf        = f.asInstanceOf[(Double, Double) => Double]
                   var z: Double = zd
-                  while (currIdx < len) {
+                  while (currIdx < size) {
                     z = sf(z, indexed.doubleAt(col, currIdx))
                     currIdx += 1
                   }
@@ -2127,7 +2195,7 @@ object Traversal {
                 case _ =>
                   val sf = f.asInstanceOf[(Z, Double) => Z]
                   var z  = zero
-                  while (currIdx < len) {
+                  while (currIdx < size) {
                     z = sf(z, indexed.doubleAt(col, currIdx))
                     currIdx += 1
                   }
@@ -2137,7 +2205,7 @@ object Traversal {
               val col = x.asInstanceOf[Col[Boolean]]
               val sf  = f.asInstanceOf[(Z, Boolean) => Z]
               var z   = zero
-              while (currIdx < len) {
+              while (currIdx < size) {
                 z = sf(z, indexed.booleanAt(col, currIdx))
                 currIdx += 1
               }
@@ -2146,7 +2214,7 @@ object Traversal {
               val col = x.asInstanceOf[Col[Byte]]
               val sf  = f.asInstanceOf[(Z, Byte) => Z]
               var z   = zero
-              while (currIdx < len) {
+              while (currIdx < size) {
                 z = sf(z, indexed.byteAt(col, currIdx))
                 currIdx += 1
               }
@@ -2155,7 +2223,7 @@ object Traversal {
               val col = x.asInstanceOf[Col[Short]]
               val sf  = f.asInstanceOf[(Z, Short) => Z]
               var z   = zero
-              while (currIdx < len) {
+              while (currIdx < size) {
                 z = sf(z, indexed.shortAt(col, currIdx))
                 currIdx += 1
               }
@@ -2164,7 +2232,7 @@ object Traversal {
               val col = x.asInstanceOf[Col[Float]]
               val sf  = f.asInstanceOf[(Z, Float) => Z]
               var z   = zero
-              while (currIdx < len) {
+              while (currIdx < size) {
                 z = sf(z, indexed.floatAt(col, currIdx))
                 currIdx += 1
               }
@@ -2173,14 +2241,14 @@ object Traversal {
               val col = x.asInstanceOf[Col[Char]]
               val sf  = f.asInstanceOf[(Z, Char) => Z]
               var z   = zero
-              while (currIdx < len) {
+              while (currIdx < size) {
                 z = sf(z, indexed.charAt(col, currIdx))
                 currIdx += 1
               }
               z
             case _ =>
               var z = zero
-              while (currIdx < len) {
+              while (currIdx < size) {
                 z = f(z, indexed.objectAt(x, currIdx))
                 currIdx += 1
               }
@@ -2238,8 +2306,13 @@ object Traversal {
           if (idx + 1 == bindings.length)
             modifySeqAt(deconstructor, constructor, col, f, colIdx, atBinding.elemClassTag)
           else {
+            val sizeHint =
+              deconstructor match {
+                case indexed: SeqDeconstructor.SpecializedIndexed[Col] => indexed.size(col)
+                case _                                                 => 8
+              }
             implicit val classTag: ClassTag[Any] = atBinding.elemClassTag.asInstanceOf[ClassTag[Any]]
-            val builder                          = constructor.newBuilder[Any](deconstructor.size(col))
+            val builder                          = constructor.newBuilder[Any](sizeHint)
             val it                               = deconstructor.deconstruct(col)
             var currIdx                          = 0
             while (it.hasNext) {
@@ -2277,7 +2350,12 @@ object Traversal {
           if (idx + 1 == bindings.length)
             modifySeqAtIndices(indices, deconstructor, constructor, col, f, atIndicesBinding.elemClassTag)
           else {
-            val builder             = constructor.newBuilder[Any](deconstructor.size(col))
+            val sizeHint =
+              deconstructor match {
+                case indexed: SeqDeconstructor.SpecializedIndexed[Col] => indexed.size(col)
+                case _                                                 => 8
+              }
+            val builder             = constructor.newBuilder[Any](sizeHint)
             val it                  = deconstructor.deconstruct(col)
             var colIdx              = indices(0)
             var currIdx, indicesIdx = 0
@@ -2323,8 +2401,13 @@ object Traversal {
           val col           = x.asInstanceOf[Col[A]]
           if (idx + 1 == bindings.length) modifySeq(deconstructor, constructor, col, f, seqBinding.elemClassTag)
           else {
+            val sizeHint =
+              deconstructor match {
+                case indexed: SeqDeconstructor.SpecializedIndexed[Col] => indexed.size(col)
+                case _                                                 => 8
+              }
             implicit val classTag: ClassTag[Any] = seqBinding.elemClassTag.asInstanceOf[ClassTag[Any]]
-            val builder                          = constructor.newBuilder[Any](deconstructor.size(col))
+            val builder                          = constructor.newBuilder[Any](sizeHint)
             val it                               = deconstructor.deconstruct(col)
             while (it.hasNext) constructor.add(builder, modifyRecursive(registers, idx + 1, it.next(), f))
             constructor.result(builder)
@@ -2333,7 +2416,7 @@ object Traversal {
           val deconstructor = mapKeyBinding.mapDeconstructor
           val constructor   = mapKeyBinding.mapConstructor
           if (idx + 1 == bindings.length) {
-            val builder = constructor.newObjectBuilder[A, Value](deconstructor.size(x.asInstanceOf[Map[Key, Value]]))
+            val builder = constructor.newObjectBuilder[A, Value]()
             val it      = deconstructor.deconstruct(x.asInstanceOf[Map[A, Value]])
             while (it.hasNext) {
               val next = it.next()
@@ -2341,7 +2424,7 @@ object Traversal {
             }
             constructor.resultObject(builder)
           } else {
-            val builder = constructor.newObjectBuilder[Any, Value](deconstructor.size(x.asInstanceOf[Map[Any, Value]]))
+            val builder = constructor.newObjectBuilder[Any, Value]()
             val it      = deconstructor.deconstruct(x.asInstanceOf[Map[Any, Value]])
             while (it.hasNext) {
               val next = it.next()
@@ -2357,7 +2440,7 @@ object Traversal {
           val deconstructor = mapValueBinding.mapDeconstructor
           val constructor   = mapValueBinding.mapConstructor
           if (idx + 1 == bindings.length) {
-            val builder = constructor.newObjectBuilder[Key, A](deconstructor.size(x.asInstanceOf[Map[Key, A]]))
+            val builder = constructor.newObjectBuilder[Key, A]()
             val it      = deconstructor.deconstruct(x.asInstanceOf[Map[Key, A]])
             while (it.hasNext) {
               val next = it.next()
@@ -2365,7 +2448,7 @@ object Traversal {
             }
             constructor.resultObject(builder)
           } else {
-            val builder = constructor.newObjectBuilder[Key, Any](deconstructor.size(x.asInstanceOf[Map[Key, Any]]))
+            val builder = constructor.newObjectBuilder[Key, Any]()
             val it      = deconstructor.deconstruct(x.asInstanceOf[Map[Key, Any]])
             while (it.hasNext) {
               val next = it.next()
@@ -2388,12 +2471,12 @@ object Traversal {
       elemClassTag: ClassTag[?]
     ): Col[A] = {
       implicit val classTag: ClassTag[A] = elemClassTag.asInstanceOf[ClassTag[A]]
-      val len                            = deconstructor.size(x)
-      val builder                        = constructor.newBuilder[A](len)
       deconstructor match {
         case indexed: SeqDeconstructor.SpecializedIndexed[Col] =>
+          val size    = indexed.size(x)
+          val builder = constructor.newBuilder[A](size)
           var currIdx = 0
-          while (currIdx < len) {
+          while (currIdx < size) {
             constructor.add(
               builder, {
                 val value = indexed.objectAt(x, currIdx)
@@ -2403,7 +2486,9 @@ object Traversal {
             )
             currIdx += 1
           }
+          constructor.result(builder)
         case _ =>
+          val builder = constructor.newBuilder[A]()
           val it      = deconstructor.deconstruct(x)
           var currIdx = -1
           while (it.hasNext)
@@ -2415,8 +2500,8 @@ object Traversal {
                 else f(value)
               }
             )
+          constructor.result(builder)
       }
-      constructor.result(builder)
     }
 
     private[this] def modifySeqAtIndices(
@@ -2428,13 +2513,13 @@ object Traversal {
       elemClassTag: ClassTag[?]
     ): Col[A] = {
       implicit val classTag: ClassTag[A] = elemClassTag.asInstanceOf[ClassTag[A]]
-      val len                            = deconstructor.size(x)
-      val builder                        = constructor.newBuilder[A](len)
       deconstructor match {
         case indexed: SeqDeconstructor.SpecializedIndexed[Col] =>
+          val size                = indexed.size(x)
           var colIdx              = indices(0)
           var currIdx, indicesIdx = 0
-          while (currIdx < len) {
+          val builder             = constructor.newBuilder[A](size)
+          while (currIdx < size) {
             constructor.add(
               builder, {
                 val value = indexed.objectAt(x, currIdx)
@@ -2448,7 +2533,9 @@ object Traversal {
             )
             currIdx += 1
           }
+          constructor.result(builder)
         case _ =>
+          val builder             = constructor.newBuilder[A]()
           val it                  = deconstructor.deconstruct(x)
           var colIdx              = indices(0)
           var currIdx, indicesIdx = 0
@@ -2466,8 +2553,8 @@ object Traversal {
             )
             currIdx += 1
           }
+          constructor.result(builder)
       }
-      constructor.result(builder)
     }
 
     private[this] def modifySeq(
@@ -2478,21 +2565,22 @@ object Traversal {
       elemClassTag: ClassTag[?]
     ): Col[A] = {
       implicit val classTag: ClassTag[A] = elemClassTag.asInstanceOf[ClassTag[A]]
-      val len                            = deconstructor.size(x)
-      val builder                        = constructor.newBuilder[A](len)
       deconstructor match {
         case indexed: SeqDeconstructor.SpecializedIndexed[Col] =>
+          val size    = indexed.size(x)
+          val builder = constructor.newBuilder[A](size)
           var currIdx = 0
-          while (currIdx < len) {
+          while (currIdx < size) {
             constructor.add(builder, f(indexed.objectAt(x, currIdx)))
             currIdx += 1
           }
           constructor.result(builder)
         case _ =>
-          val it = deconstructor.deconstruct(x)
+          val builder = constructor.newBuilder[A]()
+          val it      = deconstructor.deconstruct(x)
           while (it.hasNext) constructor.add(builder, f(it.next()))
+          constructor.result(builder)
       }
-      constructor.result(builder)
     }
 
     def modifyOption(s: S, f: A => A): Option[S] = {
@@ -2542,33 +2630,42 @@ object Traversal {
 
     lazy val toDynamic: DynamicOptic = new DynamicOptic({
       if (bindings eq null) init()
+      val nodes = ChunkBuilder.make[DynamicOptic.Node]()
       val len   = bindings.length
-      val nodes = new Array[DynamicOptic.Node](len)
       var idx   = 0
       while (idx < len) {
-        nodes(idx) = bindings(idx) match {
-          case _: LensBinding                                        => new DynamicOptic.Node.Field(focusTerms(idx).name)
-          case _: PrismBinding                                       => new DynamicOptic.Node.Case(focusTerms(idx).name)
-          case _: WrappedBinding[Wrapping, Wrapped] @scala.unchecked => DynamicOptic.Node.Wrapped
-          case at: AtBinding[Col] @scala.unchecked                   => new DynamicOptic.Node.AtIndex(at.index)
-          case atKey: AtKeyBinding[Key, Map] @scala.unchecked        =>
-            new DynamicOptic.Node.AtMapKey(atKey.keySchema.toDynamicValue(atKey.key))
-          case atIndices: AtIndicesBinding[Col] @scala.unchecked =>
-            new DynamicOptic.Node.AtIndices(ArraySeq.unsafeWrapArray(atIndices.indices))
-          case atKeys: AtKeysBinding[Key, Map] @scala.unchecked =>
-            new DynamicOptic.Node.AtMapKeys(atKeys.keys.map(atKeys.keySchema.toDynamicValue))
-          case _: SeqBinding[Col] @scala.unchecked    => DynamicOptic.Node.Elements
-          case _: MapKeyBinding[Map] @scala.unchecked => DynamicOptic.Node.MapKeys
-          case _                                      => DynamicOptic.Node.MapValues
+        nodes.addOne {
+          bindings(idx) match {
+            case _: LensBinding =>
+              new DynamicOptic.Node.Field(focusTerms(idx).name)
+            case _: PrismBinding =>
+              new DynamicOptic.Node.Case(focusTerms(idx).name)
+            case _: WrappedBinding[Wrapping, Wrapped] @scala.unchecked =>
+              DynamicOptic.Node.Wrapped
+            case at: AtBinding[Col] @scala.unchecked =>
+              new DynamicOptic.Node.AtIndex(at.index)
+            case atKey: AtKeyBinding[Key, Map] @scala.unchecked =>
+              new DynamicOptic.Node.AtMapKey(atKey.keySchema.toDynamicValue(atKey.key))
+            case atIndices: AtIndicesBinding[Col] @scala.unchecked =>
+              new DynamicOptic.Node.AtIndices(ArraySeq.unsafeWrapArray(atIndices.indices))
+            case atKeys: AtKeysBinding[Key, Map] @scala.unchecked =>
+              new DynamicOptic.Node.AtMapKeys(atKeys.keys.map(atKeys.keySchema.toDynamicValue))
+            case _: SeqBinding[Col] @scala.unchecked =>
+              DynamicOptic.Node.Elements
+            case _: MapKeyBinding[Map] @scala.unchecked =>
+              DynamicOptic.Node.MapKeys
+            case _ =>
+              DynamicOptic.Node.MapValues
+          }
         }
         idx += 1
       }
-      Chunk.fromArray(nodes)
+      nodes.result()
     })
 
     override def toString: String = {
       if (bindings eq null) init()
-      val sb  = new java.lang.StringBuilder("Traversal(_")
+      val sb  = new java.lang.StringBuilder
       val len = bindings.length
       var idx = 0
       while (idx < len) {
@@ -2596,7 +2693,7 @@ object Traversal {
         }
         idx += 1
       }
-      sb.append(')').toString
+      s"Traversal(_${sb.toString})"
     }
 
     override def hashCode: Int = java.util.Arrays.hashCode(sources.asInstanceOf[Array[AnyRef]]) ^
@@ -2636,28 +2733,39 @@ object Traversal {
      * DynamicValue, searches for matches via single-pass decode, and folds.
      */
     def fold[Z](s: S)(zero: Z, f: (Z, A) => Z): Z = {
+      // Convert source value to DynamicValue for searching
       val dv = sourceReflect.toDynamicValue(s)
+
       // Collect all decoded matches using iterative DFS (single decode per candidate)
       val matches = searchCollectDecoded(dv)
+
       // Fold over already-decoded values
       var result = zero
-      matches.foreach(a => result = f(result, a))
+      matches.foreach { a =>
+        result = f(result, a)
+      }
       result
     }
 
     def check(s: S): Option[OpticCheck] = {
+      // Convert to DynamicValue and search
       val dv = sourceReflect.toDynamicValue(s)
+
       // Check if at least one candidate decodes successfully (single decode per candidate)
       val anyMatch = searchHasMatch(dv)
+
       if (anyMatch) None
-      else new Some(new OpticCheck(new ::(new OpticCheck.EmptySequence(toDynamic, toDynamic), Nil)))
+      else Some(new OpticCheck(new ::(OpticCheck.EmptySequence(toDynamic, toDynamic), Nil)))
     }
 
-    def modify(s: S, f: A => A): S =
-      sourceReflect.fromDynamicValue(searchModify(sourceReflect.toDynamicValue(s), f), Nil) match {
+    def modify(s: S, f: A => A): S = {
+      val dv       = sourceReflect.toDynamicValue(s)
+      val modified = searchModify(dv, f)
+      sourceReflect.fromDynamicValue(modified, Nil) match {
         case Right(result) => result
-        case _             => s // Should not happen if source schema is correct
+        case Left(_)       => s // Should not happen if source schema is correct
       }
+    }
 
     def modifyOption(s: S, f: A => A): Option[S] = {
       val dv                   = sourceReflect.toDynamicValue(s)
@@ -2672,7 +2780,7 @@ object Traversal {
       if (anyModified) {
         sourceReflect.fromDynamicValue(modified, Nil) match {
           case Right(result) => Some(result)
-          case _             => None
+          case Left(_)       => None
         }
       } else None
     }
@@ -2691,30 +2799,34 @@ object Traversal {
         sourceReflect.fromDynamicValue(modified, Nil) match {
           case Right(result) => Right(result)
           case Left(error)   =>
-            new Left(new OpticCheck(new ::(new OpticCheck.WrappingError(toDynamic, toDynamic, error), Nil)))
+            Left(new OpticCheck(new ::(OpticCheck.WrappingError(toDynamic, toDynamic, error), Nil)))
         }
-      } else new Left(new OpticCheck(new ::(new OpticCheck.EmptySequence(toDynamic, toDynamic), Nil)))
+      } else Left(new OpticCheck(new ::(OpticCheck.EmptySequence(toDynamic, toDynamic), Nil)))
     }
 
-    lazy val toDynamic: DynamicOptic =
-      new DynamicOptic(Chunk.single(new DynamicOptic.Node.TypeSearch(focusReflect.typeId)))
+    lazy val toDynamic: DynamicOptic = new DynamicOptic(Vector(DynamicOptic.Node.TypeSearch(focusReflect.typeId)))
 
     override def toString: String = s"Traversal(_.searchFor[${focusReflect.typeId.name}])"
 
     // Override composition methods to handle SearchTraversal specially
-    override def apply[B](that: Lens[A, B]): Traversal[S, B] = new ComposedSearchTraversal(this, that)
+    override def apply[B](that: Lens[A, B]): Traversal[S, B] =
+      new ComposedSearchTraversal(this, that)
 
-    override def apply[B <: A](that: Prism[A, B]): Traversal[S, B] = new ComposedSearchTraversal(this, that)
+    override def apply[B <: A](that: Prism[A, B]): Traversal[S, B] =
+      new ComposedSearchTraversal(this, that)
 
-    override def apply[B](that: Optional[A, B]): Traversal[S, B] = new ComposedSearchTraversal(this, that)
+    override def apply[B](that: Optional[A, B]): Traversal[S, B] =
+      new ComposedSearchTraversal(this, that)
 
-    override def apply[B](that: Traversal[A, B]): Traversal[S, B] = new ComposedSearchTraversal(this, that)
+    override def apply[B](that: Traversal[A, B]): Traversal[S, B] =
+      new ComposedSearchTraversal(this, that)
 
     override def hashCode: Int = sourceReflect.hashCode ^ focusReflect.hashCode ^ 31
 
     override def equals(obj: Any): Boolean = obj match {
-      case other: SearchTraversal[?, ?] => sourceReflect == other.sourceReflect && focusReflect == other.focusReflect
-      case _                            => false
+      case other: SearchTraversal[?, ?] =>
+        sourceReflect == other.sourceReflect && focusReflect == other.focusReflect
+      case _ => false
     }
 
     /**
@@ -2722,25 +2834,33 @@ object Traversal {
      * matching the focus type. Each candidate is decoded exactly once. Order is
      * depth-first, left-to-right.
      */
-    private[this] def searchCollectDecoded(root: DynamicValue): List[A] = {
+    private def searchCollectDecoded(root: DynamicValue): List[A] = {
       var stack: List[DynamicValue]       = List(root)
       val results: mutable.ArrayBuffer[A] = mutable.ArrayBuffer.empty
+
       while (stack.nonEmpty) {
         val current = stack.head
         stack = stack.tail
-        tryDecodeFocus(current).foreach(results.addOne) // Try to decode — single decode per candidate
-        current match {                                 // Push children onto stack for DFS
+
+        // Try to decode — single decode per candidate
+        tryDecodeFocus(current).foreach(results += _)
+
+        // Push children onto stack for DFS
+        current match {
           case r: DynamicValue.Record =>
-            stack = r.fields.foldRight(stack)(_._2 :: _)
+            stack = r.fields.iterator.map(_._2).toList ++ stack
           case v: DynamicValue.Variant =>
             stack = v.value :: stack
           case s: DynamicValue.Sequence =>
-            stack = s.elements.foldRight(stack)(_ :: _)
-          case m: DynamicValue.Map => // Search both keys and values
-            stack = m.entries.foldRight(stack)((kv, stack) => kv._1 :: kv._2 :: stack)
-          case _ =>
+            stack = s.elements.iterator.toList ++ stack
+          case m: DynamicValue.Map =>
+            // Search both keys and values
+            stack = m.entries.iterator.flatMap { case (k, v) => Iterator(k, v) }.toList ++ stack
+          case _: DynamicValue.Primitive | DynamicValue.Null =>
+            ()
         }
       }
+
       results.toList
     }
 
@@ -2748,22 +2868,26 @@ object Traversal {
      * Iterative stack-based depth-first check for at least one match. Returns
      * true as soon as a decodable candidate is found.
      */
-    private[this] def searchHasMatch(root: DynamicValue): Boolean = {
+    private def searchHasMatch(root: DynamicValue): Boolean = {
       var stack: List[DynamicValue] = List(root)
+
       while (stack.nonEmpty) {
         val current = stack.head
         stack = stack.tail
+
         if (tryDecodeFocus(current).isDefined) return true
+
         current match {
           case r: DynamicValue.Record =>
-            stack = r.fields.foldRight(stack)(_._2 :: _)
+            stack = r.fields.iterator.map(_._2).toList ++ stack
           case v: DynamicValue.Variant =>
             stack = v.value :: stack
           case s: DynamicValue.Sequence =>
-            stack = s.elements.foldRight(stack)(_ :: _)
+            stack = s.elements.iterator.toList ++ stack
           case m: DynamicValue.Map =>
-            stack = m.entries.foldRight(stack)((kv, stack) => kv._1 :: kv._2 :: stack)
-          case _ =>
+            stack = m.entries.iterator.flatMap { case (k, v) => Iterator(k, v) }.toList ++ stack
+          case _: DynamicValue.Primitive | DynamicValue.Null =>
+            ()
         }
       }
 
@@ -2774,21 +2898,24 @@ object Traversal {
      * Try to decode a DynamicValue as the focus type. Returns Some(a) if
      * successful, None otherwise. Single decode — no double decoding.
      */
-    private[this] def tryDecodeFocus(dv: DynamicValue): Option[A] = focusReflect.fromDynamicValue(dv, Nil) match {
-      case Right(a) => new Some(a)
-      case _        => None
-    }
+    private def tryDecodeFocus(dv: DynamicValue): Option[A] =
+      focusReflect.fromDynamicValue(dv, Nil) match {
+        case Right(a) => Some(a)
+        case Left(_)  => None
+      }
 
     /**
      * Iterative modification of all values matching the focus type. Uses
      * stack-based traversal (via DynamicValue.iterativeTransform) to avoid
      * stack overflow on deeply nested structures.
      */
-    private[this] def searchModify(dv: DynamicValue, f: A => A): DynamicValue =
+    private def searchModify(dv: DynamicValue, f: A => A): DynamicValue =
       DynamicValue.iterativeTransform(dv) { value =>
         tryDecodeFocus(value) match {
-          case Some(a) => focusReflect.toDynamicValue(f(a))
-          case _       => value
+          case Some(a) =>
+            val modified = f(a)
+            focusReflect.toDynamicValue(modified)
+          case None => value
         }
       }
   }
@@ -2809,6 +2936,7 @@ object Traversal {
     search: SearchTraversal[S, T],
     inner: Optic[T, A]
   ) extends Traversal[S, A] {
+
     def source: Reflect.Bound[S] = search.source
 
     def focus: Reflect.Bound[A] = inner.focus
@@ -2820,18 +2948,20 @@ object Traversal {
         (acc, t) =>
           // For each T, use the inner optic to get/fold over A values
           inner match {
-            case lens: Lens[T, A] @unchecked   => f(acc, lens.get(t))
+            case lens: Lens[T, A] @unchecked =>
+              f(acc, lens.get(t))
             case prism: Prism[T, A] @unchecked =>
               prism.getOption(t) match {
                 case Some(a) => f(acc, a)
-                case _       => acc
+                case None    => acc
               }
             case optional: Optional[T, A] @unchecked =>
               optional.getOption(t) match {
                 case Some(a) => f(acc, a)
-                case _       => acc
+                case None    => acc
               }
-            case traversal: Traversal[T, A] @unchecked => traversal.fold[Z](t)(acc, f)
+            case traversal: Traversal[T, A] @unchecked =>
+              traversal.fold[Z](t)(acc, f)
           }
       )
 
@@ -2846,7 +2976,7 @@ object Traversal {
           (_, t) =>
             inner.check(t) match {
               case Some(opticCheck) => errors ++= opticCheck.errors
-              case _                =>
+              case None             => ()
             }
         )
         errors.result() match {
@@ -2867,12 +2997,11 @@ object Traversal {
             case Some(modified) =>
               anyModified = true
               modified
-            case _ => t
+            case None => t
           }
         }
       )
-      if (anyModified) Some(result)
-      else None
+      if (anyModified) Some(result) else None
     }
 
     def modifyOrFail(s: S, f: A => A): Either[OpticCheck, S] = {
@@ -2895,10 +3024,10 @@ object Traversal {
         }
       )
       firstError match {
-        case Left(error) => new Left(error)
-        case _           =>
-          if (anyModified) new Right(result)
-          else new Left(new OpticCheck(new ::(OpticCheck.EmptySequence(toDynamic, toDynamic), Nil)))
+        case Left(error) => Left(error)
+        case Right(_)    =>
+          if (anyModified) Right(result)
+          else Left(new OpticCheck(new ::(OpticCheck.EmptySequence(toDynamic, toDynamic), Nil)))
       }
     }
 
@@ -2910,8 +3039,9 @@ object Traversal {
     override def hashCode: Int = search.hashCode ^ inner.hashCode
 
     override def equals(obj: Any): Boolean = obj match {
-      case other: ComposedSearchTraversal[?, ?, ?] => search == other.search && inner == other.inner
-      case _                                       => false
+      case other: ComposedSearchTraversal[?, ?, ?] =>
+        search == other.search && inner == other.inner
+      case _ => false
     }
 
     // Override apply methods to handle composition with this non-TraversalImpl traversal
@@ -2947,6 +3077,7 @@ object Traversal {
     prefix: Optic[S, T],
     inner: Traversal[T, A]
   ) extends Traversal[S, A] {
+
     def source: Reflect.Bound[S] = prefix.source
 
     def focus: Reflect.Bound[A] = inner.focus
@@ -2954,104 +3085,93 @@ object Traversal {
     def fold[Z](s: S)(zero: Z, f: (Z, A) => Z): Z =
       // Apply prefix to get T value(s), then apply inner traversal to each
       prefix match {
-        case lens: Lens[S, T] @unchecked   => inner.fold[Z](lens.get(s))(zero, f)
+        case lens: Lens[S, T] @unchecked =>
+          val t = lens.get(s)
+          inner.fold[Z](t)(zero, f)
         case prism: Prism[S, T] @unchecked =>
           prism.getOption(s) match {
             case Some(t) => inner.fold[Z](t)(zero, f)
-            case _       => zero
+            case None    => zero
           }
         case optional: Optional[S, T] @unchecked =>
           optional.getOption(s) match {
             case Some(t) => inner.fold[Z](t)(zero, f)
-            case _       => zero
+            case None    => zero
           }
-        case traversal: Traversal[S, T] @unchecked => traversal.fold[Z](s)(zero, (acc, t) => inner.fold[Z](t)(acc, f))
+        case traversal: Traversal[S, T] @unchecked =>
+          traversal.fold[Z](s)(zero, (acc, t) => inner.fold[Z](t)(acc, f))
       }
 
-    def check(s: S): Option[OpticCheck] = {
+    def check(s: S): Option[OpticCheck] =
       // First check prefix
-      val prefixErrorOpt = prefix.check(s)
-      if (prefixErrorOpt.isDefined) prefixErrorOpt
-      else {
-        // Then check inner traversal on all T values from prefix
-        prefix match {
-          case lens: Lens[S, T] @unchecked   => inner.check(lens.get(s))
-          case prism: Prism[S, T] @unchecked =>
-            prism.getOption(s) match {
-              case Some(t) => inner.check(t)
-              case _       => None
-            }
-          case optional: Optional[S, T] @unchecked =>
-            optional.getOption(s) match {
-              case Some(t) => inner.check(t)
-              case _       => None
-            }
-          case traversal: Traversal[S, T] @unchecked =>
-            val errors = List.newBuilder[OpticCheck.Single]
-            traversal.fold[Unit](s)(
-              (),
-              (_, t) =>
-                inner.check(t) match {
-                  case Some(opticCheck) => errors ++= opticCheck.errors
-                  case _                => ()
-                }
-            )
-            errors.result() match {
-              case Nil          => None
-              case head :: tail => new Some(new OpticCheck(new ::(head, tail)))
-            }
-        }
+      prefix.check(s) match {
+        case Some(prefixError) => Some(prefixError)
+        case None              =>
+          // Then check inner traversal on all T values from prefix
+          prefix match {
+            case lens: Lens[S, T] @unchecked =>
+              inner.check(lens.get(s))
+            case prism: Prism[S, T] @unchecked =>
+              prism.getOption(s).flatMap(inner.check)
+            case optional: Optional[S, T] @unchecked =>
+              optional.getOption(s).flatMap(inner.check)
+            case traversal: Traversal[S, T] @unchecked =>
+              val errors = List.newBuilder[OpticCheck.Single]
+              traversal.fold[Unit](s)(
+                (),
+                (_, t) =>
+                  inner.check(t) match {
+                    case Some(opticCheck) => errors ++= opticCheck.errors
+                    case None             => ()
+                  }
+              )
+              errors.result() match {
+                case Nil          => None
+                case head :: tail => Some(new OpticCheck(new ::(head, tail)))
+              }
+          }
       }
-    }
 
     def modify(s: S, f: A => A): S =
       prefix match {
-        case lens: Lens[S, T] @unchecked   => lens.replace(s, inner.modify(lens.get(s), f))
+        case lens: Lens[S, T] @unchecked =>
+          val t        = lens.get(s)
+          val modified = inner.modify(t, f)
+          lens.replace(s, modified)
         case prism: Prism[S, T] @unchecked =>
           prism.getOption(s) match {
             case Some(t) =>
-              prism.replaceOption(s, inner.modify(t, f)) match {
-                case Some(replaces) => replaces
-                case _              => s
-              }
-            case _ => s
+              val modified = inner.modify(t, f)
+              prism.replaceOption(s, modified).getOrElse(s)
+            case None => s
           }
         case optional: Optional[S, T] @unchecked =>
           optional.getOption(s) match {
             case Some(t) =>
-              optional.replaceOption(s, inner.modify(t, f)) match {
-                case Some(replaced) => replaced
-                case _              => s
-              }
-            case _ => s
+              val modified = inner.modify(t, f)
+              optional.replaceOption(s, modified).getOrElse(s)
+            case None => s
           }
-        case traversal: Traversal[S, T] @unchecked => traversal.modify(s, (t: T) => inner.modify(t, f))
+        case traversal: Traversal[S, T] @unchecked =>
+          traversal.modify(s, (t: T) => inner.modify(t, f))
       }
 
     def modifyOption(s: S, f: A => A): Option[S] =
       prefix match {
         case lens: Lens[S, T] @unchecked =>
-          inner.modifyOption(lens.get(s), f) match {
-            case Some(modified) => new Some(lens.replace(s, modified))
-            case _              => None
-          }
+          val t = lens.get(s)
+          inner.modifyOption(t, f).map(lens.replace(s, _))
         case prism: Prism[S, T] @unchecked =>
           prism.getOption(s) match {
             case Some(t) =>
-              inner.modifyOption(t, f) match {
-                case Some(modified) => prism.replaceOption(s, modified)
-                case _              => None
-              }
-            case _ => None
+              inner.modifyOption(t, f).flatMap(modified => prism.replaceOption(s, modified))
+            case None => None
           }
         case optional: Optional[S, T] @unchecked =>
           optional.getOption(s) match {
             case Some(t) =>
-              inner.modifyOption(t, f) match {
-                case Some(modified) => optional.replaceOption(s, modified)
-                case _              => None
-              }
-            case _ => None
+              inner.modifyOption(t, f).flatMap(modified => optional.replaceOption(s, modified))
+            case None => None
           }
         case traversal: Traversal[S, T] @unchecked =>
           var anyModified = false
@@ -3062,42 +3182,35 @@ object Traversal {
                 case Some(modified) =>
                   anyModified = true
                   modified
-                case _ => t
+                case None => t
               }
             }
           )
-          if (anyModified) new Some(result)
-          else None
+          if (anyModified) Some(result) else None
       }
 
     def modifyOrFail(s: S, f: A => A): Either[OpticCheck, S] =
       prefix match {
         case lens: Lens[S, T] @unchecked =>
-          inner.modifyOrFail(lens.get(s), f) match {
-            case Right(modified) => new Right(lens.replace(s, modified))
-            case l               => l.asInstanceOf[Either[OpticCheck, S]]
-          }
+          val t = lens.get(s)
+          inner.modifyOrFail(t, f).map(lens.replace(s, _))
         case prism: Prism[S, T] @unchecked =>
           prism.getOption(s) match {
             case Some(t) =>
-              inner.modifyOrFail(t, f) match {
-                case Right(modified) => prism.replaceOrFail(s, modified)
-                case l               => l.asInstanceOf[Either[OpticCheck, S]]
-              }
-            case _ => new Left(new OpticCheck(new ::(new OpticCheck.EmptySequence(toDynamic, toDynamic), Nil)))
+              inner.modifyOrFail(t, f).flatMap(modified => prism.replaceOrFail(s, modified))
+            case None =>
+              Left(new OpticCheck(new ::(OpticCheck.EmptySequence(toDynamic, toDynamic), Nil)))
           }
         case optional: Optional[S, T] @unchecked =>
           optional.getOption(s) match {
             case Some(t) =>
-              inner.modifyOrFail(t, f) match {
-                case Right(modified) => optional.replaceOrFail(s, modified)
-                case l               => l.asInstanceOf[Either[OpticCheck, S]]
-              }
-            case _ => new Left(new OpticCheck(new ::(new OpticCheck.EmptySequence(toDynamic, toDynamic), Nil)))
+              inner.modifyOrFail(t, f).flatMap(modified => optional.replaceOrFail(s, modified))
+            case None =>
+              Left(new OpticCheck(new ::(OpticCheck.EmptySequence(toDynamic, toDynamic), Nil)))
           }
         case traversal: Traversal[S, T] @unchecked =>
           var anyModified                          = false
-          var firstError: Either[OpticCheck, Unit] = new Right(())
+          var firstError: Either[OpticCheck, Unit] = Right(())
           val result                               = traversal.modify(
             s,
             (t: T) => {
@@ -3108,17 +3221,17 @@ object Traversal {
                     anyModified = true
                     modified
                   case Left(error) =>
-                    firstError = new Left(error)
+                    firstError = Left(error)
                     t
                 }
               }
             }
           )
           firstError match {
-            case Left(error) => new Left(error)
-            case _           =>
-              if (anyModified) new Right(result)
-              else new Left(new OpticCheck(new ::(new OpticCheck.EmptySequence(toDynamic, toDynamic), Nil)))
+            case Left(error) => Left(error)
+            case Right(_)    =>
+              if (anyModified) Right(result)
+              else Left(new OpticCheck(new ::(OpticCheck.EmptySequence(toDynamic, toDynamic), Nil)))
           }
       }
 
@@ -3129,8 +3242,9 @@ object Traversal {
     override def hashCode: Int = prefix.hashCode ^ inner.hashCode
 
     override def equals(obj: Any): Boolean = obj match {
-      case other: PrefixedSearchTraversal[?, ?, ?] => prefix == other.prefix && inner == other.inner
-      case _                                       => false
+      case other: PrefixedSearchTraversal[?, ?, ?] =>
+        prefix == other.prefix && inner == other.inner
+      case _ => false
     }
 
     // Override apply methods to handle composition with this non-TraversalImpl traversal

--- a/schema/shared/src/main/scala/zio/blocks/schema/OpticCheck.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/OpticCheck.scala
@@ -93,4 +93,10 @@ object OpticCheck {
     def message: String =
       s"During attempted access at ${full.toScalaString}, encountered an error at ${prefix.toScalaString}: ${error.message}"
   }
+
+  case class DynamicConversionError(error: String) extends Error {
+    def full: DynamicOptic   = DynamicOptic.root
+    def prefix: DynamicOptic = DynamicOptic.root
+    def message: String      = s"Dynamic value conversion error: $error"
+  }
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/PrimitiveType.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/PrimitiveType.scala
@@ -34,6 +34,35 @@ sealed trait PrimitiveType[A] {
   def validation: Validation[A]
 }
 
+/**
+ * Sub-trait of PrimitiveType for numeric types that support arithmetic
+ * operations. Provides access to the Scala Numeric type class for the
+ * underlying type.
+ *
+ * This trait is sealed within the PrimitiveType hierarchy - all implementations
+ * are the numeric case classes (Byte, Short, Int, Long, Float, Double, BigInt,
+ * BigDecimal).
+ */
+sealed trait NumericPrimitiveType[A] extends PrimitiveType[A] {
+  def numeric: Numeric[A]
+
+  /**
+   * Returns a Schema for this numeric primitive type.
+   */
+  def schema: Schema[A] = new Schema(
+    new Reflect.Primitive(
+      this,
+      typeId,
+      binding
+    )
+  )
+
+  /**
+   * Convert to NumericTypeTag for DynamicSchemaExpr.
+   */
+  def toTag: DynamicSchemaExpr.NumericTypeTag
+}
+
 object PrimitiveType {
   case object Unit extends PrimitiveType[scala.Unit] {
     def validation: Validation[scala.Unit] = Validation.None
@@ -68,10 +97,14 @@ object PrimitiveType {
       }
   }
 
-  case class Byte(validation: Validation[scala.Byte]) extends PrimitiveType[scala.Byte] {
+  case class Byte(validation: Validation[scala.Byte]) extends NumericPrimitiveType[scala.Byte] {
+    def numeric: Numeric[scala.Byte] = implicitly[Numeric[scala.Byte]]
+
     def toDynamicValue(value: scala.Byte): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Byte(value))
 
     def typeId: TypeId[scala.Byte] = TypeId.byte
+
+    def toTag: DynamicSchemaExpr.NumericTypeTag = DynamicSchemaExpr.NumericTypeTag.ByteTag
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -101,10 +134,14 @@ object PrimitiveType {
     }
   }
 
-  case class Short(validation: Validation[scala.Short]) extends PrimitiveType[scala.Short] {
+  case class Short(validation: Validation[scala.Short]) extends NumericPrimitiveType[scala.Short] {
+    def numeric: Numeric[scala.Short] = implicitly[Numeric[scala.Short]]
+
     def toDynamicValue(value: scala.Short): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Short(value))
 
     def typeId: TypeId[scala.Short] = TypeId.short
+
+    def toTag: DynamicSchemaExpr.NumericTypeTag = DynamicSchemaExpr.NumericTypeTag.ShortTag
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -134,10 +171,14 @@ object PrimitiveType {
     }
   }
 
-  case class Int(validation: Validation[scala.Int]) extends PrimitiveType[scala.Int] {
+  case class Int(validation: Validation[scala.Int]) extends NumericPrimitiveType[scala.Int] {
+    def numeric: Numeric[scala.Int] = implicitly[Numeric[scala.Int]]
+
     def toDynamicValue(value: scala.Int): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Int(value))
 
     def typeId: TypeId[scala.Int] = TypeId.int
+
+    def toTag: DynamicSchemaExpr.NumericTypeTag = DynamicSchemaExpr.NumericTypeTag.IntTag
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -167,10 +208,14 @@ object PrimitiveType {
     }
   }
 
-  case class Long(validation: Validation[scala.Long]) extends PrimitiveType[scala.Long] {
+  case class Long(validation: Validation[scala.Long]) extends NumericPrimitiveType[scala.Long] {
+    def numeric: Numeric[scala.Long] = implicitly[Numeric[scala.Long]]
+
     def toDynamicValue(value: scala.Long): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Long(value))
 
     def typeId: TypeId[scala.Long] = TypeId.long
+
+    def toTag: DynamicSchemaExpr.NumericTypeTag = DynamicSchemaExpr.NumericTypeTag.LongTag
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -200,10 +245,14 @@ object PrimitiveType {
     }
   }
 
-  case class Float(validation: Validation[scala.Float]) extends PrimitiveType[scala.Float] {
+  case class Float(validation: Validation[scala.Float]) extends NumericPrimitiveType[scala.Float] {
+    def numeric: Numeric[scala.Float] = implicitly[Numeric[scala.Float]]
+
     def toDynamicValue(value: scala.Float): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Float(value))
 
     def typeId: TypeId[scala.Float] = TypeId.float
+
+    def toTag: DynamicSchemaExpr.NumericTypeTag = DynamicSchemaExpr.NumericTypeTag.FloatTag
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -233,10 +282,14 @@ object PrimitiveType {
     }
   }
 
-  case class Double(validation: Validation[scala.Double]) extends PrimitiveType[scala.Double] {
+  case class Double(validation: Validation[scala.Double]) extends NumericPrimitiveType[scala.Double] {
+    def numeric: Numeric[scala.Double] = implicitly[Numeric[scala.Double]]
+
     def toDynamicValue(value: scala.Double): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Double(value))
 
     def typeId: TypeId[scala.Double] = TypeId.double
+
+    def toTag: DynamicSchemaExpr.NumericTypeTag = DynamicSchemaExpr.NumericTypeTag.DoubleTag
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -315,10 +368,14 @@ object PrimitiveType {
       }
   }
 
-  case class BigInt(validation: Validation[scala.BigInt]) extends PrimitiveType[scala.BigInt] {
+  case class BigInt(validation: Validation[scala.BigInt]) extends NumericPrimitiveType[scala.BigInt] {
+    def numeric: Numeric[scala.BigInt] = implicitly[Numeric[scala.BigInt]]
+
     def toDynamicValue(value: scala.BigInt): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.BigInt(value))
 
     def typeId: TypeId[scala.BigInt] = TypeId.bigInt
+
+    def toTag: DynamicSchemaExpr.NumericTypeTag = DynamicSchemaExpr.NumericTypeTag.BigIntTag
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,
@@ -354,11 +411,15 @@ object PrimitiveType {
     }
   }
 
-  case class BigDecimal(validation: Validation[scala.BigDecimal]) extends PrimitiveType[scala.BigDecimal] {
+  case class BigDecimal(validation: Validation[scala.BigDecimal]) extends NumericPrimitiveType[scala.BigDecimal] {
+    def numeric: Numeric[scala.BigDecimal] = implicitly[Numeric[scala.BigDecimal]]
+
     def toDynamicValue(value: scala.BigDecimal): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.BigDecimal(value))
 
     def typeId: TypeId[scala.BigDecimal] = TypeId.bigDecimal
+
+    def toTag: DynamicSchemaExpr.NumericTypeTag = DynamicSchemaExpr.NumericTypeTag.BigDecimalTag
 
     private[schema] def fromDynamicValue(
       value: DynamicValue,

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaError.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaError.scala
@@ -200,23 +200,23 @@ object SchemaError {
   case class MigrationError(source: DynamicOptic, kind: MigrationErrorKind) extends Single {
     override def message: String = kind match {
       case MigrationErrorKind.PathNotFound =>
-        s"Path not found: $source"
+        s"Path not found: ${source.toScalaString}"
       case MigrationErrorKind.TypeMismatch(expected, actual) =>
-        s"Type mismatch at $source: expected $expected, got $actual"
+        s"Type mismatch at ${source.toScalaString}: expected $expected, got $actual"
       case MigrationErrorKind.MissingDefault(fieldName) =>
-        s"Missing default value for field '$fieldName' at $source"
+        s"Missing default value for field '$fieldName' at ${source.toScalaString}"
       case MigrationErrorKind.TransformFailed(reason) =>
-        s"Transform failed at $source: $reason"
+        s"Transform failed at ${source.toScalaString}: $reason"
       case MigrationErrorKind.FieldNotFound(fieldName) =>
-        s"Field '$fieldName' not found at $source"
+        s"Field '$fieldName' not found at ${source.toScalaString}"
       case MigrationErrorKind.FieldAlreadyExists(fieldName) =>
-        s"Field '$fieldName' already exists at $source"
+        s"Field '$fieldName' already exists at ${source.toScalaString}"
       case MigrationErrorKind.CaseNotFound(caseName) =>
-        s"Case '$caseName' not found at $source"
+        s"Case '$caseName' not found at ${source.toScalaString}"
       case MigrationErrorKind.InvalidValue(reason) =>
-        s"Invalid value at $source: $reason"
+        s"Invalid value at ${source.toScalaString}: $reason"
       case MigrationErrorKind.MandateFailed(reason) =>
-        s"Mandate failed at $source: $reason"
+        s"Mandate failed at ${source.toScalaString}: $reason"
     }
   }
 

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaError.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaError.scala
@@ -16,7 +16,7 @@
 
 package zio.blocks.schema
 
-import zio.blocks.chunk.Chunk
+import scala.collection.immutable.ArraySeq
 import scala.util.control.NoStackTrace
 
 final case class SchemaError(errors: ::[SchemaError.Single]) extends Exception with NoStackTrace {
@@ -108,12 +108,13 @@ object SchemaError {
     case e: ExpectationMismatch => e.copy(source = f(e.source))
     case e: UnknownCase         => e.copy(source = f(e.source))
     case e: Message             => e.copy(source = f(e.source))
+    case e: MigrationError      => e.copy(source = f(e.source))
   }
 
   private[this] def toDynamicOptic(trace: List[DynamicOptic.Node]): DynamicOptic = {
     val nodes = trace.toArray
     reverse(nodes)
-    new DynamicOptic(Chunk.fromArray(nodes))
+    new DynamicOptic(ArraySeq.unsafeWrapArray(nodes))
   }
 
   private[this] def reverse(nodes: Array[DynamicOptic.Node]): Unit =
@@ -192,4 +193,78 @@ object SchemaError {
       if (source.nodes.isEmpty) details
       else s"$details at: ${source.toString}"
   }
+
+  /**
+   * Migration-specific errors. These occur during schema migration operations.
+   */
+  case class MigrationError(source: DynamicOptic, kind: MigrationErrorKind) extends Single {
+    override def message: String = kind match {
+      case MigrationErrorKind.PathNotFound =>
+        s"Path not found: $source"
+      case MigrationErrorKind.TypeMismatch(expected, actual) =>
+        s"Type mismatch at $source: expected $expected, got $actual"
+      case MigrationErrorKind.MissingDefault(fieldName) =>
+        s"Missing default value for field '$fieldName' at $source"
+      case MigrationErrorKind.TransformFailed(reason) =>
+        s"Transform failed at $source: $reason"
+      case MigrationErrorKind.FieldNotFound(fieldName) =>
+        s"Field '$fieldName' not found at $source"
+      case MigrationErrorKind.FieldAlreadyExists(fieldName) =>
+        s"Field '$fieldName' already exists at $source"
+      case MigrationErrorKind.CaseNotFound(caseName) =>
+        s"Case '$caseName' not found at $source"
+      case MigrationErrorKind.InvalidValue(reason) =>
+        s"Invalid value at $source: $reason"
+      case MigrationErrorKind.MandateFailed(reason) =>
+        s"Mandate failed at $source: $reason"
+    }
+  }
+
+  /**
+   * Sum type for different kinds of migration errors.
+   */
+  sealed trait MigrationErrorKind
+
+  object MigrationErrorKind {
+    case object PathNotFound                                  extends MigrationErrorKind
+    case class TypeMismatch(expected: String, actual: String) extends MigrationErrorKind
+    case class MissingDefault(fieldName: String)              extends MigrationErrorKind
+    case class TransformFailed(reason: String)                extends MigrationErrorKind
+    case class FieldNotFound(fieldName: String)               extends MigrationErrorKind
+    case class FieldAlreadyExists(fieldName: String)          extends MigrationErrorKind
+    case class CaseNotFound(caseName: String)                 extends MigrationErrorKind
+    case class InvalidValue(reason: String)                   extends MigrationErrorKind
+    case class MandateFailed(reason: String)                  extends MigrationErrorKind
+  }
+
+  // Helper methods for creating migration errors
+  def migrationError(path: DynamicOptic, kind: MigrationErrorKind): SchemaError =
+    new SchemaError(new ::(MigrationError(path, kind), Nil))
+
+  def pathNotFound(path: DynamicOptic): SchemaError =
+    migrationError(path, MigrationErrorKind.PathNotFound)
+
+  def typeMismatch(path: DynamicOptic, expected: String, actual: String): SchemaError =
+    migrationError(path, MigrationErrorKind.TypeMismatch(expected, actual))
+
+  def missingDefault(path: DynamicOptic, fieldName: String): SchemaError =
+    migrationError(path, MigrationErrorKind.MissingDefault(fieldName))
+
+  def transformFailed(path: DynamicOptic, reason: String): SchemaError =
+    migrationError(path, MigrationErrorKind.TransformFailed(reason))
+
+  def fieldNotFound(path: DynamicOptic, fieldName: String): SchemaError =
+    migrationError(path, MigrationErrorKind.FieldNotFound(fieldName))
+
+  def fieldAlreadyExists(path: DynamicOptic, fieldName: String): SchemaError =
+    migrationError(path, MigrationErrorKind.FieldAlreadyExists(fieldName))
+
+  def caseNotFound(path: DynamicOptic, caseName: String): SchemaError =
+    migrationError(path, MigrationErrorKind.CaseNotFound(caseName))
+
+  def invalidValue(path: DynamicOptic, reason: String): SchemaError =
+    migrationError(path, MigrationErrorKind.InvalidValue(reason))
+
+  def mandateFailed(path: DynamicOptic, reason: String): SchemaError =
+    migrationError(path, MigrationErrorKind.MandateFailed(reason))
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
@@ -16,160 +16,358 @@
 
 package zio.blocks.schema
 
-import zio.blocks.chunk.Chunk
-
 /**
- * A {{SchemaExpr}} is an expression on the value of a type fully described by a
- * {{Schema}}.
+ * A typed wrapper around DynamicSchemaExpr that provides compile-time type
+ * safety.
  *
- * {{SchemaExpr}} are used for persistence DSLs, implemented in third-party
- * libraries, as well as for validation, implemented in this library. In
- * addition, {{SchemaExpr}} could be used for data migration.
+ * @tparam A
+ *   The input type
+ * @tparam B
+ *   The output type
+ * @param dynamic
+ *   The underlying serializable expression
+ * @param inputSchema
+ *   Schema for converting A to DynamicValue
+ * @param outputSchema
+ *   Schema for converting DynamicValue back to B
  */
-sealed trait SchemaExpr[A, +B] { self =>
+final case class SchemaExpr[A, B](
+  dynamic: DynamicSchemaExpr,
+  inputSchema: Schema[A],
+  outputSchema: Schema[B]
+) {
 
   /**
-   * Evaluate the expression on the input value.
-   *
-   * @param input
-   *   the input value
-   *
-   * @return
-   *   the result of the expression
+   * Evaluate the expression on a typed input.
    */
-  def eval(input: A): Either[OpticCheck, Seq[B]]
-
-  /**
-   * Evaluate the expression on the input value.
-   *
-   * @param input
-   *   the input value
-   *
-   * @return
-   *   the result of the expression, converted to {{DynamicValue}} values.
-   */
-  def evalDynamic(input: A): Either[OpticCheck, Seq[DynamicValue]]
-
-  final def &&[B2](that: SchemaExpr[A, B2])(implicit ev: B <:< Boolean, ev2: B2 =:= Boolean): SchemaExpr[A, Boolean] =
-    new SchemaExpr.Logical(self.asEquivalent[Boolean], that.asEquivalent[Boolean], SchemaExpr.LogicalOperator.And)
-
-  final def ||[B2](that: SchemaExpr[A, B2])(implicit ev: B <:< Boolean, ev2: B2 =:= Boolean): SchemaExpr[A, Boolean] =
-    new SchemaExpr.Logical(self.asEquivalent[Boolean], that.asEquivalent[Boolean], SchemaExpr.LogicalOperator.Or)
-
-  private final def asEquivalent[B2](implicit ev: B <:< B2): SchemaExpr[A, B2] = {
-    val _ = ev // suppress unused warning
-    self.asInstanceOf[SchemaExpr[A, B2]]
+  def eval[B1 >: B](input: A)(implicit schema: Schema[B1]): Either[OpticCheck, Seq[B1]] = {
+    val dynamicInput = inputSchema.toDynamicValue(input)
+    dynamic.eval(dynamicInput) match {
+      case Right(results) =>
+        val converted = results.map(dv => schema.fromDynamicValue(dv))
+        val errors    = converted.collect { case Left(e) => e }
+        if (errors.nonEmpty) {
+          val errList = errors.map(e => OpticCheck.DynamicConversionError(e.message))
+          Left(new OpticCheck(new ::(errList.head, errList.tail.toList)))
+        } else {
+          Right(converted.collect { case Right(v) => v })
+        }
+      case Left(error) =>
+        Left(schemaErrorToOpticCheck(error, input, dynamic))
+    }
   }
+
+  /**
+   * Evaluate the expression and return DynamicValue results.
+   */
+  def evalDynamic(input: A): Either[OpticCheck, Seq[DynamicValue]] = {
+    val dynamicInput = inputSchema.toDynamicValue(input)
+    dynamic.eval(dynamicInput).left.map(e => schemaErrorToOpticCheck(e, input, dynamic))
+  }
+
+  private def schemaErrorToOpticCheck(error: SchemaError, input: A, expr: DynamicSchemaExpr): OpticCheck = {
+    val opticError = error.errors.head match {
+      case SchemaError.Message(source, details) if details.startsWith("UnexpectedCase:") =>
+        val expectedCase = details.stripPrefix("UnexpectedCase: expected ").takeWhile(_ != ',')
+        val actualCase   = details.dropWhile(_ != ',').stripPrefix(", got ")
+        val fullPath     = extractFullPath(expr).getOrElse(source)
+        OpticCheck.UnexpectedCase(expectedCase, actualCase, fullPath, source, input)
+
+      case SchemaError.Message(source, "EmptySequence") =>
+        val fullPath = extractFullPath(expr).getOrElse(source)
+        OpticCheck.EmptySequence(fullPath, source)
+
+      case SchemaError.Message(source, details) if details.startsWith("SequenceIndexOutOfBounds:") =>
+        val parts    = details.stripPrefix("SequenceIndexOutOfBounds: ").split(", ")
+        val index    = parts(0).stripPrefix("index ").toInt
+        val size     = parts(1).stripPrefix("size ").toInt
+        val fullPath = extractFullPath(expr).getOrElse(source)
+        OpticCheck.SequenceIndexOutOfBounds(fullPath, source, index, size)
+
+      case SchemaError.Message(source, details) if details.startsWith("MissingKey:") =>
+        val fullPath = extractFullPath(expr).getOrElse(source)
+        val keyStr   = details.stripPrefix("MissingKey:")
+        OpticCheck.MissingKey(fullPath, source, keyStr)
+
+      case SchemaError.Message(source, "EmptyMap") =>
+        val fullPath = extractFullPath(expr).getOrElse(source)
+        OpticCheck.EmptyMap(fullPath, source)
+
+      case _ =>
+        OpticCheck.DynamicConversionError(error.message)
+    }
+    new OpticCheck(new ::(opticError, Nil))
+  }
+
+  private def extractFullPath(expr: DynamicSchemaExpr): Option[DynamicOptic] = expr match {
+    case DynamicSchemaExpr.Select(path)                  => Some(path)
+    case DynamicSchemaExpr.Relational(left, _, _)        => extractFullPath(left)
+    case DynamicSchemaExpr.Logical(left, _, _)           => extractFullPath(left)
+    case DynamicSchemaExpr.Not(e)                        => extractFullPath(e)
+    case DynamicSchemaExpr.Arithmetic(left, _, _, _)     => extractFullPath(left)
+    case DynamicSchemaExpr.Bitwise(left, _, _)           => extractFullPath(left)
+    case DynamicSchemaExpr.BitwiseNot(e)                 => extractFullPath(e)
+    case DynamicSchemaExpr.StringConcat(left, _)         => extractFullPath(left)
+    case DynamicSchemaExpr.StringRegexMatch(_, string)   => extractFullPath(string)
+    case DynamicSchemaExpr.StringLength(string)          => extractFullPath(string)
+    case DynamicSchemaExpr.StringSubstring(string, _, _) => extractFullPath(string)
+    case DynamicSchemaExpr.StringTrim(string)            => extractFullPath(string)
+    case DynamicSchemaExpr.StringToUpperCase(string)     => extractFullPath(string)
+    case DynamicSchemaExpr.StringToLowerCase(string)     => extractFullPath(string)
+    case DynamicSchemaExpr.StringReplace(string, _, _)   => extractFullPath(string)
+    case DynamicSchemaExpr.StringStartsWith(string, _)   => extractFullPath(string)
+    case DynamicSchemaExpr.StringEndsWith(string, _)     => extractFullPath(string)
+    case DynamicSchemaExpr.StringContains(string, _)     => extractFullPath(string)
+    case DynamicSchemaExpr.StringIndexOf(string, _)      => extractFullPath(string)
+    case _                                               => None
+  }
+
+  /**
+   * Get the underlying dynamic expression.
+   */
+  def toDynamic: DynamicSchemaExpr = dynamic
+
+  // Logical combinators
+  def &&[B2](
+    that: SchemaExpr[A, B2]
+  )(implicit ev: B <:< Boolean, ev2: B2 =:= Boolean): SchemaExpr[A, Boolean] =
+    SchemaExpr(
+      DynamicSchemaExpr.Logical(this.dynamic, that.dynamic, DynamicSchemaExpr.LogicalOperator.And),
+      inputSchema,
+      Schema[Boolean]
+    )
+
+  def ||[B2](
+    that: SchemaExpr[A, B2]
+  )(implicit ev: B <:< Boolean, ev2: B2 =:= Boolean): SchemaExpr[A, Boolean] =
+    SchemaExpr(
+      DynamicSchemaExpr.Logical(this.dynamic, that.dynamic, DynamicSchemaExpr.LogicalOperator.Or),
+      inputSchema,
+      Schema[Boolean]
+    )
 }
 
 object SchemaExpr {
-  final case class Literal[S, A](value: A, schema: Schema[A]) extends SchemaExpr[S, A] {
-    def eval(input: S): Either[OpticCheck, Seq[A]] = result
 
-    def evalDynamic(input: S): Either[OpticCheck, Seq[DynamicValue]] = dynamicResult
-
-    private[this] val result        = new Right(Chunk.single(value))
-    private[this] val dynamicResult = new Right(Chunk.single(schema.toDynamicValue(value)))
-  }
-
-  final case class Optic[A, B](optic: zio.blocks.schema.Optic[A, B]) extends SchemaExpr[A, B] {
-    def eval(input: A): Either[OpticCheck, Seq[B]] = optic match {
-      case l: Lens[?, ?] =>
-        new Right(Chunk.single(l.get(input)))
-      case p: Prism[?, ?] =>
-        p.getOrFail(input) match {
-          case Right(x: B @scala.unchecked) => new Right(Chunk.single(x))
-          case left                         => left.asInstanceOf[Either[OpticCheck, Seq[B]]]
-        }
-      case o: Optional[?, ?] =>
-        o.getOrFail(input) match {
-          case Right(x) => new Right(Chunk.single(x))
-          case left     => left.asInstanceOf[Either[OpticCheck, Seq[B]]]
-        }
-      case t: Traversal[?, ?] =>
-        val sb = Seq.newBuilder[B]
-        t.fold[Unit](input)((), (_, a) => sb.addOne(a))
-        val r = sb.result()
-        if (r.isEmpty) new Left(t.check(input).get)
-        else new Right(r)
+  /**
+   * Create a Literal expression from the schema's default value. Gets the
+   * default value from the schema and wraps it in a Literal. Returns None if
+   * the schema has no default value.
+   */
+  def schemaDefault[A](implicit schema: Schema[A]): Option[SchemaExpr[Any, A]] =
+    schema.getDefaultValue.map { defaultValue =>
+      val dynValue = schema.toDynamicValue(defaultValue)
+      SchemaExpr(
+        DynamicSchemaExpr.Literal(dynValue),
+        schema.asInstanceOf[Schema[Any]],
+        schema
+      )
     }
 
-    def evalDynamic(input: A): Either[OpticCheck, Seq[DynamicValue]] = optic match {
-      case l: Lens[?, ?] =>
-        new Right(Chunk.single(toDynamicValue(l.get(input))))
-      case p: Prism[?, ?] =>
-        p.getOrFail(input) match {
-          case Right(x: B @scala.unchecked) => new Right(Chunk.single(toDynamicValue(x)))
-          case left                         => left.asInstanceOf[Either[OpticCheck, Seq[DynamicValue]]]
-        }
-      case o: Optional[?, ?] =>
-        o.getOrFail(input) match {
-          case Right(x) => new Right(Chunk.single(toDynamicValue(x)))
-          case left     => left.asInstanceOf[Either[OpticCheck, Seq[DynamicValue]]]
-        }
-      case t: Traversal[?, ?] =>
-        val sb = Seq.newBuilder[DynamicValue]
-        t.fold[Unit](input)((), (_, a) => sb.addOne(toDynamicValue(a)))
-        val r = sb.result()
-        if (r.isEmpty) new Left(t.check(input).get)
-        else new Right(r)
+  def literal[S, A](value: A)(implicit schema: Schema[A]): SchemaExpr[S, A] =
+    SchemaExpr(
+      DynamicSchemaExpr.Literal(schema.toDynamicValue(value)),
+      Schema[Unit].transform[S](_ => null.asInstanceOf[S], _ => ()),
+      schema
+    )
+
+  def optic[S, A](path: DynamicOptic, sourceSchema: Schema[S]): SchemaExpr[S, A] =
+    SchemaExpr(
+      DynamicSchemaExpr.Select(path),
+      sourceSchema,
+      Schema[Unit].asInstanceOf[Schema[A]]
+    )
+
+  def logical[S](
+    left: SchemaExpr[S, Boolean],
+    right: SchemaExpr[S, Boolean],
+    operator: LogicalOperator
+  ): SchemaExpr[S, Boolean] = {
+    val dynOp = operator match {
+      case LogicalOperator.And => DynamicSchemaExpr.LogicalOperator.And
+      case LogicalOperator.Or  => DynamicSchemaExpr.LogicalOperator.Or
     }
-
-    private[this] val toDynamicValue: B => DynamicValue = optic.focus.toDynamicValue
+    SchemaExpr(
+      DynamicSchemaExpr.Logical(left.dynamic, right.dynamic, dynOp),
+      left.inputSchema,
+      Schema[Boolean]
+    )
   }
 
-  sealed trait UnaryOp[A, +B] extends SchemaExpr[A, B] {
-    def expr: SchemaExpr[A, B]
+  def relational[S, A](
+    left: SchemaExpr[S, A],
+    right: SchemaExpr[S, A],
+    operator: RelationalOperator
+  ): SchemaExpr[S, Boolean] = {
+    val dynOp = operator match {
+      case RelationalOperator.LessThan           => DynamicSchemaExpr.RelationalOperator.LessThan
+      case RelationalOperator.LessThanOrEqual    => DynamicSchemaExpr.RelationalOperator.LessThanOrEqual
+      case RelationalOperator.GreaterThan        => DynamicSchemaExpr.RelationalOperator.GreaterThan
+      case RelationalOperator.GreaterThanOrEqual => DynamicSchemaExpr.RelationalOperator.GreaterThanOrEqual
+      case RelationalOperator.Equal              => DynamicSchemaExpr.RelationalOperator.Equal
+      case RelationalOperator.NotEqual           => DynamicSchemaExpr.RelationalOperator.NotEqual
+    }
+    SchemaExpr(
+      DynamicSchemaExpr.Relational(left.dynamic, right.dynamic, dynOp),
+      left.inputSchema,
+      Schema[Boolean]
+    )
   }
 
-  sealed trait BinaryOp[A, +B, +C] extends SchemaExpr[A, C] {
-    def left: SchemaExpr[A, B]
+  def not[S](expr: SchemaExpr[S, Boolean]): SchemaExpr[S, Boolean] =
+    SchemaExpr(
+      DynamicSchemaExpr.Not(expr.dynamic),
+      expr.inputSchema,
+      Schema[Boolean]
+    )
 
-    def right: SchemaExpr[A, B]
+  def arithmetic[S, A](
+    left: SchemaExpr[S, A],
+    right: SchemaExpr[S, A],
+    operator: ArithmeticOperator,
+    numericType: NumericPrimitiveType[A]
+  ): SchemaExpr[S, A] = {
+    val dynOp = operator match {
+      case ArithmeticOperator.Add      => DynamicSchemaExpr.ArithmeticOperator.Add
+      case ArithmeticOperator.Subtract => DynamicSchemaExpr.ArithmeticOperator.Subtract
+      case ArithmeticOperator.Multiply => DynamicSchemaExpr.ArithmeticOperator.Multiply
+      case ArithmeticOperator.Divide   => DynamicSchemaExpr.ArithmeticOperator.Divide
+      case ArithmeticOperator.Pow      => DynamicSchemaExpr.ArithmeticOperator.Pow
+      case ArithmeticOperator.Modulo   => DynamicSchemaExpr.ArithmeticOperator.Modulo
+    }
+    SchemaExpr(
+      DynamicSchemaExpr.Arithmetic(left.dynamic, right.dynamic, dynOp, numericType.toTag),
+      left.inputSchema,
+      numericType.schema
+    )
   }
 
-  final case class Relational[A, B](left: SchemaExpr[A, B], right: SchemaExpr[A, B], operator: RelationalOperator)
-      extends BinaryOp[A, B, Boolean] {
-    def eval(input: A): Either[OpticCheck, Seq[Boolean]] =
-      if ((operator eq RelationalOperator.Equal) || (operator eq RelationalOperator.NotEqual)) {
-        for {
-          xs <- left.eval(input)
-          ys <- right.eval(input)
-        } yield {
-          if (operator eq RelationalOperator.Equal) for { x <- xs; y <- ys } yield x == y
-          else for { x <- xs; y <- ys } yield x != y
-        }
-      } else { // FIXME: Use Ordering to avoid converisons to dynamic values
-        for {
-          xs <- left.evalDynamic(input)
-          ys <- right.evalDynamic(input)
-        } yield {
-          if (operator eq RelationalOperator.LessThan) for { x <- xs; y <- ys } yield x < y
-          else if (operator eq RelationalOperator.LessThanOrEqual) for { x <- xs; y <- ys } yield x <= y
-          else if (operator eq RelationalOperator.GreaterThan) for { x <- xs; y <- ys } yield x > y
-          else for { x <- xs; y <- ys } yield x >= y
-        }
-      }
+  def bitwise[S, A](
+    left: SchemaExpr[S, A],
+    right: SchemaExpr[S, A],
+    operator: BitwiseOperator
+  ): SchemaExpr[S, A] = {
+    val dynOp = operator match {
+      case BitwiseOperator.And                => DynamicSchemaExpr.BitwiseOperator.And
+      case BitwiseOperator.Or                 => DynamicSchemaExpr.BitwiseOperator.Or
+      case BitwiseOperator.Xor                => DynamicSchemaExpr.BitwiseOperator.Xor
+      case BitwiseOperator.LeftShift          => DynamicSchemaExpr.BitwiseOperator.LeftShift
+      case BitwiseOperator.RightShift         => DynamicSchemaExpr.BitwiseOperator.RightShift
+      case BitwiseOperator.UnsignedRightShift => DynamicSchemaExpr.BitwiseOperator.UnsignedRightShift
+    }
+    SchemaExpr(
+      DynamicSchemaExpr.Bitwise(left.dynamic, right.dynamic, dynOp),
+      left.inputSchema,
+      left.outputSchema
+    )
+  }
 
-    def evalDynamic(input: A): Either[OpticCheck, Seq[DynamicValue]] =
-      for {
-        xs <- left.evalDynamic(input)
-        ys <- right.evalDynamic(input)
-      } yield operator match {
-        case _: RelationalOperator.LessThan.type           => for { x <- xs; y <- ys } yield toDynamicValue(x < y)
-        case _: RelationalOperator.LessThanOrEqual.type    => for { x <- xs; y <- ys } yield toDynamicValue(x <= y)
-        case _: RelationalOperator.GreaterThan.type        => for { x <- xs; y <- ys } yield toDynamicValue(x > y)
-        case _: RelationalOperator.GreaterThanOrEqual.type => for { x <- xs; y <- ys } yield toDynamicValue(x >= y)
-        case _: RelationalOperator.Equal.type              => for { x <- xs; y <- ys } yield toDynamicValue(x == y)
-        case _: RelationalOperator.NotEqual.type           => for { x <- xs; y <- ys } yield toDynamicValue(x != y)
-      }
+  def bitwiseNot[S, A](expr: SchemaExpr[S, A]): SchemaExpr[S, A] =
+    SchemaExpr(
+      DynamicSchemaExpr.BitwiseNot(expr.dynamic),
+      expr.inputSchema,
+      expr.outputSchema
+    )
 
-    private[this] def toDynamicValue(value: Boolean): DynamicValue =
-      new DynamicValue.Primitive(new PrimitiveValue.Boolean(value))
+  def stringConcat[S](left: SchemaExpr[S, String], right: SchemaExpr[S, String]): SchemaExpr[S, String] =
+    SchemaExpr(
+      DynamicSchemaExpr.StringConcat(left.dynamic, right.dynamic),
+      left.inputSchema,
+      Schema[String]
+    )
+
+  def stringRegexMatch[S](regex: SchemaExpr[S, String], string: SchemaExpr[S, String]): SchemaExpr[S, Boolean] =
+    SchemaExpr(
+      DynamicSchemaExpr.StringRegexMatch(regex.dynamic, string.dynamic),
+      string.inputSchema,
+      Schema[Boolean]
+    )
+
+  def stringLength[S](string: SchemaExpr[S, String]): SchemaExpr[S, Int] =
+    SchemaExpr(
+      DynamicSchemaExpr.StringLength(string.dynamic),
+      string.inputSchema,
+      Schema[Int]
+    )
+
+  def stringSubstring[S](
+    string: SchemaExpr[S, String],
+    start: SchemaExpr[S, Int],
+    end: SchemaExpr[S, Int]
+  ): SchemaExpr[S, String] =
+    SchemaExpr(
+      DynamicSchemaExpr.StringSubstring(string.dynamic, start.dynamic, end.dynamic),
+      string.inputSchema,
+      Schema[String]
+    )
+
+  def stringTrim[S](string: SchemaExpr[S, String]): SchemaExpr[S, String] =
+    SchemaExpr(
+      DynamicSchemaExpr.StringTrim(string.dynamic),
+      string.inputSchema,
+      Schema[String]
+    )
+
+  def stringToUpperCase[S](string: SchemaExpr[S, String]): SchemaExpr[S, String] =
+    SchemaExpr(
+      DynamicSchemaExpr.StringToUpperCase(string.dynamic),
+      string.inputSchema,
+      Schema[String]
+    )
+
+  def stringToLowerCase[S](string: SchemaExpr[S, String]): SchemaExpr[S, String] =
+    SchemaExpr(
+      DynamicSchemaExpr.StringToLowerCase(string.dynamic),
+      string.inputSchema,
+      Schema[String]
+    )
+
+  def stringReplace[S](
+    string: SchemaExpr[S, String],
+    target: SchemaExpr[S, String],
+    replacement: SchemaExpr[S, String]
+  ): SchemaExpr[S, String] =
+    SchemaExpr(
+      DynamicSchemaExpr.StringReplace(string.dynamic, target.dynamic, replacement.dynamic),
+      string.inputSchema,
+      Schema[String]
+    )
+
+  def stringStartsWith[S](string: SchemaExpr[S, String], prefix: SchemaExpr[S, String]): SchemaExpr[S, Boolean] =
+    SchemaExpr(
+      DynamicSchemaExpr.StringStartsWith(string.dynamic, prefix.dynamic),
+      string.inputSchema,
+      Schema[Boolean]
+    )
+
+  def stringEndsWith[S](string: SchemaExpr[S, String], suffix: SchemaExpr[S, String]): SchemaExpr[S, Boolean] =
+    SchemaExpr(
+      DynamicSchemaExpr.StringEndsWith(string.dynamic, suffix.dynamic),
+      string.inputSchema,
+      Schema[Boolean]
+    )
+
+  def stringContains[S](string: SchemaExpr[S, String], substring: SchemaExpr[S, String]): SchemaExpr[S, Boolean] =
+    SchemaExpr(
+      DynamicSchemaExpr.StringContains(string.dynamic, substring.dynamic),
+      string.inputSchema,
+      Schema[Boolean]
+    )
+
+  def stringIndexOf[S](string: SchemaExpr[S, String], substring: SchemaExpr[S, String]): SchemaExpr[S, Int] =
+    SchemaExpr(
+      DynamicSchemaExpr.StringIndexOf(string.dynamic, substring.dynamic),
+      string.inputSchema,
+      Schema[Int]
+    )
+
+  sealed trait LogicalOperator
+  object LogicalOperator {
+    case object And extends LogicalOperator
+    case object Or  extends LogicalOperator
   }
 
   sealed trait RelationalOperator
-
   object RelationalOperator {
     case object LessThan           extends RelationalOperator
     case object GreaterThan        extends RelationalOperator
@@ -179,143 +377,394 @@ object SchemaExpr {
     case object NotEqual           extends RelationalOperator
   }
 
-  final case class Logical[A](left: SchemaExpr[A, Boolean], right: SchemaExpr[A, Boolean], operator: LogicalOperator)
-      extends BinaryOp[A, Boolean, Boolean] {
-    def eval(input: A): Either[OpticCheck, Seq[Boolean]] =
-      for {
-        xs <- left.eval(input)
-        ys <- right.eval(input)
-      } yield operator match {
-        case _: LogicalOperator.And.type => for { x <- xs; y <- ys } yield x && y
-        case _: LogicalOperator.Or.type  => for { x <- xs; y <- ys } yield x || y
-      }
-
-    def evalDynamic(input: A): Either[OpticCheck, Seq[DynamicValue]] =
-      for {
-        xs <- left.eval(input)
-        ys <- right.eval(input)
-      } yield operator match {
-        case _: LogicalOperator.And.type => for { x <- xs; y <- ys } yield toDynamicValue(x && y)
-        case _: LogicalOperator.Or.type  => for { x <- xs; y <- ys } yield toDynamicValue(x || y)
-      }
-
-    private[this] def toDynamicValue(value: Boolean): DynamicValue =
-      new DynamicValue.Primitive(new PrimitiveValue.Boolean(value))
-  }
-
-  sealed trait LogicalOperator
-
-  object LogicalOperator {
-    case object And extends LogicalOperator
-    case object Or  extends LogicalOperator
-  }
-
-  final case class Not[A](expr: SchemaExpr[A, Boolean]) extends UnaryOp[A, Boolean] {
-    def eval(input: A): Either[OpticCheck, Seq[Boolean]] =
-      for {
-        xs <- expr.eval(input)
-      } yield xs.map(!_)
-
-    def evalDynamic(input: A): Either[OpticCheck, Seq[DynamicValue]] =
-      for {
-        xs <- expr.eval(input)
-      } yield xs.map(x => toDynamicValue(!x))
-
-    private[this] def toDynamicValue(value: Boolean): DynamicValue =
-      new DynamicValue.Primitive(new PrimitiveValue.Boolean(value))
-  }
-
-  final case class Arithmetic[S, A](
-    left: SchemaExpr[S, A],
-    right: SchemaExpr[S, A],
-    operator: ArithmeticOperator,
-    isNumeric: IsNumeric[A]
-  ) extends BinaryOp[S, A, A] {
-    def eval(input: S): Either[OpticCheck, Seq[A]] =
-      for {
-        xs <- left.eval(input)
-        ys <- right.eval(input)
-      } yield {
-        val n = isNumeric.numeric
-        operator match {
-          case _: ArithmeticOperator.Add.type      => for { x <- xs; y <- ys } yield n.plus(x, y)
-          case _: ArithmeticOperator.Subtract.type => for { x <- xs; y <- ys } yield n.minus(x, y)
-          case _: ArithmeticOperator.Multiply.type => for { x <- xs; y <- ys } yield n.times(x, y)
-        }
-      }
-
-    def evalDynamic(input: S): Either[OpticCheck, Seq[DynamicValue]] =
-      for {
-        xs <- left.eval(input)
-        ys <- right.eval(input)
-      } yield {
-        val n = isNumeric.numeric
-        operator match {
-          case _: ArithmeticOperator.Add.type      => for { x <- xs; y <- ys } yield toDynamicValue(n.plus(x, y))
-          case _: ArithmeticOperator.Subtract.type => for { x <- xs; y <- ys } yield toDynamicValue(n.minus(x, y))
-          case _: ArithmeticOperator.Multiply.type => for { x <- xs; y <- ys } yield toDynamicValue(n.times(x, y))
-        }
-      }
-
-    private[this] val toDynamicValue: A => DynamicValue = isNumeric.primitiveType.toDynamicValue
-  }
-
   sealed trait ArithmeticOperator
-
   object ArithmeticOperator {
     case object Add      extends ArithmeticOperator
     case object Subtract extends ArithmeticOperator
     case object Multiply extends ArithmeticOperator
+    case object Divide   extends ArithmeticOperator
+    case object Pow      extends ArithmeticOperator
+    case object Modulo   extends ArithmeticOperator
   }
 
-  final case class StringConcat[A](left: SchemaExpr[A, String], right: SchemaExpr[A, String])
-      extends BinaryOp[A, String, String] {
-    def eval(input: A): Either[OpticCheck, Seq[String]] =
-      for {
-        xs <- left.eval(input)
-        ys <- right.eval(input)
-      } yield for { x <- xs; y <- ys } yield x + y
-
-    def evalDynamic(input: A): Either[OpticCheck, Seq[DynamicValue]] =
-      for {
-        xs <- left.eval(input)
-        ys <- right.eval(input)
-      } yield for { x <- xs; y <- ys } yield toDynamicValue(x + y)
-
-    private[this] def toDynamicValue(value: String): DynamicValue =
-      new DynamicValue.Primitive(new PrimitiveValue.String(value))
+  sealed trait BitwiseOperator
+  object BitwiseOperator {
+    case object And                extends BitwiseOperator
+    case object Or                 extends BitwiseOperator
+    case object Xor                extends BitwiseOperator
+    case object LeftShift          extends BitwiseOperator
+    case object RightShift         extends BitwiseOperator
+    case object UnsignedRightShift extends BitwiseOperator
   }
 
-  final case class StringRegexMatch[A](regex: SchemaExpr[A, String], string: SchemaExpr[A, String])
-      extends SchemaExpr[A, Boolean] {
-    def eval(input: A): Either[OpticCheck, Seq[Boolean]] =
-      for {
-        xs <- regex.eval(input)
-        ys <- string.eval(input)
-      } yield for { x <- xs; y <- ys } yield y.matches(x)
+  def PrimitiveConversion[S](conversionType: ConversionType): ConversionType = conversionType
 
-    def evalDynamic(input: A): Either[OpticCheck, Seq[DynamicValue]] =
-      for {
-        xs <- regex.eval(input)
-        ys <- string.eval(input)
-      } yield for { x <- xs; y <- ys } yield toDynamicValue(y.matches(x))
-
-    private[this] def toDynamicValue(value: Boolean): DynamicValue =
-      new DynamicValue.Primitive(new PrimitiveValue.Boolean(value))
+  sealed trait ConversionType {
+    def convert(value: DynamicValue): Either[Predef.String, DynamicValue]
   }
 
-  final case class StringLength[A](string: SchemaExpr[A, String]) extends SchemaExpr[A, Int] {
-    def eval(input: A): Either[OpticCheck, Seq[Int]] =
-      for {
-        xs <- string.eval(input)
-      } yield xs.map(_.length)
+  object ConversionType {
+    // Numeric widening conversions (lossless)
+    case object ByteToShort extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Byte(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Short(v.toShort)))
+        case _ => Left(s"Expected Byte, got $value")
+      }
+    }
 
-    def evalDynamic(input: A): Either[OpticCheck, Seq[DynamicValue]] =
-      for {
-        xs <- string.eval(input)
-      } yield xs.map(x => toDynamicValue(x.length))
+    case object ByteToInt extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Byte(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Int(v.toInt)))
+        case _ => Left(s"Expected Byte, got $value")
+      }
+    }
 
-    private[this] def toDynamicValue(value: Int): DynamicValue =
-      new DynamicValue.Primitive(new PrimitiveValue.Int(value))
+    case object ByteToLong extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Byte(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Long(v.toLong)))
+        case _ => Left(s"Expected Byte, got $value")
+      }
+    }
+
+    case object ShortToInt extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Short(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Int(v.toInt)))
+        case _ => Left(s"Expected Short, got $value")
+      }
+    }
+
+    case object ShortToLong extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Short(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Long(v.toLong)))
+        case _ => Left(s"Expected Short, got $value")
+      }
+    }
+
+    case object IntToLong extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Int(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Long(v.toLong)))
+        case _ => Left(s"Expected Int, got $value")
+      }
+    }
+
+    case object FloatToDouble extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Float(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Double(v.toDouble)))
+        case _ => Left(s"Expected Float, got $value")
+      }
+    }
+
+    // Numeric narrowing conversions (potentially lossy)
+    case object ShortToByte extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Short(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Byte(v.toByte)))
+        case _ => Left(s"Expected Short, got $value")
+      }
+    }
+
+    case object IntToByte extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Int(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Byte(v.toByte)))
+        case _ => Left(s"Expected Int, got $value")
+      }
+    }
+
+    case object IntToShort extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Int(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Short(v.toShort)))
+        case _ => Left(s"Expected Int, got $value")
+      }
+    }
+
+    case object LongToByte extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Long(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Byte(v.toByte)))
+        case _ => Left(s"Expected Long, got $value")
+      }
+    }
+
+    case object LongToShort extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Long(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Short(v.toShort)))
+        case _ => Left(s"Expected Long, got $value")
+      }
+    }
+
+    case object LongToInt extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Long(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Int(v.toInt)))
+        case _ => Left(s"Expected Long, got $value")
+      }
+    }
+
+    case object DoubleToFloat extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Double(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Float(v.toFloat)))
+        case _ => Left(s"Expected Double, got $value")
+      }
+    }
+
+    // Integer to floating point
+    case object IntToFloat extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Int(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Float(v.toFloat)))
+        case _ => Left(s"Expected Int, got $value")
+      }
+    }
+
+    case object IntToDouble extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Int(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Double(v.toDouble)))
+        case _ => Left(s"Expected Int, got $value")
+      }
+    }
+
+    case object LongToFloat extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Long(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Float(v.toFloat)))
+        case _ => Left(s"Expected Long, got $value")
+      }
+    }
+
+    case object LongToDouble extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Long(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Double(v.toDouble)))
+        case _ => Left(s"Expected Long, got $value")
+      }
+    }
+
+    // String conversions
+    case object IntToString extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Int(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
+        case _ => Left(s"Expected Int, got $value")
+      }
+    }
+
+    case object LongToString extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Long(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
+        case _ => Left(s"Expected Long, got $value")
+      }
+    }
+
+    case object DoubleToString extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Double(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
+        case _ => Left(s"Expected Double, got $value")
+      }
+    }
+
+    case object BooleanToString extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Boolean(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
+        case _ => Left(s"Expected Boolean, got $value")
+      }
+    }
+
+    // String parsing (may fail)
+    case object StringToInt extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.String(v)) =>
+          try Right(DynamicValue.Primitive(PrimitiveValue.Int(v.toInt)))
+          catch { case _: NumberFormatException => Left(s"Cannot parse '$v' as Int") }
+        case _ => Left(s"Expected String, got $value")
+      }
+    }
+
+    case object StringToLong extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.String(v)) =>
+          try Right(DynamicValue.Primitive(PrimitiveValue.Long(v.toLong)))
+          catch { case _: NumberFormatException => Left(s"Cannot parse '$v' as Long") }
+        case _ => Left(s"Expected String, got $value")
+      }
+    }
+
+    case object StringToDouble extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.String(v)) =>
+          try Right(DynamicValue.Primitive(PrimitiveValue.Double(v.toDouble)))
+          catch { case _: NumberFormatException => Left(s"Cannot parse '$v' as Double") }
+        case _ => Left(s"Expected String, got $value")
+      }
+    }
+
+    case object StringToBoolean extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.String(v: Predef.String)) =>
+          v.toLowerCase match {
+            case "true"  => Right(DynamicValue.Primitive(PrimitiveValue.Boolean(true)))
+            case "false" => Right(DynamicValue.Primitive(PrimitiveValue.Boolean(false)))
+            case _       => Left(s"Cannot parse '$v' as Boolean")
+          }
+        case _ => Left(s"Expected String, got $value")
+      }
+    }
+
+    // Char conversions
+    case object CharToInt extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Char(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Int(v.toInt)))
+        case _ => Left(s"Expected Char, got $value")
+      }
+    }
+
+    case object IntToChar extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Int(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Char(v.toChar)))
+        case _ => Left(s"Expected Int, got $value")
+      }
+    }
+
+    case object CharToString extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Char(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
+        case _ => Left(s"Expected Char, got $value")
+      }
+    }
+
+    // Byte/Short to Float/Double
+    case object ByteToFloat extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Byte(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Float(v.toFloat)))
+        case _ => Left(s"Expected Byte, got $value")
+      }
+    }
+
+    case object ByteToDouble extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Byte(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Double(v.toDouble)))
+        case _ => Left(s"Expected Byte, got $value")
+      }
+    }
+
+    case object ShortToFloat extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Short(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Float(v.toFloat)))
+        case _ => Left(s"Expected Short, got $value")
+      }
+    }
+
+    case object ShortToDouble extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Short(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Double(v.toDouble)))
+        case _ => Left(s"Expected Short, got $value")
+      }
+    }
+
+    // Float/Double to Int/Long (truncation)
+    case object FloatToInt extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Float(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Int(v.toInt)))
+        case _ => Left(s"Expected Float, got $value")
+      }
+    }
+
+    case object FloatToLong extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Float(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Long(v.toLong)))
+        case _ => Left(s"Expected Float, got $value")
+      }
+    }
+
+    case object DoubleToInt extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Double(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Int(v.toInt)))
+        case _ => Left(s"Expected Double, got $value")
+      }
+    }
+
+    case object DoubleToLong extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Double(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.Long(v.toLong)))
+        case _ => Left(s"Expected Double, got $value")
+      }
+    }
+
+    // More String conversions
+    case object FloatToString extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Float(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
+        case _ => Left(s"Expected Float, got $value")
+      }
+    }
+
+    case object ShortToString extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Short(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
+        case _ => Left(s"Expected Short, got $value")
+      }
+    }
+
+    case object ByteToString extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.Byte(v)) =>
+          Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
+        case _ => Left(s"Expected Byte, got $value")
+      }
+    }
+
+    case object StringToFloat extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.String(v)) =>
+          try Right(DynamicValue.Primitive(PrimitiveValue.Float(v.toFloat)))
+          catch { case _: NumberFormatException => Left(s"Cannot parse '$v' as Float") }
+        case _ => Left(s"Expected String, got $value")
+      }
+    }
+
+    case object StringToShort extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.String(v)) =>
+          try Right(DynamicValue.Primitive(PrimitiveValue.Short(v.toShort)))
+          catch { case _: NumberFormatException => Left(s"Cannot parse '$v' as Short") }
+        case _ => Left(s"Expected String, got $value")
+      }
+    }
+
+    case object StringToByte extends ConversionType {
+      def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
+        case DynamicValue.Primitive(PrimitiveValue.String(v)) =>
+          try Right(DynamicValue.Primitive(PrimitiveValue.Byte(v.toByte)))
+          catch { case _: NumberFormatException => Left(s"Cannot parse '$v' as Byte") }
+        case _ => Left(s"Expected String, got $value")
+      }
+    }
   }
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
@@ -16,6 +16,8 @@
 
 package zio.blocks.schema
 
+import scala.util.Try
+
 /**
  * A typed wrapper around DynamicSchemaExpr that provides compile-time type
  * safety.
@@ -78,11 +80,11 @@ final case class SchemaExpr[A, B](
         OpticCheck.EmptySequence(fullPath, source)
 
       case SchemaError.Message(source, details) if details.startsWith("SequenceIndexOutOfBounds:") =>
-        val parts    = details.stripPrefix("SequenceIndexOutOfBounds: ").split(", ")
-        val index    = parts(0).stripPrefix("index ").toInt
-        val size     = parts(1).stripPrefix("size ").toInt
         val fullPath = extractFullPath(expr).getOrElse(source)
-        OpticCheck.SequenceIndexOutOfBounds(fullPath, source, index, size)
+        parseSequenceIndexOutOfBounds(details) match {
+          case Some((index, size)) => OpticCheck.SequenceIndexOutOfBounds(fullPath, source, index, size)
+          case None                => OpticCheck.DynamicConversionError(error.message)
+        }
 
       case SchemaError.Message(source, details) if details.startsWith("MissingKey:") =>
         val fullPath = extractFullPath(expr).getOrElse(source)
@@ -122,6 +124,23 @@ final case class SchemaExpr[A, B](
     case _                                               => None
   }
 
+  private def parseSequenceIndexOutOfBounds(details: String): Option[(Int, Int)] = {
+    val prefix = "SequenceIndexOutOfBounds: "
+    if (!details.startsWith(prefix)) None
+    else {
+      val parts = details.stripPrefix(prefix).split(", ")
+      if (parts.length != 2) None
+      else {
+        val maybeIndex = Try(parts(0).stripPrefix("index ").toInt).toOption
+        val maybeSize  = Try(parts(1).stripPrefix("size ").toInt).toOption
+        for {
+          index <- maybeIndex
+          size  <- maybeSize
+        } yield (index, size)
+      }
+    }
+  }
+
   /**
    * Get the underlying dynamic expression.
    */
@@ -148,6 +167,66 @@ final case class SchemaExpr[A, B](
 }
 
 object SchemaExpr {
+
+  private def outOfRange(value: Any, target: String): Either[Predef.String, DynamicValue] =
+    Left(s"Value $value is out of range for $target")
+
+  private def lossyConversion(value: Any, target: String): Either[Predef.String, DynamicValue] =
+    Left(s"Value $value cannot be converted to $target without losing information")
+
+  private def checkedIntegralNarrow(
+    value: Long,
+    min: Long,
+    max: Long,
+    target: String
+  )(result: => DynamicValue): Either[Predef.String, DynamicValue] =
+    if (value < min || value > max) outOfRange(value, target)
+    else Right(result)
+
+  private def checkedFiniteFloatToInt(value: Float): Either[Predef.String, DynamicValue] =
+    if (!java.lang.Float.isFinite(value)) lossyConversion(value, "Int")
+    else if (value < Int.MinValue.toFloat || value > Int.MaxValue.toFloat) outOfRange(value, "Int")
+    else {
+      val converted = value.toInt
+      if (converted.toFloat != value) lossyConversion(value, "Int")
+      else Right(DynamicValue.Primitive(PrimitiveValue.Int(converted)))
+    }
+
+  private def checkedFiniteFloatToLong(value: Float): Either[Predef.String, DynamicValue] =
+    if (!java.lang.Float.isFinite(value)) lossyConversion(value, "Long")
+    else if (value < Long.MinValue.toFloat || value > Long.MaxValue.toFloat) outOfRange(value, "Long")
+    else {
+      val converted = value.toLong
+      if (converted.toFloat != value) lossyConversion(value, "Long")
+      else Right(DynamicValue.Primitive(PrimitiveValue.Long(converted)))
+    }
+
+  private def checkedFiniteDoubleToInt(value: Double): Either[Predef.String, DynamicValue] =
+    if (!java.lang.Double.isFinite(value)) lossyConversion(value, "Int")
+    else if (value < Int.MinValue.toDouble || value > Int.MaxValue.toDouble) outOfRange(value, "Int")
+    else {
+      val converted = value.toInt
+      if (converted.toDouble != value) lossyConversion(value, "Int")
+      else Right(DynamicValue.Primitive(PrimitiveValue.Int(converted)))
+    }
+
+  private def checkedFiniteDoubleToLong(value: Double): Either[Predef.String, DynamicValue] =
+    if (!java.lang.Double.isFinite(value)) lossyConversion(value, "Long")
+    else if (value < Long.MinValue.toDouble || value > Long.MaxValue.toDouble) outOfRange(value, "Long")
+    else {
+      val converted = value.toLong
+      if (converted.toDouble != value) lossyConversion(value, "Long")
+      else Right(DynamicValue.Primitive(PrimitiveValue.Long(converted)))
+    }
+
+  private def checkedDoubleToFloat(value: Double): Either[Predef.String, DynamicValue] =
+    if (!java.lang.Double.isFinite(value)) lossyConversion(value, "Float")
+    else {
+      val converted = value.toFloat
+      if (!java.lang.Float.isFinite(converted) || converted.toDouble != value)
+        lossyConversion(value, "Float")
+      else Right(DynamicValue.Primitive(PrimitiveValue.Float(converted)))
+    }
 
   /**
    * Create a Literal expression from the schema's default value. Gets the
@@ -465,7 +544,9 @@ object SchemaExpr {
     case object ShortToByte extends ConversionType {
       def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
         case DynamicValue.Primitive(PrimitiveValue.Short(v)) =>
-          Right(DynamicValue.Primitive(PrimitiveValue.Byte(v.toByte)))
+          checkedIntegralNarrow(v.toLong, Byte.MinValue.toLong, Byte.MaxValue.toLong, "Byte")(
+            DynamicValue.Primitive(PrimitiveValue.Byte(v.toByte))
+          )
         case _ => Left(s"Expected Short, got $value")
       }
     }
@@ -473,7 +554,9 @@ object SchemaExpr {
     case object IntToByte extends ConversionType {
       def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
         case DynamicValue.Primitive(PrimitiveValue.Int(v)) =>
-          Right(DynamicValue.Primitive(PrimitiveValue.Byte(v.toByte)))
+          checkedIntegralNarrow(v.toLong, Byte.MinValue.toLong, Byte.MaxValue.toLong, "Byte")(
+            DynamicValue.Primitive(PrimitiveValue.Byte(v.toByte))
+          )
         case _ => Left(s"Expected Int, got $value")
       }
     }
@@ -481,7 +564,9 @@ object SchemaExpr {
     case object IntToShort extends ConversionType {
       def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
         case DynamicValue.Primitive(PrimitiveValue.Int(v)) =>
-          Right(DynamicValue.Primitive(PrimitiveValue.Short(v.toShort)))
+          checkedIntegralNarrow(v.toLong, Short.MinValue.toLong, Short.MaxValue.toLong, "Short")(
+            DynamicValue.Primitive(PrimitiveValue.Short(v.toShort))
+          )
         case _ => Left(s"Expected Int, got $value")
       }
     }
@@ -489,7 +574,9 @@ object SchemaExpr {
     case object LongToByte extends ConversionType {
       def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
         case DynamicValue.Primitive(PrimitiveValue.Long(v)) =>
-          Right(DynamicValue.Primitive(PrimitiveValue.Byte(v.toByte)))
+          checkedIntegralNarrow(v, Byte.MinValue.toLong, Byte.MaxValue.toLong, "Byte")(
+            DynamicValue.Primitive(PrimitiveValue.Byte(v.toByte))
+          )
         case _ => Left(s"Expected Long, got $value")
       }
     }
@@ -497,7 +584,9 @@ object SchemaExpr {
     case object LongToShort extends ConversionType {
       def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
         case DynamicValue.Primitive(PrimitiveValue.Long(v)) =>
-          Right(DynamicValue.Primitive(PrimitiveValue.Short(v.toShort)))
+          checkedIntegralNarrow(v, Short.MinValue.toLong, Short.MaxValue.toLong, "Short")(
+            DynamicValue.Primitive(PrimitiveValue.Short(v.toShort))
+          )
         case _ => Left(s"Expected Long, got $value")
       }
     }
@@ -505,7 +594,9 @@ object SchemaExpr {
     case object LongToInt extends ConversionType {
       def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
         case DynamicValue.Primitive(PrimitiveValue.Long(v)) =>
-          Right(DynamicValue.Primitive(PrimitiveValue.Int(v.toInt)))
+          checkedIntegralNarrow(v, Int.MinValue.toLong, Int.MaxValue.toLong, "Int")(
+            DynamicValue.Primitive(PrimitiveValue.Int(v.toInt))
+          )
         case _ => Left(s"Expected Long, got $value")
       }
     }
@@ -513,7 +604,7 @@ object SchemaExpr {
     case object DoubleToFloat extends ConversionType {
       def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
         case DynamicValue.Primitive(PrimitiveValue.Double(v)) =>
-          Right(DynamicValue.Primitive(PrimitiveValue.Float(v.toFloat)))
+          checkedDoubleToFloat(v)
         case _ => Left(s"Expected Double, got $value")
       }
     }
@@ -636,7 +727,9 @@ object SchemaExpr {
     case object IntToChar extends ConversionType {
       def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
         case DynamicValue.Primitive(PrimitiveValue.Int(v)) =>
-          Right(DynamicValue.Primitive(PrimitiveValue.Char(v.toChar)))
+          checkedIntegralNarrow(v.toLong, Char.MinValue.toLong, Char.MaxValue.toLong, "Char")(
+            DynamicValue.Primitive(PrimitiveValue.Char(v.toChar))
+          )
         case _ => Left(s"Expected Int, got $value")
       }
     }
@@ -682,11 +775,10 @@ object SchemaExpr {
       }
     }
 
-    // Float/Double to Int/Long (truncation)
     case object FloatToInt extends ConversionType {
       def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
         case DynamicValue.Primitive(PrimitiveValue.Float(v)) =>
-          Right(DynamicValue.Primitive(PrimitiveValue.Int(v.toInt)))
+          checkedFiniteFloatToInt(v)
         case _ => Left(s"Expected Float, got $value")
       }
     }
@@ -694,7 +786,7 @@ object SchemaExpr {
     case object FloatToLong extends ConversionType {
       def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
         case DynamicValue.Primitive(PrimitiveValue.Float(v)) =>
-          Right(DynamicValue.Primitive(PrimitiveValue.Long(v.toLong)))
+          checkedFiniteFloatToLong(v)
         case _ => Left(s"Expected Float, got $value")
       }
     }
@@ -702,7 +794,7 @@ object SchemaExpr {
     case object DoubleToInt extends ConversionType {
       def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
         case DynamicValue.Primitive(PrimitiveValue.Double(v)) =>
-          Right(DynamicValue.Primitive(PrimitiveValue.Int(v.toInt)))
+          checkedFiniteDoubleToInt(v)
         case _ => Left(s"Expected Double, got $value")
       }
     }
@@ -710,7 +802,7 @@ object SchemaExpr {
     case object DoubleToLong extends ConversionType {
       def convert(value: DynamicValue): Either[Predef.String, DynamicValue] = value match {
         case DynamicValue.Primitive(PrimitiveValue.Double(v)) =>
-          Right(DynamicValue.Primitive(PrimitiveValue.Long(v.toLong)))
+          checkedFiniteDoubleToLong(v)
         case _ => Left(s"Expected Double, got $value")
       }
     }

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -1,0 +1,566 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{DynamicValue, DynamicSchemaExpr, SchemaError}
+
+/**
+ * A pure, serializable migration that operates on `DynamicValue`. This is the
+ * untyped core of the migration system, containing a sequence of
+ * `MigrationAction`s that are applied in order.
+ *
+ * `DynamicMigration` is fully serializable because:
+ *   - It contains no closures or functions
+ *   - All transformations are represented as `DynamicSchemaExpr`
+ *   - All paths are represented as data (`DynamicOptic`)
+ *
+ * This enables migrations to be:
+ *   - Stored in registries
+ *   - Transmitted over the network
+ *   - Applied dynamically
+ *   - Inspected and transformed
+ *   - Used to generate SQL DDL, upgraders, etc.
+ */
+final case class DynamicMigration(actions: Chunk[MigrationAction]) {
+
+  /**
+   * Apply this migration to a `DynamicValue`.
+   *
+   * @param value
+   *   The input value to migrate
+   * @return
+   *   Either a `SchemaError` or the migrated value
+   */
+  def apply(value: DynamicValue): Either[SchemaError, DynamicValue] =
+    DynamicMigration.execute(actions, value)
+
+  /**
+   * Compose this migration with another, applying this migration first, then
+   * the other.
+   *
+   * @param that
+   *   The migration to apply after this one
+   * @return
+   *   A new migration that applies both in sequence
+   */
+  def ++(that: DynamicMigration): DynamicMigration =
+    new DynamicMigration(actions ++ that.actions)
+
+  /**
+   * Alias for `++`.
+   */
+  def andThen(that: DynamicMigration): DynamicMigration = this ++ that
+
+  /**
+   * Returns the structural reverse of this migration. The reverse migration has
+   * all actions reversed and in reverse order.
+   *
+   * Note: Runtime execution of the reverse migration is best-effort. It may
+   * fail if information was lost during the forward migration (e.g., dropping a
+   * field without capturing its value).
+   */
+  def reverse: DynamicMigration =
+    new DynamicMigration(Chunk.fromIterable(actions.reverseIterator.map(_.reverse).toSeq))
+
+  /**
+   * Returns true if this migration has no actions (identity migration).
+   */
+  def isEmpty: Boolean = actions.isEmpty
+
+  /**
+   * Returns the number of actions in this migration.
+   */
+  def size: Int = actions.size
+}
+
+object DynamicMigration {
+
+  /**
+   * An empty migration that performs no transformations.
+   */
+  val empty: DynamicMigration = new DynamicMigration(Chunk.empty)
+
+  /**
+   * Create a migration from a single action.
+   */
+  def single(action: MigrationAction): DynamicMigration =
+    new DynamicMigration(Chunk(action))
+
+  /**
+   * Create a migration from multiple actions.
+   */
+  def apply(actions: MigrationAction*): DynamicMigration =
+    new DynamicMigration(Chunk.fromIterable(actions))
+
+  /**
+   * Execute a sequence of migration actions on a value. Actions are applied in
+   * order, with the output of each action becoming the input to the next.
+   */
+  private[migration] def execute(
+    actions: Chunk[MigrationAction],
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] = {
+    var current: DynamicValue = value
+    var idx                   = 0
+    val len                   = actions.length
+
+    while (idx < len) {
+      ActionExecutor.execute(actions(idx), current) match {
+        case Right(newValue) =>
+          current = newValue
+          idx += 1
+        case left @ Left(_) =>
+          return left
+      }
+    }
+
+    Right(current)
+  }
+}
+
+/**
+ * Internal executor for migration actions. This executor uses DynamicSchemaExpr
+ * directly for all expression evaluation.
+ */
+private[migration] object ActionExecutor {
+  import MigrationAction._
+
+  private val MaxPathDepth: Int = 64
+
+  def execute(action: MigrationAction, value: DynamicValue): Either[SchemaError, DynamicValue] =
+    action match {
+      case a @ AddField(at, default) =>
+        evalExpr(default, value).flatMap { defaultValue =>
+          a.fieldName match {
+            case Some(fieldName) => executeAddField(at, fieldName, defaultValue, value)
+            case None            => Left(SchemaError.transformFailed(at, "AddField path must end with a Field node"))
+          }
+        }
+
+      case a @ DropField(at, _) =>
+        a.fieldName match {
+          case Some(fieldName) => executeDropField(at, fieldName, value)
+          case None            => Left(SchemaError.transformFailed(at, "DropField path must end with a Field node"))
+        }
+
+      case RenameField(at, to) =>
+        executeRename(at, to, value)
+
+      case TransformField(at, transform) =>
+        evalExpr(transform, value).flatMap { transformValue =>
+          executeTransformValueLiteral(at, transformValue, value)
+        }
+
+      case MandateField(at, default) =>
+        evalExpr(default, value).flatMap { defaultValue =>
+          executeMandate(at, defaultValue, value)
+        }
+
+      case OptionalizeField(at) =>
+        executeOptionalize(at, value)
+
+      case ChangeFieldType(at, converter) =>
+        evalExpr(converter, value).flatMap { convertedValue =>
+          executeChangeTypeLiteral(at, convertedValue, value)
+        }
+
+      case RenameCase(at, from, to) =>
+        executeRenameCase(at, from, to, value)
+
+      case TransformCase(at, actions) =>
+        executeTransformCase(at, actions, value)
+
+      case MigrateField(at, migration) =>
+        executeApplyMigration(at, migration, value)
+
+      case TransformElements(at, transform) =>
+        evalExpr(transform, value).flatMap { transformValue =>
+          executeTransformElements(at, transformValue, value)
+        }
+
+      case TransformKeys(at, transform) =>
+        evalExpr(transform, value).flatMap { transformValue =>
+          executeTransformKeys(at, transformValue, value)
+        }
+
+      case TransformValues(at, transform) =>
+        evalExpr(transform, value).flatMap { transformValue =>
+          executeTransformValues(at, transformValue, value)
+        }
+
+      case i: Irreversible =>
+        Left(SchemaError.transformFailed(i.at, s"Cannot execute reverse of irreversible action: ${i.originalAction}"))
+    }
+
+  /**
+   * Evaluate a DynamicSchemaExpr and extract a single DynamicValue. For now, we
+   * only support expressions that return a single value (first value in the
+   * sequence).
+   */
+  private def evalExpr(
+    expr: DynamicSchemaExpr,
+    input: DynamicValue
+  ): Either[SchemaError, DynamicValue] =
+    expr.eval(input).flatMap { results =>
+      results.headOption match {
+        case Some(value) => Right(value)
+        case None        =>
+          Left(
+            SchemaError.transformFailed(
+              zio.blocks.schema.DynamicOptic.root,
+              s"Expression evaluation returned no values"
+            )
+          )
+      }
+    }
+
+  // ==================== Record Action Execution ====================
+
+  private def executeAddField(
+    at: zio.blocks.schema.DynamicOptic,
+    fieldName: String,
+    default: DynamicValue,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] = {
+    // The path includes the field name, so we navigate to the parent
+    val parentPath = zio.blocks.schema.DynamicOptic(at.nodes.dropRight(1))
+    modifyAt(parentPath, value) {
+      case DynamicValue.Record(fields) =>
+        if (fields.exists(_._1 == fieldName)) {
+          Left(SchemaError.fieldAlreadyExists(at, fieldName))
+        } else {
+          Right(DynamicValue.Record(fields :+ (fieldName -> default)))
+        }
+      case other =>
+        Left(SchemaError.typeMismatch(at, "Record", other.getClass.getSimpleName))
+    }
+  }
+
+  private def executeDropField(
+    at: zio.blocks.schema.DynamicOptic,
+    fieldName: String,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] = {
+    // The path includes the field name, so we navigate to the parent
+    val parentPath = zio.blocks.schema.DynamicOptic(at.nodes.dropRight(1))
+    modifyAt(parentPath, value) {
+      case DynamicValue.Record(fields) =>
+        val idx = fields.indexWhere(_._1 == fieldName)
+        if (idx < 0) {
+          Left(SchemaError.fieldNotFound(at, fieldName))
+        } else {
+          Right(DynamicValue.Record(fields.patch(idx, Nil, 1)))
+        }
+      case other =>
+        Left(SchemaError.typeMismatch(at, "Record", other.getClass.getSimpleName))
+    }
+  }
+
+  private def executeRename(
+    at: zio.blocks.schema.DynamicOptic,
+    to: String,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] = {
+    // Extract from name and parent path
+    val from = at.nodes.lastOption match {
+      case Some(zio.blocks.schema.DynamicOptic.Node.Field(name)) => name
+      case _                                                     => return Left(SchemaError.transformFailed(at, "Rename path must end with a Field node"))
+    }
+    val parentPath = zio.blocks.schema.DynamicOptic(at.nodes.dropRight(1))
+
+    modifyAt(parentPath, value) {
+      case DynamicValue.Record(fields) =>
+        val idx = fields.indexWhere(_._1 == from)
+        if (idx < 0) {
+          Left(SchemaError.fieldNotFound(at, from))
+        } else if (fields.exists(_._1 == to)) {
+          Left(SchemaError.fieldAlreadyExists(at, to))
+        } else {
+          val (_, v) = fields(idx)
+          Right(DynamicValue.Record(fields.updated(idx, (to, v))))
+        }
+      case other =>
+        Left(SchemaError.typeMismatch(at, "Record", other.getClass.getSimpleName))
+    }
+  }
+
+  private def executeTransformValueLiteral(
+    at: zio.blocks.schema.DynamicOptic,
+    newValue: DynamicValue,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] =
+    modifyAt(at, value) { _ =>
+      Right(newValue)
+    }
+
+  private def executeChangeTypeLiteral(
+    at: zio.blocks.schema.DynamicOptic,
+    convertedValue: DynamicValue,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] =
+    modifyAt(at, value) { _ =>
+      Right(convertedValue)
+    }
+
+  // ==================== Collection/Map Action Execution ====================
+
+  private def executeTransformElements(
+    at: zio.blocks.schema.DynamicOptic,
+    transformValue: DynamicValue,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] =
+    modifyAt(at, value) {
+      case DynamicValue.Sequence(elements) =>
+        Right(DynamicValue.Sequence(elements.map(_ => transformValue)))
+      case other =>
+        Left(SchemaError.typeMismatch(at, "Sequence", other.getClass.getSimpleName))
+    }
+
+  private def executeTransformKeys(
+    at: zio.blocks.schema.DynamicOptic,
+    transformValue: DynamicValue,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] =
+    modifyAt(at, value) {
+      case DynamicValue.Map(entries) =>
+        Right(DynamicValue.Map(entries.map { case (_, v) => (transformValue, v) }))
+      case other =>
+        Left(SchemaError.typeMismatch(at, "Map", other.getClass.getSimpleName))
+    }
+
+  private def executeTransformValues(
+    at: zio.blocks.schema.DynamicOptic,
+    transformValue: DynamicValue,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] =
+    modifyAt(at, value) {
+      case DynamicValue.Map(entries) =>
+        Right(DynamicValue.Map(entries.map { case (k, _) => (k, transformValue) }))
+      case other =>
+        Left(SchemaError.typeMismatch(at, "Map", other.getClass.getSimpleName))
+    }
+
+  private def executeMandate(
+    at: zio.blocks.schema.DynamicOptic,
+    default: DynamicValue,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] =
+    modifyAt(at, value) {
+      // Option is represented as a Variant with cases "None" and "Some"
+      case DynamicValue.Variant("None", _) =>
+        Right(default)
+      case DynamicValue.Variant("Some", inner) =>
+        Right(inner)
+      case other =>
+        // If it's not an Option variant, assume it's already the value
+        Right(other)
+    }
+
+  private def executeOptionalize(
+    at: zio.blocks.schema.DynamicOptic,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] =
+    modifyAt(at, value) { v =>
+      // Wrap the value in Some
+      Right(DynamicValue.Variant("Some", v))
+    }
+
+  // ==================== Enum Action Execution ====================
+
+  private def executeRenameCase(
+    at: zio.blocks.schema.DynamicOptic,
+    from: String,
+    to: String,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] =
+    modifyAt(at, value) {
+      case DynamicValue.Variant(caseName, inner) if caseName == from =>
+        Right(DynamicValue.Variant(to, inner))
+      case v @ DynamicValue.Variant(_, _) =>
+        // Different case, no change needed
+        Right(v)
+      case other =>
+        Left(SchemaError.typeMismatch(at, "Variant", other.getClass.getSimpleName))
+    }
+
+  private def executeTransformCase(
+    at: zio.blocks.schema.DynamicOptic,
+    actions: Chunk[MigrationAction],
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] =
+    modifyAt(at, value) {
+      case DynamicValue.Variant(name, inner) =>
+        DynamicMigration.execute(actions, inner).map(DynamicValue.Variant(name, _))
+      case other =>
+        Left(SchemaError.typeMismatch(at, "Variant", other.getClass.getSimpleName))
+    }
+
+  private def executeApplyMigration(
+    at: zio.blocks.schema.DynamicOptic,
+    migration: DynamicMigration,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] =
+    modifyAt(at, value) { nestedValue =>
+      migration(nestedValue)
+    }
+
+  // ==================== Helper Methods ====================
+
+  /**
+   * Navigate to a path and apply a modification function. If the path is empty
+   * (root), apply directly to the value.
+   */
+  private def modifyAt(
+    path: zio.blocks.schema.DynamicOptic,
+    value: DynamicValue
+  )(f: DynamicValue => Either[SchemaError, DynamicValue]): Either[SchemaError, DynamicValue] = {
+    val nodes = path.nodes
+    if (nodes.isEmpty) {
+      f(value)
+    } else {
+      modifyAtPath(nodes, 0, value, path)(f)
+    }
+  }
+
+  private def modifyAtPath(
+    nodes: IndexedSeq[zio.blocks.schema.DynamicOptic.Node],
+    idx: Int,
+    value: DynamicValue,
+    fullPath: zio.blocks.schema.DynamicOptic
+  )(f: DynamicValue => Either[SchemaError, DynamicValue]): Either[SchemaError, DynamicValue] = {
+    import zio.blocks.schema.DynamicOptic.Node
+
+    if (idx >= nodes.length) {
+      f(value)
+    } else if (idx >= MaxPathDepth) {
+      Left(SchemaError.transformFailed(fullPath, s"Maximum path depth ($MaxPathDepth) exceeded"))
+    } else {
+      nodes(idx) match {
+        case Node.Field(name) =>
+          value match {
+            case DynamicValue.Record(fields) =>
+              val fieldIdx = fields.indexWhere(_._1 == name)
+              if (fieldIdx < 0) {
+                Left(SchemaError.fieldNotFound(fullPath, name))
+              } else {
+                val (fieldName, fieldValue) = fields(fieldIdx)
+                modifyAtPath(nodes, idx + 1, fieldValue, fullPath)(f).map { newFieldValue =>
+                  DynamicValue.Record(fields.updated(fieldIdx, (fieldName, newFieldValue)))
+                }
+              }
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Record", other.getClass.getSimpleName))
+          }
+
+        case Node.Case(caseName) =>
+          value match {
+            case DynamicValue.Variant(name, inner) if name == caseName =>
+              modifyAtPath(nodes, idx + 1, inner, fullPath)(f).map { newInner =>
+                DynamicValue.Variant(name, newInner)
+              }
+            case DynamicValue.Variant(_, _) =>
+              Left(SchemaError.caseNotFound(fullPath, caseName))
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Variant", other.getClass.getSimpleName))
+          }
+
+        case Node.Elements =>
+          value match {
+            case DynamicValue.Sequence(elements) =>
+              val results = elements.foldLeft[Either[SchemaError, Chunk[DynamicValue]]](Right(Chunk.empty)) {
+                case (Right(acc), elem) =>
+                  modifyAtPath(nodes, idx + 1, elem, fullPath)(f).map(acc :+ _)
+                case (left, _) =>
+                  left
+              }
+              results.map(DynamicValue.Sequence(_))
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Sequence", other.getClass.getSimpleName))
+          }
+
+        case Node.MapKeys =>
+          value match {
+            case DynamicValue.Map(entries) =>
+              val results =
+                entries.foldLeft[Either[SchemaError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
+                  case (Right(acc), (k, v)) =>
+                    modifyAtPath(nodes, idx + 1, k, fullPath)(f).map(newK => acc :+ (newK -> v))
+                  case (left, _) =>
+                    left
+                }
+              results.map(DynamicValue.Map(_))
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Map", other.getClass.getSimpleName))
+          }
+
+        case Node.MapValues =>
+          value match {
+            case DynamicValue.Map(entries) =>
+              val results =
+                entries.foldLeft[Either[SchemaError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
+                  case (Right(acc), (k, v)) =>
+                    modifyAtPath(nodes, idx + 1, v, fullPath)(f).map(newV => acc :+ (k -> newV))
+                  case (left, _) =>
+                    left
+                }
+              results.map(DynamicValue.Map(_))
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Map", other.getClass.getSimpleName))
+          }
+
+        case Node.AtIndex(index) =>
+          value match {
+            case DynamicValue.Sequence(elements) =>
+              if (index < 0 || index >= elements.length) {
+                Left(SchemaError.pathNotFound(fullPath))
+              } else {
+                modifyAtPath(nodes, idx + 1, elements(index), fullPath)(f).map { newElem =>
+                  DynamicValue.Sequence(elements.updated(index, newElem))
+                }
+              }
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Sequence", other.getClass.getSimpleName))
+          }
+
+        case Node.AtMapKey(key) =>
+          value match {
+            case DynamicValue.Map(entries) =>
+              val keyValue = key.asInstanceOf[DynamicValue]
+              val entryIdx = entries.indexWhere(_._1 == keyValue)
+              if (entryIdx < 0) {
+                Left(SchemaError.pathNotFound(fullPath))
+              } else {
+                val (k, v) = entries(entryIdx)
+                modifyAtPath(nodes, idx + 1, v, fullPath)(f).map { newV =>
+                  DynamicValue.Map(entries.updated(entryIdx, (k, newV)))
+                }
+              }
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Map", other.getClass.getSimpleName))
+          }
+
+        case Node.Wrapped =>
+          // For wrapper types, just continue to the inner value
+          modifyAtPath(nodes, idx + 1, value, fullPath)(f)
+
+        case _ =>
+          Left(SchemaError.transformFailed(fullPath, s"Unsupported path node: ${nodes(idx)}"))
+      }
+    }
+  }
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -18,6 +18,7 @@ package zio.blocks.schema.migration
 
 import zio.blocks.chunk.Chunk
 import zio.blocks.schema.{DynamicValue, DynamicSchemaExpr, SchemaError}
+import scala.util.control.NonFatal
 
 /**
  * A pure, serializable migration that operates on `DynamicValue`. This is the
@@ -75,7 +76,7 @@ final case class DynamicMigration(actions: Chunk[MigrationAction]) {
    * field without capturing its value).
    */
   def reverse: DynamicMigration =
-    new DynamicMigration(Chunk.fromIterable(actions.reverseIterator.map(_.reverse).toSeq))
+    new DynamicMigration(Chunk.fromIterator(actions.reverseIterator.map(_.reverse)))
 
   /**
    * Returns true if this migration has no actions (identity migration).
@@ -120,7 +121,18 @@ object DynamicMigration {
     val len                   = actions.length
 
     while (idx < len) {
-      ActionExecutor.execute(actions(idx), current) match {
+      val result =
+        try ActionExecutor.execute(actions(idx), current)
+        catch {
+          case NonFatal(ex) =>
+            Left(
+              SchemaError.transformFailed(
+                actions(idx).at,
+                s"Unexpected error during migration: ${ex.getClass.getSimpleName}: ${ex.getMessage}"
+              )
+            )
+        }
+      result match {
         case Right(newValue) =>
           current = newValue
           idx += 1
@@ -178,8 +190,8 @@ private[migration] object ActionExecutor {
       case RenameCase(at, from, to) =>
         executeRenameCase(at, from, to, value)
 
-      case TransformCase(at, actions) =>
-        executeTransformCase(at, actions, value)
+      case TransformCase(at, targetCaseName, actions) =>
+        executeTransformCase(at, targetCaseName, actions, value)
 
       case MigrateField(at, migration) =>
         executeApplyMigration(at, migration, value)
@@ -324,9 +336,10 @@ private[migration] object ActionExecutor {
   ): Either[SchemaError, DynamicValue] =
     modifyAt(at, value) {
       case DynamicValue.Sequence(elements) =>
-        val transformed = elements.foldLeft[Either[SchemaError, Chunk[DynamicValue]]](Right(Chunk.empty)) {
-          case (Right(acc), element) =>
-            evalExpr(transform, element, at).map(acc :+ _)
+        val transformed = elements.zipWithIndex.foldLeft[Either[SchemaError, Chunk[DynamicValue]]](Right(Chunk.empty)) {
+          case (Right(acc), (element, idx)) =>
+            val elemPath = zio.blocks.schema.DynamicOptic(at.nodes :+ zio.blocks.schema.DynamicOptic.Node.AtIndex(idx))
+            evalExpr(transform, element, elemPath).map(acc :+ _)
           case (left, _) =>
             left
         }
@@ -345,7 +358,9 @@ private[migration] object ActionExecutor {
         val transformed =
           entries.foldLeft[Either[SchemaError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
             case (Right(acc), (key, currentValue)) =>
-              evalExpr(transform, key, at).map(newKey => acc :+ (newKey -> currentValue))
+              val keyPath =
+                zio.blocks.schema.DynamicOptic(at.nodes :+ zio.blocks.schema.DynamicOptic.Node.AtMapKey(key))
+              evalExpr(transform, key, keyPath).map(newKey => acc :+ (newKey -> currentValue))
             case (left, _) =>
               left
           }
@@ -364,7 +379,9 @@ private[migration] object ActionExecutor {
         val transformed =
           entries.foldLeft[Either[SchemaError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
             case (Right(acc), (key, currentValue)) =>
-              evalExpr(transform, currentValue, at).map(newValue => acc :+ (key -> newValue))
+              val valuePath =
+                zio.blocks.schema.DynamicOptic(at.nodes :+ zio.blocks.schema.DynamicOptic.Node.AtMapKey(key))
+              evalExpr(transform, currentValue, valuePath).map(newValue => acc :+ (key -> newValue))
             case (left, _) =>
               left
           }
@@ -405,7 +422,11 @@ private[migration] object ActionExecutor {
     from: String,
     to: String,
     value: DynamicValue
-  ): Either[SchemaError, DynamicValue] =
+  ): Either[SchemaError, DynamicValue] = {
+    if (from.isEmpty || to.isEmpty)
+      return Left(
+        SchemaError.transformFailed(at, s"renameCase requires non-empty case names, got from='$from', to='$to'")
+      )
     modifyAt(at, value) {
       case DynamicValue.Variant(caseName, inner) if caseName == from =>
         Right(DynamicValue.Variant(to, inner))
@@ -415,18 +436,30 @@ private[migration] object ActionExecutor {
       case other =>
         Left(SchemaError.typeMismatch(at, "Variant", other.getClass.getSimpleName))
     }
+  }
 
   private def executeTransformCase(
     at: zio.blocks.schema.DynamicOptic,
+    targetCaseName: String,
     actions: Chunk[MigrationAction],
     value: DynamicValue
-  ): Either[SchemaError, DynamicValue] =
-    modifyAt(at, value) {
-      case DynamicValue.Variant(name, inner) =>
-        DynamicMigration.execute(actions, inner).map(DynamicValue.Variant(name, _))
+  ): Either[SchemaError, DynamicValue] = {
+    val sourceCaseName = at.nodes.lastOption.collect { case zio.blocks.schema.DynamicOptic.Node.Case(name) => name }
+      .getOrElse(targetCaseName)
+    val parentPath = zio.blocks.schema.DynamicOptic(at.nodes.dropRight(1).filter {
+      case _: zio.blocks.schema.DynamicOptic.Node.Case => false
+      case _                                           => true
+    })
+
+    modifyAt(parentPath, value) {
+      case DynamicValue.Variant(name, inner) if name == sourceCaseName =>
+        DynamicMigration.execute(actions, inner).map(DynamicValue.Variant(targetCaseName, _))
+      case v: DynamicValue.Variant =>
+        Right(v) // non-matching case, pass through unchanged
       case other =>
         Left(SchemaError.typeMismatch(at, "Variant", other.getClass.getSimpleName))
     }
+  }
 
   private def executeApplyMigration(
     at: zio.blocks.schema.DynamicOptic,
@@ -585,8 +618,15 @@ private[migration] object ActionExecutor {
           // For wrapper types, just continue to the inner value
           modifyAtPath(nodes, idx + 1, value, fullPath)(f)
 
-        case _ =>
-          Left(SchemaError.transformFailed(fullPath, s"Unsupported path node: ${nodes(idx)}"))
+        case Node.AtIndices(_) | Node.AtMapKeys(_) =>
+          Left(
+            SchemaError.transformFailed(
+              fullPath,
+              s"Batch path nodes (AtIndices/AtMapKeys) are not supported in migration paths"
+            )
+          )
+        case Node.TypeSearch(_) | Node.SchemaSearch(_) =>
+          Left(SchemaError.transformFailed(fullPath, s"Type/Schema search nodes are not supported in migration paths"))
       }
     }
   }

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -145,7 +145,7 @@ private[migration] object ActionExecutor {
   def execute(action: MigrationAction, value: DynamicValue): Either[SchemaError, DynamicValue] =
     action match {
       case a @ AddField(at, default) =>
-        evalExpr(default, value).flatMap { defaultValue =>
+        evalExpr(default, value, at).flatMap { defaultValue =>
           a.fieldName match {
             case Some(fieldName) => executeAddField(at, fieldName, defaultValue, value)
             case None            => Left(SchemaError.transformFailed(at, "AddField path must end with a Field node"))
@@ -165,7 +165,7 @@ private[migration] object ActionExecutor {
         executeTransformField(at, transform, value)
 
       case MandateField(at, default) =>
-        evalExpr(default, value).flatMap { defaultValue =>
+        evalExpr(default, value, at).flatMap { defaultValue =>
           executeMandate(at, defaultValue, value)
         }
 
@@ -204,7 +204,8 @@ private[migration] object ActionExecutor {
    */
   private def evalExpr(
     expr: DynamicSchemaExpr,
-    input: DynamicValue
+    input: DynamicValue,
+    at: zio.blocks.schema.DynamicOptic
   ): Either[SchemaError, DynamicValue] =
     expr.eval(input).flatMap { results =>
       results match {
@@ -212,14 +213,14 @@ private[migration] object ActionExecutor {
         case Seq()      =>
           Left(
             SchemaError.transformFailed(
-              zio.blocks.schema.DynamicOptic.root,
+              at,
               s"Expression evaluation returned no values"
             )
           )
         case _ =>
           Left(
             SchemaError.transformFailed(
-              zio.blocks.schema.DynamicOptic.root,
+              at,
               s"Expression evaluation must return exactly one value, got ${results.size}"
             )
           )
@@ -302,7 +303,7 @@ private[migration] object ActionExecutor {
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
     modifyAt(at, value) { currentValue =>
-      evalExpr(transform, currentValue)
+      evalExpr(transform, currentValue, at)
     }
 
   private def executeChangeFieldType(
@@ -311,7 +312,7 @@ private[migration] object ActionExecutor {
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
     modifyAt(at, value) { currentValue =>
-      evalExpr(converter, currentValue)
+      evalExpr(converter, currentValue, at)
     }
 
   // ==================== Collection/Map Action Execution ====================
@@ -325,7 +326,7 @@ private[migration] object ActionExecutor {
       case DynamicValue.Sequence(elements) =>
         val transformed = elements.foldLeft[Either[SchemaError, Chunk[DynamicValue]]](Right(Chunk.empty)) {
           case (Right(acc), element) =>
-            evalExpr(transform, element).map(acc :+ _)
+            evalExpr(transform, element, at).map(acc :+ _)
           case (left, _) =>
             left
         }
@@ -344,7 +345,7 @@ private[migration] object ActionExecutor {
         val transformed =
           entries.foldLeft[Either[SchemaError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
             case (Right(acc), (key, currentValue)) =>
-              evalExpr(transform, key).map(newKey => acc :+ (newKey -> currentValue))
+              evalExpr(transform, key, at).map(newKey => acc :+ (newKey -> currentValue))
             case (left, _) =>
               left
           }
@@ -363,7 +364,7 @@ private[migration] object ActionExecutor {
         val transformed =
           entries.foldLeft[Either[SchemaError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
             case (Right(acc), (key, currentValue)) =>
-              evalExpr(transform, currentValue).map(newValue => acc :+ (key -> newValue))
+              evalExpr(transform, currentValue, at).map(newValue => acc :+ (key -> newValue))
             case (left, _) =>
               left
           }

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -162,9 +162,7 @@ private[migration] object ActionExecutor {
         executeRename(at, to, value)
 
       case TransformField(at, transform) =>
-        evalExpr(transform, value).flatMap { transformValue =>
-          executeTransformValueLiteral(at, transformValue, value)
-        }
+        executeTransformField(at, transform, value)
 
       case MandateField(at, default) =>
         evalExpr(default, value).flatMap { defaultValue =>
@@ -175,9 +173,7 @@ private[migration] object ActionExecutor {
         executeOptionalize(at, value)
 
       case ChangeFieldType(at, converter) =>
-        evalExpr(converter, value).flatMap { convertedValue =>
-          executeChangeTypeLiteral(at, convertedValue, value)
-        }
+        executeChangeFieldType(at, converter, value)
 
       case RenameCase(at, from, to) =>
         executeRenameCase(at, from, to, value)
@@ -189,19 +185,13 @@ private[migration] object ActionExecutor {
         executeApplyMigration(at, migration, value)
 
       case TransformElements(at, transform) =>
-        evalExpr(transform, value).flatMap { transformValue =>
-          executeTransformElements(at, transformValue, value)
-        }
+        executeTransformElements(at, transform, value)
 
       case TransformKeys(at, transform) =>
-        evalExpr(transform, value).flatMap { transformValue =>
-          executeTransformKeys(at, transformValue, value)
-        }
+        executeTransformKeys(at, transform, value)
 
       case TransformValues(at, transform) =>
-        evalExpr(transform, value).flatMap { transformValue =>
-          executeTransformValues(at, transformValue, value)
-        }
+        executeTransformValues(at, transform, value)
 
       case i: Irreversible =>
         Left(SchemaError.transformFailed(i.at, s"Cannot execute reverse of irreversible action: ${i.originalAction}"))
@@ -217,13 +207,20 @@ private[migration] object ActionExecutor {
     input: DynamicValue
   ): Either[SchemaError, DynamicValue] =
     expr.eval(input).flatMap { results =>
-      results.headOption match {
-        case Some(value) => Right(value)
-        case None        =>
+      results match {
+        case Seq(value) => Right(value)
+        case Seq()      =>
           Left(
             SchemaError.transformFailed(
               zio.blocks.schema.DynamicOptic.root,
               s"Expression evaluation returned no values"
+            )
+          )
+        case _ =>
+          Left(
+            SchemaError.transformFailed(
+              zio.blocks.schema.DynamicOptic.root,
+              s"Expression evaluation must return exactly one value, got ${results.size}"
             )
           )
       }
@@ -299,58 +296,78 @@ private[migration] object ActionExecutor {
     }
   }
 
-  private def executeTransformValueLiteral(
+  private def executeTransformField(
     at: zio.blocks.schema.DynamicOptic,
-    newValue: DynamicValue,
+    transform: DynamicSchemaExpr,
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
-    modifyAt(at, value) { _ =>
-      Right(newValue)
+    modifyAt(at, value) { currentValue =>
+      evalExpr(transform, currentValue)
     }
 
-  private def executeChangeTypeLiteral(
+  private def executeChangeFieldType(
     at: zio.blocks.schema.DynamicOptic,
-    convertedValue: DynamicValue,
+    converter: DynamicSchemaExpr,
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
-    modifyAt(at, value) { _ =>
-      Right(convertedValue)
+    modifyAt(at, value) { currentValue =>
+      evalExpr(converter, currentValue)
     }
 
   // ==================== Collection/Map Action Execution ====================
 
   private def executeTransformElements(
     at: zio.blocks.schema.DynamicOptic,
-    transformValue: DynamicValue,
+    transform: DynamicSchemaExpr,
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
     modifyAt(at, value) {
       case DynamicValue.Sequence(elements) =>
-        Right(DynamicValue.Sequence(elements.map(_ => transformValue)))
+        val transformed = elements.foldLeft[Either[SchemaError, Chunk[DynamicValue]]](Right(Chunk.empty)) {
+          case (Right(acc), element) =>
+            evalExpr(transform, element).map(acc :+ _)
+          case (left, _) =>
+            left
+        }
+        transformed.map(DynamicValue.Sequence(_))
       case other =>
         Left(SchemaError.typeMismatch(at, "Sequence", other.getClass.getSimpleName))
     }
 
   private def executeTransformKeys(
     at: zio.blocks.schema.DynamicOptic,
-    transformValue: DynamicValue,
+    transform: DynamicSchemaExpr,
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
     modifyAt(at, value) {
       case DynamicValue.Map(entries) =>
-        Right(DynamicValue.Map(entries.map { case (_, v) => (transformValue, v) }))
+        val transformed =
+          entries.foldLeft[Either[SchemaError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
+            case (Right(acc), (key, currentValue)) =>
+              evalExpr(transform, key).map(newKey => acc :+ (newKey -> currentValue))
+            case (left, _) =>
+              left
+          }
+        transformed.map(DynamicValue.Map(_))
       case other =>
         Left(SchemaError.typeMismatch(at, "Map", other.getClass.getSimpleName))
     }
 
   private def executeTransformValues(
     at: zio.blocks.schema.DynamicOptic,
-    transformValue: DynamicValue,
+    transform: DynamicSchemaExpr,
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
     modifyAt(at, value) {
       case DynamicValue.Map(entries) =>
-        Right(DynamicValue.Map(entries.map { case (k, _) => (k, transformValue) }))
+        val transformed =
+          entries.foldLeft[Either[SchemaError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
+            case (Right(acc), (key, currentValue)) =>
+              evalExpr(transform, currentValue).map(newValue => acc :+ (key -> newValue))
+            case (left, _) =>
+              left
+          }
+        transformed.map(DynamicValue.Map(_))
       case other =>
         Left(SchemaError.typeMismatch(at, "Map", other.getClass.getSimpleName))
     }
@@ -540,14 +557,23 @@ private[migration] object ActionExecutor {
         case Node.AtMapKey(key) =>
           value match {
             case DynamicValue.Map(entries) =>
-              val keyValue = key.asInstanceOf[DynamicValue]
-              val entryIdx = entries.indexWhere(_._1 == keyValue)
-              if (entryIdx < 0) {
-                Left(SchemaError.pathNotFound(fullPath))
+              if (key == null) {
+                Left(
+                  SchemaError.invalidValue(
+                    fullPath,
+                    "Expected DynamicValue map key, got: null"
+                  )
+                )
               } else {
-                val (k, v) = entries(entryIdx)
-                modifyAtPath(nodes, idx + 1, v, fullPath)(f).map { newV =>
-                  DynamicValue.Map(entries.updated(entryIdx, (k, newV)))
+                val keyValue = key
+                val entryIdx = entries.indexWhere(_._1 == keyValue)
+                if (entryIdx < 0) {
+                  Left(SchemaError.pathNotFound(fullPath))
+                } else {
+                  val (k, v) = entries(entryIdx)
+                  modifyAtPath(nodes, idx + 1, v, fullPath)(f).map { newV =>
+                    DynamicValue.Map(entries.updated(entryIdx, (k, newV)))
+                  }
                 }
               }
             case other =>

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{Schema, SchemaError}
+
+/**
+ * A typed migration that transforms values from type `A` to type `B`.
+ *
+ * `Migration[A, B]` provides a type-safe wrapper around `DynamicMigration`,
+ * handling the conversion between typed values and `DynamicValue`
+ * automatically.
+ *
+ * The migration process:
+ *   1. Convert input `A` to `DynamicValue` using `sourceSchema`
+ *   2. Apply the `dynamicMigration` to transform the dynamic value
+ *   3. Convert the result back to `B` using `targetSchema`
+ *
+ * The schemas can be any `Schema[A]` and `Schema[B]`, including:
+ *   - Regular schemas derived from case classes/enums
+ *   - Structural schemas (JVM only) for compile-time-only types
+ *
+ * This allows migrations between current runtime types and past structural
+ * versions without requiring old case classes to exist at runtime.
+ *
+ * @tparam A
+ *   The source type
+ * @tparam B
+ *   The target type
+ * @param sourceSchema
+ *   Schema for the source type (can be structural or regular)
+ * @param targetSchema
+ *   Schema for the target type (can be structural or regular)
+ * @param dynamicMigration
+ *   The underlying untyped migration
+ */
+final case class Migration[A, B](
+  sourceSchema: Schema[A],
+  targetSchema: Schema[B],
+  dynamicMigration: DynamicMigration
+) {
+
+  /**
+   * Apply this migration to transform a value from type `A` to type `B`.
+   *
+   * @param value
+   *   The input value to migrate
+   * @return
+   *   Either a `SchemaError` or the migrated value
+   */
+  def apply(value: A): Either[SchemaError, B] = {
+    val dynamicValue = sourceSchema.toDynamicValue(value)
+    dynamicMigration(dynamicValue).flatMap { result =>
+      targetSchema.fromDynamicValue(result)
+    }
+  }
+
+  /**
+   * Compose this migration with another, applying this migration first, then
+   * the other.
+   *
+   * @param that
+   *   The migration to apply after this one
+   * @return
+   *   A new migration that applies both in sequence
+   */
+  def ++[C](that: Migration[B, C]): Migration[A, C] =
+    new Migration(sourceSchema, that.targetSchema, dynamicMigration ++ that.dynamicMigration)
+
+  /**
+   * Alias for `++`.
+   */
+  def andThen[C](that: Migration[B, C]): Migration[A, C] = this ++ that
+
+  /**
+   * Returns the structural reverse of this migration.
+   *
+   * Note: Runtime execution of the reverse migration is best-effort. It may
+   * fail if information was lost during the forward migration.
+   */
+  def reverse: Migration[B, A] =
+    new Migration(targetSchema, sourceSchema, dynamicMigration.reverse)
+
+  /**
+   * Returns true if this migration has no actions (identity migration).
+   */
+  def isEmpty: Boolean = dynamicMigration.isEmpty
+
+  /**
+   * Returns the number of actions in this migration.
+   */
+  def size: Int = dynamicMigration.size
+
+  /**
+   * Get the list of actions in this migration.
+   */
+  def actions: Chunk[MigrationAction] = dynamicMigration.actions
+}
+
+object Migration extends MigrationSelectorSyntax with MigrationCompanionVersionSpecific {
+
+  def identity[A](implicit schema: Schema[A]): Migration[A, A] =
+    new Migration(schema, schema, DynamicMigration.empty)
+
+  def fromAction[A, B](action: MigrationAction)(implicit
+    sourceSchema: Schema[A],
+    targetSchema: Schema[B]
+  ): Migration[A, B] =
+    new Migration(sourceSchema, targetSchema, DynamicMigration.single(action))
+
+  def fromActions[A, B](actions: MigrationAction*)(implicit
+    sourceSchema: Schema[A],
+    targetSchema: Schema[B]
+  ): Migration[A, B] =
+    new Migration(sourceSchema, targetSchema, new DynamicMigration(Chunk.fromIterable(actions)))
+
+  def fromDynamic[A, B](dynamicMigration: DynamicMigration)(implicit
+    sourceSchema: Schema[A],
+    targetSchema: Schema[B]
+  ): Migration[A, B] =
+    new Migration(sourceSchema, targetSchema, dynamicMigration)
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
@@ -117,13 +117,13 @@ object Migration extends MigrationSelectorSyntax with MigrationCompanionVersionS
   def identity[A](implicit schema: Schema[A]): Migration[A, A] =
     new Migration(schema, schema, DynamicMigration.empty)
 
-  def fromAction[A, B](action: MigrationAction)(implicit
+  private[migration] def fromAction[A, B](action: MigrationAction)(implicit
     sourceSchema: Schema[A],
     targetSchema: Schema[B]
   ): Migration[A, B] =
     new Migration(sourceSchema, targetSchema, DynamicMigration.single(action))
 
-  def fromActions[A, B](actions: MigrationAction*)(implicit
+  private[migration] def fromActions[A, B](actions: MigrationAction*)(implicit
     sourceSchema: Schema[A],
     targetSchema: Schema[B]
   ): Migration[A, B] =

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
@@ -104,7 +104,7 @@ object MigrationAction {
       val parentPath = DynamicOptic(at.nodes.dropRight(1))
       from match {
         case Some(oldName) => RenameField(parentPath.field(to), oldName)
-        case None          => Irreversible(at, "RenameField")
+        case None          => Irreversible(parentPath, "RenameField")
       }
     }
 
@@ -202,10 +202,18 @@ object MigrationAction {
    */
   final case class TransformCase(
     at: DynamicOptic,
+    targetCaseName: String,
     actions: Chunk[MigrationAction]
   ) extends MigrationAction {
-    override def reverse: MigrationAction =
-      TransformCase(at, actions.reverse.map(_.reverse))
+    override def reverse: MigrationAction = {
+      val sourceCaseName =
+        at.nodes.lastOption.collect { case DynamicOptic.Node.Case(name) => name }.getOrElse(targetCaseName)
+      TransformCase(
+        DynamicOptic(at.nodes.dropRight(1) :+ DynamicOptic.Node.Case(targetCaseName)),
+        sourceCaseName,
+        actions.reverse.map(_.reverse)
+      )
+    }
   }
 
   /**
@@ -281,7 +289,7 @@ object MigrationAction {
    * Sentinel action representing a non-invertible operation. Executing this
    * action always fails with a descriptive error. This is returned by
    * `.reverse` on actions that cannot be structurally reversed (e.g.,
-   * `TransformValue`, `ChangeType`).
+   * `TransformField`, `ChangeFieldType`, `OptionalizeField`).
    *
    * @param at
    *   The path where the original action operated
@@ -292,6 +300,11 @@ object MigrationAction {
     at: DynamicOptic,
     originalAction: String
   ) extends MigrationAction {
+
+    /**
+     * Reversing an irreversible action returns itself — it always fails at
+     * runtime.
+     */
     override def reverse: MigrationAction = this
   }
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
@@ -229,8 +229,7 @@ object MigrationAction {
 
   /**
    * Replace each element in a collection with the result of evaluating the
-   * expression. The expression is evaluated once against the root input value,
-   * and every element is replaced with the same result.
+   * expression against that element.
    *
    * @param at
    *   The path to the collection
@@ -247,9 +246,8 @@ object MigrationAction {
   // ==================== Map Actions ====================
 
   /**
-   * Replace each key in a map with the result of evaluating the expression. The
-   * expression is evaluated once against the root input value, and every key is
-   * replaced with the same result.
+   * Replace each key in a map with the result of evaluating the expression
+   * against that key.
    *
    * @param at
    *   The path to the map
@@ -264,9 +262,8 @@ object MigrationAction {
   }
 
   /**
-   * Replace each value in a map with the result of evaluating the expression.
-   * The expression is evaluated once against the root input value, and every
-   * value is replaced with the same result.
+   * Replace each value in a map with the result of evaluating the expression
+   * against that value.
    *
    * @param at
    *   The path to the map

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{DynamicOptic, DynamicSchemaExpr}
+
+/**
+ * Represents a single migration action that operates at a specific path. All
+ * actions are fully serializable (no closures or functions) and support
+ * structural reversal.
+ */
+sealed trait MigrationAction {
+
+  /**
+   * The path at which this action operates.
+   */
+  def at: DynamicOptic
+
+  /**
+   * Returns the structural inverse of this action. Note: Runtime reversal is
+   * best-effort and may fail if information was lost during the forward
+   * migration.
+   */
+  def reverse: MigrationAction
+}
+
+object MigrationAction {
+
+  // ==================== Record Actions ====================
+
+  /**
+   * Add a new field to a record with a default value. The field name is the
+   * last component of the `at` path.
+   *
+   * @param at
+   *   The path to the field to add (must end with a Field node)
+   * @param default
+   *   The default value expression for the new field
+   */
+  final case class AddField(
+    at: DynamicOptic,
+    default: DynamicSchemaExpr
+  ) extends MigrationAction {
+    override def reverse: MigrationAction = DropField(at, default)
+
+    /** The field name, extracted from the path */
+    def fieldName: Option[String] = at.nodes.lastOption match {
+      case Some(DynamicOptic.Node.Field(name)) => Some(name)
+      case _                                   => None
+    }
+  }
+
+  /**
+   * Drop a field from a record. The field name is the last component of the
+   * `at` path.
+   *
+   * @param at
+   *   The path to the field to drop (must end with a Field node)
+   * @param defaultForReverse
+   *   Default value expression to use when reversing (adding the field back)
+   */
+  final case class DropField(
+    at: DynamicOptic,
+    defaultForReverse: DynamicSchemaExpr
+  ) extends MigrationAction {
+    override def reverse: MigrationAction = AddField(at, defaultForReverse)
+
+    /** The field name, extracted from the path */
+    def fieldName: Option[String] = at.nodes.lastOption match {
+      case Some(DynamicOptic.Node.Field(name)) => Some(name)
+      case _                                   => None
+    }
+  }
+
+  /**
+   * Rename a field in a record.
+   *
+   * @param at
+   *   The path to the field to rename (must end with a Field node)
+   * @param to
+   *   The new field name
+   */
+  final case class RenameField(
+    at: DynamicOptic,
+    to: String
+  ) extends MigrationAction {
+    override def reverse: MigrationAction = {
+      // Extract the old field name from the path and create reverse
+      val parentPath = DynamicOptic(at.nodes.dropRight(1))
+      from match {
+        case Some(oldName) => RenameField(parentPath.field(to), oldName)
+        case None          => Irreversible(at, "RenameField")
+      }
+    }
+
+    /** The original field name, extracted from the path */
+    def from: Option[String] = at.nodes.lastOption match {
+      case Some(DynamicOptic.Node.Field(name)) => Some(name)
+      case _                                   => None
+    }
+  }
+
+  /**
+   * Transform a value at a path using a pure expression.
+   *
+   * @param at
+   *   The path to the value to transform
+   * @param transform
+   *   The transformation expression
+   */
+  final case class TransformField(
+    at: DynamicOptic,
+    transform: DynamicSchemaExpr
+  ) extends MigrationAction {
+    override def reverse: MigrationAction = Irreversible(at, "TransformField")
+  }
+
+  /**
+   * Convert an optional field to a required field.
+   *
+   * @param at
+   *   The path to the optional value
+   * @param default
+   *   The default value expression to use if the optional is None
+   */
+  final case class MandateField(
+    at: DynamicOptic,
+    default: DynamicSchemaExpr
+  ) extends MigrationAction {
+    override def reverse: MigrationAction = OptionalizeField(at)
+  }
+
+  /**
+   * Convert a required field to an optional field.
+   *
+   * @param at
+   *   The path to the required value
+   */
+  final case class OptionalizeField(
+    at: DynamicOptic
+  ) extends MigrationAction {
+    override def reverse: MigrationAction = Irreversible(at, "OptionalizeField")
+  }
+
+  /**
+   * Change the type of a value at a path (primitive-to-primitive only).
+   *
+   * @param at
+   *   The path to the value
+   * @param converter
+   *   The conversion expression
+   */
+  final case class ChangeFieldType(
+    at: DynamicOptic,
+    converter: DynamicSchemaExpr
+  ) extends MigrationAction {
+    override def reverse: MigrationAction = Irreversible(at, "ChangeFieldType")
+  }
+
+  // ==================== Enum Actions ====================
+
+  /**
+   * Rename an enum case.
+   *
+   * @param at
+   *   The path to the enum value
+   * @param from
+   *   The current case name
+   * @param to
+   *   The new case name
+   */
+  final case class RenameCase(
+    at: DynamicOptic,
+    from: String,
+    to: String
+  ) extends MigrationAction {
+    override def reverse: MigrationAction = RenameCase(at, to, from)
+  }
+
+  /**
+   * Transform the fields within an enum case.
+   *
+   * @param at
+   *   The path to the enum value
+   * @param actions
+   *   The actions to apply to the case's record
+   */
+  final case class TransformCase(
+    at: DynamicOptic,
+    actions: Chunk[MigrationAction]
+  ) extends MigrationAction {
+    override def reverse: MigrationAction =
+      TransformCase(at, actions.reverse.map(_.reverse))
+  }
+
+  /**
+   * Apply an existing migration to a nested field. This is used for migration
+   * composition where a pre-built Migration is applied to a field.
+   *
+   * @param at
+   *   The path to the nested field
+   * @param migration
+   *   The DynamicMigration to apply to the nested value
+   */
+  final case class MigrateField(
+    at: DynamicOptic,
+    migration: DynamicMigration
+  ) extends MigrationAction {
+    override def reverse: MigrationAction =
+      MigrateField(at, migration.reverse)
+  }
+
+  // ==================== Collection Actions ====================
+
+  /**
+   * Replace each element in a collection with the result of evaluating the
+   * expression. The expression is evaluated once against the root input value,
+   * and every element is replaced with the same result.
+   *
+   * @param at
+   *   The path to the collection
+   * @param transform
+   *   The expression whose result replaces each element
+   */
+  final case class TransformElements(
+    at: DynamicOptic,
+    transform: DynamicSchemaExpr
+  ) extends MigrationAction {
+    override def reverse: MigrationAction = Irreversible(at, "TransformElements")
+  }
+
+  // ==================== Map Actions ====================
+
+  /**
+   * Replace each key in a map with the result of evaluating the expression. The
+   * expression is evaluated once against the root input value, and every key is
+   * replaced with the same result.
+   *
+   * @param at
+   *   The path to the map
+   * @param transform
+   *   The expression whose result replaces each key
+   */
+  final case class TransformKeys(
+    at: DynamicOptic,
+    transform: DynamicSchemaExpr
+  ) extends MigrationAction {
+    override def reverse: MigrationAction = Irreversible(at, "TransformKeys")
+  }
+
+  /**
+   * Replace each value in a map with the result of evaluating the expression.
+   * The expression is evaluated once against the root input value, and every
+   * value is replaced with the same result.
+   *
+   * @param at
+   *   The path to the map
+   * @param transform
+   *   The expression whose result replaces each value
+   */
+  final case class TransformValues(
+    at: DynamicOptic,
+    transform: DynamicSchemaExpr
+  ) extends MigrationAction {
+    override def reverse: MigrationAction = Irreversible(at, "TransformValues")
+  }
+
+  /**
+   * Sentinel action representing a non-invertible operation. Executing this
+   * action always fails with a descriptive error. This is returned by
+   * `.reverse` on actions that cannot be structurally reversed (e.g.,
+   * `TransformValue`, `ChangeType`).
+   *
+   * @param at
+   *   The path where the original action operated
+   * @param originalAction
+   *   The name of the original non-invertible action
+   */
+  final case class Irreversible(
+    at: DynamicOptic,
+    originalAction: String
+  ) extends MigrationAction {
+    override def reverse: MigrationAction = this
+  }
+}

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/BitwiseOpticSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/BitwiseOpticSpec.scala
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema
+
+import zio.test._
+
+object BitwiseOpticSpec extends ZIOSpecDefault {
+
+  case class ByteRecord(value: Byte, mask: Byte)
+  object ByteRecord extends CompanionOptics[ByteRecord] {
+    implicit val schema: Schema[ByteRecord] = Schema.derived
+    val value: Lens[ByteRecord, Byte]       = $(_.value)
+    val mask: Lens[ByteRecord, Byte]        = $(_.mask)
+  }
+
+  case class ShortRecord(value: Short, mask: Short)
+  object ShortRecord extends CompanionOptics[ShortRecord] {
+    implicit val schema: Schema[ShortRecord] = Schema.derived
+    val value: Lens[ShortRecord, Short]      = $(_.value)
+    val mask: Lens[ShortRecord, Short]       = $(_.mask)
+  }
+
+  case class IntRecord(value: Int, mask: Int, shift: Int)
+  object IntRecord extends CompanionOptics[IntRecord] {
+    implicit val schema: Schema[IntRecord] = Schema.derived
+    val value: Lens[IntRecord, Int]        = $(_.value)
+    val mask: Lens[IntRecord, Int]         = $(_.mask)
+    val shift: Lens[IntRecord, Int]        = $(_.shift)
+  }
+
+  case class LongRecord(value: Long, mask: Long, shift: Long)
+  object LongRecord extends CompanionOptics[LongRecord] {
+    implicit val schema: Schema[LongRecord] = Schema.derived
+    val value: Lens[LongRecord, Long]       = $(_.value)
+    val mask: Lens[LongRecord, Long]        = $(_.mask)
+    val shift: Lens[LongRecord, Long]       = $(_.shift)
+  }
+
+  case class MixedIntegrals(b: Byte, s: Short, i: Int, l: Long)
+  object MixedIntegrals extends CompanionOptics[MixedIntegrals] {
+    implicit val schema: Schema[MixedIntegrals] = Schema.derived
+    val b: Lens[MixedIntegrals, Byte]           = $(_.b)
+    val s: Lens[MixedIntegrals, Short]          = $(_.s)
+    val i: Lens[MixedIntegrals, Int]            = $(_.i)
+    val l: Lens[MixedIntegrals, Long]           = $(_.l)
+  }
+
+  type PersonV0 = { val firstName: String; val lastName: String; val age: Int }
+  type PersonV1 = { val fullName: String; val age: Int; val score: Long }
+
+  type IntOrLong    = Int | Long
+  type ByteOrInt    = Byte | Int
+  type AllIntegrals = Byte | Short | Int | Long
+
+  case class UnionHolder(intOrLong: IntOrLong, byteOrInt: ByteOrInt)
+  object UnionHolder extends CompanionOptics[UnionHolder] {
+    implicit val schema: Schema[UnionHolder]        = Schema.derived
+    val intOrLong: Lens[UnionHolder, IntOrLong]     = $(_.intOrLong)
+    val byteOrInt: Lens[UnionHolder, ByteOrInt]     = $(_.byteOrInt)
+    val intOrLong_int: Optional[UnionHolder, Int]   = $(_.intOrLong.when[Int])
+    val intOrLong_long: Optional[UnionHolder, Long] = $(_.intOrLong.when[Long])
+  }
+
+  type OldCreditCard    = { type Tag = "CreditCard"; def number: String; def exp: String; def cvv: Int }
+  type OldWireTransfer  = { type Tag = "WireTransfer"; def account: String; def routing: Int }
+  type OldPaymentMethod = OldCreditCard | OldWireTransfer
+
+  case class Nested(inner: IntRecord)
+  object Nested extends CompanionOptics[Nested] {
+    implicit val schema: Schema[Nested] = Schema.derived
+    val inner: Lens[Nested, IntRecord]  = $(_.inner)
+    val innerValue: Lens[Nested, Int]   = $(_.inner.value)
+    val innerMask: Lens[Nested, Int]    = $(_.inner.mask)
+  }
+
+  def spec = suite("BitwiseOpticSpec")(
+    suite("Case class with Byte fields")(
+      test("& (AND) with literal") {
+        val record = ByteRecord(0x0f.toByte, 0xf0.toByte)
+        val expr   = ByteRecord.value & 0x03.toByte
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("| (OR) with literal") {
+        val record = ByteRecord(0x0f.toByte, 0xf0.toByte)
+        val expr   = ByteRecord.value | 0xf0.toByte
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("^ (XOR) with literal") {
+        val record = ByteRecord(0xff.toByte, 0x0f.toByte)
+        val expr   = ByteRecord.value ^ 0x0f.toByte
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("<< (left shift) with literal") {
+        val record = ByteRecord(0x01.toByte, 0x00.toByte)
+        val expr   = ByteRecord.value << 4.toByte
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test(">> (right shift) with literal") {
+        val record = ByteRecord(0x10.toByte, 0x00.toByte)
+        val expr   = ByteRecord.value >> 2.toByte
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test(">>> (unsigned right shift) with literal") {
+        val record = ByteRecord(0x80.toByte, 0x00.toByte)
+        val expr   = ByteRecord.value >>> 1.toByte
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      }
+    ),
+    suite("Case class with Short fields")(
+      test("& (AND) with literal") {
+        val record = ShortRecord(0x00ff.toShort, 0xff00.toShort)
+        val expr   = ShortRecord.value & 0x000f.toShort
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("| (OR) with literal") {
+        val record = ShortRecord(0x00ff.toShort, 0xff00.toShort)
+        val expr   = ShortRecord.value | 0xff00.toShort
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("<< (left shift) with literal") {
+        val record = ShortRecord(0x0001.toShort, 0x0000.toShort)
+        val expr   = ShortRecord.value << 8.toShort
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      }
+    ),
+    suite("Case class with Int fields")(
+      test("& (AND) with literal") {
+        val record = IntRecord(0x0000ffff, 0xffff0000, 4)
+        val expr   = IntRecord.value & 0x000000ff
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("| (OR) with literal") {
+        val record = IntRecord(0x0000ffff, 0xffff0000, 4)
+        val expr   = IntRecord.value | 0xffff0000
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("^ (XOR) with literal") {
+        val record = IntRecord(0xffffffff, 0x00000000, 4)
+        val expr   = IntRecord.value ^ 0x0f0f0f0f
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("<< (left shift) with literal") {
+        val record = IntRecord(1, 0, 4)
+        val expr   = IntRecord.value << 16
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test(">> (right shift) with literal") {
+        val record = IntRecord(0x00010000, 0, 4)
+        val expr   = IntRecord.value >> 8
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test(">>> (unsigned right shift) with literal") {
+        val record = IntRecord(0x80000000, 0, 4)
+        val expr   = IntRecord.value >>> 1
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      }
+    ),
+    suite("Case class with Long fields")(
+      test("& (AND) with literal") {
+        val record = LongRecord(0x00000000ffffffffL, 0xffffffff00000000L, 4L)
+        val expr   = LongRecord.value & 0x00000000000000ffL
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("| (OR) with literal") {
+        val record = LongRecord(0x00000000ffffffffL, 0xffffffff00000000L, 4L)
+        val expr   = LongRecord.value | 0xffffffff00000000L
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("^ (XOR) with literal") {
+        val record = LongRecord(0xffffffffffffffffL, 0L, 4L)
+        val expr   = LongRecord.value ^ 0x0f0f0f0f0f0f0f0fL
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("<< (left shift) with literal") {
+        val record = LongRecord(1L, 0L, 4L)
+        val expr   = LongRecord.value << 32L
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test(">> (right shift) with literal") {
+        val record = LongRecord(0x0001000000000000L, 0L, 4L)
+        val expr   = LongRecord.value >> 16L
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test(">>> (unsigned right shift) with literal") {
+        val record = LongRecord(0x8000000000000000L, 0L, 4L)
+        val expr   = LongRecord.value >>> 1L
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      }
+    ),
+    suite("Mixed integral types in one record")(
+      test("Byte & with Byte literal") {
+        val record = MixedIntegrals(0x0f.toByte, 0x00ff.toShort, 0x0000ffff, 0xffffffffL)
+        val expr   = MixedIntegrals.b & 0x03.toByte
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("Short | with Short literal") {
+        val record = MixedIntegrals(0x0f.toByte, 0x00ff.toShort, 0x0000ffff, 0xffffffffL)
+        val expr   = MixedIntegrals.s | 0xff00.toShort
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("Int ^ with Int literal") {
+        val record = MixedIntegrals(0x0f.toByte, 0x00ff.toShort, 0x0000ffff, 0xffffffffL)
+        val expr   = MixedIntegrals.i ^ 0xffff0000
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("Long << with Long literal") {
+        val record = MixedIntegrals(0x0f.toByte, 0x00ff.toShort, 0x0000ffff, 1L)
+        val expr   = MixedIntegrals.l << 32L
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      }
+    ),
+    suite("Nested structures")(
+      test("& on nested Int field") {
+        val record = Nested(IntRecord(0x0000ffff, 0xffff0000, 4))
+        val expr   = Nested.innerValue & 0x000000ff
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("| on nested Int field") {
+        val record = Nested(IntRecord(0x0000ffff, 0xffff0000, 4))
+        val expr   = Nested.innerMask | 0x0000ffff
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("<< on nested Int field") {
+        val record = Nested(IntRecord(1, 0, 4))
+        val expr   = Nested.innerValue << 8
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      }
+    ),
+    suite("Union types with integrals")(
+      test("Union Int | Long - access Int via when[Int]") {
+        val record = UnionHolder(42, 0xff.toByte)
+        val expr   = UnionHolder.intOrLong_int & 0x0f
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight)
+      },
+      test("Union Int | Long - access Long via when[Long]") {
+        val record = UnionHolder(100L, 0x0f.toByte)
+        val expr   = UnionHolder.intOrLong_long | 0xffL
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight)
+      }
+    ),
+    suite("All bitwise operators with case class optics")(
+      test("unary_~ (bitwise NOT)") {
+        val record = IntRecord(0x0f0f0f0f, 0, 0)
+        val expr   = ~IntRecord.value
+        val result = expr.evalDynamic(record)
+        assertTrue(result.isRight && result.exists(_.nonEmpty))
+      },
+      test("multiple bitwise operations") {
+        val record  = IntRecord(0xff, 0x0f, 4)
+        val expr1   = IntRecord.value & 0x0f
+        val expr2   = IntRecord.mask | 0xf0
+        val result1 = expr1.evalDynamic(record)
+        val result2 = expr2.evalDynamic(record)
+        assertTrue(result1.isRight && result2.isRight)
+      }
+    )
+  )
+}

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/migration/MigrationBuildValidationSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/migration/MigrationBuildValidationSpec.scala
@@ -1,0 +1,517 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.test.*
+import zio.blocks.schema.*
+
+object MigrationBuildValidationSpec extends ZIOSpecDefault {
+
+  private def literal[A: Schema](value: A): SchemaExpr[Any, A] =
+    SchemaExpr.literal(value)
+
+  def spec: Spec[TestEnvironment, Any] = suite("MigrationBuildValidationSpec")(
+    suite("build validation")(
+      test("build succeeds when all fields are handled via auto-mapping") {
+        case class PersonV1(name: String, age: Int)
+        case class PersonV2(name: String, age: Int)
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .build
+
+        val input  = PersonV1("Alice", 30)
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2("Alice", 30)))
+      },
+      test("build succeeds when new field is added") {
+        case class PersonV1(name: String)
+        case class PersonV2(name: String, age: Int)
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .addField(_.age, literal(0))
+          .build
+
+        val input  = PersonV1("Alice")
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2("Alice", 0)))
+      },
+      test("build succeeds when field is dropped") {
+        case class PersonV1(name: String, age: Int)
+        case class PersonV2(name: String)
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .dropField(_.age, literal(0))
+          .build
+
+        val input  = PersonV1("Alice", 30)
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2("Alice")))
+      },
+      test("build succeeds when field is renamed") {
+        case class PersonV1(firstName: String)
+        case class PersonV2(fullName: String)
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .renameField(_.firstName, _.fullName)
+          .build
+
+        val input  = PersonV1("Alice")
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2("Alice")))
+      },
+      test("build succeeds when field is transformed") {
+        case class PersonV1(age: Int)
+        case class PersonV2(age: Long)
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .transformField(_.age, _.age, literal(30L))
+          .build
+
+        val input  = PersonV1(30)
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2(30L)))
+      },
+      test("build fails to compile when target field is missing") {
+        typeCheck {
+          """
+          import zio.blocks.schema.Schema
+          import zio.blocks.schema.migration.Migration
+          
+          case class V1(name: String)
+          case class V2(name: String, age: Int)
+
+          given Schema[V1] = Schema.derived[V1]
+          given Schema[V2] = Schema.derived[V2]
+
+          Migration.newBuilder[V1, V2].build
+          """
+        }.map { result =>
+          assertTrue(result.isLeft)
+        }
+      },
+      test("build fails to compile when source field is not handled") {
+        typeCheck {
+          """
+          import zio.blocks.schema.Schema
+          import zio.blocks.schema.migration.Migration
+          
+          case class V1(name: String, age: Int)
+          case class V2(name: String)
+
+          given Schema[V1] = Schema.derived[V1]
+          given Schema[V2] = Schema.derived[V2]
+
+          Migration.newBuilder[V1, V2].build
+          """
+        }.map { result =>
+          assertTrue(result.isLeft)
+        }
+      },
+      test("buildPartial succeeds even when fields are missing") {
+        case class PersonV1(name: String, age: Int)
+        case class PersonV2(name: String, birthYear: Int)
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .buildPartial
+
+        assertTrue(migration.actions.isEmpty)
+      },
+      test("build succeeds with migrateField for nested type migration") {
+        case class AddressV1(street: String, city: String)
+        case class AddressV2(street: String, city: String, zip: String)
+        case class PersonV1(name: String, address: AddressV1)
+        case class PersonV2(name: String, address: AddressV2)
+
+        given Schema[AddressV1] = Schema.derived[AddressV1]
+        given Schema[AddressV2] = Schema.derived[AddressV2]
+        given Schema[PersonV1]  = Schema.derived[PersonV1]
+        given Schema[PersonV2]  = Schema.derived[PersonV2]
+
+        val addressMigration = Migration
+          .newBuilder[AddressV1, AddressV2]
+          .addField(_.zip, literal("00000"))
+          .build
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .migrateField(_.address, addressMigration)
+          .build
+
+        val input  = PersonV1("Alice", AddressV1("123 Main St", "Springfield"))
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2("Alice", AddressV2("123 Main St", "Springfield", "00000"))))
+      },
+      test("build fails to compile when nested field is missing without migrateField") {
+        typeCheck {
+          """
+          import zio.blocks.schema.Schema
+          import zio.blocks.schema.migration.Migration
+
+          case class AddressV1(street: String, city: String)
+          case class AddressV2(street: String, city: String, zip: String)
+          case class PersonV1(name: String, address: AddressV1)
+          case class PersonV2(name: String, address: AddressV2)
+
+          given Schema[AddressV1] = Schema.derived[AddressV1]
+          given Schema[AddressV2] = Schema.derived[AddressV2]
+          given Schema[PersonV1]  = Schema.derived[PersonV1]
+          given Schema[PersonV2]  = Schema.derived[PersonV2]
+
+          Migration.newBuilder[PersonV1, PersonV2].build
+          """
+        }.map { result =>
+          assertTrue(result.isLeft)
+        }
+      },
+      test("build succeeds with migrateField when dropping nested field") {
+        case class AddressV1(street: String, city: String, zip: String)
+        case class AddressV2(street: String, city: String)
+        case class PersonV1(name: String, address: AddressV1)
+        case class PersonV2(name: String, address: AddressV2)
+
+        given Schema[AddressV1] = Schema.derived[AddressV1]
+        given Schema[AddressV2] = Schema.derived[AddressV2]
+        given Schema[PersonV1]  = Schema.derived[PersonV1]
+        given Schema[PersonV2]  = Schema.derived[PersonV2]
+
+        val addressMigration = Migration
+          .newBuilder[AddressV1, AddressV2]
+          .dropField(_.zip, literal("00000"))
+          .build
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .migrateField(_.address, addressMigration)
+          .build
+
+        val input  = PersonV1("Alice", AddressV1("123 Main St", "Springfield", "12345"))
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2("Alice", AddressV2("123 Main St", "Springfield"))))
+      },
+      test("build succeeds when nested types are identical (auto-mapped)") {
+        case class Address(street: String, city: String)
+        case class PersonV1(name: String, address: Address)
+        case class PersonV2(name: String, address: Address, age: Int)
+
+        given Schema[Address]  = Schema.derived[Address]
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .addField(_.age, literal(0))
+          .build
+
+        val input  = PersonV1("Alice", Address("123 Main St", "Springfield"))
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2("Alice", Address("123 Main St", "Springfield"), 0)))
+      },
+      test("build succeeds with deep nested addField") {
+        case class Address1(street: String)
+        case class Person1(name: String, address: Address1)
+
+        case class Address2(street: String, number: Int)
+        case class Person2(name: String, address: Address2)
+
+        given Schema[Address1] = Schema.derived
+        given Schema[Person1]  = Schema.derived
+        given Schema[Address2] = Schema.derived
+        given Schema[Person2]  = Schema.derived
+
+        val migration = Migration
+          .newBuilder[Person1, Person2]
+          .addField(_.address.number, literal(0))
+          .build
+
+        val input  = Person1("Alice", Address1("123 Main"))
+        val result = migration(input)
+
+        assertTrue(result == Right(Person2("Alice", Address2("123 Main", 0))))
+      },
+      test("build succeeds with deep nested renameField") {
+        case class Address1(street: String, city: String)
+        case class Person1(name: String, address: Address1)
+
+        case class Address2(streetName: String, city: String)
+        case class Person2(name: String, address: Address2)
+
+        given Schema[Address1] = Schema.derived
+        given Schema[Person1]  = Schema.derived
+        given Schema[Address2] = Schema.derived
+        given Schema[Person2]  = Schema.derived
+
+        val migration = Migration
+          .newBuilder[Person1, Person2]
+          .renameField(_.address.street, _.address.streetName)
+          .build
+
+        val input  = Person1("Alice", Address1("123 Main", "NYC"))
+        val result = migration(input)
+
+        assertTrue(result == Right(Person2("Alice", Address2("123 Main", "NYC"))))
+      },
+      test("build succeeds with 3-level deep addField") {
+        case class Street1(name: String)
+        case class Address1(street: Street1, city: String)
+        case class Person1(name: String, address: Address1)
+
+        case class Street2(name: String, number: Int)
+        case class Address2(street: Street2, city: String)
+        case class Person2(name: String, address: Address2)
+
+        given Schema[Street1]  = Schema.derived
+        given Schema[Address1] = Schema.derived
+        given Schema[Person1]  = Schema.derived
+        given Schema[Street2]  = Schema.derived
+        given Schema[Address2] = Schema.derived
+        given Schema[Person2]  = Schema.derived
+
+        val migration = Migration
+          .newBuilder[Person1, Person2]
+          .addField(_.address.street.number, literal(0))
+          .build
+
+        val input  = Person1("Alice", Address1(Street1("Main"), "NYC"))
+        val result = migration(input)
+
+        assertTrue(result == Right(Person2("Alice", Address2(Street2("Main", 0), "NYC"))))
+      },
+      test("build fails when deep nested target field not provided") {
+        typeCheck {
+          """
+          import zio.blocks.schema.Schema
+          import zio.blocks.schema.migration.Migration
+
+          case class Street1(name: String)
+          case class Address1(street: Street1)
+          case class Person1(info: Address1)
+
+          case class Street2(name: String, number: Int)
+          case class Address2(street: Street2)
+          case class Person2(info: Address2)
+
+          given Schema[Street1]  = Schema.derived
+          given Schema[Address1] = Schema.derived
+          given Schema[Person1]  = Schema.derived
+          given Schema[Street2]  = Schema.derived
+          given Schema[Address2] = Schema.derived
+          given Schema[Person2]  = Schema.derived
+
+          Migration.newBuilder[Person1, Person2].build
+          """
+        }.map { result =>
+          assertTrue(result.isLeft)
+        }
+      },
+      test("phantom type tracks deep field path correctly") {
+        case class Inner1(x: Int)
+        case class Outer1(inner: Inner1, y: String)
+
+        case class Inner2(x: Int, z: Boolean)
+        case class Outer2(inner: Inner2, y: String)
+
+        given Schema[Inner1] = Schema.derived
+        given Schema[Outer1] = Schema.derived
+        given Schema[Inner2] = Schema.derived
+        given Schema[Outer2] = Schema.derived
+
+        val migration = Migration
+          .newBuilder[Outer1, Outer2]
+          .addField(_.inner.z, literal(false))
+          .build
+
+        val input  = Outer1(Inner1(42), "hello")
+        val result = migration(input)
+
+        assertTrue(result == Right(Outer2(Inner2(42, false), "hello")))
+      },
+      test("phantom type distinguishes depth: shallow field does not satisfy deep requirement") {
+        typeCheck {
+          """
+          import zio.blocks.schema.Schema
+          import zio.blocks.schema.migration.Migration
+
+          case class Inner1(x: Int)
+          case class Outer1(inner: Inner1, extra: String)
+
+          case class Inner2(x: Int, extra: String)
+          case class Outer2(inner: Inner2, extra: String)
+
+          given Schema[Inner1] = Schema.derived
+          given Schema[Outer1] = Schema.derived
+          given Schema[Inner2] = Schema.derived
+          given Schema[Outer2] = Schema.derived
+
+          Migration.newBuilder[Outer1, Outer2].build
+          """
+        }.map { result =>
+          assertTrue(result.isLeft)
+        }
+      }
+    ),
+    suite("Changeset type inference")(
+      test("addField accumulates AddField in Changeset") {
+        typeCheck {
+          """
+          import zio.blocks.schema.Schema
+          import zio.blocks.schema.SchemaExpr
+          import zio.blocks.schema.migration._
+
+          case class V1(name: String)
+          case class V2(name: String, age: Int)
+          given Schema[V1] = Schema.derived
+          given Schema[V2] = Schema.derived
+
+          val x: Int = Migration.newBuilder[V1, V2].addField(_.age, SchemaExpr.literal(0))
+          """
+        }.map { result =>
+          assertTrue(
+            result.isLeft,
+            result.left.exists(_.contains("Changeset.AddField[(\"age\" : String)]"))
+          )
+        }
+      },
+      test("dropField accumulates DropField in Changeset") {
+        typeCheck {
+          """
+          import zio.blocks.schema.Schema
+          import zio.blocks.schema.SchemaExpr
+          import zio.blocks.schema.migration._
+
+          case class V1(name: String, age: Int)
+          case class V2(name: String)
+          given Schema[V1] = Schema.derived
+          given Schema[V2] = Schema.derived
+
+          val x: Int = Migration.newBuilder[V1, V2].dropField(_.age, SchemaExpr.literal(0))
+          """
+        }.map { result =>
+          assertTrue(
+            result.isLeft,
+            result.left.exists(_.contains("Changeset.DropField[(\"age\" : String)]"))
+          )
+        }
+      },
+      test("renameField accumulates RenameField in Changeset") {
+        typeCheck {
+          """
+          import zio.blocks.schema.Schema
+          import zio.blocks.schema.migration._
+
+          case class V1(name: String)
+          case class V2(fullName: String)
+          given Schema[V1] = Schema.derived
+          given Schema[V2] = Schema.derived
+
+          val x: Int = Migration.newBuilder[V1, V2].renameField(_.name, _.fullName)
+          """
+        }.map { result =>
+          assertTrue(
+            result.isLeft,
+            result.left.exists(msg =>
+              msg.contains("Changeset.RenameField[(\"name\" : String)") &&
+                msg.contains("(\"fullName\" : String)]")
+            )
+          )
+        }
+      },
+      test("transformField accumulates TransformField in Changeset") {
+        typeCheck {
+          """
+          import zio.blocks.schema.Schema
+          import zio.blocks.schema.SchemaExpr
+          import zio.blocks.schema.migration._
+
+          case class V1(age: Int)
+          case class V2(age: Long)
+          given Schema[V1] = Schema.derived
+          given Schema[V2] = Schema.derived
+
+          val x: Int = Migration.newBuilder[V1, V2].transformField(_.age, _.age, SchemaExpr.literal(0L))
+          """
+        }.map { result =>
+          assertTrue(
+            result.isLeft,
+            result.left.exists(msg =>
+              msg.contains("Changeset.TransformField[(\"age\" : String)") &&
+                msg.contains("(\"age\" : String)]")
+            )
+          )
+        }
+      },
+      test("chained operations accumulate all operations in Changeset") {
+        typeCheck {
+          """
+          import zio.blocks.schema.Schema
+          import zio.blocks.schema.SchemaExpr
+          import zio.blocks.schema.migration._
+
+          case class V1(name: String, age: Int)
+          case class V2(fullName: String, age: Int, email: String)
+          given Schema[V1] = Schema.derived
+          given Schema[V2] = Schema.derived
+
+          val x: Int = Migration.newBuilder[V1, V2]
+            .renameField(_.name, _.fullName)
+            .addField(_.email, SchemaExpr.literal(""))
+          """
+        }.map { result =>
+          assertTrue(
+            result.isLeft,
+            result.left.exists(msg =>
+              msg.contains("Changeset.RenameField[(\"name\" : String)") &&
+                msg.contains("(\"fullName\" : String)]")
+            ),
+            result.left.exists(_.contains("Changeset.AddField[(\"email\" : String)]"))
+          )
+        }
+      }
+    )
+  )
+}

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/migration/MigrationBuildValidationSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/migration/MigrationBuildValidationSpec.scala
@@ -146,18 +146,18 @@ object MigrationBuildValidationSpec extends ZIOSpecDefault {
           assertTrue(result.isLeft)
         }
       },
-      test("buildPartial succeeds even when fields are missing") {
-        case class PersonV1(name: String, age: Int)
-        case class PersonV2(name: String, birthYear: Int)
+      test("builder can be inspected before build") {
+        case class PersonV1(name: String)
+        case class PersonV2(name: String, age: Int)
 
         given Schema[PersonV1] = Schema.derived[PersonV1]
         given Schema[PersonV2] = Schema.derived[PersonV2]
 
-        val migration = Migration
+        val builder = Migration
           .newBuilder[PersonV1, PersonV2]
-          .buildPartial
+          .addField(_.age, literal(0))
 
-        assertTrue(migration.actions.isEmpty)
+        assertTrue(builder.actions.length == 1)
       },
       test("build succeeds with migrateField for nested type migration") {
         case class AddressV1(street: String, city: String)
@@ -392,6 +392,49 @@ object MigrationBuildValidationSpec extends ZIOSpecDefault {
           """
         }.map { result =>
           assertTrue(result.isLeft)
+        }
+      },
+      test("build succeeds with migrateField for nested structural target fields") {
+        typeCheck {
+          """
+          import scala.language.reflectiveCalls
+          import scala.reflect.Selectable.reflectiveSelectable
+          import zio.blocks.schema.Schema
+          import zio.blocks.schema.SchemaExpr
+          import zio.blocks.schema.migration.Migration
+
+          type StreetV1 = { def name: String }
+          type AddressV1 = { def street: StreetV1; def city: String }
+          type PersonV1 = { def name: String; def address: AddressV1 }
+
+          type StreetV2 = { def name: String; def number: Int }
+          type AddressV2 = { def street: StreetV2; def city: String }
+          type PersonV2 = { def name: String; def address: AddressV2 }
+
+          given Schema[StreetV1] = Schema.derived[StreetV1]
+          given Schema[AddressV1] = Schema.derived[AddressV1]
+          given Schema[PersonV1] = Schema.derived[PersonV1]
+          given Schema[StreetV2] = Schema.derived[StreetV2]
+          given Schema[AddressV2] = Schema.derived[AddressV2]
+          given Schema[PersonV2] = Schema.derived[PersonV2]
+
+          val streetMigration: Migration[StreetV1, StreetV2] = Migration
+            .newBuilder[StreetV1, StreetV2]
+            .addField(_.number, SchemaExpr.literal(0))
+            .build
+
+          val addressMigration: Migration[AddressV1, AddressV2] = Migration
+            .newBuilder[AddressV1, AddressV2]
+            .migrateField(_.street, streetMigration)
+            .build
+
+          Migration
+            .newBuilder[PersonV1, PersonV2]
+            .migrateField(_.address, addressMigration)
+            .build
+          """
+        }.map { result =>
+          assertTrue(result.isRight)
         }
       }
     ),

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/migration/MigrationBuildValidationSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/migration/MigrationBuildValidationSpec.scala
@@ -436,7 +436,7 @@ object MigrationBuildValidationSpec extends ZIOSpecDefault {
         }.map { result =>
           assertTrue(result.isRight)
         }
-      }
+      } @@ TestAspect.exceptJS
     ),
     suite("Changeset type inference")(
       test("addField accumulates AddField in Changeset") {

--- a/schema/shared/src/test/scala/zio/blocks/schema/PrimitiveTypeSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/PrimitiveTypeSpec.scala
@@ -793,6 +793,188 @@ object PrimitiveTypeSpec extends SchemaBaseSpec {
         val roundTrip            = schema.fromDynamicValue(dv)
         assertTrue(roundTrip == Right(PrimitiveType.Int(Validation.Numeric.Positive)))
       }
+    ),
+    suite("narrowing failure paths")(
+      test("Byte rejects out-of-range Short, Int, Long, Float, Double, BigInt, BigDecimal") {
+        val tpe    = PrimitiveType.Byte(None)
+        val errMsg = SchemaError.expectationMismatch(Nil, "Expected Byte")
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Short(300))))(isLeft(equalTo(errMsg))) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(300))))(isLeft(equalTo(errMsg))) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(300L))))(isLeft(equalTo(errMsg))) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Float(300.5f))))(isLeft(equalTo(errMsg))) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Double(300.5))))(isLeft(equalTo(errMsg))) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.BigInt(BigInt(300)))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal(300.5)))))(
+          isLeft(equalTo(errMsg))
+        )
+      },
+      test("Short rejects out-of-range Int, Long, Float, Double, BigInt, BigDecimal") {
+        val tpe    = PrimitiveType.Short(None)
+        val errMsg = SchemaError.expectationMismatch(Nil, "Expected Short")
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(40000))))(isLeft(equalTo(errMsg))) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(40000L))))(isLeft(equalTo(errMsg))) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Float(40000.5f))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Double(40000.5))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.BigInt(BigInt(40000)))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal(40000.5)))))(
+          isLeft(equalTo(errMsg))
+        )
+      },
+      test("Int rejects out-of-range Float, Long, Double, BigInt, BigDecimal") {
+        val tpe    = PrimitiveType.Int(None)
+        val errMsg = SchemaError.expectationMismatch(Nil, "Expected Int")
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Float(1.5f))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(3000000000L))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Double(3000000000.5))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.BigInt(BigInt(3000000000L)))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal(1.5)))))(
+          isLeft(equalTo(errMsg))
+        )
+      },
+      test("Long rejects out-of-range Float, Double, BigInt, BigDecimal") {
+        val tpe    = PrimitiveType.Long(None)
+        val errMsg = SchemaError.expectationMismatch(Nil, "Expected Long")
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Float(1.5f))))(isLeft(equalTo(errMsg))) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Double(1.5))))(isLeft(equalTo(errMsg))) &&
+        assert(
+          tpe.fromDynamicValue(
+            DynamicValue.Primitive(PrimitiveValue.BigInt(BigInt("99999999999999999999")))
+          )
+        )(isLeft(equalTo(errMsg))) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal(1.5)))))(
+          isLeft(equalTo(errMsg))
+        )
+      },
+      test("Float rejects lossy Int, Long, Double, BigInt, BigDecimal") {
+        val tpe    = PrimitiveType.Float(None)
+        val errMsg = SchemaError.expectationMismatch(Nil, "Expected Float")
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(16777217))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(9007199254740993L))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Double(1.0000000001))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(
+          tpe.fromDynamicValue(
+            DynamicValue.Primitive(PrimitiveValue.BigInt(BigInt("99999999999999999999")))
+          )
+        )(isLeft(equalTo(errMsg))) &&
+        assert(
+          tpe.fromDynamicValue(
+            DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal("1.00000000000001")))
+          )
+        )(isLeft(equalTo(errMsg)))
+      },
+      test("Double rejects lossy Long, BigInt, BigDecimal") {
+        val tpe    = PrimitiveType.Double(None)
+        val errMsg = SchemaError.expectationMismatch(Nil, "Expected Double")
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(9007199254740993L))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(
+          tpe.fromDynamicValue(
+            DynamicValue.Primitive(PrimitiveValue.BigInt(BigInt("99999999999999999999")))
+          )
+        )(isLeft(equalTo(errMsg))) &&
+        assert(
+          tpe.fromDynamicValue(
+            DynamicValue.Primitive(
+              PrimitiveValue.BigDecimal(BigDecimal("1.0000000000000000001"))
+            )
+          )
+        )(isLeft(equalTo(errMsg)))
+      },
+      test("Char rejects out-of-range Int, Long, Float, Double, BigInt, BigDecimal") {
+        val tpe    = PrimitiveType.Char(None)
+        val errMsg = SchemaError.expectationMismatch(Nil, "Expected Char")
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Int(70000))))(isLeft(equalTo(errMsg))) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Long(70000L))))(isLeft(equalTo(errMsg))) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Float(70000.5f))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Double(70000.5))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.BigInt(BigInt(70000)))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal(70000.5)))))(
+          isLeft(equalTo(errMsg))
+        )
+      },
+      test("BigInt rejects non-finite Float and Double, and fractional values") {
+        val tpe    = PrimitiveType.BigInt(None)
+        val errMsg = SchemaError.expectationMismatch(Nil, "Expected BigInt")
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Float(Float.NaN))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Float(Float.PositiveInfinity))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Double(Double.NaN))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Double(Double.PositiveInfinity))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Float(1.5f))))(isLeft(equalTo(errMsg))) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Double(1.5))))(isLeft(equalTo(errMsg))) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal(1.5)))))(
+          isLeft(equalTo(errMsg))
+        )
+      },
+      test("BigDecimal rejects non-finite Float and Double") {
+        val tpe    = PrimitiveType.BigDecimal(None)
+        val errMsg = SchemaError.expectationMismatch(Nil, "Expected BigDecimal")
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Float(Float.NaN))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Float(Float.PositiveInfinity))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Double(Double.NaN))))(
+          isLeft(equalTo(errMsg))
+        ) &&
+        assert(tpe.fromDynamicValue(DynamicValue.Primitive(PrimitiveValue.Double(Double.PositiveInfinity))))(
+          isLeft(equalTo(errMsg))
+        )
+      },
+      test("fromDynamicValue with non-Primitive DynamicValue fails for numeric types") {
+        val record = DynamicValue.Record("x" -> DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        assert(PrimitiveType.Byte(None).fromDynamicValue(record))(isLeft) &&
+        assert(PrimitiveType.Short(None).fromDynamicValue(record))(isLeft) &&
+        assert(PrimitiveType.Int(None).fromDynamicValue(record))(isLeft) &&
+        assert(PrimitiveType.Long(None).fromDynamicValue(record))(isLeft) &&
+        assert(PrimitiveType.Float(None).fromDynamicValue(record))(isLeft) &&
+        assert(PrimitiveType.Double(None).fromDynamicValue(record))(isLeft) &&
+        assert(PrimitiveType.Char(None).fromDynamicValue(record))(isLeft) &&
+        assert(PrimitiveType.BigInt(None).fromDynamicValue(record))(isLeft) &&
+        assert(PrimitiveType.BigDecimal(None).fromDynamicValue(record))(isLeft)
+      }
+    ),
+    suite("typeReprToPrimitiveType via fromTypeId")(
+      test("returns None for null typeId") {
+        assertTrue(PrimitiveType.fromTypeId(null) == scala.None)
+      }
     )
   )
 }

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaExprSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaExprSpec.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema
+
+import zio.test._
+
+object SchemaExprSpec extends ZIOSpecDefault {
+
+  private def intLit(n: Int): SchemaExpr[Any, Int] =
+    SchemaExpr.literal[Any, Int](n)
+
+  private def stringLit(s: String): SchemaExpr[Any, String] =
+    SchemaExpr.literal[Any, String](s)
+
+  private def boolLit(b: Boolean): SchemaExpr[Any, Boolean] =
+    SchemaExpr.literal[Any, Boolean](b)
+
+  private def byteLit(b: Byte): SchemaExpr[Any, Byte] =
+    SchemaExpr.literal[Any, Byte](b)
+
+  private def shortLit(s: Short): SchemaExpr[Any, Short] =
+    SchemaExpr.literal[Any, Short](s)
+
+  private def longLit(l: Long): SchemaExpr[Any, Long] =
+    SchemaExpr.literal[Any, Long](l)
+
+  def spec = suite("SchemaExprSpec")(
+    suite("Literal")(
+      test("creates int literal") {
+        val lit      = intLit(42)
+        val expected = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(42)))
+        assertTrue(lit.dynamic == expected)
+      },
+      test("creates string literal") {
+        val lit      = stringLit("hello")
+        val expected = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("hello")))
+        assertTrue(lit.dynamic == expected)
+      },
+      test("creates boolean literal") {
+        val lit      = boolLit(true)
+        val expected = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Boolean(true)))
+        assertTrue(lit.dynamic == expected)
+      },
+      test("evalDynamic returns literal value") {
+        val lit = intLit(99)
+        assertTrue(lit.evalDynamic(()) == Right(Seq(DynamicValue.Primitive(PrimitiveValue.Int(99)))))
+      }
+    ),
+    suite("PrimitiveConversion")(
+      test("ByteToInt conversion") {
+        val conv  = SchemaExpr.ConversionType.ByteToInt
+        val input = DynamicValue.Primitive(PrimitiveValue.Byte(42.toByte))
+        assertTrue(conv.convert(input) == Right(DynamicValue.Primitive(PrimitiveValue.Int(42))))
+      },
+      test("IntToLong conversion") {
+        val conv  = SchemaExpr.ConversionType.IntToLong
+        val input = DynamicValue.Primitive(PrimitiveValue.Int(100))
+        assertTrue(conv.convert(input) == Right(DynamicValue.Primitive(PrimitiveValue.Long(100L))))
+      },
+      test("StringToInt conversion succeeds") {
+        val conv  = SchemaExpr.ConversionType.StringToInt
+        val input = DynamicValue.Primitive(PrimitiveValue.String("42"))
+        assertTrue(conv.convert(input) == Right(DynamicValue.Primitive(PrimitiveValue.Int(42))))
+      },
+      test("StringToInt conversion fails on invalid input") {
+        val conv  = SchemaExpr.ConversionType.StringToInt
+        val input = DynamicValue.Primitive(PrimitiveValue.String("abc"))
+        assertTrue(conv.convert(input).isLeft)
+      },
+      test("FloatToDouble conversion") {
+        val conv  = SchemaExpr.ConversionType.FloatToDouble
+        val input = DynamicValue.Primitive(PrimitiveValue.Float(3.14f))
+        assertTrue(conv.convert(input).isRight)
+      }
+    ),
+    suite("Bitwise")(
+      test("And operator (Byte)") {
+        val expr   = SchemaExpr.bitwise(byteLit(12), byteLit(10), SchemaExpr.BitwiseOperator.And)
+        val result = expr.evalDynamic(())
+        assertTrue(result.isRight && result.exists(seq => seq.nonEmpty))
+      },
+      test("evalDynamic with byte and byte (Or)") {
+        val expr   = SchemaExpr.bitwise(byteLit(12), byteLit(10), SchemaExpr.BitwiseOperator.Or)
+        val result = expr.evalDynamic(())
+        assertTrue(result.isRight && result.exists(seq => seq.nonEmpty))
+      },
+      test("evalDynamic with byte and byte (Xor)") {
+        val expr   = SchemaExpr.bitwise(byteLit(12), byteLit(10), SchemaExpr.BitwiseOperator.Xor)
+        val result = expr.evalDynamic(())
+        assertTrue(result.isRight && result.exists(seq => seq.nonEmpty))
+      },
+      test("evalDynamic with short and short (And)") {
+        val expr   = SchemaExpr.bitwise(shortLit(12), shortLit(10), SchemaExpr.BitwiseOperator.And)
+        val result = expr.evalDynamic(())
+        assertTrue(result.isRight && result.exists(seq => seq.nonEmpty))
+      },
+      test("evalDynamic with short and short (Or)") {
+        val expr   = SchemaExpr.bitwise(shortLit(12), shortLit(10), SchemaExpr.BitwiseOperator.Or)
+        val result = expr.evalDynamic(())
+        assertTrue(result.isRight && result.exists(seq => seq.nonEmpty))
+      },
+      test("evalDynamic with int and int (Xor)") {
+        val expr   = SchemaExpr.bitwise(intLit(12), intLit(10), SchemaExpr.BitwiseOperator.Xor)
+        val result = expr.evalDynamic(())
+        assertTrue(result.isRight && result.exists(seq => seq.nonEmpty))
+      }
+    )
+  )
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaExprSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaExprSpec.scala
@@ -85,6 +85,21 @@ object SchemaExprSpec extends ZIOSpecDefault {
         val conv  = SchemaExpr.ConversionType.FloatToDouble
         val input = DynamicValue.Primitive(PrimitiveValue.Float(3.14f))
         assertTrue(conv.convert(input).isRight)
+      },
+      test("IntToByte rejects out-of-range values") {
+        val conv  = SchemaExpr.ConversionType.IntToByte
+        val input = DynamicValue.Primitive(PrimitiveValue.Int(128))
+        assertTrue(conv.convert(input).isLeft)
+      },
+      test("FloatToInt rejects fractional values") {
+        val conv  = SchemaExpr.ConversionType.FloatToInt
+        val input = DynamicValue.Primitive(PrimitiveValue.Float(3.5f))
+        assertTrue(conv.convert(input).isLeft)
+      },
+      test("DoubleToFloat rejects lossy values") {
+        val conv  = SchemaExpr.ConversionType.DoubleToFloat
+        val input = DynamicValue.Primitive(PrimitiveValue.Double(0.1d))
+        assertTrue(conv.convert(input).isLeft)
       }
     ),
     suite("Bitwise")(
@@ -117,6 +132,21 @@ object SchemaExprSpec extends ZIOSpecDefault {
         val expr   = SchemaExpr.bitwise(intLit(12), intLit(10), SchemaExpr.BitwiseOperator.Xor)
         val result = expr.evalDynamic(())
         assertTrue(result.isRight && result.exists(seq => seq.nonEmpty))
+      }
+    ),
+    suite("Error handling")(
+      test("evalDynamic reports invalid substring indices as OpticCheck") {
+        val expr = SchemaExpr(
+          DynamicSchemaExpr.StringSubstring(
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("hello"))),
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(3))),
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(10)))
+          ),
+          Schema[Unit],
+          Schema[String]
+        )
+
+        assertTrue(expr.evalDynamic(()).isLeft)
       }
     )
   )

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSpec.scala
@@ -2870,6 +2870,281 @@ object JsonSpec extends SchemaBaseSpec {
         val result = json.delete(path)
         assertTrue(result == json)
       }
+    ),
+    suite("additional path operation coverage")(
+      test("modifyOrFail on non-array with Elements returns Left") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.modifyOrFail(DynamicOptic.elements) { case j => j }
+        assertTrue(result.isLeft)
+      },
+      test("modifyOrFail on non-object with MapValues returns Left") {
+        val json   = Json.Array(Json.Number(1))
+        val result = json.modifyOrFail(DynamicOptic.mapValues) { case j => j }
+        assertTrue(result.isLeft)
+      },
+      test("modifyOrFail with AtIndex on non-array returns Left") {
+        val json   = Json.String("hello")
+        val result = json.modifyOrFail(DynamicOptic.root.at(0)) { case j => j }
+        assertTrue(result.isLeft)
+      },
+      test("modifyOrFail with AtIndex out of bounds returns Left") {
+        val json   = Json.Array(Json.Number(1))
+        val result = json.modifyOrFail(DynamicOptic.root.at(5)) { case j => j }
+        assertTrue(result.isLeft)
+      },
+      test("modifyOrFail propagates error through nested AtIndex") {
+        val json   = Json.Array(Json.Object("x" -> Json.Number(1)))
+        val result = json.modifyOrFail(DynamicOptic.root.at(0).field("missing")) { case j => j }
+        assertTrue(result.isLeft)
+      },
+      test("modifyOrFail with fallthrough node types delegates to non-failing version") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.modifyOrFail(DynamicOptic.root.atIndices(0, 1)) { case j => j }
+        assertTrue(result.isLeft)
+      },
+      test("modifyOrFail with MapKeys falls through to non-failing delegate") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.modifyOrFail(DynamicOptic.mapKeys) { case j => j }
+        assertTrue(result.isLeft)
+      },
+      test("modify with AtIndex on non-array returns unchanged") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.modify(DynamicOptic.root.at(0))(_ => Json.Number(99))
+        assertTrue(result == json)
+      },
+      test("modify with Elements on non-array returns unchanged") {
+        val json   = Json.String("hello")
+        val result = json.modify(DynamicOptic.elements)(_ => Json.Number(99))
+        assertTrue(result == json)
+      },
+      test("modify with MapValues on non-object returns unchanged") {
+        val json   = Json.Array(Json.Number(1))
+        val result = json.modify(DynamicOptic.mapValues)(_ => Json.Number(99))
+        assertTrue(result == json)
+      },
+      test("modify with AtIndices on non-array returns unchanged") {
+        val json   = Json.String("hello")
+        val result = json.modify(DynamicOptic.root.atIndices(0, 1))(_ => Json.Number(99))
+        assertTrue(result == json)
+      },
+      test("modify with AtMapKey non-string key returns unchanged") {
+        val json = Json.Object("a" -> Json.Number(1))
+        val path = new DynamicOptic(
+          Chunk.single(DynamicOptic.Node.AtMapKey(DynamicValue.Primitive(PrimitiveValue.Int(42))))
+        )
+        val result = json.modify(path)(_ => Json.Number(99))
+        assertTrue(result == json)
+      },
+      test("modify with AtMapKey on non-object returns unchanged") {
+        val json   = Json.Array(Json.Number(1))
+        val result = json.modify(DynamicOptic.root.atKey("x")(Schema.string))(_ => Json.Number(99))
+        assertTrue(result == json)
+      },
+      test("modify with AtMapKeys on non-object returns unchanged") {
+        val json   = Json.Array(Json.Number(1))
+        val result = json.modify(DynamicOptic.root.atKeys("a")(Schema.string))(_ => Json.Number(99))
+        assertTrue(result == json)
+      },
+      test("modify with MapKeys returns unchanged") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.modify(DynamicOptic.mapKeys)(_ => Json.String("b"))
+        assertTrue(result == json)
+      },
+      test("modify with Elements where inner modification fails returns elements unchanged") {
+        val json   = Json.Array(Json.Object("x" -> Json.Number(1)), Json.Object("y" -> Json.Number(2)))
+        val result = json.modify(DynamicOptic.elements.field("z"))(_ => Json.Number(99))
+        assertTrue(result == json)
+      },
+      test("modify with MapValues where inner modification fails returns values unchanged") {
+        val json   = Json.Object("a" -> Json.Object("x" -> Json.Number(1)))
+        val result = json.modify(DynamicOptic.mapValues.field("missing"))(_ => Json.Number(99))
+        assertTrue(result == json)
+      },
+      test("modify with AtIndices where inner modification partially fails") {
+        val json   = Json.Array(Json.Number(1), Json.Object("x" -> Json.Number(2)), Json.Number(3))
+        val result = json.modify(DynamicOptic.root.atIndices(0, 1).field("x"))(_ => Json.Number(99))
+        assertTrue(result.get(1).get("x").as[BigDecimal] == Right(BigDecimal(99)))
+      },
+      test("modify with AtMapKeys where inner modification partially fails") {
+        val json   = Json.Object("a" -> Json.Object("x" -> Json.Number(1)), "b" -> Json.Number(2))
+        val result =
+          json.modify(DynamicOptic.root.atKeys("a", "b")(Schema.string).field("x"))(_ => Json.Number(99))
+        assertTrue(
+          result.get("a").get("x").as[BigDecimal] == Right(BigDecimal(99)),
+          result.get("b").as[BigDecimal] == Right(BigDecimal(2))
+        )
+      },
+      test("delete with AtIndex on non-array returns unchanged") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.delete(DynamicOptic.root.at(0))
+        assertTrue(result == json)
+      },
+      test("delete with AtIndex out of bounds returns unchanged") {
+        val json   = Json.Array(Json.Number(1))
+        val result = json.delete(DynamicOptic.root.at(5))
+        assertTrue(result == json)
+      },
+      test("delete with Elements on non-array returns unchanged") {
+        val json   = Json.String("hello")
+        val result = json.delete(DynamicOptic.elements)
+        assertTrue(result == json)
+      },
+      test("delete with Elements non-last applies recursively through elements") {
+        val json = Json.Array(
+          Json.Object("x" -> Json.Number(1), "y" -> Json.Number(2)),
+          Json.Object("x" -> Json.Number(3), "y" -> Json.Number(4))
+        )
+        val result = json.delete(DynamicOptic.elements.field("x"))
+        assertTrue(
+          result.get(0).get("y").as[BigDecimal] == Right(BigDecimal(2)),
+          result.get(0).get("x").isEmpty,
+          result.get(1).get("y").as[BigDecimal] == Right(BigDecimal(4)),
+          result.get(1).get("x").isEmpty
+        )
+      },
+      test("delete with unsupported node type returns unchanged") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.delete(DynamicOptic.mapValues)
+        assertTrue(result == json)
+      },
+      test("delete on root returns unchanged") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.delete(DynamicOptic.root)
+        assertTrue(result == json)
+      },
+      test("deleteOrFail with non-existent nested field") {
+        val json   = Json.Object("a" -> Json.Object("b" -> Json.Number(1)))
+        val result = json.deleteOrFail(DynamicOptic.root.field("a").field("missing"))
+        assertTrue(result.isLeft)
+      },
+      test("deleteOrFail on non-object for field returns Left") {
+        val json   = Json.Array(Json.Number(1))
+        val result = json.deleteOrFail(DynamicOptic.root.field("x"))
+        assertTrue(result.isLeft)
+      },
+      test("insert with AtIndex on non-array returns unchanged") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.insert(DynamicOptic.root.at(0), Json.Number(1))
+        assertTrue(result == json)
+      },
+      test("insert at negative index returns unchanged") {
+        val json   = Json.Array(Json.Number(1))
+        val result = json.insert(DynamicOptic.root.at(-1), Json.Number(99))
+        assertTrue(result == json)
+      },
+      test("insert with unsupported node type returns unchanged") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.insert(DynamicOptic.elements, Json.Number(99))
+        assertTrue(result == json)
+      },
+      test("insert at root returns unchanged") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.insert(DynamicOptic.root, Json.Number(99))
+        assertTrue(result == json)
+      },
+      test("insert with nested AtIndex navigates into element") {
+        val json   = Json.Array(Json.Object("items" -> Json.Array(Json.Number(1))))
+        val result = json.insert(DynamicOptic.root.at(0).field("items").at(1), Json.Number(2))
+        val items  = result.get(0).get("items")
+        assertTrue(
+          items.get(DynamicOptic.root.at(0)).as[BigDecimal] == Right(BigDecimal(1)),
+          items.get(DynamicOptic.root.at(1)).as[BigDecimal] == Right(BigDecimal(2))
+        )
+      },
+      test("insert nested field where intermediate field doesn't exist returns unchanged") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.insert(DynamicOptic.root.field("b").field("c"), Json.Number(42))
+        assertTrue(result == json)
+      },
+      test("insertOrFail at root returns Left") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.insertOrFail(DynamicOptic.root, Json.Number(99))
+        assertTrue(result.isLeft)
+      },
+      test("insertOrFail with AtIndex out of bounds returns Left") {
+        val json   = Json.Array(Json.Number(1))
+        val result = json.insertOrFail(DynamicOptic.root.at(10), Json.Number(99))
+        assertTrue(result.isLeft)
+      },
+      test("insertOrFail with AtIndex on non-array returns Left") {
+        val json   = Json.String("hello")
+        val result = json.insertOrFail(DynamicOptic.root.at(0), Json.Number(99))
+        assertTrue(result.isLeft)
+      },
+      test("insertOrFail with unsupported node type returns Left") {
+        val json   = Json.Object("a" -> Json.Number(1))
+        val result = json.insertOrFail(DynamicOptic.elements, Json.Number(99))
+        assertTrue(result.isLeft)
+      },
+      test("insertOrFail on non-object for field returns Left") {
+        val json   = Json.Array(Json.Number(1))
+        val result = json.insertOrFail(DynamicOptic.root.field("a"), Json.Number(99))
+        assertTrue(result.isLeft)
+      },
+      test("insertOrFail propagates error through nested AtIndex") {
+        val json   = Json.Array(Json.Object("x" -> Json.Number(1)))
+        val result = json.insertOrFail(DynamicOptic.root.at(0).field("x"), Json.Number(99))
+        assertTrue(result.isLeft)
+      },
+      test("insertOrFail with nested AtIndex where parent out of bounds") {
+        val json   = Json.Array(Json.Number(1))
+        val result = json.insertOrFail(DynamicOptic.root.at(5).field("x"), Json.Number(99))
+        assertTrue(result.isLeft)
+      },
+      test("fromKVUnsafe creates nested array with padding") {
+        val result = Json.fromKVUnsafe(
+          Seq(
+            (DynamicOptic.root.at(2), Json.Number(42))
+          )
+        )
+        val isArray      = result.is(JsonType.Array)
+        val firstIsNull  = result.get(0).one == Right(Json.Null)
+        val secondIsNull = result.get(1).one == Right(Json.Null)
+        val thirdIs42    = result.get(2).as[BigDecimal] == Right(BigDecimal(42))
+
+        assertTrue(isArray && firstIsNull && secondIsNull && thirdIs42)
+      },
+      test("fromKVUnsafe with AtIndex into existing array extends with padding") {
+        val result = Json.fromKVUnsafe(
+          Seq(
+            (DynamicOptic.root.at(0), Json.Number(1)),
+            (DynamicOptic.root.at(3), Json.Number(4))
+          )
+        )
+        assertTrue(
+          result.get(0).as[BigDecimal] == Right(BigDecimal(1)),
+          result.get(3).as[BigDecimal] == Right(BigDecimal(4))
+        )
+      },
+      test("fromKVUnsafe with nested field after AtIndex") {
+        val result = Json.fromKVUnsafe(
+          Seq(
+            (DynamicOptic.root.at(0).field("name"), Json.String("Alice"))
+          )
+        )
+        assertTrue(result.get(0).get("name").as[String] == Right("Alice"))
+      },
+      test("fromKVUnsafe with unsupported node type in path") {
+        val result = Json.fromKVUnsafe(
+          Seq(
+            (DynamicOptic.elements, Json.Number(42))
+          )
+        )
+        assertTrue(result == Json.Null)
+      },
+      test("fromKV with overwriting paths succeeds") {
+        val result = Json.fromKV(
+          Seq(
+            (DynamicOptic.root.field("a"), Json.Number(1)),
+            (DynamicOptic.root.field("a").field("nested"), Json.Number(2))
+          )
+        )
+        assertTrue(result.isRight)
+      },
+      test("fromKVUnsafe with single root value") {
+        val result = Json.fromKVUnsafe(Seq((DynamicOptic.root, Json.Number(42))))
+        assertTrue(result == Json.Number(42))
+      }
     )
   )
 

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
@@ -413,7 +413,766 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
         assertTrue(errors.forall(_.message.nonEmpty))
       }
     ),
+    suite("ConversionType coverage")(
+      test("StringToInt success and failure") {
+        val conv = SchemaExpr.ConversionType.StringToInt
+        val ok   = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("42")))
+        val fail = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("abc")))
+        val bad  = conv.convert(DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        assertTrue(ok.isRight && fail.isLeft && bad.isLeft)
+      },
+      test("StringToLong success and failure") {
+        val conv = SchemaExpr.ConversionType.StringToLong
+        val ok   = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("100")))
+        val fail = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("abc")))
+        val bad  = conv.convert(DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        assertTrue(ok.isRight && fail.isLeft && bad.isLeft)
+      },
+      test("StringToDouble success and failure") {
+        val conv = SchemaExpr.ConversionType.StringToDouble
+        val ok   = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("3.14")))
+        val fail = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("abc")))
+        val bad  = conv.convert(DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        assertTrue(ok.isRight && fail.isLeft && bad.isLeft)
+      },
+      test("StringToFloat success and failure") {
+        val conv = SchemaExpr.ConversionType.StringToFloat
+        val ok   = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("1.5")))
+        val fail = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("abc")))
+        val bad  = conv.convert(DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        assertTrue(ok.isRight && fail.isLeft && bad.isLeft)
+      },
+      test("StringToShort success and failure") {
+        val conv = SchemaExpr.ConversionType.StringToShort
+        val ok   = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("10")))
+        val fail = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("abc")))
+        val bad  = conv.convert(DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        assertTrue(ok.isRight && fail.isLeft && bad.isLeft)
+      },
+      test("StringToByte success and failure") {
+        val conv = SchemaExpr.ConversionType.StringToByte
+        val ok   = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("5")))
+        val fail = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("abc")))
+        val bad  = conv.convert(DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        assertTrue(ok.isRight && fail.isLeft && bad.isLeft)
+      },
+      test("StringToBoolean success and failure") {
+        val conv = SchemaExpr.ConversionType.StringToBoolean
+        val t    = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("true")))
+        val f    = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("false")))
+        val fail = conv.convert(DynamicValue.Primitive(PrimitiveValue.String("maybe")))
+        val bad  = conv.convert(DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        assertTrue(t.isRight && f.isRight && fail.isLeft && bad.isLeft)
+      },
+      test("widening conversions") {
+        import SchemaExpr.ConversionType._
+        val results = List(
+          ByteToShort.convert(DynamicValue.Primitive(PrimitiveValue.Byte(1))),
+          ByteToInt.convert(DynamicValue.Primitive(PrimitiveValue.Byte(1))),
+          ByteToLong.convert(DynamicValue.Primitive(PrimitiveValue.Byte(1))),
+          ByteToFloat.convert(DynamicValue.Primitive(PrimitiveValue.Byte(1))),
+          ByteToDouble.convert(DynamicValue.Primitive(PrimitiveValue.Byte(1))),
+          ShortToInt.convert(DynamicValue.Primitive(PrimitiveValue.Short(1))),
+          ShortToLong.convert(DynamicValue.Primitive(PrimitiveValue.Short(1))),
+          ShortToFloat.convert(DynamicValue.Primitive(PrimitiveValue.Short(1))),
+          ShortToDouble.convert(DynamicValue.Primitive(PrimitiveValue.Short(1))),
+          IntToLong.convert(DynamicValue.Primitive(PrimitiveValue.Int(1))),
+          IntToFloat.convert(DynamicValue.Primitive(PrimitiveValue.Int(1))),
+          IntToDouble.convert(DynamicValue.Primitive(PrimitiveValue.Int(1))),
+          LongToFloat.convert(DynamicValue.Primitive(PrimitiveValue.Long(1L))),
+          LongToDouble.convert(DynamicValue.Primitive(PrimitiveValue.Long(1L))),
+          FloatToDouble.convert(DynamicValue.Primitive(PrimitiveValue.Float(1.0f)))
+        )
+        assertTrue(results.forall(_.isRight))
+      },
+      test("narrowing conversions succeed when exact and in range") {
+        import SchemaExpr.ConversionType._
+        val results = List(
+          ShortToByte.convert(DynamicValue.Primitive(PrimitiveValue.Short(1))),
+          IntToByte.convert(DynamicValue.Primitive(PrimitiveValue.Int(1))),
+          IntToShort.convert(DynamicValue.Primitive(PrimitiveValue.Int(1))),
+          LongToByte.convert(DynamicValue.Primitive(PrimitiveValue.Long(1L))),
+          LongToShort.convert(DynamicValue.Primitive(PrimitiveValue.Long(1L))),
+          LongToInt.convert(DynamicValue.Primitive(PrimitiveValue.Long(1L))),
+          DoubleToFloat.convert(DynamicValue.Primitive(PrimitiveValue.Double(1.0))),
+          DoubleToInt.convert(DynamicValue.Primitive(PrimitiveValue.Double(1.0))),
+          DoubleToLong.convert(DynamicValue.Primitive(PrimitiveValue.Double(1.0))),
+          FloatToInt.convert(DynamicValue.Primitive(PrimitiveValue.Float(1.0f))),
+          FloatToLong.convert(DynamicValue.Primitive(PrimitiveValue.Float(1.0f))),
+          IntToChar.convert(DynamicValue.Primitive(PrimitiveValue.Int(65)))
+        )
+        assertTrue(results.forall(_.isRight))
+      },
+      test("narrowing conversions fail when lossy or out of range") {
+        import SchemaExpr.ConversionType._
+        val results = List(
+          ShortToByte.convert(DynamicValue.Primitive(PrimitiveValue.Short(128))),
+          IntToByte.convert(DynamicValue.Primitive(PrimitiveValue.Int(128))),
+          IntToShort.convert(DynamicValue.Primitive(PrimitiveValue.Int(Short.MaxValue.toInt + 1))),
+          LongToByte.convert(DynamicValue.Primitive(PrimitiveValue.Long(128L))),
+          LongToShort.convert(DynamicValue.Primitive(PrimitiveValue.Long(Short.MaxValue.toLong + 1L))),
+          LongToInt.convert(DynamicValue.Primitive(PrimitiveValue.Long(Int.MaxValue.toLong + 1L))),
+          DoubleToFloat.convert(DynamicValue.Primitive(PrimitiveValue.Double(0.1d))),
+          DoubleToInt.convert(DynamicValue.Primitive(PrimitiveValue.Double(1.5d))),
+          DoubleToLong.convert(DynamicValue.Primitive(PrimitiveValue.Double(1.5d))),
+          FloatToInt.convert(DynamicValue.Primitive(PrimitiveValue.Float(1.5f))),
+          FloatToLong.convert(DynamicValue.Primitive(PrimitiveValue.Float(1.5f))),
+          IntToChar.convert(DynamicValue.Primitive(PrimitiveValue.Int(Char.MaxValue.toInt + 1)))
+        )
+        assertTrue(results.forall(_.isLeft))
+      },
+      test("toString conversions") {
+        import SchemaExpr.ConversionType._
+        val results = List(
+          IntToString.convert(DynamicValue.Primitive(PrimitiveValue.Int(42))),
+          LongToString.convert(DynamicValue.Primitive(PrimitiveValue.Long(42L))),
+          DoubleToString.convert(DynamicValue.Primitive(PrimitiveValue.Double(3.14))),
+          FloatToString.convert(DynamicValue.Primitive(PrimitiveValue.Float(1.5f))),
+          BooleanToString.convert(DynamicValue.Primitive(PrimitiveValue.Boolean(true))),
+          ShortToString.convert(DynamicValue.Primitive(PrimitiveValue.Short(10))),
+          ByteToString.convert(DynamicValue.Primitive(PrimitiveValue.Byte(5))),
+          CharToString.convert(DynamicValue.Primitive(PrimitiveValue.Char('a'))),
+          CharToInt.convert(DynamicValue.Primitive(PrimitiveValue.Char('a')))
+        )
+        assertTrue(results.forall(_.isRight))
+      },
+      test("conversion type mismatch errors") {
+        import SchemaExpr.ConversionType._
+        val wrong   = DynamicValue.Primitive(PrimitiveValue.String("x"))
+        val results = List(
+          ByteToShort.convert(wrong),
+          ShortToInt.convert(wrong),
+          IntToLong.convert(wrong),
+          LongToInt.convert(wrong),
+          FloatToInt.convert(wrong),
+          DoubleToInt.convert(wrong),
+          CharToInt.convert(wrong),
+          IntToChar.convert(wrong),
+          ByteToFloat.convert(wrong),
+          ShortToFloat.convert(wrong),
+          FloatToLong.convert(wrong),
+          DoubleToFloat.convert(wrong),
+          ShortToByte.convert(wrong),
+          IntToByte.convert(wrong),
+          IntToShort.convert(wrong),
+          LongToByte.convert(wrong),
+          LongToShort.convert(wrong),
+          LongToFloat.convert(wrong),
+          ByteToDouble.convert(wrong),
+          ShortToDouble.convert(wrong),
+          IntToFloat.convert(wrong),
+          IntToDouble.convert(wrong),
+          LongToDouble.convert(wrong),
+          FloatToDouble.convert(wrong),
+          DoubleToLong.convert(wrong),
+          IntToString.convert(wrong),
+          LongToString.convert(wrong),
+          DoubleToString.convert(wrong),
+          FloatToString.convert(wrong),
+          BooleanToString.convert(wrong),
+          ShortToString.convert(wrong),
+          ByteToString.convert(wrong),
+          CharToString.convert(wrong)
+        )
+        assertTrue(results.forall(_.isLeft))
+      }
+    ),
+    suite("PrimitiveConversion via DynamicSchemaExpr")(
+      test("PrimitiveConversion evaluates correctly") {
+        val expr   = DynamicSchemaExpr.PrimitiveConversion(SchemaExpr.ConversionType.IntToString)
+        val result = expr.eval(DynamicValue.Primitive(PrimitiveValue.Int(42)))
+        assertTrue(result == Right(Seq(DynamicValue.Primitive(PrimitiveValue.String("42")))))
+      },
+      test("PrimitiveConversion returns error for wrong type") {
+        val expr   = DynamicSchemaExpr.PrimitiveConversion(SchemaExpr.ConversionType.IntToString)
+        val result = expr.eval(DynamicValue.Primitive(PrimitiveValue.String("x")))
+        assertTrue(result.isLeft)
+      }
+    ),
+    suite("MigrationAction.reverse coverage")(
+      test("TransformField reverse is Irreversible") {
+        val action = MigrationAction.TransformField(root.field("x"), dynamicLiteral(0))
+        assertTrue(action.reverse.isInstanceOf[MigrationAction.Irreversible])
+      },
+      test("OptionalizeField reverse is Irreversible") {
+        val action = MigrationAction.OptionalizeField(root.field("x"))
+        assertTrue(action.reverse.isInstanceOf[MigrationAction.Irreversible])
+      },
+      test("ChangeFieldType reverse is Irreversible") {
+        val action = MigrationAction.ChangeFieldType(root.field("x"), dynamicLiteral(0))
+        assertTrue(action.reverse.isInstanceOf[MigrationAction.Irreversible])
+      },
+      test("TransformElements reverse is Irreversible") {
+        val action = MigrationAction.TransformElements(root, dynamicLiteral(0))
+        assertTrue(action.reverse.isInstanceOf[MigrationAction.Irreversible])
+      },
+      test("TransformKeys reverse is Irreversible") {
+        val action = MigrationAction.TransformKeys(root, dynamicLiteral(0))
+        assertTrue(action.reverse.isInstanceOf[MigrationAction.Irreversible])
+      },
+      test("TransformValues reverse is Irreversible") {
+        val action = MigrationAction.TransformValues(root, dynamicLiteral(0))
+        assertTrue(action.reverse.isInstanceOf[MigrationAction.Irreversible])
+      },
+      test("RenameCase reverse swaps from and to") {
+        val action   = MigrationAction.RenameCase(root, "A", "B")
+        val reversed = action.reverse.asInstanceOf[MigrationAction.RenameCase]
+        assertTrue(reversed.from == "B" && reversed.to == "A")
+      },
+      test("TransformCase reverse reverses inner actions") {
+        val action = MigrationAction.TransformCase(
+          root,
+          zio.blocks.chunk.Chunk(
+            MigrationAction.AddField(root.field("a"), dynamicLiteral(1)),
+            MigrationAction.RenameField(root.field("b"), "c")
+          )
+        )
+        val reversed = action.reverse.asInstanceOf[MigrationAction.TransformCase]
+        assertTrue(reversed.actions.length == 2)
+      },
+      test("Irreversible reverse is itself") {
+        val action = MigrationAction.Irreversible(root, "test")
+        assertTrue(action.reverse eq action)
+      },
+      test("RenameField reverse with valid path") {
+        val action   = MigrationAction.RenameField(root.field("old"), "new")
+        val reversed = action.reverse
+        assertTrue(reversed.isInstanceOf[MigrationAction.RenameField])
+      },
+      test("RenameField reverse with invalid path gives Irreversible") {
+        val action   = MigrationAction.RenameField(root, "new")
+        val reversed = action.reverse
+        assertTrue(reversed.isInstanceOf[MigrationAction.Irreversible])
+      }
+    ),
+    suite("Rename on non-Record value")(
+      test("RenameField fails on non-Record") {
+        val migration = DynamicMigration.single(
+          MigrationAction.RenameField(root.field("x"), "y")
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      }
+    ),
+    suite("DynamicSchemaExpr evaluation")(
+      test("Select field from record") {
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic.root.field("name"))
+        val result = expr.eval(sampleRecord)
+        assertTrue(result == Right(Seq(DynamicValue.Primitive(PrimitiveValue.String("Alice")))))
+      },
+      test("Select missing field returns empty") {
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic.root.field("missing"))
+        val result = expr.eval(sampleRecord)
+        assertTrue(result == Right(Seq.empty))
+      },
+      test("Select field from non-Record returns empty") {
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic.root.field("x"))
+        val result = expr.eval(DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        assertTrue(result == Right(Seq.empty))
+      },
+      test("Select Case matching") {
+        val input  = DynamicValue.Variant("Active", DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.Case("Active"))))
+        val result = expr.eval(input)
+        assertTrue(result == Right(Seq(DynamicValue.Primitive(PrimitiveValue.Int(1)))))
+      },
+      test("Select Case non-matching returns error") {
+        val input  = DynamicValue.Variant("Inactive", DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.Case("Active"))))
+        val result = expr.eval(input)
+        assertTrue(result.isLeft)
+      },
+      test("Select Case on None variant") {
+        val input  = DynamicValue.Variant("None", DynamicValue.Record())
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.Case("Some"))))
+        val result = expr.eval(input)
+        assertTrue(result.isLeft)
+      },
+      test("Select Case on Some variant") {
+        val input  = DynamicValue.Variant("Some", DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.Case("Other"))))
+        val result = expr.eval(input)
+        assertTrue(result.isLeft)
+      },
+      test("Select Elements from Sequence") {
+        val input = DynamicValue.Sequence(
+          zio.blocks.chunk.Chunk(
+            DynamicValue.Primitive(PrimitiveValue.Int(1)),
+            DynamicValue.Primitive(PrimitiveValue.Int(2))
+          )
+        )
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.Elements)))
+        val result = expr.eval(input)
+        assertTrue(result.isRight && result.toOption.get.size == 2)
+      },
+      test("Select Elements from empty Sequence returns error") {
+        val input  = DynamicValue.Sequence(zio.blocks.chunk.Chunk.empty)
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.Elements)))
+        val result = expr.eval(input)
+        assertTrue(result.isLeft)
+      },
+      test("Select AtIndex success") {
+        val input = DynamicValue.Sequence(
+          zio.blocks.chunk.Chunk(
+            DynamicValue.Primitive(PrimitiveValue.Int(10)),
+            DynamicValue.Primitive(PrimitiveValue.Int(20))
+          )
+        )
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.AtIndex(1))))
+        val result = expr.eval(input)
+        assertTrue(result == Right(Seq(DynamicValue.Primitive(PrimitiveValue.Int(20)))))
+      },
+      test("Select AtIndex out of bounds") {
+        val input  = DynamicValue.Sequence(zio.blocks.chunk.Chunk(DynamicValue.Primitive(PrimitiveValue.Int(1))))
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.AtIndex(5))))
+        val result = expr.eval(input)
+        assertTrue(result.isLeft)
+      },
+      test("Select AtIndices") {
+        val input = DynamicValue.Sequence(
+          zio.blocks.chunk.Chunk(
+            DynamicValue.Primitive(PrimitiveValue.Int(10)),
+            DynamicValue.Primitive(PrimitiveValue.Int(20)),
+            DynamicValue.Primitive(PrimitiveValue.Int(30))
+          )
+        )
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.AtIndices(Seq(0, 2)))))
+        val result = expr.eval(input)
+        assertTrue(result.isRight && result.toOption.get.size == 2)
+      },
+      test("Select MapKeys from Map") {
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1)))
+          )
+        )
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.MapKeys)))
+        val result = expr.eval(input)
+        assertTrue(result.isRight && result.toOption.get.size == 1)
+      },
+      test("Select MapKeys from empty Map returns error") {
+        val input  = DynamicValue.Map(zio.blocks.chunk.Chunk.empty)
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.MapKeys)))
+        val result = expr.eval(input)
+        assertTrue(result.isLeft)
+      },
+      test("Select MapValues from Map") {
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1)))
+          )
+        )
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.MapValues)))
+        val result = expr.eval(input)
+        assertTrue(result.isRight && result.toOption.get.size == 1)
+      },
+      test("Select MapValues from empty Map returns error") {
+        val input  = DynamicValue.Map(zio.blocks.chunk.Chunk.empty)
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.MapValues)))
+        val result = expr.eval(input)
+        assertTrue(result.isLeft)
+      },
+      test("Select AtMapKey success") {
+        val key   = DynamicValue.Primitive(PrimitiveValue.String("a"))
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (key, DynamicValue.Primitive(PrimitiveValue.Int(1)))
+          )
+        )
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.AtMapKey(key))))
+        val result = expr.eval(input)
+        assertTrue(result == Right(Seq(DynamicValue.Primitive(PrimitiveValue.Int(1)))))
+      },
+      test("Select AtMapKey missing") {
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1)))
+          )
+        )
+        val key    = DynamicValue.Primitive(PrimitiveValue.String("z"))
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.AtMapKey(key))))
+        val result = expr.eval(input)
+        assertTrue(result.isLeft)
+      },
+      test("Select AtMapKeys") {
+        val k1    = DynamicValue.Primitive(PrimitiveValue.String("a"))
+        val k2    = DynamicValue.Primitive(PrimitiveValue.String("b"))
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (k1, DynamicValue.Primitive(PrimitiveValue.Int(1))),
+            (k2, DynamicValue.Primitive(PrimitiveValue.Int(2)))
+          )
+        )
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.AtMapKeys(Seq(k1)))))
+        val result = expr.eval(input)
+        assertTrue(result.isRight && result.toOption.get.size == 1)
+      },
+      test("Select Wrapped passes through") {
+        val expr   = DynamicSchemaExpr.Select(DynamicOptic(IndexedSeq(DynamicOptic.Node.Wrapped)))
+        val result = expr.eval(DynamicValue.Primitive(PrimitiveValue.Int(42)))
+        assertTrue(result == Right(Seq(DynamicValue.Primitive(PrimitiveValue.Int(42)))))
+      },
+      test("Relational operators") {
+        val lit1  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        val lit2  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(2)))
+        val dummy = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        import DynamicSchemaExpr.RelationalOperator._
+        val results = List(
+          DynamicSchemaExpr.Relational(lit1, lit2, LessThan).eval(dummy),
+          DynamicSchemaExpr.Relational(lit1, lit2, LessThanOrEqual).eval(dummy),
+          DynamicSchemaExpr.Relational(lit1, lit2, GreaterThan).eval(dummy),
+          DynamicSchemaExpr.Relational(lit1, lit2, GreaterThanOrEqual).eval(dummy),
+          DynamicSchemaExpr.Relational(lit1, lit2, Equal).eval(dummy),
+          DynamicSchemaExpr.Relational(lit1, lit2, NotEqual).eval(dummy)
+        )
+        assertTrue(results.forall(_.isRight))
+      },
+      test("Logical operators") {
+        val t     = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Boolean(true)))
+        val f     = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Boolean(false)))
+        val dummy = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        import DynamicSchemaExpr.LogicalOperator._
+        val andResult = DynamicSchemaExpr.Logical(t, f, And).eval(dummy)
+        val orResult  = DynamicSchemaExpr.Logical(t, f, Or).eval(dummy)
+        val notResult = DynamicSchemaExpr.Not(t).eval(dummy)
+        assertTrue(andResult.isRight && orResult.isRight && notResult.isRight)
+      },
+      test("StringConcat") {
+        val a      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("hello")))
+        val b      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String(" world")))
+        val dummy  = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val result = DynamicSchemaExpr.StringConcat(a, b).eval(dummy)
+        assertTrue(result == Right(Seq(DynamicValue.Primitive(PrimitiveValue.String("hello world")))))
+      },
+      test("StringLength") {
+        val s      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("hello")))
+        val dummy  = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val result = DynamicSchemaExpr.StringLength(s).eval(dummy)
+        assertTrue(result == Right(Seq(DynamicValue.Primitive(PrimitiveValue.Int(5)))))
+      },
+      test("StringTrim") {
+        val s      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("  hi  ")))
+        val dummy  = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val result = DynamicSchemaExpr.StringTrim(s).eval(dummy)
+        assertTrue(result == Right(Seq(DynamicValue.Primitive(PrimitiveValue.String("hi")))))
+      },
+      test("StringToUpperCase and StringToLowerCase") {
+        val s     = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("Hello")))
+        val dummy = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val upper = DynamicSchemaExpr.StringToUpperCase(s).eval(dummy)
+        val lower = DynamicSchemaExpr.StringToLowerCase(s).eval(dummy)
+        assertTrue(
+          upper == Right(Seq(DynamicValue.Primitive(PrimitiveValue.String("HELLO")))) &&
+            lower == Right(Seq(DynamicValue.Primitive(PrimitiveValue.String("hello"))))
+        )
+      },
+      test("StringSubstring") {
+        val s      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("hello world")))
+        val start  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(0)))
+        val end    = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(5)))
+        val dummy  = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val result = DynamicSchemaExpr.StringSubstring(s, start, end).eval(dummy)
+        assertTrue(result == Right(Seq(DynamicValue.Primitive(PrimitiveValue.String("hello")))))
+      },
+      test("StringSubstring fails for invalid indices") {
+        val s     = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("hello world")))
+        val dummy = DynamicValue.Primitive(PrimitiveValue.Int(0))
+
+        val negative = DynamicSchemaExpr
+          .StringSubstring(
+            s,
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(-1))),
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(5)))
+          )
+          .eval(dummy)
+
+        val reversed = DynamicSchemaExpr
+          .StringSubstring(
+            s,
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(6))),
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(5)))
+          )
+          .eval(dummy)
+
+        val tooLong = DynamicSchemaExpr
+          .StringSubstring(
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("hello"))),
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(0))),
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(20)))
+          )
+          .eval(dummy)
+
+        assertTrue(negative.isLeft && reversed.isLeft && tooLong.isLeft)
+      },
+      test("StringReplace") {
+        val s      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("hello world")))
+        val target = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("world")))
+        val repl   = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("there")))
+        val dummy  = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val result = DynamicSchemaExpr.StringReplace(s, target, repl).eval(dummy)
+        assertTrue(result == Right(Seq(DynamicValue.Primitive(PrimitiveValue.String("hello there")))))
+      },
+      test("StringStartsWith and StringEndsWith") {
+        val s      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("hello")))
+        val prefix = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("he")))
+        val suffix = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("lo")))
+        val dummy  = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val starts = DynamicSchemaExpr.StringStartsWith(s, prefix).eval(dummy)
+        val ends   = DynamicSchemaExpr.StringEndsWith(s, suffix).eval(dummy)
+        assertTrue(starts.isRight && ends.isRight)
+      },
+      test("StringContains and StringIndexOf") {
+        val s        = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("hello world")))
+        val sub      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("world")))
+        val dummy    = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val contains = DynamicSchemaExpr.StringContains(s, sub).eval(dummy)
+        val indexOf  = DynamicSchemaExpr.StringIndexOf(s, sub).eval(dummy)
+        assertTrue(contains.isRight && indexOf.isRight)
+      },
+      test("StringRegexMatch") {
+        val regex  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("h.*o")))
+        val s      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("hello")))
+        val dummy  = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val result = DynamicSchemaExpr.StringRegexMatch(regex, s).eval(dummy)
+        assertTrue(result == Right(Seq(DynamicValue.Primitive(PrimitiveValue.Boolean(true)))))
+      },
+      test("StringRegexMatch fails for invalid regex") {
+        val regex  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("(")))
+        val s      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("hello")))
+        val dummy  = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val result = DynamicSchemaExpr.StringRegexMatch(regex, s).eval(dummy)
+        assertTrue(result.isLeft)
+      },
+      test("Arithmetic operations with all numeric types") {
+        val dummy = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        import DynamicSchemaExpr.{ArithmeticOperator, NumericTypeTag}
+
+        def testTag(tag: NumericTypeTag, a: DynamicSchemaExpr, b: DynamicSchemaExpr): Boolean = {
+          val ops = List(
+            ArithmeticOperator.Add,
+            ArithmeticOperator.Subtract,
+            ArithmeticOperator.Multiply,
+            ArithmeticOperator.Divide,
+            ArithmeticOperator.Modulo,
+            ArithmeticOperator.Pow
+          )
+          ops.forall(op => DynamicSchemaExpr.Arithmetic(a, b, op, tag).eval(dummy).isRight)
+        }
+
+        val intA   = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(10)))
+        val intB   = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(3)))
+        val longA  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Long(10L)))
+        val longB  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Long(3L)))
+        val floatA = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Float(10.0f)))
+        val floatB = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Float(3.0f)))
+        val dblA   = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Double(10.0)))
+        val dblB   = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Double(3.0)))
+        val byteA  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Byte(10)))
+        val byteB  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Byte(3)))
+        val shortA = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Short(10)))
+        val shortB = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Short(3)))
+        val bigIA  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.BigInt(BigInt(10))))
+        val bigIB  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.BigInt(BigInt(3))))
+        val bigDA  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal(10))))
+        val bigDB  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal(3))))
+
+        assertTrue(
+          testTag(NumericTypeTag.IntTag, intA, intB) &&
+            testTag(NumericTypeTag.LongTag, longA, longB) &&
+            testTag(NumericTypeTag.FloatTag, floatA, floatB) &&
+            testTag(NumericTypeTag.DoubleTag, dblA, dblB) &&
+            testTag(NumericTypeTag.ByteTag, byteA, byteB) &&
+            testTag(NumericTypeTag.ShortTag, shortA, shortB) &&
+            testTag(NumericTypeTag.BigIntTag, bigIA, bigIB) &&
+            testTag(NumericTypeTag.BigDecimalTag, bigDA, bigDB)
+        )
+      },
+      test("Arithmetic type mismatch errors") {
+        val dummy = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        import DynamicSchemaExpr.{ArithmeticOperator, NumericTypeTag}
+        val wrong   = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("x")))
+        val results = List(
+          DynamicSchemaExpr.Arithmetic(wrong, wrong, ArithmeticOperator.Add, NumericTypeTag.IntTag).eval(dummy),
+          DynamicSchemaExpr.Arithmetic(wrong, wrong, ArithmeticOperator.Add, NumericTypeTag.LongTag).eval(dummy),
+          DynamicSchemaExpr.Arithmetic(wrong, wrong, ArithmeticOperator.Add, NumericTypeTag.FloatTag).eval(dummy),
+          DynamicSchemaExpr.Arithmetic(wrong, wrong, ArithmeticOperator.Add, NumericTypeTag.DoubleTag).eval(dummy),
+          DynamicSchemaExpr.Arithmetic(wrong, wrong, ArithmeticOperator.Add, NumericTypeTag.ByteTag).eval(dummy),
+          DynamicSchemaExpr.Arithmetic(wrong, wrong, ArithmeticOperator.Add, NumericTypeTag.ShortTag).eval(dummy),
+          DynamicSchemaExpr.Arithmetic(wrong, wrong, ArithmeticOperator.Add, NumericTypeTag.BigIntTag).eval(dummy),
+          DynamicSchemaExpr.Arithmetic(wrong, wrong, ArithmeticOperator.Add, NumericTypeTag.BigDecimalTag).eval(dummy)
+        )
+        assertTrue(results.forall(_.isLeft))
+      },
+      test("Arithmetic divide and modulo reject zero divisors") {
+        val dummy = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        import DynamicSchemaExpr.{ArithmeticOperator, NumericTypeTag}
+
+        val results = List(
+          DynamicSchemaExpr
+            .Arithmetic(
+              DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(10))),
+              DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(0))),
+              ArithmeticOperator.Divide,
+              NumericTypeTag.IntTag
+            )
+            .eval(dummy),
+          DynamicSchemaExpr
+            .Arithmetic(
+              DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Long(10L))),
+              DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Long(0L))),
+              ArithmeticOperator.Modulo,
+              NumericTypeTag.LongTag
+            )
+            .eval(dummy),
+          DynamicSchemaExpr
+            .Arithmetic(
+              DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Float(10.0f))),
+              DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Float(0.0f))),
+              ArithmeticOperator.Divide,
+              NumericTypeTag.FloatTag
+            )
+            .eval(dummy),
+          DynamicSchemaExpr
+            .Arithmetic(
+              DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Double(10.0))),
+              DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Double(0.0))),
+              ArithmeticOperator.Modulo,
+              NumericTypeTag.DoubleTag
+            )
+            .eval(dummy),
+          DynamicSchemaExpr
+            .Arithmetic(
+              DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.BigInt(BigInt(10)))),
+              DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.BigInt(BigInt(0)))),
+              ArithmeticOperator.Divide,
+              NumericTypeTag.BigIntTag
+            )
+            .eval(dummy),
+          DynamicSchemaExpr
+            .Arithmetic(
+              DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal(10)))),
+              DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal(0)))),
+              ArithmeticOperator.Modulo,
+              NumericTypeTag.BigDecimalTag
+            )
+            .eval(dummy)
+        )
+
+        assertTrue(results.forall(_.isLeft))
+      },
+      test("Arithmetic power rejects unsafe exponents") {
+        val dummy = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        import DynamicSchemaExpr.{ArithmeticOperator, NumericTypeTag}
+
+        val negativeExponent = DynamicSchemaExpr
+          .Arithmetic(
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.BigInt(BigInt(2)))),
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.BigInt(BigInt(-1)))),
+            ArithmeticOperator.Pow,
+            NumericTypeTag.BigIntTag
+          )
+          .eval(dummy)
+
+        val hugeExponent = DynamicSchemaExpr
+          .Arithmetic(
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal(2)))),
+            DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.BigDecimal(BigDecimal(10001)))),
+            ArithmeticOperator.Pow,
+            NumericTypeTag.BigDecimalTag
+          )
+          .eval(dummy)
+
+        assertTrue(negativeExponent.isLeft && hugeExponent.isLeft)
+      },
+      test("Bitwise operations") {
+        val a     = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(0xff)))
+        val b     = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(0x0f)))
+        val dummy = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        import DynamicSchemaExpr.BitwiseOperator._
+        val results = List(
+          DynamicSchemaExpr.Bitwise(a, b, And).eval(dummy),
+          DynamicSchemaExpr.Bitwise(a, b, Or).eval(dummy),
+          DynamicSchemaExpr.Bitwise(a, b, Xor).eval(dummy),
+          DynamicSchemaExpr.Bitwise(a, b, LeftShift).eval(dummy),
+          DynamicSchemaExpr.Bitwise(a, b, RightShift).eval(dummy),
+          DynamicSchemaExpr.Bitwise(a, b, UnsignedRightShift).eval(dummy)
+        )
+        assertTrue(results.forall(_.isRight))
+      },
+      test("BitwiseNot on various integral types") {
+        val dummy   = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val results = List(
+          DynamicSchemaExpr
+            .BitwiseNot(DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Byte(1))))
+            .eval(dummy),
+          DynamicSchemaExpr
+            .BitwiseNot(DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Short(1))))
+            .eval(dummy),
+          DynamicSchemaExpr
+            .BitwiseNot(DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(1))))
+            .eval(dummy),
+          DynamicSchemaExpr
+            .BitwiseNot(DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Long(1L))))
+            .eval(dummy)
+        )
+        assertTrue(results.forall(_.isRight))
+      },
+      test("BitwiseNot on non-integral fails") {
+        val dummy  = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val result = DynamicSchemaExpr
+          .BitwiseNot(DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("x"))))
+          .eval(dummy)
+        assertTrue(result.isLeft)
+      },
+      test("Bitwise with Long operands") {
+        val a      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Long(0xffL)))
+        val b      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Long(0x0fL)))
+        val dummy  = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val result = DynamicSchemaExpr.Bitwise(a, b, DynamicSchemaExpr.BitwiseOperator.And).eval(dummy)
+        assertTrue(result.isRight)
+      },
+      test("Bitwise shift with Long operand") {
+        val a      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Long(1L)))
+        val b      = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(2)))
+        val dummy  = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val result = DynamicSchemaExpr.Bitwise(a, b, DynamicSchemaExpr.BitwiseOperator.LeftShift).eval(dummy)
+        assertTrue(result.isRight)
+      },
+      test("extractIntegral with Byte and Short") {
+        val byteExpr  = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Byte(5)))
+        val shortExpr = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Short(10)))
+        val dummy     = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val r1        = DynamicSchemaExpr.Bitwise(byteExpr, shortExpr, DynamicSchemaExpr.BitwiseOperator.And).eval(dummy)
+        assertTrue(r1.isRight)
+      },
+      test("extractIntegral failure on non-integral") {
+        val strExpr = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("x")))
+        val intExpr = DynamicSchemaExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        val dummy   = DynamicValue.Primitive(PrimitiveValue.Int(0))
+        val result  = DynamicSchemaExpr.Bitwise(strExpr, intExpr, DynamicSchemaExpr.BitwiseOperator.And).eval(dummy)
+        assertTrue(result.isLeft)
+      }
+    ),
     suite("DynamicMigration utilities")(
+      test("expression evaluation fails when traversal returns multiple values") {
+        val input = DynamicValue.Record(
+          "items" -> DynamicValue.Sequence(
+            zio.blocks.chunk.Chunk(
+              DynamicValue.Primitive(PrimitiveValue.Int(1)),
+              DynamicValue.Primitive(PrimitiveValue.Int(2))
+            )
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.AddField(
+            root.field("value"),
+            DynamicSchemaExpr.Select(DynamicOptic.root.field("items").elements)
+          )
+        )
+
+        assertTrue(
+          migration(input).left.exists(_.message.contains("must return exactly one value, got 2"))
+        )
+      },
       test("empty migration is identity") {
         assertTrue(DynamicMigration.empty(sampleRecord) == Right(sampleRecord))
       },
@@ -442,6 +1201,421 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
           MigrationAction.AddField(root.field("x"), dynamicLiteral(1))
         )
         assertTrue(m(sampleRecord).isLeft)
+      }
+    ),
+    suite("MigrateField execution")(
+      test("applies nested migration to a field value") {
+        val input = DynamicValue.Record(
+          "address" -> DynamicValue.Record(
+            "street" -> DynamicValue.Primitive(PrimitiveValue.String("Main St"))
+          )
+        )
+        val nestedMigration = DynamicMigration.single(
+          MigrationAction.AddField(DynamicOptic.root.field("city"), dynamicLiteral("NYC"))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.MigrateField(root.field("address"), nestedMigration)
+        )
+        val result = migration(input)
+        assertTrue(result.isRight)
+        val record = result.toOption.get.asInstanceOf[DynamicValue.Record]
+        val addr   = record.fields.find(_._1 == "address").get._2.asInstanceOf[DynamicValue.Record]
+        assertTrue(addr.fields.exists(_._1 == "city"))
+      },
+      test("MigrateField at root applies migration directly") {
+        val nestedMigration = DynamicMigration.single(
+          MigrationAction.AddField(DynamicOptic.root.field("extra"), dynamicLiteral(true))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.MigrateField(root, nestedMigration)
+        )
+        val result = migration(sampleRecord)
+        assertTrue(result.isRight)
+      },
+      test("MigrateField with failing nested migration propagates error") {
+        val failingMigration = DynamicMigration.single(
+          MigrationAction.DropField(DynamicOptic.root.field("nonexistent"), dynamicLiteral(0))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.MigrateField(root.field("name"), failingMigration)
+        )
+        assertTrue(migration(sampleRecord).isLeft)
+      }
+    ),
+    suite("modifyAtPath nested navigation")(
+      test("navigate through Case node to modify nested field") {
+        val input = DynamicValue.Variant(
+          "Active",
+          DynamicValue.Record("status" -> DynamicValue.Primitive(PrimitiveValue.Int(1)))
+        )
+        val path = DynamicOptic(
+          IndexedSeq(
+            DynamicOptic.Node.Case("Active"),
+            DynamicOptic.Node.Field("status")
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(99))
+        )
+        val result = migration(input)
+        assertTrue(
+          result == Right(
+            DynamicValue.Variant(
+              "Active",
+              DynamicValue.Record("status" -> DynamicValue.Primitive(PrimitiveValue.Int(99)))
+            )
+          )
+        )
+      },
+      test("navigate through Elements to modify nested fields in each element") {
+        val input = DynamicValue.Sequence(
+          zio.blocks.chunk.Chunk(
+            DynamicValue.Record("x" -> DynamicValue.Primitive(PrimitiveValue.Int(1))),
+            DynamicValue.Record("x" -> DynamicValue.Primitive(PrimitiveValue.Int(2)))
+          )
+        )
+        val path = DynamicOptic(
+          IndexedSeq(
+            DynamicOptic.Node.Elements,
+            DynamicOptic.Node.Field("x")
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(0))
+        )
+        val result = migration(input)
+        assertTrue(
+          result == Right(
+            DynamicValue.Sequence(
+              zio.blocks.chunk.Chunk(
+                DynamicValue.Record("x" -> DynamicValue.Primitive(PrimitiveValue.Int(0))),
+                DynamicValue.Record("x" -> DynamicValue.Primitive(PrimitiveValue.Int(0)))
+              )
+            )
+          )
+        )
+      },
+      test("navigate through MapValues to modify nested fields") {
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (
+              DynamicValue.Primitive(PrimitiveValue.String("k1")),
+              DynamicValue.Record("v" -> DynamicValue.Primitive(PrimitiveValue.Int(1)))
+            )
+          )
+        )
+        val path = DynamicOptic(
+          IndexedSeq(
+            DynamicOptic.Node.MapValues,
+            DynamicOptic.Node.Field("v")
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(42))
+        )
+        val result = migration(input)
+        assertTrue(result.isRight)
+      },
+      test("navigate through MapKeys to modify nested structure") {
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (
+              DynamicValue.Record("id" -> DynamicValue.Primitive(PrimitiveValue.Int(1))),
+              DynamicValue.Primitive(PrimitiveValue.String("val"))
+            )
+          )
+        )
+        val path = DynamicOptic(
+          IndexedSeq(
+            DynamicOptic.Node.MapKeys,
+            DynamicOptic.Node.Field("id")
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(99))
+        )
+        val result = migration(input)
+        assertTrue(result.isRight)
+      },
+      test("navigate through AtIndex to modify nested field") {
+        val input = DynamicValue.Sequence(
+          zio.blocks.chunk.Chunk(
+            DynamicValue.Record("x" -> DynamicValue.Primitive(PrimitiveValue.Int(10))),
+            DynamicValue.Record("x" -> DynamicValue.Primitive(PrimitiveValue.Int(20)))
+          )
+        )
+        val path = DynamicOptic(
+          IndexedSeq(
+            DynamicOptic.Node.AtIndex(1),
+            DynamicOptic.Node.Field("x")
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(99))
+        )
+        val result = migration(input)
+        assertTrue(
+          result == Right(
+            DynamicValue.Sequence(
+              zio.blocks.chunk.Chunk(
+                DynamicValue.Record("x" -> DynamicValue.Primitive(PrimitiveValue.Int(10))),
+                DynamicValue.Record("x" -> DynamicValue.Primitive(PrimitiveValue.Int(99)))
+              )
+            )
+          )
+        )
+      },
+      test("navigate through AtMapKey to modify nested field") {
+        val key   = DynamicValue.Primitive(PrimitiveValue.String("a"))
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (key, DynamicValue.Record("v" -> DynamicValue.Primitive(PrimitiveValue.Int(1))))
+          )
+        )
+        val path = DynamicOptic(
+          IndexedSeq(
+            DynamicOptic.Node.AtMapKey(key),
+            DynamicOptic.Node.Field("v")
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(42))
+        )
+        val result = migration(input)
+        assertTrue(result.isRight)
+      },
+      test("AtMapKey with non-DynamicValue key fails safely") {
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (
+              DynamicValue.Primitive(PrimitiveValue.String("a")),
+              DynamicValue.Record("v" -> DynamicValue.Primitive(PrimitiveValue.Int(1)))
+            )
+          )
+        )
+        val badNode =
+          DynamicOptic.Node
+            .AtMapKey(DynamicValue.Primitive(PrimitiveValue.String("placeholder")))
+            .asInstanceOf[DynamicOptic.Node.AtMapKey]
+        val path = DynamicOptic(
+          IndexedSeq(
+            badNode.copy(key = null.asInstanceOf[DynamicValue]),
+            DynamicOptic.Node.Field("v")
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(42))
+        )
+        assertTrue(migration(input).isLeft)
+      },
+      test("navigate through Wrapped node") {
+        val input = DynamicValue.Record(
+          "x" -> DynamicValue.Primitive(PrimitiveValue.Int(5))
+        )
+        val path = DynamicOptic(
+          IndexedSeq(
+            DynamicOptic.Node.Wrapped,
+            DynamicOptic.Node.Field("x")
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(99))
+        )
+        val result = migration(input)
+        assertTrue(
+          result == Right(
+            DynamicValue.Record("x" -> DynamicValue.Primitive(PrimitiveValue.Int(99)))
+          )
+        )
+      },
+      test("unsupported path node (AtIndices) fails in modifyAtPath") {
+        val input = DynamicValue.Sequence(
+          zio.blocks.chunk.Chunk(
+            DynamicValue.Primitive(PrimitiveValue.Int(1))
+          )
+        )
+        val path = DynamicOptic(
+          IndexedSeq(
+            DynamicOptic.Node.AtIndices(Seq(0))
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(0))
+        )
+        assertTrue(migration(input).isLeft)
+      },
+      test("unsupported path node (AtMapKeys) fails in modifyAtPath") {
+        val key   = DynamicValue.Primitive(PrimitiveValue.String("a"))
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (key, DynamicValue.Primitive(PrimitiveValue.Int(1)))
+          )
+        )
+        val path = DynamicOptic(
+          IndexedSeq(
+            DynamicOptic.Node.AtMapKeys(Seq(key))
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(0))
+        )
+        assertTrue(migration(input).isLeft)
+      },
+      test("exceeding max path depth returns error") {
+        val deepNodes                             = (0 until 65).map(i => DynamicOptic.Node.Field(s"f$i"))
+        val path                                  = DynamicOptic(deepNodes.toIndexedSeq)
+        def buildRecord(depth: Int): DynamicValue =
+          if (depth >= 65) DynamicValue.Primitive(PrimitiveValue.Int(0))
+          else DynamicValue.Record(s"f$depth" -> buildRecord(depth + 1))
+        val input     = buildRecord(0)
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(99))
+        )
+        assertTrue(migration(input).isLeft)
+      },
+      test("Elements fold stops on first error in sequence") {
+        val input = DynamicValue.Sequence(
+          zio.blocks.chunk.Chunk(
+            DynamicValue.Record("x" -> DynamicValue.Primitive(PrimitiveValue.Int(1))),
+            DynamicValue.Primitive(PrimitiveValue.Int(2))
+          )
+        )
+        val path = DynamicOptic(
+          IndexedSeq(
+            DynamicOptic.Node.Elements,
+            DynamicOptic.Node.Field("x")
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(0))
+        )
+        assertTrue(migration(input).isLeft)
+      },
+      test("MapKeys fold stops on first error") {
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (DynamicValue.Primitive(PrimitiveValue.Int(1)), DynamicValue.Primitive(PrimitiveValue.Int(10)))
+          )
+        )
+        val path = DynamicOptic(
+          IndexedSeq(
+            DynamicOptic.Node.MapKeys,
+            DynamicOptic.Node.Field("x")
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(0))
+        )
+        assertTrue(migration(input).isLeft)
+      },
+      test("MapValues fold stops on first error") {
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (DynamicValue.Primitive(PrimitiveValue.String("k")), DynamicValue.Primitive(PrimitiveValue.Int(1)))
+          )
+        )
+        val path = DynamicOptic(
+          IndexedSeq(
+            DynamicOptic.Node.MapValues,
+            DynamicOptic.Node.Field("x")
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(path, dynamicLiteral(0))
+        )
+        assertTrue(migration(input).isLeft)
+      },
+      test("navigate through nested record fields (2 levels deep)") {
+        val input = DynamicValue.Record(
+          "outer" -> DynamicValue.Record(
+            "inner" -> DynamicValue.Primitive(PrimitiveValue.Int(1))
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(root.field("outer").field("inner"), dynamicLiteral(42))
+        )
+        assertTrue(
+          migration(input) == Right(
+            DynamicValue.Record(
+              "outer" -> DynamicValue.Record(
+                "inner" -> DynamicValue.Primitive(PrimitiveValue.Int(42))
+              )
+            )
+          )
+        )
+      },
+      test("nested field not found at intermediate level") {
+        val input = DynamicValue.Record(
+          "outer" -> DynamicValue.Record(
+            "x" -> DynamicValue.Primitive(PrimitiveValue.Int(1))
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(root.field("outer").field("missing"), dynamicLiteral(0))
+        )
+        assertTrue(migration(input).isLeft)
+      }
+    ),
+    suite("evalExpr edge cases")(
+      test("expression returning empty sequence fails") {
+        val input = DynamicValue.Record(
+          "x" -> DynamicValue.Primitive(PrimitiveValue.Int(1))
+        )
+        val selectMissing = DynamicSchemaExpr.Select(DynamicOptic.root.field("nonexistent"))
+        val migration     = DynamicMigration.single(
+          MigrationAction.TransformField(root.field("x"), selectMissing)
+        )
+        assertTrue(migration(input).isLeft)
+      }
+    ),
+    suite("MigrationAction.reverse additional")(
+      test("MandateField reverse is OptionalizeField") {
+        val action   = MigrationAction.MandateField(root.field("x"), dynamicLiteral(0))
+        val reversed = action.reverse
+        assertTrue(reversed.isInstanceOf[MigrationAction.OptionalizeField])
+      },
+      test("MigrateField reverse reverses nested migration") {
+        val nested = DynamicMigration(
+          MigrationAction.AddField(root.field("a"), dynamicLiteral(1)),
+          MigrationAction.AddField(root.field("b"), dynamicLiteral(2))
+        )
+        val action   = MigrationAction.MigrateField(root.field("x"), nested)
+        val reversed = action.reverse.asInstanceOf[MigrationAction.MigrateField]
+        assertTrue(reversed.migration.actions.length == 2)
+        assertTrue(reversed.migration.actions.head.isInstanceOf[MigrationAction.DropField])
+      },
+      test("AddField reverse is DropField") {
+        val action   = MigrationAction.AddField(root.field("x"), dynamicLiteral(0))
+        val reversed = action.reverse
+        assertTrue(reversed.isInstanceOf[MigrationAction.DropField])
+      },
+      test("DropField reverse is AddField") {
+        val action   = MigrationAction.DropField(root.field("x"), dynamicLiteral(0))
+        val reversed = action.reverse
+        assertTrue(reversed.isInstanceOf[MigrationAction.AddField])
+      }
+    ),
+    suite("DynamicMigration composition")(
+      test("++ composes two migrations") {
+        val m1       = DynamicMigration.single(MigrationAction.AddField(root.field("x"), dynamicLiteral(1)))
+        val m2       = DynamicMigration.single(MigrationAction.AddField(root.field("y"), dynamicLiteral(2)))
+        val composed = m1 ++ m2
+        assertTrue(composed.size == 2)
+        val result = composed(DynamicValue.Record())
+        assertTrue(result.isRight)
+        val rec = result.toOption.get.asInstanceOf[DynamicValue.Record]
+        assertTrue(rec.fields.length == 2)
+      },
+      test("multi-action migration applies all in sequence") {
+        val m = DynamicMigration(
+          MigrationAction.AddField(root.field("x"), dynamicLiteral(1)),
+          MigrationAction.AddField(root.field("y"), dynamicLiteral(2)),
+          MigrationAction.AddField(root.field("z"), dynamicLiteral(3))
+        )
+        val result = m(DynamicValue.Record())
+        assertTrue(result.isRight)
+        val rec = result.toOption.get.asInstanceOf[DynamicValue.Record]
+        assertTrue(rec.fields.length == 3)
       }
     )
   )

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
@@ -170,6 +170,7 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
         val migration = DynamicMigration.single(
           MigrationAction.TransformCase(
             root,
+            "User",
             zio.blocks.chunk.Chunk(
               MigrationAction.AddField(DynamicOptic.root.field("age"), dynamicLiteral(0))
             )
@@ -181,7 +182,7 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
       },
       test("fails on non-Variant value") {
         val migration = DynamicMigration.single(
-          MigrationAction.TransformCase(root, zio.blocks.chunk.Chunk.empty)
+          MigrationAction.TransformCase(root, "User", zio.blocks.chunk.Chunk.empty)
         )
         assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
       }
@@ -622,6 +623,7 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
       test("TransformCase reverse reverses inner actions") {
         val action = MigrationAction.TransformCase(
           root,
+          "TestCase",
           zio.blocks.chunk.Chunk(
             MigrationAction.AddField(root.field("a"), dynamicLiteral(1)),
             MigrationAction.RenameField(root.field("b"), "c")

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
@@ -1,0 +1,448 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.test._
+import zio.blocks.schema._
+
+object DynamicMigrationSpec extends ZIOSpecDefault {
+
+  private def dynamicLiteral[A: Schema](value: A): DynamicSchemaExpr =
+    DynamicSchemaExpr.Literal(Schema[A].toDynamicValue(value))
+
+  private val root = DynamicOptic.root
+
+  private val sampleRecord = DynamicValue.Record(
+    "name" -> DynamicValue.Primitive(PrimitiveValue.String("Alice")),
+    "age"  -> DynamicValue.Primitive(PrimitiveValue.Int(30))
+  )
+
+  def spec: Spec[TestEnvironment, Any] = suite("DynamicMigrationSpec")(
+    suite("executeMandate")(
+      test("unwraps Some variant") {
+        val input = DynamicValue.Record(
+          "status" -> DynamicValue.Variant("Some", DynamicValue.Primitive(PrimitiveValue.Int(42)))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.MandateField(root.field("status"), dynamicLiteral(0))
+        )
+        assertTrue(
+          migration(input) == Right(
+            DynamicValue.Record("status" -> DynamicValue.Primitive(PrimitiveValue.Int(42)))
+          )
+        )
+      },
+      test("replaces None variant with default") {
+        val input = DynamicValue.Record(
+          "status" -> DynamicValue.Variant("None", DynamicValue.Record())
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.MandateField(root.field("status"), dynamicLiteral(99))
+        )
+        val result = migration(input)
+        assertTrue(
+          result == Right(
+            DynamicValue.Record("status" -> DynamicValue.Primitive(PrimitiveValue.Int(99)))
+          )
+        )
+      },
+      test("passes through non-Option value unchanged") {
+        val input = DynamicValue.Record(
+          "status" -> DynamicValue.Primitive(PrimitiveValue.Int(10))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.MandateField(root.field("status"), dynamicLiteral(0))
+        )
+        assertTrue(
+          migration(input) == Right(
+            DynamicValue.Record("status" -> DynamicValue.Primitive(PrimitiveValue.Int(10)))
+          )
+        )
+      }
+    ),
+    suite("executeOptionalize")(
+      test("wraps value in Some variant") {
+        val input = DynamicValue.Record(
+          "age" -> DynamicValue.Primitive(PrimitiveValue.Int(25))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.OptionalizeField(root.field("age"))
+        )
+        assertTrue(
+          migration(input) == Right(
+            DynamicValue.Record(
+              "age" -> DynamicValue.Variant("Some", DynamicValue.Primitive(PrimitiveValue.Int(25)))
+            )
+          )
+        )
+      }
+    ),
+    suite("executeRenameField")(
+      test("renames a field in a record") {
+        val migration = DynamicMigration.single(
+          MigrationAction.RenameField(root.field("name"), "fullName")
+        )
+        assertTrue(
+          migration(sampleRecord) == Right(
+            DynamicValue.Record(
+              "fullName" -> DynamicValue.Primitive(PrimitiveValue.String("Alice")),
+              "age"      -> DynamicValue.Primitive(PrimitiveValue.Int(30))
+            )
+          )
+        )
+      },
+      test("fails when target field already exists") {
+        val migration = DynamicMigration.single(
+          MigrationAction.RenameField(root.field("name"), "age")
+        )
+        assertTrue(migration(sampleRecord).isLeft)
+      },
+      test("fails when source field not found") {
+        val migration = DynamicMigration.single(
+          MigrationAction.RenameField(root.field("missing"), "other")
+        )
+        assertTrue(migration(sampleRecord).isLeft)
+      },
+      test("fails when path does not end with Field node") {
+        val migration = DynamicMigration.single(
+          MigrationAction.RenameField(root, "other")
+        )
+        assertTrue(migration(sampleRecord).isLeft)
+      }
+    ),
+    suite("executeChangeType")(
+      test("changes field value via converter expression") {
+        val input = DynamicValue.Record(
+          "score" -> DynamicValue.Primitive(PrimitiveValue.Int(42))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.ChangeFieldType(root.field("score"), dynamicLiteral("42"))
+        )
+        assertTrue(
+          migration(input) == Right(
+            DynamicValue.Record("score" -> DynamicValue.Primitive(PrimitiveValue.String("42")))
+          )
+        )
+      }
+    ),
+    suite("executeRenameCase")(
+      test("renames matching case") {
+        val input     = DynamicValue.Variant("Active", DynamicValue.Record())
+        val migration = DynamicMigration.single(
+          MigrationAction.RenameCase(root, "Active", "Enabled")
+        )
+        assertTrue(migration(input) == Right(DynamicValue.Variant("Enabled", DynamicValue.Record())))
+      },
+      test("leaves non-matching case unchanged") {
+        val input     = DynamicValue.Variant("Inactive", DynamicValue.Record())
+        val migration = DynamicMigration.single(
+          MigrationAction.RenameCase(root, "Active", "Enabled")
+        )
+        assertTrue(migration(input) == Right(input))
+      },
+      test("fails on non-Variant value") {
+        val migration = DynamicMigration.single(
+          MigrationAction.RenameCase(root, "Active", "Enabled")
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      }
+    ),
+    suite("executeTransformCase")(
+      test("applies actions to variant inner value") {
+        val input = DynamicValue.Variant(
+          "User",
+          DynamicValue.Record("name" -> DynamicValue.Primitive(PrimitiveValue.String("Bob")))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformCase(
+            root,
+            zio.blocks.chunk.Chunk(
+              MigrationAction.AddField(DynamicOptic.root.field("age"), dynamicLiteral(0))
+            )
+          )
+        )
+        val result  = migration(input)
+        val variant = result.toOption.get.asInstanceOf[DynamicValue.Variant]
+        assertTrue(result.isRight && variant.caseNameValue == "User")
+      },
+      test("fails on non-Variant value") {
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformCase(root, zio.blocks.chunk.Chunk.empty)
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      }
+    ),
+    suite("Irreversible")(
+      test("executing Irreversible action fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.Irreversible(root, "TransformField")
+        )
+        assertTrue(migration(sampleRecord).isLeft)
+      }
+    ),
+    suite("modifyAtPath error branches")(
+      test("Field node on non-Record value fails") {
+        val input     = DynamicValue.Primitive(PrimitiveValue.Int(1))
+        val migration = DynamicMigration.single(
+          MigrationAction.OptionalizeField(root.field("x"))
+        )
+        assertTrue(migration(input).isLeft)
+      },
+      test("Case node on non-matching case fails") {
+        val input     = DynamicValue.Variant("Other", DynamicValue.Record())
+        val migration = DynamicMigration.single(
+          MigrationAction.AddField(
+            DynamicOptic(IndexedSeq(DynamicOptic.Node.Case("Expected"), DynamicOptic.Node.Field("x"))),
+            dynamicLiteral(0)
+          )
+        )
+        assertTrue(migration(input).isLeft)
+      },
+      test("Case node on non-Variant fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.AddField(
+            DynamicOptic(IndexedSeq(DynamicOptic.Node.Case("X"), DynamicOptic.Node.Field("x"))),
+            dynamicLiteral(0)
+          )
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      },
+      test("Elements node on non-Sequence fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(
+            DynamicOptic(IndexedSeq(DynamicOptic.Node.Elements)),
+            dynamicLiteral(0)
+          )
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      },
+      test("MapKeys node on non-Map fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(
+            DynamicOptic(IndexedSeq(DynamicOptic.Node.MapKeys)),
+            dynamicLiteral(0)
+          )
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      },
+      test("MapValues node on non-Map fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(
+            DynamicOptic(IndexedSeq(DynamicOptic.Node.MapValues)),
+            dynamicLiteral(0)
+          )
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      },
+      test("AtIndex on non-Sequence fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(
+            DynamicOptic(IndexedSeq(DynamicOptic.Node.AtIndex(0))),
+            dynamicLiteral(0)
+          )
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      },
+      test("AtIndex out of bounds fails") {
+        val input     = DynamicValue.Sequence(zio.blocks.chunk.Chunk(DynamicValue.Primitive(PrimitiveValue.Int(1))))
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(
+            DynamicOptic(IndexedSeq(DynamicOptic.Node.AtIndex(5))),
+            dynamicLiteral(0)
+          )
+        )
+        assertTrue(migration(input).isLeft)
+      },
+      test("AtMapKey on non-Map fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(
+            DynamicOptic(IndexedSeq(DynamicOptic.Node.AtMapKey(DynamicValue.Primitive(PrimitiveValue.String("k"))))),
+            dynamicLiteral(0)
+          )
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      },
+      test("AtMapKey with missing key fails") {
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1)))
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(
+            DynamicOptic(IndexedSeq(DynamicOptic.Node.AtMapKey(DynamicValue.Primitive(PrimitiveValue.String("z"))))),
+            dynamicLiteral(0)
+          )
+        )
+        assertTrue(migration(input).isLeft)
+      }
+    ),
+    suite("TransformElements/Keys/Values execution")(
+      test("TransformElements on non-Sequence fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformElements(root, dynamicLiteral(0))
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      },
+      test("TransformElements replaces all elements") {
+        val input = DynamicValue.Sequence(
+          zio.blocks.chunk.Chunk(
+            DynamicValue.Primitive(PrimitiveValue.Int(1)),
+            DynamicValue.Primitive(PrimitiveValue.Int(2))
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformElements(root, dynamicLiteral(99))
+        )
+        val result = migration(input)
+        assertTrue(
+          result == Right(
+            DynamicValue.Sequence(
+              zio.blocks.chunk.Chunk(
+                DynamicValue.Primitive(PrimitiveValue.Int(99)),
+                DynamicValue.Primitive(PrimitiveValue.Int(99))
+              )
+            )
+          )
+        )
+      },
+      test("TransformKeys on non-Map fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformKeys(root, dynamicLiteral("k"))
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      },
+      test("TransformKeys replaces all keys") {
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1)))
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformKeys(root, dynamicLiteral("newKey"))
+        )
+        val result = migration(input)
+        assertTrue(result.isRight)
+      },
+      test("TransformValues on non-Map fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformValues(root, dynamicLiteral(0))
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      },
+      test("TransformValues replaces all values") {
+        val input = DynamicValue.Map(
+          zio.blocks.chunk.Chunk(
+            (DynamicValue.Primitive(PrimitiveValue.String("a")), DynamicValue.Primitive(PrimitiveValue.Int(1)))
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformValues(root, dynamicLiteral(0))
+        )
+        val result = migration(input)
+        assertTrue(result.isRight)
+      }
+    ),
+    suite("AddField/DropField error paths")(
+      test("AddField with path not ending in Field fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.AddField(root, dynamicLiteral(0))
+        )
+        assertTrue(migration(sampleRecord).isLeft)
+      },
+      test("DropField with path not ending in Field fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.DropField(root, dynamicLiteral(0))
+        )
+        assertTrue(migration(sampleRecord).isLeft)
+      },
+      test("AddField on non-Record fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.AddField(root.field("x"), dynamicLiteral(0))
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      },
+      test("DropField for nonexistent field fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.DropField(root.field("missing"), dynamicLiteral(0))
+        )
+        assertTrue(migration(sampleRecord).isLeft)
+      },
+      test("DropField on non-Record fails") {
+        val migration = DynamicMigration.single(
+          MigrationAction.DropField(root.field("x"), dynamicLiteral(0))
+        )
+        assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
+      },
+      test("AddField fails when field already exists") {
+        val migration = DynamicMigration.single(
+          MigrationAction.AddField(root.field("name"), dynamicLiteral("dup"))
+        )
+        assertTrue(migration(sampleRecord).isLeft)
+      }
+    ),
+    suite("MigrationError.message coverage")(
+      test("all MigrationErrorKind variants produce messages") {
+        import SchemaError.MigrationErrorKind._
+        val path   = DynamicOptic.root
+        val errors = List(
+          SchemaError.MigrationError(path, PathNotFound),
+          SchemaError.MigrationError(path, TypeMismatch("Record", "Int")),
+          SchemaError.MigrationError(path, MissingDefault("age")),
+          SchemaError.MigrationError(path, TransformFailed("reason")),
+          SchemaError.MigrationError(path, FieldNotFound("name")),
+          SchemaError.MigrationError(path, FieldAlreadyExists("name")),
+          SchemaError.MigrationError(path, CaseNotFound("Active")),
+          SchemaError.MigrationError(path, InvalidValue("bad")),
+          SchemaError.MigrationError(path, MandateFailed("missing"))
+        )
+        assertTrue(errors.forall(_.message.nonEmpty))
+      }
+    ),
+    suite("DynamicMigration utilities")(
+      test("empty migration is identity") {
+        assertTrue(DynamicMigration.empty(sampleRecord) == Right(sampleRecord))
+      },
+      test("isEmpty and size") {
+        assertTrue(DynamicMigration.empty.isEmpty && DynamicMigration.empty.size == 0)
+        val m = DynamicMigration.single(MigrationAction.OptionalizeField(root.field("x")))
+        assertTrue(!m.isEmpty && m.size == 1)
+      },
+      test("andThen composes") {
+        val m1       = DynamicMigration.single(MigrationAction.AddField(root.field("x"), dynamicLiteral(1)))
+        val m2       = DynamicMigration.single(MigrationAction.DropField(root.field("x"), dynamicLiteral(1)))
+        val composed = m1.andThen(m2)
+        assertTrue(composed.size == 2)
+      },
+      test("reverse reverses action order") {
+        val m = DynamicMigration(
+          MigrationAction.AddField(root.field("a"), dynamicLiteral(1)),
+          MigrationAction.AddField(root.field("b"), dynamicLiteral(2))
+        )
+        val rev = m.reverse
+        assertTrue(rev.actions.head.isInstanceOf[MigrationAction.DropField])
+      },
+      test("multi-action migration stops on first error") {
+        val m = DynamicMigration(
+          MigrationAction.DropField(root.field("nonexistent"), dynamicLiteral(0)),
+          MigrationAction.AddField(root.field("x"), dynamicLiteral(1))
+        )
+        assertTrue(m(sampleRecord).isLeft)
+      }
+    )
+  )
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -1,0 +1,1026 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.test._
+import zio.blocks.schema._
+
+object MigrationSpec extends ZIOSpecDefault {
+
+  private def dynamicLiteral[A: Schema](value: A): DynamicSchemaExpr =
+    DynamicSchemaExpr.Literal(Schema[A].toDynamicValue(value))
+
+  private def literal[A: Schema](value: A): SchemaExpr[Any, A] =
+    SchemaExpr.literal(value)
+
+  def spec: Spec[TestEnvironment, Any] = suite("MigrationSpec")(
+    suite("Laws")(
+      test("identity element - left") {
+        case class V1(name: String)
+        case class V2(name: String, age: Int)
+
+        implicit val s1: Schema[V1] = Schema.derived
+        implicit val s2: Schema[V2] = Schema.derived
+
+        val m     = Migration.newBuilder[V1, V2].addField(_.age, literal(0)).build
+        val input = V1("Alice")
+        assertTrue((Migration.identity[V1] ++ m)(input) == m(input))
+      },
+
+      test("identity element - right") {
+        case class V1(name: String)
+        case class V2(name: String, age: Int)
+
+        implicit val s1: Schema[V1] = Schema.derived
+        implicit val s2: Schema[V2] = Schema.derived
+
+        val m     = Migration.newBuilder[V1, V2].addField(_.age, literal(0)).build
+        val input = V1("Alice")
+        assertTrue((m ++ Migration.identity[V2])(input) == m(input))
+      },
+
+      test("associativity") {
+        case class V1(name: String)
+        case class V2(name: String, age: Int)
+        case class V3(name: String, age: Int, city: String)
+        case class V4(fullName: String, age: Int, city: String)
+
+        implicit val s1: Schema[V1] = Schema.derived
+        implicit val s2: Schema[V2] = Schema.derived
+        implicit val s3: Schema[V3] = Schema.derived
+        implicit val s4: Schema[V4] = Schema.derived
+
+        val m1 = Migration.newBuilder[V1, V2].addField(_.age, literal(0)).build
+        val m2 = Migration.newBuilder[V2, V3].addField(_.city, literal("")).build
+        val m3 = Migration.newBuilder[V3, V4].renameField(_.name, _.fullName).build
+
+        val input = V1("Alice")
+        assertTrue(((m1 ++ m2) ++ m3)(input) == (m1 ++ (m2 ++ m3))(input))
+      },
+
+      test("double-reverse involution") {
+        case class V1(name: String)
+        case class V2(name: String, age: Int)
+
+        implicit val s1: Schema[V1] = Schema.derived
+        implicit val s2: Schema[V2] = Schema.derived
+
+        val m = Migration.newBuilder[V1, V2].addField(_.age, literal(0)).build
+        assertTrue(m.reverse.reverse.actions == m.actions)
+      },
+
+      test("semantic inverse for rename") {
+        case class V1(firstName: String)
+        case class V2(fullName: String)
+
+        implicit val s1: Schema[V1] = Schema.derived
+        implicit val s2: Schema[V2] = Schema.derived
+
+        val m         = Migration.newBuilder[V1, V2].renameField(_.firstName, _.fullName).build
+        val input     = V1("Alice")
+        val roundTrip = m(input).flatMap(m.reverse(_))
+        assertTrue(roundTrip == Right(input))
+      }
+    ),
+
+    suite("Selector Syntax")(
+      test("simple field selector") {
+        case class PersonV1(name: String)
+        case class PersonV2(name: String, age: Int)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .addField(_.age, literal(0))
+          .build
+
+        val input  = PersonV1("Alice")
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2("Alice", 0)))
+      },
+
+      test("renameField selector syntax") {
+        case class PersonV1(firstName: String)
+        case class PersonV2(fullName: String)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .renameField(_.firstName, _.fullName)
+          .build
+
+        val input  = PersonV1("Alice")
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2("Alice")))
+      },
+
+      test("dropField selector syntax") {
+        case class PersonV1(name: String, age: Int)
+        case class PersonV2(name: String)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .dropField(_.age, literal(0))
+          .build
+
+        val input  = PersonV1("Alice", 30)
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2("Alice")))
+      },
+
+      test("transformField selector syntax") {
+        case class PersonV1(age: Int)
+        case class PersonV2(age: Long)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .transformField(_.age, _.age, literal(30L))
+          .build
+
+        val input  = PersonV1(30)
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2(30L)))
+      },
+
+      test("changeFieldType selector syntax") {
+        case class PersonV1(score: Int)
+        case class PersonV2(score: String)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .changeFieldType(_.score, _.score, literal("42"))
+          .build
+
+        val input  = PersonV1(42)
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2("42")))
+      },
+
+      test("mandateField builder creates correct action") {
+        case class PersonV1(age: Option[Int])
+        case class PersonV2(age: Int)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .mandateField(_.age, _.age, literal(0))
+          .buildPartial
+
+        assertTrue(migration.actions.length == 1 && migration.actions.head.isInstanceOf[MigrationAction.MandateField])
+      },
+
+      test("optionalizeField builder creates correct action") {
+        case class PersonV1(age: Int)
+        case class PersonV2(age: Option[Int])
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .optionalizeField(_.age, _.age)
+          .buildPartial
+
+        assertTrue(
+          migration.actions.length == 1 && migration.actions.head.isInstanceOf[MigrationAction.OptionalizeField]
+        )
+      },
+
+      test("transformElements builder creates correct action") {
+        case class Container(items: List[Int])
+
+        implicit val schema: Schema[Container] = Schema.derived[Container]
+
+        val migration = Migration
+          .newBuilder[Container, Container]
+          .transformElements(_.items, literal(0))
+          .buildPartial
+
+        assertTrue(
+          migration.actions.length == 1 && migration.actions.head.isInstanceOf[MigrationAction.TransformElements]
+        )
+      },
+
+      test("transformKeys builder creates correct action") {
+        case class Container(data: Map[String, Int])
+
+        implicit val schema: Schema[Container] = Schema.derived[Container]
+
+        val migration = Migration
+          .newBuilder[Container, Container]
+          .transformKeys(_.data, literal("key"))
+          .buildPartial
+
+        assertTrue(migration.actions.length == 1 && migration.actions.head.isInstanceOf[MigrationAction.TransformKeys])
+      },
+
+      test("transformValues builder creates correct action") {
+        case class Container(data: Map[String, Int])
+
+        implicit val schema: Schema[Container] = Schema.derived[Container]
+
+        val migration = Migration
+          .newBuilder[Container, Container]
+          .transformValues(_.data, literal(0))
+          .buildPartial
+
+        assertTrue(
+          migration.actions.length == 1 && migration.actions.head.isInstanceOf[MigrationAction.TransformValues]
+        )
+      },
+
+      test("renameCase builder creates correct action") {
+        sealed trait Status
+        case object Active  extends Status
+        case object Pending extends Status
+
+        implicit val schema: Schema[Status] = Schema.derived[Status]
+
+        val migration = Migration
+          .newBuilder[Status, Status]
+          .renameCase("Active", "Enabled")
+          .buildPartial
+
+        assertTrue(migration.actions.length == 1 && migration.actions.head.isInstanceOf[MigrationAction.RenameCase])
+      }
+    ),
+
+    suite("Migration Companion Methods")(
+      test("Migration.identity creates empty migration") {
+        case class Person(name: String)
+        implicit val schema: Schema[Person] = Schema.derived[Person]
+
+        val migration = Migration.identity[Person]
+        assertTrue(migration.isEmpty && migration.size == 0)
+      },
+
+      test("Migration.fromAction creates single-action migration") {
+        case class PersonV1(name: String)
+        case class PersonV2(name: String, age: Int)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val action = MigrationAction.AddField(
+          DynamicOptic.root.field("age"),
+          dynamicLiteral(0)
+        )
+        val migration = Migration.fromAction[PersonV1, PersonV2](action)
+        assertTrue(migration.size == 1)
+      },
+
+      test("Migration.fromDynamic wraps DynamicMigration") {
+        case class PersonV1(name: String)
+        case class PersonV2(name: String, age: Int)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val dynamicMigration = DynamicMigration.single(
+          MigrationAction.AddField(
+            DynamicOptic.root.field("age"),
+            dynamicLiteral(0)
+          )
+        )
+        val migration = Migration.fromDynamic[PersonV1, PersonV2](dynamicMigration)
+        assertTrue(migration.size == 1 && migration.dynamicMigration == dynamicMigration)
+      },
+
+      test("Migration.++ composes migrations") {
+        case class PersonV1(name: String)
+        case class PersonV2(name: String, age: Int)
+        case class PersonV3(name: String, age: Int, city: String)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val v3Schema: Schema[PersonV3] = Schema.derived[PersonV3]
+
+        val m1 = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .addField(_.age, literal(0))
+          .build
+        val m2 = Migration
+          .newBuilder[PersonV2, PersonV3]
+          .addField(_.city, literal(""))
+          .build
+        val composed = m1 ++ m2
+        assertTrue(composed.size == 2)
+      },
+
+      test("Migration.reverse swaps schemas") {
+        case class PersonV1(name: String)
+        case class PersonV2(name: String, age: Int)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .addField(_.age, literal(0))
+          .build
+        val reversed = migration.reverse
+        assertTrue(reversed.sourceSchema == v2Schema && reversed.targetSchema == v1Schema)
+      }
+    ),
+
+    suite("Migration Composition with migrateField")(
+      test("migrateField with explicit migration") {
+        case class User(name: String, age: Int)
+        case class UserV2(name: String, age: Int, email: String)
+        case class Profile(id: Int, user: User)
+        case class ProfileV2(id: Int, user: UserV2)
+
+        implicit val userSchema: Schema[User]           = Schema.derived[User]
+        implicit val userV2Schema: Schema[UserV2]       = Schema.derived[UserV2]
+        implicit val profileSchema: Schema[Profile]     = Schema.derived[Profile]
+        implicit val profileV2Schema: Schema[ProfileV2] = Schema.derived[ProfileV2]
+
+        val userMigration: Migration[User, UserV2] = Migration
+          .newBuilder[User, UserV2]
+          .addField(_.email, literal("default@example.com"))
+          .build
+
+        val profileMigration = Migration
+          .newBuilder[Profile, ProfileV2]
+          .migrateField(_.user, userMigration)
+          .build
+
+        val input  = Profile(1, User("Alice", 30))
+        val result = profileMigration(input)
+
+        assertTrue(result == Right(ProfileV2(1, UserV2("Alice", 30, "default@example.com"))))
+      },
+
+      test("migrateField with implicit migration") {
+        case class Address(street: String, city: String)
+        case class AddressV2(street: String, city: String, zip: String)
+        case class Company(name: String, address: Address)
+        case class CompanyV2(name: String, address: AddressV2)
+
+        implicit val addressSchema: Schema[Address]     = Schema.derived[Address]
+        implicit val addressV2Schema: Schema[AddressV2] = Schema.derived[AddressV2]
+        implicit val companySchema: Schema[Company]     = Schema.derived[Company]
+        implicit val companyV2Schema: Schema[CompanyV2] = Schema.derived[CompanyV2]
+
+        implicit val addressMigration: Migration[Address, AddressV2] = Migration
+          .newBuilder[Address, AddressV2]
+          .addField(_.zip, literal("00000"))
+          .build
+
+        val companyMigration = Migration
+          .newBuilder[Company, CompanyV2]
+          .migrateField(_.address)
+          .build
+
+        val input  = Company("Acme", Address("123 Main St", "Springfield"))
+        val result = companyMigration(input)
+
+        assertTrue(result == Right(CompanyV2("Acme", AddressV2("123 Main St", "Springfield", "00000"))))
+      },
+
+      test("migrateField tracks nested fields for validation") {
+        case class Inner(a: Int, b: String)
+        case class InnerV2(a: Int, b: String, c: Boolean)
+        case class Outer(x: String, inner: Inner)
+        case class OuterV2(x: String, inner: InnerV2)
+
+        implicit val innerSchema: Schema[Inner]     = Schema.derived[Inner]
+        implicit val innerV2Schema: Schema[InnerV2] = Schema.derived[InnerV2]
+        implicit val outerSchema: Schema[Outer]     = Schema.derived[Outer]
+        implicit val outerV2Schema: Schema[OuterV2] = Schema.derived[OuterV2]
+
+        val innerMigration: Migration[Inner, InnerV2] = Migration
+          .newBuilder[Inner, InnerV2]
+          .addField(_.c, literal(false))
+          .build
+
+        val outerMigration = Migration
+          .newBuilder[Outer, OuterV2]
+          .migrateField(_.inner, innerMigration)
+          .build
+
+        val input  = Outer("test", Inner(42, "hello"))
+        val result = outerMigration(input)
+
+        assertTrue(result == Right(OuterV2("test", InnerV2(42, "hello", false))))
+      },
+
+      test("MigrateField action reverse works correctly") {
+        val innerMigration = DynamicMigration.single(
+          MigrationAction.AddField(
+            DynamicOptic.root.field("newField"),
+            dynamicLiteral(42)
+          )
+        )
+        val action   = MigrationAction.MigrateField(DynamicOptic.root.field("nested"), innerMigration)
+        val reversed = action.reverse
+
+        assertTrue(
+          reversed.isInstanceOf[MigrationAction.MigrateField] &&
+            reversed
+              .asInstanceOf[MigrationAction.MigrateField]
+              .migration
+              .actions
+              .head
+              .isInstanceOf[MigrationAction.DropField]
+        )
+      },
+
+      test("MigrateField executes nested migration at path") {
+        val input = DynamicValue.Record(
+          "id"   -> DynamicValue.Primitive(PrimitiveValue.Int(1)),
+          "data" -> DynamicValue.Record(
+            "name" -> DynamicValue.Primitive(PrimitiveValue.String("test"))
+          )
+        )
+
+        val nestedMigration = DynamicMigration.single(
+          MigrationAction.AddField(
+            DynamicOptic.root.field("age"),
+            dynamicLiteral(25)
+          )
+        )
+
+        val migration = DynamicMigration.single(
+          MigrationAction.MigrateField(DynamicOptic.root.field("data"), nestedMigration)
+        )
+
+        val expected = DynamicValue.Record(
+          "id"   -> DynamicValue.Primitive(PrimitiveValue.Int(1)),
+          "data" -> DynamicValue.Record(
+            "name" -> DynamicValue.Primitive(PrimitiveValue.String("test")),
+            "age"  -> DynamicValue.Primitive(PrimitiveValue.Int(25))
+          )
+        )
+
+        assertTrue(migration(input) == Right(expected))
+      },
+
+      test("migrateField combined with other operations") {
+        case class Settings(theme: String)
+        case class SettingsV2(theme: String, fontSize: Int)
+        case class Config(name: String, settings: Settings)
+        case class ConfigV2(title: String, settings: SettingsV2)
+
+        implicit val settingsSchema: Schema[Settings]     = Schema.derived[Settings]
+        implicit val settingsV2Schema: Schema[SettingsV2] = Schema.derived[SettingsV2]
+        implicit val configSchema: Schema[Config]         = Schema.derived[Config]
+        implicit val configV2Schema: Schema[ConfigV2]     = Schema.derived[ConfigV2]
+
+        val settingsMigration: Migration[Settings, SettingsV2] = Migration
+          .newBuilder[Settings, SettingsV2]
+          .addField(_.fontSize, literal(12))
+          .build
+
+        val configMigration = Migration
+          .newBuilder[Config, ConfigV2]
+          .renameField(_.name, _.title)
+          .migrateField(_.settings, settingsMigration)
+          .build
+
+        val input  = Config("MyConfig", Settings("dark"))
+        val result = configMigration(input)
+
+        assertTrue(result == Right(ConfigV2("MyConfig", SettingsV2("dark", 12))))
+      }
+    ),
+
+    suite("Nested Type Migrations")(
+      test("Migration.fromActions API works for direct action construction") {
+        case class AddressV1(street: String, city: String)
+        case class PersonV1(name: String, address: AddressV1)
+
+        case class AddressV2(street: String, city: String, zip: String)
+        case class PersonV2(name: String, address: AddressV2)
+
+        implicit val addressV1Schema: Schema[AddressV1] = Schema.derived[AddressV1]
+        implicit val personV1Schema: Schema[PersonV1]   = Schema.derived[PersonV1]
+        implicit val addressV2Schema: Schema[AddressV2] = Schema.derived[AddressV2]
+        implicit val personV2Schema: Schema[PersonV2]   = Schema.derived[PersonV2]
+
+        val migration = Migration.fromActions[PersonV1, PersonV2](
+          MigrationAction.AddField(
+            DynamicOptic.root.field("address").field("zip"),
+            dynamicLiteral("00000")
+          )
+        )
+
+        val input  = PersonV1("Alice", AddressV1("123 Main St", "NYC"))
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2("Alice", AddressV2("123 Main St", "NYC", "00000"))))
+      },
+
+      test("2-level nested case class migration - rename nested field") {
+        case class AddressV1(street: String, city: String)
+        case class PersonV1(name: String, address: AddressV1)
+
+        case class AddressV2(streetName: String, city: String)
+        case class PersonV2(name: String, address: AddressV2)
+
+        implicit val addressV1Schema: Schema[AddressV1] = Schema.derived[AddressV1]
+        implicit val personV1Schema: Schema[PersonV1]   = Schema.derived[PersonV1]
+        implicit val addressV2Schema: Schema[AddressV2] = Schema.derived[AddressV2]
+        implicit val personV2Schema: Schema[PersonV2]   = Schema.derived[PersonV2]
+
+        val addressMigration = Migration
+          .newBuilder[AddressV1, AddressV2]
+          .renameField(_.street, _.streetName)
+          .build
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .migrateField(_.address, addressMigration)
+          .build
+
+        val input  = PersonV1("Bob", AddressV1("456 Oak Ave", "LA"))
+        val result = migration(input)
+
+        assertTrue(result == Right(PersonV2("Bob", AddressV2("456 Oak Ave", "LA"))))
+      },
+
+      test("3-level nested case class migration - Company with Department with Employee") {
+        case class EmployeeV1(name: String, salary: Int)
+        case class DepartmentV1(name: String, employee: EmployeeV1)
+        case class CompanyV1(name: String, department: DepartmentV1)
+
+        case class EmployeeV2(name: String, salary: Int, bonus: Int)
+        case class DepartmentV2(name: String, employee: EmployeeV2)
+        case class CompanyV2(name: String, department: DepartmentV2)
+
+        implicit val employeeV1Schema: Schema[EmployeeV1]     = Schema.derived[EmployeeV1]
+        implicit val departmentV1Schema: Schema[DepartmentV1] = Schema.derived[DepartmentV1]
+        implicit val companyV1Schema: Schema[CompanyV1]       = Schema.derived[CompanyV1]
+        implicit val employeeV2Schema: Schema[EmployeeV2]     = Schema.derived[EmployeeV2]
+        implicit val departmentV2Schema: Schema[DepartmentV2] = Schema.derived[DepartmentV2]
+        implicit val companyV2Schema: Schema[CompanyV2]       = Schema.derived[CompanyV2]
+
+        val employeeMigration = Migration
+          .newBuilder[EmployeeV1, EmployeeV2]
+          .addField(_.bonus, literal(1000))
+          .build
+
+        val departmentMigration = Migration
+          .newBuilder[DepartmentV1, DepartmentV2]
+          .migrateField(_.employee, employeeMigration)
+          .build
+
+        val migration = Migration
+          .newBuilder[CompanyV1, CompanyV2]
+          .migrateField(_.department, departmentMigration)
+          .buildPartial
+
+        val input = CompanyV1(
+          "TechCorp",
+          DepartmentV1("Engineering", EmployeeV1("Charlie", 80000))
+        )
+        val result = migration(input)
+
+        assertTrue(
+          result == Right(
+            CompanyV2(
+              "TechCorp",
+              DepartmentV2("Engineering", EmployeeV2("Charlie", 80000, 1000))
+            )
+          )
+        )
+      },
+
+      test("4-level nested case class migration") {
+        case class L4V1(value: String)
+        case class L3V1(name: String, l4: L4V1)
+        case class L2V1(id: Int, l3: L3V1)
+        case class L1V1(title: String, l2: L2V1)
+
+        case class L4V2(value: String, metadata: String)
+        case class L3V2(name: String, l4: L4V2)
+        case class L2V2(id: Int, l3: L3V2)
+        case class L1V2(title: String, l2: L2V2)
+
+        implicit val l4V1Schema: Schema[L4V1] = Schema.derived[L4V1]
+        implicit val l3V1Schema: Schema[L3V1] = Schema.derived[L3V1]
+        implicit val l2V1Schema: Schema[L2V1] = Schema.derived[L2V1]
+        implicit val l1V1Schema: Schema[L1V1] = Schema.derived[L1V1]
+        implicit val l4V2Schema: Schema[L4V2] = Schema.derived[L4V2]
+        implicit val l3V2Schema: Schema[L3V2] = Schema.derived[L3V2]
+        implicit val l2V2Schema: Schema[L2V2] = Schema.derived[L2V2]
+        implicit val l1V2Schema: Schema[L1V2] = Schema.derived[L1V2]
+
+        val l4Migration = Migration
+          .newBuilder[L4V1, L4V2]
+          .addField(_.metadata, literal("default"))
+          .build
+
+        val l3Migration = Migration
+          .newBuilder[L3V1, L3V2]
+          .migrateField(_.l4, l4Migration)
+          .build
+
+        val l2Migration = Migration
+          .newBuilder[L2V1, L2V2]
+          .migrateField(_.l3, l3Migration)
+          .buildPartial
+
+        val migration = Migration
+          .newBuilder[L1V1, L1V2]
+          .migrateField(_.l2, l2Migration)
+          .buildPartial
+
+        val input = L1V1(
+          "Root",
+          L2V1(1, L3V1("Middle", L4V1("Leaf")))
+        )
+        val result = migration(input)
+
+        assertTrue(
+          result == Right(
+            L1V2(
+              "Root",
+              L2V2(1, L3V2("Middle", L4V2("Leaf", "default")))
+            )
+          )
+        )
+      },
+
+      test("Option[NestedType] migration - identity migration preserves structure") {
+        case class AddressV1(city: String)
+        case class PersonV1(name: String, address: Option[AddressV1])
+
+        case class AddressV2(city: String)
+        case class PersonV2(name: String, address: Option[AddressV2])
+
+        implicit val addressV1Schema: Schema[AddressV1] = Schema.derived[AddressV1]
+        implicit val personV1Schema: Schema[PersonV1]   = Schema.derived[PersonV1]
+        implicit val addressV2Schema: Schema[AddressV2] = Schema.derived[AddressV2]
+        implicit val personV2Schema: Schema[PersonV2]   = Schema.derived[PersonV2]
+
+        val migration = Migration.newBuilder[PersonV1, PersonV2].buildPartial
+
+        val inputWithSome  = PersonV1("Dave", Some(AddressV1("Boston")))
+        val resultWithSome = migration(inputWithSome)
+
+        assertTrue(resultWithSome == Right(PersonV2("Dave", Some(AddressV2("Boston")))))
+      },
+
+      test("List[NestedType] migration - simple container structure transformation") {
+        case class ItemV1(name: String)
+        case class ContainerV1(items: List[ItemV1])
+
+        case class ItemV2(name: String)
+        case class ContainerV2(items: List[ItemV2])
+
+        implicit val itemV1Schema: Schema[ItemV1]           = Schema.derived[ItemV1]
+        implicit val containerV1Schema: Schema[ContainerV1] = Schema.derived[ContainerV1]
+        implicit val itemV2Schema: Schema[ItemV2]           = Schema.derived[ItemV2]
+        implicit val containerV2Schema: Schema[ContainerV2] = Schema.derived[ContainerV2]
+
+        val migration = Migration.newBuilder[ContainerV1, ContainerV2].buildPartial
+
+        val input = ContainerV1(
+          List(ItemV1("Item1"), ItemV1("Item2"))
+        )
+        val result = migration(input)
+
+        assertTrue(result.isRight)
+      },
+
+      test("Map[String, NestedType] migration - simple map structure transformation") {
+        case class ConfigV1(value: String)
+        case class SettingsV1(configs: Map[String, ConfigV1])
+
+        case class ConfigV2(value: String)
+        case class SettingsV2(configs: Map[String, ConfigV2])
+
+        implicit val configV1Schema: Schema[ConfigV1]     = Schema.derived[ConfigV1]
+        implicit val settingsV1Schema: Schema[SettingsV1] = Schema.derived[SettingsV1]
+        implicit val configV2Schema: Schema[ConfigV2]     = Schema.derived[ConfigV2]
+        implicit val settingsV2Schema: Schema[SettingsV2] = Schema.derived[SettingsV2]
+
+        val migration = Migration.newBuilder[SettingsV1, SettingsV2].buildPartial
+
+        val input = SettingsV1(
+          Map("setting1" -> ConfigV1("on"), "setting2" -> ConfigV1("off"))
+        )
+        val result = migration(input)
+
+        assertTrue(result.isRight)
+      },
+
+      test("Nested field rename in deeply nested path") {
+        case class L3V1(oldField: Int)
+        case class L2V1(l3: L3V1)
+        case class L1V1(l2: L2V1)
+
+        case class L3V2(newField: Int)
+        case class L2V2(l3: L3V2)
+        case class L1V2(l2: L2V2)
+
+        implicit val l3V1Schema: Schema[L3V1] = Schema.derived[L3V1]
+        implicit val l2V1Schema: Schema[L2V1] = Schema.derived[L2V1]
+        implicit val l1V1Schema: Schema[L1V1] = Schema.derived[L1V1]
+        implicit val l3V2Schema: Schema[L3V2] = Schema.derived[L3V2]
+        implicit val l2V2Schema: Schema[L2V2] = Schema.derived[L2V2]
+        implicit val l1V2Schema: Schema[L1V2] = Schema.derived[L1V2]
+
+        val l3Migration = Migration
+          .newBuilder[L3V1, L3V2]
+          .renameField(_.oldField, _.newField)
+          .build
+
+        val l2Migration = Migration
+          .newBuilder[L2V1, L2V2]
+          .migrateField(_.l3, l3Migration)
+          .build
+
+        val migration = Migration
+          .newBuilder[L1V1, L1V2]
+          .migrateField(_.l2, l2Migration)
+          .buildPartial
+
+        val input  = L1V1(L2V1(L3V1(42)))
+        val result = migration(input)
+
+        assertTrue(result == Right(L1V2(L2V2(L3V2(42)))))
+      },
+
+      test("Multiple operations on nested types - add and rename fields") {
+        case class InnerV1(a: Int, b: String)
+        case class OuterV1(outer: String, inner: InnerV1)
+
+        case class InnerV2(a: Int, c: String, d: Boolean)
+        case class OuterV2(outer: String, inner: InnerV2)
+
+        implicit val innerV1Schema: Schema[InnerV1] = Schema.derived[InnerV1]
+        implicit val outerV1Schema: Schema[OuterV1] = Schema.derived[OuterV1]
+        implicit val innerV2Schema: Schema[InnerV2] = Schema.derived[InnerV2]
+        implicit val outerV2Schema: Schema[OuterV2] = Schema.derived[OuterV2]
+
+        val innerMigration = Migration
+          .newBuilder[InnerV1, InnerV2]
+          .renameField(_.b, _.c)
+          .addField(_.d, literal(true))
+          .build
+
+        val migration = Migration
+          .newBuilder[OuterV1, OuterV2]
+          .migrateField(_.inner, innerMigration)
+          .build
+
+        val input  = OuterV1("Test", InnerV1(10, "hello"))
+        val result = migration(input)
+
+        assertTrue(result == Right(OuterV2("Test", InnerV2(10, "hello", true))))
+      }
+    ),
+
+    suite("Deep Nested Selectors")(
+      test("renameField with deep nested selector") {
+        case class Address1(street: String, city: String)
+        case class Person1(name: String, address: Address1)
+
+        case class Address2(streetName: String, city: String)
+        case class Person2(name: String, address: Address2)
+
+        implicit val a1Schema: Schema[Address1] = Schema.derived
+        implicit val p1Schema: Schema[Person1]  = Schema.derived
+        implicit val a2Schema: Schema[Address2] = Schema.derived
+        implicit val p2Schema: Schema[Person2]  = Schema.derived
+
+        val migration = Migration
+          .newBuilder[Person1, Person2]
+          .renameField(_.address.street, _.address.streetName)
+          .buildPartial
+
+        val input  = Person1("Alice", Address1("123 Main", "NYC"))
+        val result = migration(input)
+
+        assertTrue(result == Right(Person2("Alice", Address2("123 Main", "NYC"))))
+      },
+      test("addField with deep nested selector") {
+        case class Address1(street: String)
+        case class Person1(name: String, address: Address1)
+
+        case class Address2(street: String, number: Int)
+        case class Person2(name: String, address: Address2)
+
+        implicit val a1Schema: Schema[Address1] = Schema.derived
+        implicit val p1Schema: Schema[Person1]  = Schema.derived
+        implicit val a2Schema: Schema[Address2] = Schema.derived
+        implicit val p2Schema: Schema[Person2]  = Schema.derived
+
+        val migration = Migration
+          .newBuilder[Person1, Person2]
+          .addField(_.address.number, literal(0))
+          .buildPartial
+
+        val input  = Person1("Alice", Address1("123 Main"))
+        val result = migration(input)
+
+        assertTrue(result == Right(Person2("Alice", Address2("123 Main", 0))))
+      },
+      test("dropField with deep nested selector") {
+        case class Address1(street: String, zip: String)
+        case class Person1(name: String, address: Address1)
+
+        case class Address2(street: String)
+        case class Person2(name: String, address: Address2)
+
+        implicit val a1Schema: Schema[Address1] = Schema.derived
+        implicit val p1Schema: Schema[Person1]  = Schema.derived
+        implicit val a2Schema: Schema[Address2] = Schema.derived
+        implicit val p2Schema: Schema[Person2]  = Schema.derived
+
+        val migration = Migration
+          .newBuilder[Person1, Person2]
+          .dropField(_.address.zip, literal("00000"))
+          .buildPartial
+
+        val input  = Person1("Alice", Address1("123 Main", "10001"))
+        val result = migration(input)
+
+        assertTrue(result == Right(Person2("Alice", Address2("123 Main"))))
+      },
+      test("combined deep rename and add with nested selectors") {
+        case class Address1(street: String)
+        case class Person1(name: String, address: Address1)
+
+        case class Address2(streetName: String, number: Int)
+        case class Person2(name: String, address: Address2)
+
+        implicit val a1Schema: Schema[Address1] = Schema.derived
+        implicit val p1Schema: Schema[Person1]  = Schema.derived
+        implicit val a2Schema: Schema[Address2] = Schema.derived
+        implicit val p2Schema: Schema[Person2]  = Schema.derived
+
+        val migration = Migration
+          .newBuilder[Person1, Person2]
+          .renameField(_.address.street, _.address.streetName)
+          .addField(_.address.number, literal(0))
+          .buildPartial
+
+        val input  = Person1("Alice", Address1("123 Main"))
+        val result = migration(input)
+
+        assertTrue(result == Right(Person2("Alice", Address2("123 Main", 0))))
+      },
+      test("3-level deep addField") {
+        case class Street1(name: String)
+        case class Address1(street: Street1, city: String)
+        case class Person1(name: String, address: Address1)
+
+        case class Street2(name: String, number: Int)
+        case class Address2(street: Street2, city: String)
+        case class Person2(name: String, address: Address2)
+
+        implicit val s1: Schema[Street1]  = Schema.derived
+        implicit val a1: Schema[Address1] = Schema.derived
+        implicit val p1: Schema[Person1]  = Schema.derived
+        implicit val s2: Schema[Street2]  = Schema.derived
+        implicit val a2: Schema[Address2] = Schema.derived
+        implicit val p2: Schema[Person2]  = Schema.derived
+
+        val migration = Migration
+          .newBuilder[Person1, Person2]
+          .addField(_.address.street.number, literal(0))
+          .buildPartial
+
+        val input  = Person1("Alice", Address1(Street1("Main"), "NYC"))
+        val result = migration(input)
+
+        assertTrue(result == Right(Person2("Alice", Address2(Street2("Main", 0), "NYC"))))
+      },
+      test("3-level deep renameField") {
+        case class Street1(name: String)
+        case class Address1(street: Street1)
+        case class Person1(info: Address1)
+
+        case class Street2(label: String)
+        case class Address2(street: Street2)
+        case class Person2(info: Address2)
+
+        implicit val s1: Schema[Street1]  = Schema.derived
+        implicit val a1: Schema[Address1] = Schema.derived
+        implicit val p1: Schema[Person1]  = Schema.derived
+        implicit val s2: Schema[Street2]  = Schema.derived
+        implicit val a2: Schema[Address2] = Schema.derived
+        implicit val p2: Schema[Person2]  = Schema.derived
+
+        val migration = Migration
+          .newBuilder[Person1, Person2]
+          .renameField(_.info.street.name, _.info.street.label)
+          .buildPartial
+
+        val input  = Person1(Address1(Street1("Main")))
+        val result = migration(input)
+
+        assertTrue(result == Right(Person2(Address2(Street2("Main")))))
+      },
+      test("3-level deep combined rename and drop") {
+        case class Geo1(lat: Double, lng: Double, alt: Double)
+        case class Location1(geo: Geo1)
+        case class Event1(location: Location1)
+
+        case class Geo2(latitude: Double, lng: Double)
+        case class Location2(geo: Geo2)
+        case class Event2(location: Location2)
+
+        implicit val g1: Schema[Geo1]      = Schema.derived
+        implicit val l1: Schema[Location1] = Schema.derived
+        implicit val e1: Schema[Event1]    = Schema.derived
+        implicit val g2: Schema[Geo2]      = Schema.derived
+        implicit val l2: Schema[Location2] = Schema.derived
+        implicit val e2: Schema[Event2]    = Schema.derived
+
+        val migration = Migration
+          .newBuilder[Event1, Event2]
+          .renameField(_.location.geo.lat, _.location.geo.latitude)
+          .dropField(_.location.geo.alt, literal(0.0))
+          .buildPartial
+
+        val input  = Event1(Location1(Geo1(40.7, -74.0, 10.0)))
+        val result = migration(input)
+
+        assertTrue(result == Right(Event2(Location2(Geo2(40.7, -74.0)))))
+      },
+      test("fromActions with deep optic paths") {
+        case class Addr1(street: String, city: String)
+        case class Org1(name: String, addr: Addr1)
+
+        case class Addr2(street: String, city: String, zip: String)
+        case class Org2(name: String, addr: Addr2)
+
+        implicit val a1: Schema[Addr1] = Schema.derived
+        implicit val o1: Schema[Org1]  = Schema.derived
+        implicit val a2: Schema[Addr2] = Schema.derived
+        implicit val o2: Schema[Org2]  = Schema.derived
+
+        val migration = Migration.fromActions[Org1, Org2](
+          MigrationAction.AddField(
+            DynamicOptic.root.field("addr").field("zip"),
+            dynamicLiteral("00000")
+          )
+        )
+
+        val input  = Org1("Acme", Addr1("123 Main", "NYC"))
+        val result = migration(input)
+
+        assertTrue(result == Right(Org2("Acme", Addr2("123 Main", "NYC", "00000"))))
+      }
+    ),
+
+    suite("Recursive Type Limitations")(
+      test("recursive type basic migration works with buildPartial") {
+        // This test documents that recursive types require special care.
+        // Recursive types use Schema.Deferred to break cycles at the type level.
+        // Simple identity migrations work, but adding fields to recursive chains requires buildPartial
+
+        case class ListNodeV1(value: Int, next: Option[ListNodeV1])
+        case class ListNodeV2(value: Int, next: Option[ListNodeV2])
+
+        implicit lazy val listNodeV1Schema: Schema[ListNodeV1] = Schema.derived[ListNodeV1]
+        implicit lazy val listNodeV2Schema: Schema[ListNodeV2] = Schema.derived[ListNodeV2]
+
+        val migration = Migration.newBuilder[ListNodeV1, ListNodeV2].buildPartial
+
+        val input  = ListNodeV1(1, Some(ListNodeV1(2, None)))
+        val result = migration(input)
+
+        assertTrue(result.isRight)
+      }
+    )
+  )
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -210,7 +210,7 @@ object MigrationSpec extends ZIOSpecDefault {
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
-          .changeFieldType(_.score, _.score, literal("42"))
+          .changeFieldType(_.score, literal("42"))
           .build
 
         val input  = PersonV1(42)
@@ -316,6 +316,47 @@ object MigrationSpec extends ZIOSpecDefault {
         assertTrue(
           builder.actions.length == 1,
           builder.actions.head.isInstanceOf[MigrationAction.TransformCase]
+        )
+      },
+      test("renameCase executes enum rename on DynamicValue") {
+        import RenameCaseFixtures._
+
+        val migration = Migration
+          .newBuilder[StatusV1, StatusV2]
+          .renameCase("Pending", "Enabled")
+          .buildPartial
+
+        val input  = statusV1Schema.toDynamicValue(Pending: StatusV1)
+        val result = migration.dynamicMigration(input)
+
+        assertTrue(result == Right(statusV2Schema.toDynamicValue(Enabled: StatusV2)))
+      },
+      test("renameCase does not affect other cases") {
+        import RenameCaseFixtures._
+
+        val migration = Migration
+          .newBuilder[StatusV1, StatusV2]
+          .renameCase("Pending", "Enabled")
+          .buildPartial
+
+        val input  = statusV1Schema.toDynamicValue(Active: StatusV1)
+        val result = migration.dynamicMigration(input)
+
+        assertTrue(result.isRight)
+      },
+      test("transformCase inner migration has correct actions") {
+        import TransformCaseFixtures._
+
+        val builder = Migration
+          .newBuilder[EventV1, EventV2]
+          .transformCase[UserV1, UserV2]("UserV1")(
+            _.renameField(_.name, _.fullName).addField(_.age, literal(0))
+          )
+
+        val action = builder.actions.head.asInstanceOf[MigrationAction.TransformCase]
+        assertTrue(
+          builder.actions.length == 1,
+          action.actions.length == 2
         )
       }
     ),

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -21,11 +21,42 @@ import zio.blocks.schema._
 
 object MigrationSpec extends ZIOSpecDefault {
 
+  object RenameCaseFixtures {
+    sealed trait StatusV1
+    case object Active  extends StatusV1
+    case object Pending extends StatusV1
+
+    sealed trait StatusV2
+    case object ActiveV2 extends StatusV2
+    case object Enabled  extends StatusV2
+
+    implicit val statusV1Schema: Schema[StatusV1] = Schema.derived[StatusV1]
+    implicit val statusV2Schema: Schema[StatusV2] = Schema.derived[StatusV2]
+  }
+
+  object TransformCaseFixtures {
+    sealed trait EventV1
+    final case class UserV1(name: String) extends EventV1
+    final case class SystemV1(code: Int)  extends EventV1
+
+    sealed trait EventV2
+    final case class UserV2(fullName: String, age: Int) extends EventV2
+    final case class SystemV2(code: Int)                extends EventV2
+
+    implicit val userV1Schema: Schema[UserV1]   = Schema.derived[UserV1]
+    implicit val userV2Schema: Schema[UserV2]   = Schema.derived[UserV2]
+    implicit val eventV1Schema: Schema[EventV1] = Schema.derived[EventV1]
+    implicit val eventV2Schema: Schema[EventV2] = Schema.derived[EventV2]
+  }
+
   private def dynamicLiteral[A: Schema](value: A): DynamicSchemaExpr =
     DynamicSchemaExpr.Literal(Schema[A].toDynamicValue(value))
 
   private def literal[A: Schema](value: A): SchemaExpr[Any, A] =
     SchemaExpr.literal(value)
+
+  private def identityExpr[A: Schema]: SchemaExpr[A, A] =
+    SchemaExpr.optic(DynamicOptic.root, Schema[A])
 
   def spec: Spec[TestEnvironment, Any] = suite("MigrationSpec")(
     suite("Laws")(
@@ -188,39 +219,41 @@ object MigrationSpec extends ZIOSpecDefault {
         assertTrue(result == Right(PersonV2("42")))
       },
 
-      test("mandateField builder creates correct action") {
+      test("mandateField builder records mandate action") {
         case class PersonV1(age: Option[Int])
         case class PersonV2(age: Int)
 
         implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
         implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
-        val migration = Migration
+        val builder = Migration
           .newBuilder[PersonV1, PersonV2]
           .mandateField(_.age, _.age, literal(0))
-          .buildPartial
 
-        assertTrue(migration.actions.length == 1 && migration.actions.head.isInstanceOf[MigrationAction.MandateField])
+        assertTrue(
+          builder.actions.length == 1,
+          builder.actions.head.isInstanceOf[MigrationAction.MandateField]
+        )
       },
 
-      test("optionalizeField builder creates correct action") {
+      test("optionalizeField builder records optionalize action") {
         case class PersonV1(age: Int)
         case class PersonV2(age: Option[Int])
 
         implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
         implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
-        val migration = Migration
+        val builder = Migration
           .newBuilder[PersonV1, PersonV2]
           .optionalizeField(_.age, _.age)
-          .buildPartial
 
         assertTrue(
-          migration.actions.length == 1 && migration.actions.head.isInstanceOf[MigrationAction.OptionalizeField]
+          builder.actions.length == 1,
+          builder.actions.head.isInstanceOf[MigrationAction.OptionalizeField]
         )
       },
 
-      test("transformElements builder creates correct action") {
+      test("transformElements evaluates per element") {
         case class Container(items: List[Int])
 
         implicit val schema: Schema[Container] = Schema.derived[Container]
@@ -228,14 +261,12 @@ object MigrationSpec extends ZIOSpecDefault {
         val migration = Migration
           .newBuilder[Container, Container]
           .transformElements(_.items, literal(0))
-          .buildPartial
+          .build
 
-        assertTrue(
-          migration.actions.length == 1 && migration.actions.head.isInstanceOf[MigrationAction.TransformElements]
-        )
+        assertTrue(migration(Container(List(1, 2, 3))) == Right(Container(List(0, 0, 0))))
       },
 
-      test("transformKeys builder creates correct action") {
+      test("transformKeys evaluates per key") {
         case class Container(data: Map[String, Int])
 
         implicit val schema: Schema[Container] = Schema.derived[Container]
@@ -243,12 +274,12 @@ object MigrationSpec extends ZIOSpecDefault {
         val migration = Migration
           .newBuilder[Container, Container]
           .transformKeys(_.data, literal("key"))
-          .buildPartial
+          .build
 
-        assertTrue(migration.actions.length == 1 && migration.actions.head.isInstanceOf[MigrationAction.TransformKeys])
+        assertTrue(migration(Container(Map("a" -> 1))) == Right(Container(Map("key" -> 1))))
       },
 
-      test("transformValues builder creates correct action") {
+      test("transformValues evaluates per value") {
         case class Container(data: Map[String, Int])
 
         implicit val schema: Schema[Container] = Schema.derived[Container]
@@ -256,26 +287,36 @@ object MigrationSpec extends ZIOSpecDefault {
         val migration = Migration
           .newBuilder[Container, Container]
           .transformValues(_.data, literal(0))
-          .buildPartial
+          .build
 
-        assertTrue(
-          migration.actions.length == 1 && migration.actions.head.isInstanceOf[MigrationAction.TransformValues]
-        )
+        assertTrue(migration(Container(Map("a" -> 1, "b" -> 2))) == Right(Container(Map("a" -> 0, "b" -> 0))))
       },
 
-      test("renameCase builder creates correct action") {
-        sealed trait Status
-        case object Active  extends Status
-        case object Pending extends Status
+      test("renameCase builder records enum rename action") {
+        import RenameCaseFixtures.*
 
-        implicit val schema: Schema[Status] = Schema.derived[Status]
+        val builder = Migration
+          .newBuilder[StatusV1, StatusV2]
+          .renameCase("Pending", "Enabled")
 
-        val migration = Migration
-          .newBuilder[Status, Status]
-          .renameCase("Active", "Enabled")
-          .buildPartial
+        assertTrue(
+          builder.actions.length == 1,
+          builder.actions.head.isInstanceOf[MigrationAction.RenameCase]
+        )
+      },
+      test("transformCase builder records enum case migration") {
+        import TransformCaseFixtures.*
 
-        assertTrue(migration.actions.length == 1 && migration.actions.head.isInstanceOf[MigrationAction.RenameCase])
+        val builder = Migration
+          .newBuilder[EventV1, EventV2]
+          .transformCase[UserV1, UserV2]("UserV1")(
+            _.renameField(_.name, _.fullName).addField(_.age, literal(0))
+          )
+
+        assertTrue(
+          builder.actions.length == 1,
+          builder.actions.head.isInstanceOf[MigrationAction.TransformCase]
+        )
       }
     ),
 
@@ -286,21 +327,6 @@ object MigrationSpec extends ZIOSpecDefault {
 
         val migration = Migration.identity[Person]
         assertTrue(migration.isEmpty && migration.size == 0)
-      },
-
-      test("Migration.fromAction creates single-action migration") {
-        case class PersonV1(name: String)
-        case class PersonV2(name: String, age: Int)
-
-        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
-        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val action = MigrationAction.AddField(
-          DynamicOptic.root.field("age"),
-          dynamicLiteral(0)
-        )
-        val migration = Migration.fromAction[PersonV1, PersonV2](action)
-        assertTrue(migration.size == 1)
       },
 
       test("Migration.fromDynamic wraps DynamicMigration") {
@@ -520,7 +546,7 @@ object MigrationSpec extends ZIOSpecDefault {
     ),
 
     suite("Nested Type Migrations")(
-      test("Migration.fromActions API works for direct action construction") {
+      test("nested addField migration works through migrateField") {
         case class AddressV1(street: String, city: String)
         case class PersonV1(name: String, address: AddressV1)
 
@@ -532,12 +558,15 @@ object MigrationSpec extends ZIOSpecDefault {
         implicit val addressV2Schema: Schema[AddressV2] = Schema.derived[AddressV2]
         implicit val personV2Schema: Schema[PersonV2]   = Schema.derived[PersonV2]
 
-        val migration = Migration.fromActions[PersonV1, PersonV2](
-          MigrationAction.AddField(
-            DynamicOptic.root.field("address").field("zip"),
-            dynamicLiteral("00000")
-          )
-        )
+        val addressMigration = Migration
+          .newBuilder[AddressV1, AddressV2]
+          .addField(_.zip, literal("00000"))
+          .build
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .migrateField(_.address, addressMigration)
+          .build
 
         val input  = PersonV1("Alice", AddressV1("123 Main St", "NYC"))
         val result = migration(input)
@@ -589,20 +618,13 @@ object MigrationSpec extends ZIOSpecDefault {
         implicit val departmentV2Schema: Schema[DepartmentV2] = Schema.derived[DepartmentV2]
         implicit val companyV2Schema: Schema[CompanyV2]       = Schema.derived[CompanyV2]
 
-        val employeeMigration = Migration
-          .newBuilder[EmployeeV1, EmployeeV2]
-          .addField(_.bonus, literal(1000))
-          .build
-
-        val departmentMigration = Migration
-          .newBuilder[DepartmentV1, DepartmentV2]
-          .migrateField(_.employee, employeeMigration)
-          .build
-
         val migration = Migration
           .newBuilder[CompanyV1, CompanyV2]
-          .migrateField(_.department, departmentMigration)
-          .buildPartial
+          .transformField(_.department.name, _.department.name, identityExpr[String])
+          .transformField(_.department.employee.name, _.department.employee.name, identityExpr[String])
+          .transformField(_.department.employee.salary, _.department.employee.salary, identityExpr[Int])
+          .addField(_.department.employee.bonus, literal(1000))
+          .build
 
         val input = CompanyV1(
           "TechCorp",
@@ -640,25 +662,10 @@ object MigrationSpec extends ZIOSpecDefault {
         implicit val l2V2Schema: Schema[L2V2] = Schema.derived[L2V2]
         implicit val l1V2Schema: Schema[L1V2] = Schema.derived[L1V2]
 
-        val l4Migration = Migration
-          .newBuilder[L4V1, L4V2]
-          .addField(_.metadata, literal("default"))
-          .build
-
-        val l3Migration = Migration
-          .newBuilder[L3V1, L3V2]
-          .migrateField(_.l4, l4Migration)
-          .build
-
-        val l2Migration = Migration
-          .newBuilder[L2V1, L2V2]
-          .migrateField(_.l3, l3Migration)
-          .buildPartial
-
         val migration = Migration
           .newBuilder[L1V1, L1V2]
-          .migrateField(_.l2, l2Migration)
-          .buildPartial
+          .addField(_.l2.l3.l4.metadata, literal("default"))
+          .build
 
         val input = L1V1(
           "Root",
@@ -676,68 +683,68 @@ object MigrationSpec extends ZIOSpecDefault {
         )
       },
 
-      test("Option[NestedType] migration - identity migration preserves structure") {
-        case class AddressV1(city: String)
-        case class PersonV1(name: String, address: Option[AddressV1])
+      test("Option fields are preserved while adding outer fields") {
+        case class Address(city: String)
+        case class PersonV1(name: String, address: Option[Address])
+        case class PersonV2(name: String, address: Option[Address], active: Boolean)
 
-        case class AddressV2(city: String)
-        case class PersonV2(name: String, address: Option[AddressV2])
+        implicit val addressSchema: Schema[Address]   = Schema.derived[Address]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
-        implicit val addressV1Schema: Schema[AddressV1] = Schema.derived[AddressV1]
-        implicit val personV1Schema: Schema[PersonV1]   = Schema.derived[PersonV1]
-        implicit val addressV2Schema: Schema[AddressV2] = Schema.derived[AddressV2]
-        implicit val personV2Schema: Schema[PersonV2]   = Schema.derived[PersonV2]
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .addField(_.active, literal(true))
+          .build
 
-        val migration = Migration.newBuilder[PersonV1, PersonV2].buildPartial
-
-        val inputWithSome  = PersonV1("Dave", Some(AddressV1("Boston")))
+        val inputWithSome  = PersonV1("Dave", Some(Address("Boston")))
         val resultWithSome = migration(inputWithSome)
 
-        assertTrue(resultWithSome == Right(PersonV2("Dave", Some(AddressV2("Boston")))))
+        assertTrue(resultWithSome == Right(PersonV2("Dave", Some(Address("Boston")), true)))
       },
 
-      test("List[NestedType] migration - simple container structure transformation") {
-        case class ItemV1(name: String)
-        case class ContainerV1(items: List[ItemV1])
+      test("List fields are preserved while adding outer fields") {
+        case class Item(name: String)
+        case class ContainerV1(items: List[Item])
+        case class ContainerV2(items: List[Item], archived: Boolean)
 
-        case class ItemV2(name: String)
-        case class ContainerV2(items: List[ItemV2])
-
-        implicit val itemV1Schema: Schema[ItemV1]           = Schema.derived[ItemV1]
+        implicit val itemSchema: Schema[Item]               = Schema.derived[Item]
         implicit val containerV1Schema: Schema[ContainerV1] = Schema.derived[ContainerV1]
-        implicit val itemV2Schema: Schema[ItemV2]           = Schema.derived[ItemV2]
         implicit val containerV2Schema: Schema[ContainerV2] = Schema.derived[ContainerV2]
 
-        val migration = Migration.newBuilder[ContainerV1, ContainerV2].buildPartial
+        val migration = Migration
+          .newBuilder[ContainerV1, ContainerV2]
+          .addField(_.archived, literal(false))
+          .build
 
         val input = ContainerV1(
-          List(ItemV1("Item1"), ItemV1("Item2"))
+          List(Item("Item1"), Item("Item2"))
         )
         val result = migration(input)
 
-        assertTrue(result.isRight)
+        assertTrue(result == Right(ContainerV2(List(Item("Item1"), Item("Item2")), false)))
       },
 
-      test("Map[String, NestedType] migration - simple map structure transformation") {
-        case class ConfigV1(value: String)
-        case class SettingsV1(configs: Map[String, ConfigV1])
+      test("Map fields are preserved while adding outer fields") {
+        case class Config(value: String)
+        case class SettingsV1(configs: Map[String, Config])
+        case class SettingsV2(configs: Map[String, Config], version: Int)
 
-        case class ConfigV2(value: String)
-        case class SettingsV2(configs: Map[String, ConfigV2])
-
-        implicit val configV1Schema: Schema[ConfigV1]     = Schema.derived[ConfigV1]
+        implicit val configSchema: Schema[Config]         = Schema.derived[Config]
         implicit val settingsV1Schema: Schema[SettingsV1] = Schema.derived[SettingsV1]
-        implicit val configV2Schema: Schema[ConfigV2]     = Schema.derived[ConfigV2]
         implicit val settingsV2Schema: Schema[SettingsV2] = Schema.derived[SettingsV2]
 
-        val migration = Migration.newBuilder[SettingsV1, SettingsV2].buildPartial
+        val migration = Migration
+          .newBuilder[SettingsV1, SettingsV2]
+          .addField(_.version, literal(2))
+          .build
 
         val input = SettingsV1(
-          Map("setting1" -> ConfigV1("on"), "setting2" -> ConfigV1("off"))
+          Map("setting1" -> Config("on"), "setting2" -> Config("off"))
         )
         val result = migration(input)
 
-        assertTrue(result.isRight)
+        assertTrue(result == Right(SettingsV2(Map("setting1" -> Config("on"), "setting2" -> Config("off")), 2)))
       },
 
       test("Nested field rename in deeply nested path") {
@@ -756,20 +763,10 @@ object MigrationSpec extends ZIOSpecDefault {
         implicit val l2V2Schema: Schema[L2V2] = Schema.derived[L2V2]
         implicit val l1V2Schema: Schema[L1V2] = Schema.derived[L1V2]
 
-        val l3Migration = Migration
-          .newBuilder[L3V1, L3V2]
-          .renameField(_.oldField, _.newField)
-          .build
-
-        val l2Migration = Migration
-          .newBuilder[L2V1, L2V2]
-          .migrateField(_.l3, l3Migration)
-          .build
-
         val migration = Migration
           .newBuilder[L1V1, L1V2]
-          .migrateField(_.l2, l2Migration)
-          .buildPartial
+          .renameField(_.l2.l3.oldField, _.l2.l3.newField)
+          .build
 
         val input  = L1V1(L2V1(L3V1(42)))
         val result = migration(input)
@@ -823,7 +820,7 @@ object MigrationSpec extends ZIOSpecDefault {
         val migration = Migration
           .newBuilder[Person1, Person2]
           .renameField(_.address.street, _.address.streetName)
-          .buildPartial
+          .build
 
         val input  = Person1("Alice", Address1("123 Main", "NYC"))
         val result = migration(input)
@@ -845,7 +842,7 @@ object MigrationSpec extends ZIOSpecDefault {
         val migration = Migration
           .newBuilder[Person1, Person2]
           .addField(_.address.number, literal(0))
-          .buildPartial
+          .build
 
         val input  = Person1("Alice", Address1("123 Main"))
         val result = migration(input)
@@ -867,7 +864,7 @@ object MigrationSpec extends ZIOSpecDefault {
         val migration = Migration
           .newBuilder[Person1, Person2]
           .dropField(_.address.zip, literal("00000"))
-          .buildPartial
+          .build
 
         val input  = Person1("Alice", Address1("123 Main", "10001"))
         val result = migration(input)
@@ -890,7 +887,7 @@ object MigrationSpec extends ZIOSpecDefault {
           .newBuilder[Person1, Person2]
           .renameField(_.address.street, _.address.streetName)
           .addField(_.address.number, literal(0))
-          .buildPartial
+          .build
 
         val input  = Person1("Alice", Address1("123 Main"))
         val result = migration(input)
@@ -916,7 +913,7 @@ object MigrationSpec extends ZIOSpecDefault {
         val migration = Migration
           .newBuilder[Person1, Person2]
           .addField(_.address.street.number, literal(0))
-          .buildPartial
+          .build
 
         val input  = Person1("Alice", Address1(Street1("Main"), "NYC"))
         val result = migration(input)
@@ -942,7 +939,7 @@ object MigrationSpec extends ZIOSpecDefault {
         val migration = Migration
           .newBuilder[Person1, Person2]
           .renameField(_.info.street.name, _.info.street.label)
-          .buildPartial
+          .build
 
         val input  = Person1(Address1(Street1("Main")))
         val result = migration(input)
@@ -969,14 +966,14 @@ object MigrationSpec extends ZIOSpecDefault {
           .newBuilder[Event1, Event2]
           .renameField(_.location.geo.lat, _.location.geo.latitude)
           .dropField(_.location.geo.alt, literal(0.0))
-          .buildPartial
+          .build
 
         val input  = Event1(Location1(Geo1(40.7, -74.0, 10.0)))
         val result = migration(input)
 
         assertTrue(result == Right(Event2(Location2(Geo2(40.7, -74.0)))))
       },
-      test("fromActions with deep optic paths") {
+      test("deep nested migrateField composes validated builders") {
         case class Addr1(street: String, city: String)
         case class Org1(name: String, addr: Addr1)
 
@@ -988,12 +985,15 @@ object MigrationSpec extends ZIOSpecDefault {
         implicit val a2: Schema[Addr2] = Schema.derived
         implicit val o2: Schema[Org2]  = Schema.derived
 
-        val migration = Migration.fromActions[Org1, Org2](
-          MigrationAction.AddField(
-            DynamicOptic.root.field("addr").field("zip"),
-            dynamicLiteral("00000")
-          )
-        )
+        val addrMigration = Migration
+          .newBuilder[Addr1, Addr2]
+          .addField(_.zip, literal("00000"))
+          .build
+
+        val migration = Migration
+          .newBuilder[Org1, Org2]
+          .migrateField(_.addr, addrMigration)
+          .build
 
         val input  = Org1("Acme", Addr1("123 Main", "NYC"))
         val result = migration(input)
@@ -1003,23 +1003,17 @@ object MigrationSpec extends ZIOSpecDefault {
     ),
 
     suite("Recursive Type Limitations")(
-      test("recursive type basic migration works with buildPartial") {
-        // This test documents that recursive types require special care.
-        // Recursive types use Schema.Deferred to break cycles at the type level.
-        // Simple identity migrations work, but adding fields to recursive chains requires buildPartial
+      test("recursive type identity migration works") {
+        case class ListNode(value: Int, next: Option[ListNode])
 
-        case class ListNodeV1(value: Int, next: Option[ListNodeV1])
-        case class ListNodeV2(value: Int, next: Option[ListNodeV2])
+        implicit lazy val listNodeSchema: Schema[ListNode] = Schema.derived[ListNode]
 
-        implicit lazy val listNodeV1Schema: Schema[ListNodeV1] = Schema.derived[ListNodeV1]
-        implicit lazy val listNodeV2Schema: Schema[ListNodeV2] = Schema.derived[ListNodeV2]
+        val migration = Migration.identity[ListNode]
 
-        val migration = Migration.newBuilder[ListNodeV1, ListNodeV2].buildPartial
-
-        val input  = ListNodeV1(1, Some(ListNodeV1(2, None)))
+        val input  = ListNode(1, Some(ListNode(2, None)))
         val result = migration(input)
 
-        assertTrue(result.isRight)
+        assertTrue(result == Right(input))
       }
     )
   )

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -43,10 +43,12 @@ object MigrationSpec extends ZIOSpecDefault {
     final case class UserV2(fullName: String, age: Int) extends EventV2
     final case class SystemV2(code: Int)                extends EventV2
 
-    implicit val userV1Schema: Schema[UserV1]   = Schema.derived[UserV1]
-    implicit val userV2Schema: Schema[UserV2]   = Schema.derived[UserV2]
-    implicit val eventV1Schema: Schema[EventV1] = Schema.derived[EventV1]
-    implicit val eventV2Schema: Schema[EventV2] = Schema.derived[EventV2]
+    implicit val userV1Schema: Schema[UserV1]     = Schema.derived[UserV1]
+    implicit val userV2Schema: Schema[UserV2]     = Schema.derived[UserV2]
+    implicit val systemV1Schema: Schema[SystemV1] = Schema.derived[SystemV1]
+    implicit val systemV2Schema: Schema[SystemV2] = Schema.derived[SystemV2]
+    implicit val eventV1Schema: Schema[EventV1]   = Schema.derived[EventV1]
+    implicit val eventV2Schema: Schema[EventV2]   = Schema.derived[EventV2]
   }
 
   private def dynamicLiteral[A: Schema](value: A): DynamicSchemaExpr =
@@ -324,12 +326,11 @@ object MigrationSpec extends ZIOSpecDefault {
         val migration = Migration
           .newBuilder[StatusV1, StatusV2]
           .renameCase("Pending", "Enabled")
-          .buildPartial
+          .build
 
-        val input  = statusV1Schema.toDynamicValue(Pending: StatusV1)
-        val result = migration.dynamicMigration(input)
+        val result = migration(Pending: StatusV1)
 
-        assertTrue(result == Right(statusV2Schema.toDynamicValue(Enabled: StatusV2)))
+        assertTrue(result == Right(Enabled: StatusV2))
       },
       test("renameCase does not affect other cases") {
         import RenameCaseFixtures._
@@ -337,27 +338,29 @@ object MigrationSpec extends ZIOSpecDefault {
         val migration = Migration
           .newBuilder[StatusV1, StatusV2]
           .renameCase("Pending", "Enabled")
-          .buildPartial
+          .renameCase("Active", "ActiveV2")
+          .build
 
-        val input  = statusV1Schema.toDynamicValue(Active: StatusV1)
-        val result = migration.dynamicMigration(input)
+        val result = migration(Active: StatusV1)
 
-        assertTrue(result.isRight)
+        assertTrue(result == Right(ActiveV2: StatusV2))
       },
-      test("transformCase inner migration has correct actions") {
+      test("transformCase executes nested migration on matching case") {
         import TransformCaseFixtures._
 
-        val builder = Migration
+        val migration = Migration
           .newBuilder[EventV1, EventV2]
           .transformCase[UserV1, UserV2]("UserV1")(
             _.renameField(_.name, _.fullName).addField(_.age, literal(0))
           )
+          .transformCase[SystemV1, SystemV2]("SystemV1")(
+            _.transformField(_.code, _.code, identityExpr[Int])
+          )
+          .build
 
-        val action = builder.actions.head.asInstanceOf[MigrationAction.TransformCase]
-        assertTrue(
-          builder.actions.length == 1,
-          action.actions.length == 2
-        )
+        val result = migration(UserV1("Alice"): EventV1)
+
+        assertTrue(result == Right(UserV2("Alice", 0): EventV2))
       }
     ),
 

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -293,7 +293,7 @@ object MigrationSpec extends ZIOSpecDefault {
       },
 
       test("renameCase builder records enum rename action") {
-        import RenameCaseFixtures.*
+        import RenameCaseFixtures._
 
         val builder = Migration
           .newBuilder[StatusV1, StatusV2]
@@ -305,7 +305,7 @@ object MigrationSpec extends ZIOSpecDefault {
         )
       },
       test("transformCase builder records enum case migration") {
-        import TransformCaseFixtures.*
+        import TransformCaseFixtures._
 
         val builder = Migration
           .newBuilder[EventV1, EventV2]


### PR DESCRIPTION
## Summary

- add a typed + serializable schema migration system built on `Migration[A, B]`, `DynamicMigration`, and `MigrationAction`
- add Scala 2 / Scala 3 builder + selector macro support for path-based migrations
- add migration docs/tests and update query-dsl docs/examples to match the current `SchemaExpr` / `DynamicSchemaExpr` model

## What this PR adds

### Runtime migration layer
- `DynamicMigration` as the serializable runtime interpreter
- `MigrationAction` as the migration action ADT
- `DynamicSchemaExpr` as the serializable expression language
- typed wrapper `Migration[A, B]`

### Builder / selector API
- Scala 2 migration builder + selector syntax/macros
- Scala 3 migration builder + selector syntax/macros
- builder-based migration construction with `build` / `buildPartial`

### Supporting schema/runtime changes
- `SchemaExpr`, `Optic`, `SchemaError`, `PrimitiveType`, and numeric support updates needed by the migration/expression runtime

### Tests
- typed migration coverage in `MigrationSpec`
- dynamic runtime coverage in `DynamicMigrationSpec`
- Scala 3 validation coverage in `MigrationBuildValidationSpec`
- structural migration coverage in `StructuralMigrationSpec`
- expression / primitive / json follow-up tests for migration-related edge cases

### Docs / examples
- new migration reference doc
- migration guide updates
- `SchemaExpr` reference updates
- query-dsl guides and `schema-examples` updates so docs/examples match the current expression representation

## Follow-up fixes included on this branch

- runtime hardening in `DynamicMigration`, `DynamicSchemaExpr`, and `SchemaExpr`
- migration / schema-expr docs cleanup and sidebar updates
- query-dsl wording updates for the current `SchemaExpr` shape
- Scala 3 combinators compile-time test import fix required for CI

## Validation

- PR CI is green
- passing checks include Build Docs, lint, Test Golem, JS (2.13 / 3.3 / 3.8), and JVM (17 / 25 × 2.13 / 3.3 / 3.8)

Closes #519