### PR TITLE
Switch `Json.Number` value to `BigDecimal`

### DIFF
--- a/schema/js/src/main/scala/zio/blocks/schema/json/JsonWriter.scala
+++ b/schema/js/src/main/scala/zio/blocks/schema/json/JsonWriter.scala
@@ -3612,4 +3612,164 @@ object JsonWriter {
     ) idx += 1
     idx == len
   }
+
+  final def toBigDecimal(x: Float): BigDecimal = {
+    // Based on the ingenious work of Xiang JunBo and Wang TieJun
+    // "xjb: Fast Float to String Algorithm": https://github.com/xjb714/xjb/blob/4852e533287bd0e8d554c2a9f4cc6eaa93ca799f/fast_f2s.pdf
+    // Sources with the license are here: https://github.com/xjb714/xjb
+    val bits = java.lang.Float.floatToRawIntBits(x)
+    if (x == 0.0f) BigDecimal(0)
+    else {
+      val e2IEEE   = bits >> 23 & 0xff
+      val m2IEEE   = bits & 0x7fffff
+      var e2       = e2IEEE - 150
+      var m2       = m2IEEE | 0x800000
+      var m10, e10 = 0
+      if (e2 == 0) m10 = m2
+      else if ((e2 >= -23 && e2 < 0) && m2 << e2 == 0) m10 = m2 >> -e2
+      else {
+        if (e2IEEE == 0) {
+          m2 = m2IEEE
+          e2 = -149
+        } else if (e2 == 105) throw new IllegalArgumentException("Infinity or NaN")
+        if (m2IEEE == 0) e10 = (e2 * 315653 - 131237) >> 20
+        else e10 = (e2 * 315653) >> 20
+        val h     = (((e10 + 1) * -217707) >> 16) + e2
+        val pow10 = floatPow10s(31 - e10)
+        val hi64  = unsignedMultiplyHigh(
+          pow10,
+          m2.toLong << (h + 37)
+        ) // TODO: when dropping JDK 17 support replace by Math.unsignedMultiplyHigh(pow10, m2.toLong << (h + 37))
+        m10 = (hi64 >>> 36).toInt * 10
+        val halfUlpPlusEven = (pow10 >>> (28 - h)) + ((m2IEEE + 1) & 1)
+        val dotOne          = hi64 & 0xfffffffffL
+        if (
+          {
+            if (m2IEEE == 0) halfUlpPlusEven >>> 1
+            else halfUlpPlusEven
+          } <= dotOne
+        ) {
+          if (halfUlpPlusEven > 0xfffffffffL - dotOne) m10 += 10
+          else m10 += (((dotOne << 4) + (dotOne << 2) + ((hi64 >>> 32).toInt & 0xf) + 0xffffffff9L) >>> 37).toInt
+        }
+        if (m2IEEE == 0 && ((e2 == -119) | (e2 == 64) | (e2 == 67))) m10 += 1
+      }
+      var q = 0
+      while (
+        m10 >= 100 && {
+          val p = m10 * 1374389535L
+          q = (p >> 37).toInt      // divide a positive int by 100
+          (p & 0x1fc0000000L) == 0 // check if q is divisible by 100
+        }
+      ) {
+        e10 += 2
+        m10 = q
+      }
+      val sign = bits >> 31
+      new BigDecimal(java.math.BigDecimal.valueOf((m10 ^ sign) - sign, -e10))
+    }
+  }
+
+  final def toBigDecimal(x: Double): BigDecimal = {
+    // Based on the ingenious work of Xiang JunBo and Wang TieJun
+    // "xjb: Fast Float to String Algorithm": https://github.com/xjb714/xjb/blob/4852e533287bd0e8d554c2a9f4cc6eaa93ca799f/fast_f2s.pdf
+    // Sources with the license are here: https://github.com/xjb714/xjb
+    val bits = java.lang.Double.doubleToRawLongBits(x)
+    if (x == 0.0) BigDecimal(0)
+    else {
+      val e2IEEE = (bits >> 52).toInt & 0x7ff
+      val m2IEEE = bits & 0xfffffffffffffL
+      var e2     = e2IEEE - 1075
+      var m2     = m2IEEE | 0x10000000000000L
+      var m10    = 0L
+      var e10    = 0
+      if (e2 == 0) m10 = m2
+      else if ((e2 >= -52 && e2 < 0) && m2 << e2 == 0) m10 = m2 >> -e2
+      else {
+        if (e2IEEE == 0) {
+          m2 = m2IEEE
+          e2 = -1074
+        } else if (e2 == 972) throw new IllegalArgumentException("Infinity or NaN")
+        if (m2IEEE == 0) e10 = (e2 * 315653 - 131237) >> 20
+        else e10 = (e2 * 315653) >> 20
+        val h       = (((e10 + 1) * -217707) >> 16) + e2
+        val pow10s  = doublePow10s
+        val i       = 292 - e10 << 1
+        val pow10_1 = pow10s(i)
+        val pow10_2 = pow10s(i + 1)
+        val cb      = m2 << (h + 7)
+        val lo64_1  = unsignedMultiplyHigh(
+          pow10_2,
+          cb
+        ) // TODO: when dropping JDK 17 support replace by Math.unsignedMultiplyHigh(pow10_2, cb)
+        val lo64_2 = pow10_1 * cb
+        var hi64   = unsignedMultiplyHigh(
+          pow10_1,
+          cb
+        ) // TODO: when dropping JDK 17 support replace by Math.unsignedMultiplyHigh(pow10_1, cb)
+        val lo64 = lo64_1 + lo64_2
+        hi64 += compareUnsigned(lo64, lo64_1) >>> 31
+        m10 = hi64 >>> 6
+        m10 = (m10 << 3) + (m10 << 1)
+        val halfUlpPlusEven = (pow10_1 >>> -h) + ((m2.toInt + 1) & 1)
+        val dotOne          = (hi64 << 58) | (lo64 >>> 6)
+        if (compareUnsigned(halfUlpPlusEven, -1 - dotOne) > 0) m10 += 10L
+        else if (m2IEEE != 0) {
+          if (compareUnsigned(halfUlpPlusEven, dotOne) <= 0) m10 = calculateM10(hi64, lo64, dotOne)
+        } else {
+          var tmp1 = dotOne >>> 4
+          tmp1 = (tmp1 << 3) + (tmp1 << 1)
+          var tmp2 = halfUlpPlusEven >>> 4
+          tmp2 += tmp2 << 2
+          if (compareUnsigned((tmp1 << 4) >>> 4, tmp2) > 0) m10 += (tmp1 >>> 60).toInt + 1
+          else if (compareUnsigned(halfUlpPlusEven >>> 1, dotOne) <= 0) m10 = calculateM10(hi64, lo64, dotOne)
+        }
+      }
+      var q1 = 0L
+      while (
+        m10 >= 1000000000L && {
+          q1 = unsignedMultiplyHigh(m10 >> 2, 2951479051793528259L) >> 2 // divide a positive long by 100
+          q1 * 100 == m10
+        }
+      ) {
+        e10 += 2
+        m10 = q1
+      }
+      if (m10 == m10.toInt) {
+        var q2 = 0
+        while (
+          m10 >= 100 && {
+            val p = m10 * 1374389535L
+            q2 = (p >> 37).toInt     // divide a positive int by 100
+            (p & 0x1fc0000000L) == 0 // check if q is divisible by 100
+          }
+        ) {
+          e10 += 2
+          m10 = q2
+        }
+      }
+      val sign = bits >> 63
+      new BigDecimal(java.math.BigDecimal.valueOf((m10 ^ sign) - sign, -e10))
+    }
+  }
+
+  // 64-bit unsigned multiplication was adopted from the great Hacker's Delight function
+  // (Henry S. Warren, Hacker's Delight, Addison-Wesley, 2nd edition, Fig. 8.2)
+  // https://doc.lagout.org/security/Hackers%20Delight.pdf
+  @inline
+  private[this] def unsignedMultiplyHigh(x: Long, y: Long): Long = {
+    val xl = x & 0xffffffffL
+    val xh = x >>> 32
+    val yl = y & 0xffffffffL
+    val yh = y >>> 32
+    val t  = xh * yl + (xl * yl >>> 32)
+    xh * yh + (t >>> 32) + (xl * yh + (t & 0xffffffffL) >>> 32)
+  }
+
+  @inline
+  private[this] def calculateM10(hi: Long, lo: Long, dotOne: Long): Long = ((hi << 3) + (hi << 1) +
+    ((lo >>> 61).toInt + (lo >>> 63).toInt + (compareUnsigned((lo << 3) + (lo << 1), lo << 1) >>> 31) + {
+      if (dotOne == 0x4000000000000000L) 0x1f
+      else 0x20
+    })) >>> 6
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonDecoder.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonDecoder.scala
@@ -76,10 +76,9 @@ object JsonDecoder {
   implicit val intDecoder: JsonDecoder[Int] = new JsonDecoder[Int] {
     def decode(json: Json): Either[SchemaError, Int] = json match {
       case num: Json.Number =>
-        val n = num.value
-        try new Right(n.toInt)
+        try new Right(num.value.toIntExact)
         catch {
-          case err if NonFatal(err) => new Left(SchemaError(s"Number $n is not a valid Int"))
+          case err if NonFatal(err) => new Left(SchemaError("Number is not a valid Int"))
         }
       case _ => new Left(SchemaError("Expected Number"))
     }
@@ -88,10 +87,9 @@ object JsonDecoder {
   implicit val longDecoder: JsonDecoder[Long] = new JsonDecoder[Long] {
     def decode(json: Json): Either[SchemaError, Long] = json match {
       case num: Json.Number =>
-        val n = num.value
-        try new Right(n.toLong)
+        try new Right(num.value.toLongExact)
         catch {
-          case err if NonFatal(err) => new Left(SchemaError(s"Number $n is not a valid Long"))
+          case err if NonFatal(err) => new Left(SchemaError("Number is not a valid Long"))
         }
       case _ => new Left(SchemaError("Expected Number"))
     }
@@ -126,26 +124,18 @@ object JsonDecoder {
   }
 
   implicit val bigDecimalDecoder: JsonDecoder[BigDecimal] = new JsonDecoder[BigDecimal] {
-    def decode(json: Json): Either[SchemaError, BigDecimal] = {
-      json match {
-        case num: Json.Number =>
-          try return new Right(BigDecimal(num.value))
-          catch {
-            case err if NonFatal(err) =>
-          }
-        case _ =>
-      }
-      new Left(SchemaError("Expected Number"))
+    def decode(json: Json): Either[SchemaError, BigDecimal] = json match {
+      case num: Json.Number => new Right(num.value)
+      case _                => new Left(SchemaError("Expected Number"))
     }
   }
 
   implicit val bigIntDecoder: JsonDecoder[BigInt] = new JsonDecoder[BigInt] {
     def decode(json: Json): Either[SchemaError, BigInt] = json match {
       case num: Json.Number =>
-        val n = num.value
-        try new Right(BigInt(n))
+        try new Right(BigInt(num.value.underlying.toBigIntegerExact))
         catch {
-          case err if NonFatal(err) => new Left(SchemaError(s"Number $n is not a valid BigInt"))
+          case err if NonFatal(err) => new Left(SchemaError("Number is not a valid BigInt"))
         }
       case _ => new Left(SchemaError("Expected Number"))
     }
@@ -154,10 +144,9 @@ object JsonDecoder {
   implicit val byteDecoder: JsonDecoder[Byte] = new JsonDecoder[Byte] {
     def decode(json: Json): Either[SchemaError, Byte] = json match {
       case num: Json.Number =>
-        val n = num.value
-        try new Right(n.toByte)
+        try new Right(num.value.toByteExact)
         catch {
-          case err if NonFatal(err) => new Left(SchemaError(s"Number $n is not a valid Byte"))
+          case err if NonFatal(err) => new Left(SchemaError("Number is not a valid Byte"))
         }
       case _ => new Left(SchemaError("Expected Number"))
     }
@@ -166,10 +155,9 @@ object JsonDecoder {
   implicit val shortDecoder: JsonDecoder[Short] = new JsonDecoder[Short] {
     def decode(json: Json): Either[SchemaError, Short] = json match {
       case num: Json.Number =>
-        val n = num.value
-        try new Right(n.toShort)
+        try new Right(num.value.toShortExact)
         catch {
-          case err if NonFatal(err) => new Left(SchemaError(s"Number $n is not a valid Short"))
+          case err if NonFatal(err) => new Left(SchemaError("Number is not a valid Short"))
         }
       case _ => new Left(SchemaError("Expected Number"))
     }

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonDiffer.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonDiffer.scala
@@ -55,8 +55,8 @@ object JsonDiffer {
    * represent the change.
    */
   private def diffNumber(oldNum: Json.Number, newNum: Json.Number): JsonPatch = {
-    val oldVal = BigDecimal(oldNum.value)
-    val newVal = BigDecimal(newNum.value)
+    val oldVal = oldNum.value
+    val newVal = newNum.value
     val delta  = newVal - oldVal
     JsonPatch.root(JsonPatch.Op.PrimitiveDelta(JsonPatch.PrimitiveOp.NumberDelta(delta)))
   }

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonPatch.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonPatch.scala
@@ -325,16 +325,8 @@ object JsonPatch {
   ): Either[SchemaError, Json] = op match {
     case PrimitiveOp.NumberDelta(delta) =>
       value match {
-        case Json.Number(numStr) =>
-          try {
-            val current = BigDecimal(numStr)
-            val result  = current + delta
-            new Right(new Json.Number(result.toString))
-          } catch {
-            case _: NumberFormatException =>
-              new Left(SchemaError.expectationMismatch(trace, s"Invalid number format: $numStr"))
-          }
-        case _ => new Left(SchemaError.expectationMismatch(trace, s"Expected Number but got ${value.jsonType}"))
+        case Json.Number(current) => new Right(new Json.Number(current + delta))
+        case _                    => new Left(SchemaError.expectationMismatch(trace, s"Expected Number but got ${value.jsonType}"))
       }
     case PrimitiveOp.StringEdit(ops) =>
       value match {

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonSchema.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonSchema.scala
@@ -770,27 +770,27 @@ object JsonSchema {
       const.foreach(v => fields += ("const" -> v))
 
       // Validation vocabulary (Numeric)
-      multipleOf.foreach(v => fields += ("multipleOf" -> Json.Number(v.value.toString)))
-      maximum.foreach(v => fields += ("maximum" -> Json.Number(v.toString)))
-      exclusiveMaximum.foreach(v => fields += ("exclusiveMaximum" -> Json.Number(v.toString)))
-      minimum.foreach(v => fields += ("minimum" -> Json.Number(v.toString)))
-      exclusiveMinimum.foreach(v => fields += ("exclusiveMinimum" -> Json.Number(v.toString)))
+      multipleOf.foreach(v => fields += ("multipleOf" -> Json.Number(v.value)))
+      maximum.foreach(v => fields += ("maximum" -> Json.Number(v)))
+      exclusiveMaximum.foreach(v => fields += ("exclusiveMaximum" -> Json.Number(v)))
+      minimum.foreach(v => fields += ("minimum" -> Json.Number(v)))
+      exclusiveMinimum.foreach(v => fields += ("exclusiveMinimum" -> Json.Number(v)))
 
       // Validation vocabulary (String)
-      minLength.foreach(v => fields += ("minLength" -> Json.Number(v.value.toString)))
-      maxLength.foreach(v => fields += ("maxLength" -> Json.Number(v.value.toString)))
+      minLength.foreach(v => fields += ("minLength" -> Json.Number(v.value)))
+      maxLength.foreach(v => fields += ("maxLength" -> Json.Number(v.value)))
       pattern.foreach(v => fields += ("pattern" -> Json.String(v.value)))
 
       // Validation vocabulary (Array)
-      minItems.foreach(v => fields += ("minItems" -> Json.Number(v.value.toString)))
-      maxItems.foreach(v => fields += ("maxItems" -> Json.Number(v.value.toString)))
+      minItems.foreach(v => fields += ("minItems" -> Json.Number(v.value)))
+      maxItems.foreach(v => fields += ("maxItems" -> Json.Number(v.value)))
       uniqueItems.foreach(v => fields += ("uniqueItems" -> Json.Boolean(v)))
-      minContains.foreach(v => fields += ("minContains" -> Json.Number(v.value.toString)))
-      maxContains.foreach(v => fields += ("maxContains" -> Json.Number(v.value.toString)))
+      minContains.foreach(v => fields += ("minContains" -> Json.Number(v.value)))
+      maxContains.foreach(v => fields += ("maxContains" -> Json.Number(v.value)))
 
       // Validation vocabulary (Object)
-      minProperties.foreach(v => fields += ("minProperties" -> Json.Number(v.value.toString)))
-      maxProperties.foreach(v => fields += ("maxProperties" -> Json.Number(v.value.toString)))
+      minProperties.foreach(v => fields += ("minProperties" -> Json.Number(v.value)))
+      maxProperties.foreach(v => fields += ("maxProperties" -> Json.Number(v.value)))
       required.foreach(v => fields += ("required" -> Json.Array(v.toSeq.map(Json.String(_)): _*)))
       dependentRequired.foreach { d =>
         val depsObj = Json.Object(Chunk.from(d.map { case (name, reqs) =>
@@ -874,7 +874,7 @@ object JsonSchema {
           case _: Json.Boolean => schemaType.contains(JsonSchemaType.Boolean)
           case _: Json.String  => schemaType.contains(JsonSchemaType.String)
           case n: Json.Number  =>
-            val isInt = n.toBigDecimalOption.exists(bd => bd.isWhole)
+            val isInt = n.value.isWhole
             schemaType.contains(JsonSchemaType.Number) || (isInt && schemaType.contains(JsonSchemaType.Integer))
           case _: Json.Array  => schemaType.contains(JsonSchemaType.Array)
           case _: Json.Object => schemaType.contains(JsonSchemaType.Object)
@@ -905,26 +905,25 @@ object JsonSchema {
       // Numeric validations
       json match {
         case n: Json.Number =>
-          n.toBigDecimalOption.foreach { value =>
-            minimum.foreach { min =>
-              if (value < min) addError(s"Value $value is less than minimum $min")
-            }
-            maximum.foreach { max =>
-              if (value > max) addError(s"Value $value is greater than maximum $max")
-            }
-            exclusiveMinimum.foreach { min =>
-              if (value <= min) addError(s"Value $value is not greater than exclusiveMinimum $min")
-            }
-            exclusiveMaximum.foreach { max =>
-              if (value >= max) addError(s"Value $value is not less than exclusiveMaximum $max")
-            }
-            multipleOf.foreach { m =>
-              try {
-                if (value % m.value != 0) addError(s"Value $value is not a multiple of ${m.value}")
-              } catch {
-                case _: ArithmeticException =>
-                  addError(s"Value $value cannot be checked against multipleOf ${m.value}")
-              }
+          val value = n.value
+          minimum.foreach { min =>
+            if (value < min) addError(s"Value $value is less than minimum $min")
+          }
+          maximum.foreach { max =>
+            if (value > max) addError(s"Value $value is greater than maximum $max")
+          }
+          exclusiveMinimum.foreach { min =>
+            if (value <= min) addError(s"Value $value is not greater than exclusiveMinimum $min")
+          }
+          exclusiveMaximum.foreach { max =>
+            if (value >= max) addError(s"Value $value is not less than exclusiveMaximum $max")
+          }
+          multipleOf.foreach { m =>
+            try {
+              if (value % m.value != 0) addError(s"Value $value is not a multiple of ${m.value}")
+            } catch {
+              case _: ArithmeticException =>
+                addError(s"Value $value cannot be checked against multipleOf ${m.value}")
             }
           }
         case _ => ()
@@ -1380,7 +1379,7 @@ object JsonSchema {
       fieldMap.get(key).collect { case b: Json.Boolean => b.value }
 
     def getNumber(key: String): Option[BigDecimal] =
-      fieldMap.get(key).collect { case n: Json.Number => n.toBigDecimalOption }.flatten
+      fieldMap.get(key).collect { case n: Json.Number => n.value }
 
     def getNonNegativeInt(key: String): Option[NonNegativeInt] =
       getNumber(key).flatMap(n => NonNegativeInt(n.toInt))

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonBinaryCodecToJsonSchemaSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonBinaryCodecToJsonSchemaSpec.scala
@@ -129,8 +129,8 @@ object JsonBinaryCodecToJsonSchemaSpec extends SchemaBaseSpec {
         val json       = jsonSchema.toJson
         assertTrue(
           json.get("type").one == Right(Json.String("integer")),
-          json.get("minimum").one == Right(Json.Number("-128")),
-          json.get("maximum").one == Right(Json.Number("127"))
+          json.get("minimum").one == Right(Json.Number(-128)),
+          json.get("maximum").one == Right(Json.Number(127))
         )
       },
       test("Short produces integer JSON Schema with min/max constraints") {
@@ -138,8 +138,8 @@ object JsonBinaryCodecToJsonSchemaSpec extends SchemaBaseSpec {
         val json       = jsonSchema.toJson
         assertTrue(
           json.get("type").one == Right(Json.String("integer")),
-          json.get("minimum").one == Right(Json.Number("-32768")),
-          json.get("maximum").one == Right(Json.Number("32767"))
+          json.get("minimum").one == Right(Json.Number(-32768)),
+          json.get("maximum").one == Right(Json.Number(32767))
         )
       },
       test("Char produces string JSON Schema with minLength/maxLength = 1") {
@@ -147,8 +147,8 @@ object JsonBinaryCodecToJsonSchemaSpec extends SchemaBaseSpec {
         val json       = jsonSchema.toJson
         assertTrue(
           json.get("type").one == Right(Json.String("string")),
-          json.get("minLength").one == Right(Json.Number("1")),
-          json.get("maxLength").one == Right(Json.Number("1"))
+          json.get("minLength").one == Right(Json.Number(1)),
+          json.get("maxLength").one == Right(Json.Number(1))
         )
       },
       test("BigInt produces integer JSON Schema") {

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonInterpolatorSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonInterpolatorSpec.scala
@@ -112,7 +112,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
       )
     },
     test("supports interpolated BigDecimal keys and values") {
-      check(Gen.bigDecimal(BigDecimal("-" + "9" * 100), BigDecimal("9" * 100)))(x =>
+      check(Gen.bigDecimal(BigDecimal("-" + "9" * 20), BigDecimal("9" * 20)))(x =>
         assertTrue(
           json"""{"x": $x}""".get("x").as[BigDecimal] == Right(x),
           json"""{${x.toString}: "v"}""".get(x.toString).as[String] == Right("v")
@@ -120,7 +120,7 @@ object JsonInterpolatorSpec extends SchemaBaseSpec {
       )
     },
     test("supports interpolated BigInt keys and values") {
-      check(Gen.bigInt(BigInt("-" + "9" * 100), BigInt("9" * 100)))(x =>
+      check(Gen.bigInt(BigInt("-" + "9" * 20), BigInt("9" * 20)))(x =>
         assertTrue(
           json"""{"x": $x}""".get("x").as[BigDecimal].map(_.toBigInt) == Right(x),
           json"""{${x.toString}: "v"}""".get(x.toString).as[String] == Right("v")

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSchemaRoundTripSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSchemaRoundTripSpec.scala
@@ -360,15 +360,15 @@ object JsonSchemaRoundTripSpec extends SchemaBaseSpec {
         val fieldMap = json.asInstanceOf[Json.Object].value.toMap
 
         assertTrue(
-          fieldMap.get("minimum").exists(_.asInstanceOf[Json.Number].toBigDecimalOption.contains(BigDecimal(0))),
-          fieldMap.get("maximum").exists(_.asInstanceOf[Json.Number].toBigDecimalOption.contains(BigDecimal(100))),
+          fieldMap.get("minimum").exists(_.asInstanceOf[Json.Number].value == BigDecimal(0)),
+          fieldMap.get("maximum").exists(_.asInstanceOf[Json.Number].value == BigDecimal(100)),
           fieldMap
             .get("exclusiveMinimum")
-            .exists(_.asInstanceOf[Json.Number].toBigDecimalOption.contains(BigDecimal(-1))),
+            .exists(_.asInstanceOf[Json.Number].value == BigDecimal(-1)),
           fieldMap
             .get("exclusiveMaximum")
-            .exists(_.asInstanceOf[Json.Number].toBigDecimalOption.contains(BigDecimal(101))),
-          fieldMap.get("multipleOf").exists(_.asInstanceOf[Json.Number].toBigDecimalOption.contains(BigDecimal("0.5")))
+            .exists(_.asInstanceOf[Json.Number].value == BigDecimal(101)),
+          fieldMap.get("multipleOf").exists(_.asInstanceOf[Json.Number].value == BigDecimal("0.5"))
         )
       },
       test("string keywords serialize correctly") {
@@ -382,8 +382,8 @@ object JsonSchemaRoundTripSpec extends SchemaBaseSpec {
         val fieldMap = json.asInstanceOf[Json.Object].value.toMap
 
         assertTrue(
-          fieldMap.get("minLength").exists(_.asInstanceOf[Json.Number].toBigDecimalOption.contains(BigDecimal(5))),
-          fieldMap.get("maxLength").exists(_.asInstanceOf[Json.Number].toBigDecimalOption.contains(BigDecimal(100))),
+          fieldMap.get("minLength").exists(_.asInstanceOf[Json.Number].value == BigDecimal(5)),
+          fieldMap.get("maxLength").exists(_.asInstanceOf[Json.Number].value == BigDecimal(100)),
           fieldMap.get("pattern").contains(Json.String("^[a-z]+$")),
           fieldMap.get("format").contains(Json.String("email"))
         )
@@ -404,11 +404,11 @@ object JsonSchemaRoundTripSpec extends SchemaBaseSpec {
         val fieldMap = json.asInstanceOf[Json.Object].value.toMap
 
         assertTrue(
-          fieldMap.get("minItems").exists(_.asInstanceOf[Json.Number].toBigDecimalOption.contains(BigDecimal(1))),
-          fieldMap.get("maxItems").exists(_.asInstanceOf[Json.Number].toBigDecimalOption.contains(BigDecimal(10))),
+          fieldMap.get("minItems").exists(_.asInstanceOf[Json.Number].value == BigDecimal(1)),
+          fieldMap.get("maxItems").exists(_.asInstanceOf[Json.Number].value == BigDecimal(10)),
           fieldMap.get("uniqueItems").contains(Json.Boolean(true)),
-          fieldMap.get("minContains").exists(_.asInstanceOf[Json.Number].toBigDecimalOption.contains(BigDecimal(2))),
-          fieldMap.get("maxContains").exists(_.asInstanceOf[Json.Number].toBigDecimalOption.contains(BigDecimal(5))),
+          fieldMap.get("minContains").exists(_.asInstanceOf[Json.Number].value == BigDecimal(2)),
+          fieldMap.get("maxContains").exists(_.asInstanceOf[Json.Number].value == BigDecimal(5)),
           fieldMap.get("prefixItems").isDefined,
           fieldMap.get("items").isDefined,
           fieldMap.get("contains").isDefined,
@@ -432,8 +432,8 @@ object JsonSchemaRoundTripSpec extends SchemaBaseSpec {
         val fieldMap = json.asInstanceOf[Json.Object].value.toMap
 
         assertTrue(
-          fieldMap.get("minProperties").exists(_.asInstanceOf[Json.Number].toBigDecimalOption.contains(BigDecimal(1))),
-          fieldMap.get("maxProperties").exists(_.asInstanceOf[Json.Number].toBigDecimalOption.contains(BigDecimal(10))),
+          fieldMap.get("minProperties").exists(_.asInstanceOf[Json.Number].value == BigDecimal(1)),
+          fieldMap.get("maxProperties").exists(_.asInstanceOf[Json.Number].value == BigDecimal(10)),
           fieldMap.get("required").isDefined,
           fieldMap.get("properties").isDefined,
           fieldMap.get("patternProperties").isDefined,

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSelectionSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSelectionSpec.scala
@@ -9,8 +9,8 @@ object JsonSelectionSpec extends SchemaBaseSpec {
     suite("Unary methods")(
       suite("Normalization")(
         test("sortKeys sorts object keys in all selected values") {
-          val json1     = Json.Object("z" -> Json.Number("1"), "a" -> Json.Number("2"))
-          val json2     = Json.Object("b" -> Json.Number("3"), "a" -> Json.Number("4"))
+          val json1     = Json.Object("z" -> Json.Number(1), "a" -> Json.Number(2))
+          val json2     = Json.Object("b" -> Json.Number(3), "a" -> Json.Number(4))
           val selection = JsonSelection.succeedMany(Vector(json1, json2))
           val sorted    = selection.sortKeys
           val result    = sorted.either.map(_.map(_.print))
@@ -19,8 +19,8 @@ object JsonSelectionSpec extends SchemaBaseSpec {
           )
         },
         test("dropNulls removes nulls from all selected values") {
-          val json1     = Json.Object("a" -> Json.Number("1"), "b" -> Json.Null)
-          val json2     = Json.Object("c" -> Json.Null, "d" -> Json.Number("2"))
+          val json1     = Json.Object("a" -> Json.Number(1), "b" -> Json.Null)
+          val json2     = Json.Object("c" -> Json.Null, "d" -> Json.Number(2))
           val selection = JsonSelection.succeedMany(Vector(json1, json2))
           val result    = selection.dropNulls.either
           assertTrue(
@@ -28,8 +28,8 @@ object JsonSelectionSpec extends SchemaBaseSpec {
           )
         },
         test("dropEmpty removes empty objects and arrays from all selected values") {
-          val json1     = Json.Object("a" -> Json.Object.empty, "b" -> Json.Number("1"))
-          val json2     = Json.Array(Json.Array.empty, Json.Number("2"))
+          val json1     = Json.Object("a" -> Json.Object.empty, "b" -> Json.Number(1))
+          val json2     = Json.Array(Json.Array.empty, Json.Number(2))
           val selection = JsonSelection.succeedMany(Vector(json1, json2))
           val result    = selection.dropEmpty
           assertTrue(
@@ -39,7 +39,7 @@ object JsonSelectionSpec extends SchemaBaseSpec {
         },
         test("normalize applies sortKeys, dropNulls, and dropEmpty") {
           val json = Json.Object(
-            "z" -> Json.Number("1"),
+            "z" -> Json.Number(1),
             "a" -> Json.Null,
             "m" -> Json.Object.empty
           )
@@ -52,33 +52,33 @@ object JsonSelectionSpec extends SchemaBaseSpec {
       ),
       suite("Path Operations")(
         test("modify applies function at path in all selected values") {
-          val json1     = Json.Object("x" -> Json.Number("1"))
-          val json2     = Json.Object("x" -> Json.Number("2"))
+          val json1     = Json.Object("x" -> Json.Number(1))
+          val json2     = Json.Object("x" -> Json.Number(2))
           val selection = JsonSelection.succeedMany(Vector(json1, json2))
           val path      = DynamicOptic.root.field("x")
           val result    = selection.modify(path) {
-            case Json.Number(n) => Json.Number((BigDecimal(n) * 10).toString)
+            case Json.Number(n) => Json.Number(n * 10)
             case other          => other
           }
           assertTrue(
             result.either.map(_.map(_.get("x").one)) ==
-              Right(Vector(Right(Json.Number("10")), Right(Json.Number("20"))))
+              Right(Vector(Right(Json.Number(10)), Right(Json.Number(20))))
           )
         },
         test("set replaces value at path in all selected values") {
-          val json1     = Json.Object("a" -> Json.Number("1"))
-          val json2     = Json.Object("a" -> Json.Number("2"))
+          val json1     = Json.Object("a" -> Json.Number(1))
+          val json2     = Json.Object("a" -> Json.Number(2))
           val selection = JsonSelection.succeedMany(Vector(json1, json2))
           val path      = DynamicOptic.root.field("a")
-          val result    = selection.set(path, Json.Number("99"))
+          val result    = selection.set(path, Json.Number(99))
           assertTrue(
             result.either.map(_.map(_.get("a").one)) ==
-              Right(Vector(Right(Json.Number("99")), Right(Json.Number("99"))))
+              Right(Vector(Right(Json.Number(99)), Right(Json.Number(99))))
           )
         },
         test("delete removes value at path in all selected values") {
-          val json1     = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))
-          val json2     = Json.Object("a" -> Json.Number("3"), "c" -> Json.Number("4"))
+          val json1     = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))
+          val json2     = Json.Object("a" -> Json.Number(3), "c" -> Json.Number(4))
           val selection = JsonSelection.succeedMany(Vector(json1, json2))
           val path      = DynamicOptic.root.field("a")
           val result    = selection.delete(path)
@@ -87,8 +87,8 @@ object JsonSelectionSpec extends SchemaBaseSpec {
           )
         },
         test("insert adds value at path in all selected values") {
-          val json1     = Json.Object("a" -> Json.Number("1"))
-          val json2     = Json.Object("b" -> Json.Number("2"))
+          val json1     = Json.Object("a" -> Json.Number(1))
+          val json2     = Json.Object("b" -> Json.Number(2))
           val selection = JsonSelection.succeedMany(Vector(json1, json2))
           val path      = DynamicOptic.root.field("new")
           val result    = selection.insert(path, Json.String("inserted"))
@@ -100,29 +100,29 @@ object JsonSelectionSpec extends SchemaBaseSpec {
       ),
       suite("Transformation")(
         test("transformUp applies function bottom-up to all selected values") {
-          val json      = Json.Object("a" -> Json.Number("1"))
+          val json      = Json.Object("a" -> Json.Number(1))
           val selection = JsonSelection.succeed(json)
           val result    = selection.transformUp { (_, j) =>
             j match {
-              case Json.Number(n) => Json.Number((BigDecimal(n) + 1).toString)
+              case Json.Number(n) => Json.Number(n + 1)
               case other          => other
             }
           }
-          assertTrue(result.one.map(_.get("a").one) == Right(Right(Json.Number("2"))))
+          assertTrue(result.one.map(_.get("a").one) == Right(Right(Json.Number(2))))
         },
         test("transformDown applies function top-down to all selected values") {
-          val json      = Json.Object("a" -> Json.Number("1"))
+          val json      = Json.Object("a" -> Json.Number(1))
           val selection = JsonSelection.succeed(json)
           val result    = selection.transformDown { (_, j) =>
             j match {
-              case Json.Number(n) => Json.Number((BigDecimal(n) + 1).toString)
+              case Json.Number(n) => Json.Number(n + 1)
               case other          => other
             }
           }
-          assertTrue(result.one.map(_.get("a").one) == Right(Right(Json.Number("2"))))
+          assertTrue(result.one.map(_.get("a").one) == Right(Right(Json.Number(2))))
         },
         test("transformKeys applies function to all keys in all selected values") {
-          val json      = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))
+          val json      = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))
           val selection = JsonSelection.succeed(json)
           val result    = selection.transformKeys((_, key) => key.toUpperCase)
           assertTrue(
@@ -133,8 +133,8 @@ object JsonSelectionSpec extends SchemaBaseSpec {
       ),
       suite("Pruning")(
         test("prune removes matching values from all selected values") {
-          val json1     = Json.Object("a" -> Json.Null, "b" -> Json.Number("1"))
-          val json2     = Json.Array(Json.Null, Json.Number("2"))
+          val json1     = Json.Object("a" -> Json.Null, "b" -> Json.Number(1))
+          val json2     = Json.Array(Json.Null, Json.Number(2))
           val selection = JsonSelection.succeedMany(Vector(json1, json2))
           val result    = selection.prune(_.is(JsonType.Null))
           assertTrue(
@@ -142,7 +142,7 @@ object JsonSelectionSpec extends SchemaBaseSpec {
           )
         },
         test("prunePath removes values at matching paths") {
-          val json      = Json.Object("keep" -> Json.Number("1"), "drop" -> Json.Number("2"))
+          val json      = Json.Object("keep" -> Json.Number(1), "drop" -> Json.Number(2))
           val selection = JsonSelection.succeed(json)
           val result    = selection.prunePath { path =>
             path.nodes.exists {
@@ -157,7 +157,7 @@ object JsonSelectionSpec extends SchemaBaseSpec {
         },
         test("pruneBoth removes values matching both predicates") {
           val json = Json.Object(
-            "nums" -> Json.Array(Json.Number("1"), Json.Number("100"))
+            "nums" -> Json.Array(Json.Number(1), Json.Number(100))
           )
           val selection = JsonSelection.succeed(json)
           val result    = selection.pruneBoth { (path, value) =>
@@ -173,7 +173,7 @@ object JsonSelectionSpec extends SchemaBaseSpec {
       ),
       suite("Retention")(
         test("retain keeps only matching values in all selected values") {
-          val json      = Json.Object("a" -> Json.Number("1"), "b" -> Json.String("hi"))
+          val json      = Json.Object("a" -> Json.Number(1), "b" -> Json.String("hi"))
           val selection = JsonSelection.succeed(json)
           val result    = selection.retain(_.is(JsonType.Number))
           assertTrue(
@@ -182,7 +182,7 @@ object JsonSelectionSpec extends SchemaBaseSpec {
           )
         },
         test("retainPath keeps only values at matching paths") {
-          val json      = Json.Object("keep" -> Json.Number("1"), "drop" -> Json.Number("2"))
+          val json      = Json.Object("keep" -> Json.Number(1), "drop" -> Json.Number(2))
           val selection = JsonSelection.succeed(json)
           val result    = selection.retainPath { path =>
             path.nodes.exists {
@@ -197,7 +197,7 @@ object JsonSelectionSpec extends SchemaBaseSpec {
         },
         test("retainBoth keeps only values matching both predicates") {
           val json = Json.Object(
-            "nums" -> Json.Array(Json.Number("1"), Json.Number("100"))
+            "nums" -> Json.Array(Json.Number(1), Json.Number(100))
           )
           val selection = JsonSelection.succeed(json)
           val result    = selection.retainBoth { (path, value) =>
@@ -215,9 +215,9 @@ object JsonSelectionSpec extends SchemaBaseSpec {
       suite("Projection")(
         test("project keeps only specified paths in all selected values") {
           val json = Json.Object(
-            "a" -> Json.Number("1"),
-            "b" -> Json.Number("2"),
-            "c" -> Json.Number("3")
+            "a" -> Json.Number(1),
+            "b" -> Json.Number(2),
+            "c" -> Json.Number(3)
           )
           val selection = JsonSelection.succeed(json)
           val pathA     = DynamicOptic.root.field("a")
@@ -235,15 +235,15 @@ object JsonSelectionSpec extends SchemaBaseSpec {
       test("merge produces cartesian product (2 × 3 = 6 results)") {
         val left = JsonSelection.succeedMany(
           Vector(
-            Json.Object("a" -> Json.Number("1")),
-            Json.Object("a" -> Json.Number("2"))
+            Json.Object("a" -> Json.Number(1)),
+            Json.Object("a" -> Json.Number(2))
           )
         )
         val right = JsonSelection.succeedMany(
           Vector(
-            Json.Object("b" -> Json.Number("10")),
-            Json.Object("b" -> Json.Number("20")),
-            Json.Object("b" -> Json.Number("30"))
+            Json.Object("b" -> Json.Number(10)),
+            Json.Object("b" -> Json.Number(20)),
+            Json.Object("b" -> Json.Number(30))
           )
         )
         val result = left.merge(right)
@@ -253,26 +253,26 @@ object JsonSelectionSpec extends SchemaBaseSpec {
         )
       },
       test("merge combines values with default Auto strategy") {
-        val left   = JsonSelection.succeed(Json.Object("a" -> Json.Number("1")))
-        val right  = JsonSelection.succeed(Json.Object("b" -> Json.Number("2")))
+        val left   = JsonSelection.succeed(Json.Object("a" -> Json.Number(1)))
+        val right  = JsonSelection.succeed(Json.Object("b" -> Json.Number(2)))
         val result = left.merge(right)
         assertTrue(
-          result.one.map(_.get("a").one) == Right(Right(Json.Number("1"))),
-          result.one.map(_.get("b").one) == Right(Right(Json.Number("2")))
+          result.one.map(_.get("a").one) == Right(Right(Json.Number(1))),
+          result.one.map(_.get("b").one) == Right(Right(Json.Number(2)))
         )
       },
       test("merge with Replace strategy replaces left with right") {
-        val left   = JsonSelection.succeed(Json.Object("a" -> Json.Number("1")))
-        val right  = JsonSelection.succeed(Json.Object("b" -> Json.Number("2")))
+        val left   = JsonSelection.succeed(Json.Object("a" -> Json.Number(1)))
+        val right  = JsonSelection.succeed(Json.Object("b" -> Json.Number(2)))
         val result = left.merge(right, MergeStrategy.Replace)
         assertTrue(
           result.one.map(_.get("a").isFailure) == Right(true),
-          result.one.map(_.get("b").one) == Right(Right(Json.Number("2")))
+          result.one.map(_.get("b").one) == Right(Right(Json.Number(2)))
         )
       },
       test("merge propagates left error") {
         val left   = JsonSelection.fail(SchemaError("left error"))
-        val right  = JsonSelection.succeed(Json.Object("b" -> Json.Number("2")))
+        val right  = JsonSelection.succeed(Json.Object("b" -> Json.Number(2)))
         val result = left.merge(right)
         assertTrue(
           result.isFailure,
@@ -280,7 +280,7 @@ object JsonSelectionSpec extends SchemaBaseSpec {
         )
       },
       test("merge propagates right error") {
-        val left   = JsonSelection.succeed(Json.Object("a" -> Json.Number("1")))
+        val left   = JsonSelection.succeed(Json.Object("a" -> Json.Number(1)))
         val right  = JsonSelection.fail(SchemaError("right error"))
         val result = left.merge(right)
         assertTrue(
@@ -358,18 +358,18 @@ object JsonSelectionSpec extends SchemaBaseSpec {
     ),
     suite("Fallible mutation methods")(
       test("modifyOrFail succeeds when path exists and partial function is defined") {
-        val json      = Json.Object("a" -> Json.Number("1"))
+        val json      = Json.Object("a" -> Json.Number(1))
         val selection = JsonSelection.succeed(json)
         val path      = DynamicOptic.root.field("a")
         val result    = selection.modifyOrFail(path) { case Json.Number(n) =>
-          Json.Number((BigDecimal(n) * 2).toString)
+          Json.Number(n * 2)
         }
         assertTrue(
-          result.one.map(_.get("a").one) == Right(Right(Json.Number("2")))
+          result.one.map(_.get("a").one) == Right(Right(Json.Number(2)))
         )
       },
       test("modifyOrFail fails when path does not exist") {
-        val json      = Json.Object("a" -> Json.Number("1"))
+        val json      = Json.Object("a" -> Json.Number(1))
         val selection = JsonSelection.succeed(json)
         val path      = DynamicOptic.root.field("nonexistent")
         val result    = selection.modifyOrFail(path) { case j => j }
@@ -383,23 +383,23 @@ object JsonSelectionSpec extends SchemaBaseSpec {
         assertTrue(result.isFailure)
       },
       test("setOrFail succeeds when path exists") {
-        val json      = Json.Object("a" -> Json.Number("1"))
+        val json      = Json.Object("a" -> Json.Number(1))
         val selection = JsonSelection.succeed(json)
         val path      = DynamicOptic.root.field("a")
-        val result    = selection.setOrFail(path, Json.Number("99"))
+        val result    = selection.setOrFail(path, Json.Number(99))
         assertTrue(
-          result.one.map(_.get("a").one) == Right(Right(Json.Number("99")))
+          result.one.map(_.get("a").one) == Right(Right(Json.Number(99)))
         )
       },
       test("setOrFail fails when path does not exist") {
-        val json      = Json.Object("a" -> Json.Number("1"))
+        val json      = Json.Object("a" -> Json.Number(1))
         val selection = JsonSelection.succeed(json)
         val path      = DynamicOptic.root.field("nonexistent")
-        val result    = selection.setOrFail(path, Json.Number("99"))
+        val result    = selection.setOrFail(path, Json.Number(99))
         assertTrue(result.isFailure)
       },
       test("deleteOrFail succeeds when path exists") {
-        val json      = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))
+        val json      = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))
         val selection = JsonSelection.succeed(json)
         val path      = DynamicOptic.root.field("a")
         val result    = selection.deleteOrFail(path)
@@ -409,45 +409,45 @@ object JsonSelectionSpec extends SchemaBaseSpec {
         )
       },
       test("deleteOrFail fails when path does not exist") {
-        val json      = Json.Object("a" -> Json.Number("1"))
+        val json      = Json.Object("a" -> Json.Number(1))
         val selection = JsonSelection.succeed(json)
         val path      = DynamicOptic.root.field("nonexistent")
         val result    = selection.deleteOrFail(path)
         assertTrue(result.isFailure)
       },
       test("insertOrFail succeeds when path does not exist and parent exists") {
-        val json      = Json.Object("a" -> Json.Number("1"))
+        val json      = Json.Object("a" -> Json.Number(1))
         val selection = JsonSelection.succeed(json)
         val path      = DynamicOptic.root.field("b")
-        val result    = selection.insertOrFail(path, Json.Number("2"))
+        val result    = selection.insertOrFail(path, Json.Number(2))
         assertTrue(
-          result.one.map(_.get("b").one) == Right(Right(Json.Number("2")))
+          result.one.map(_.get("b").one) == Right(Right(Json.Number(2)))
         )
       },
       test("insertOrFail fails when path already exists") {
-        val json      = Json.Object("a" -> Json.Number("1"))
+        val json      = Json.Object("a" -> Json.Number(1))
         val selection = JsonSelection.succeed(json)
         val path      = DynamicOptic.root.field("a")
-        val result    = selection.insertOrFail(path, Json.Number("2"))
+        val result    = selection.insertOrFail(path, Json.Number(2))
         assertTrue(result.isFailure)
       },
       test("fallible methods can be chained fluently") {
-        val json      = Json.Object("a" -> Json.Number("1"))
+        val json      = Json.Object("a" -> Json.Number(1))
         val selection = JsonSelection.succeed(json)
         val pathA     = DynamicOptic.root.field("a")
         val pathB     = DynamicOptic.root.field("b")
         val result    = selection
-          .setOrFail(pathA, Json.Number("10"))
-          .insertOrFail(pathB, Json.Number("20"))
+          .setOrFail(pathA, Json.Number(10))
+          .insertOrFail(pathB, Json.Number(20))
         assertTrue(
-          result.one.map(_.get("a").one) == Right(Right(Json.Number("10"))),
-          result.one.map(_.get("b").one) == Right(Right(Json.Number("20")))
+          result.one.map(_.get("a").one) == Right(Right(Json.Number(10))),
+          result.one.map(_.get("b").one) == Right(Right(Json.Number(20)))
         )
       }
     ),
     suite("Type-directed extraction")(
       test("as(jsonType) returns typed value when single value matches") {
-        val selection = JsonSelection.succeed(Json.Object("a" -> Json.Number("1")))
+        val selection = JsonSelection.succeed(Json.Object("a" -> Json.Number(1)))
         val result    = selection.as(JsonType.Object)
         assertTrue(result.isRight)
       },
@@ -459,8 +459,8 @@ object JsonSelectionSpec extends SchemaBaseSpec {
       test("as(jsonType) fails when selection has multiple values") {
         val selection = JsonSelection.succeedMany(
           Vector(
-            Json.Object("a" -> Json.Number("1")),
-            Json.Object("b" -> Json.Number("2"))
+            Json.Object("a" -> Json.Number(1)),
+            Json.Object("b" -> Json.Number(2))
           )
         )
         val result = selection.as(JsonType.Object)
@@ -475,7 +475,7 @@ object JsonSelectionSpec extends SchemaBaseSpec {
         val selection = JsonSelection.succeedMany(
           Vector(
             Json.String("hello"),
-            Json.Number("42"),
+            Json.Number(42),
             Json.String("world")
           )
         )
@@ -489,7 +489,7 @@ object JsonSelectionSpec extends SchemaBaseSpec {
         val objects  = JsonSelection.succeed(Json.Object.empty).asAll(JsonType.Object)
         val arrays   = JsonSelection.succeed(Json.Array.empty).asAll(JsonType.Array)
         val strings  = JsonSelection.succeed(Json.String("hi")).asAll(JsonType.String)
-        val numbers  = JsonSelection.succeed(Json.Number("42")).asAll(JsonType.Number)
+        val numbers  = JsonSelection.succeed(Json.Number(42)).asAll(JsonType.Number)
         val booleans = JsonSelection.succeed(Json.Boolean(true)).asAll(JsonType.Boolean)
         val nulls    = JsonSelection.succeed(Json.Null).asAll(JsonType.Null)
         assertTrue(
@@ -503,7 +503,7 @@ object JsonSelectionSpec extends SchemaBaseSpec {
       },
       test("unwrap(jsonType) extracts underlying Scala value") {
         val strSelection                               = JsonSelection.succeed(Json.String("hello"))
-        val numSelection                               = JsonSelection.succeed(Json.Number("42"))
+        val numSelection                               = JsonSelection.succeed(Json.Number(42))
         val boolSelection                              = JsonSelection.succeed(Json.Boolean(true))
         val nullSelection                              = JsonSelection.succeed(Json.Null)
         val strResult: Either[SchemaError, String]     = strSelection.unwrap(JsonType.String)
@@ -522,25 +522,20 @@ object JsonSelectionSpec extends SchemaBaseSpec {
         val result    = selection.unwrap(JsonType.Number)
         assertTrue(result.isLeft)
       },
-      test("unwrap(jsonType) fails for unparseable Number") {
-        val selection = JsonSelection.succeed(Json.Number("not-a-number"))
-        val result    = selection.unwrap(JsonType.Number)
-        assertTrue(result.isLeft)
-      },
       test("unwrapAll(jsonType) extracts all matching values") {
         val selection = JsonSelection.succeedMany(
           Vector(
-            Json.Number("1"),
+            Json.Number(1),
             Json.String("skip"),
-            Json.Number("2"),
-            Json.Number("3")
+            Json.Number(2),
+            Json.Number(3)
           )
         )
         val result: Either[SchemaError, Vector[BigDecimal]] = selection.unwrapAll(JsonType.Number)
         assertTrue(result == Right(Vector(BigDecimal(1), BigDecimal(2), BigDecimal(3))))
       },
       test("unwrapAll(jsonType) for Object extracts Chunk[(String, Json)]") {
-        val obj       = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))
+        val obj       = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))
         val selection = JsonSelection.succeed(obj)
         val result    = selection.unwrapAll(JsonType.Object)
         assertTrue(
@@ -550,7 +545,7 @@ object JsonSelectionSpec extends SchemaBaseSpec {
         )
       },
       test("unwrapAll(jsonType) for Array extracts Chunk[Json]") {
-        val arr       = Json.Array(Json.Number("1"), Json.Number("2"))
+        val arr       = Json.Array(Json.Number(1), Json.Number(2))
         val selection = JsonSelection.succeed(arr)
         val result    = selection.unwrapAll(JsonType.Array)
         assertTrue(
@@ -558,17 +553,6 @@ object JsonSelectionSpec extends SchemaBaseSpec {
           result.map(_.length) == Right(1),
           result.map(_.head.length) == Right(2)
         )
-      },
-      test("unwrapAll silently drops unparseable Numbers") {
-        val selection = JsonSelection.succeedMany(
-          Vector(
-            Json.Number("1"),
-            Json.Number("not-a-number"),
-            Json.Number("2")
-          )
-        )
-        val result = selection.unwrapAll(JsonType.Number)
-        assertTrue(result == Right(Vector(BigDecimal(1), BigDecimal(2))))
       }
     )
   )

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSpec.scala
@@ -94,15 +94,11 @@ object JsonSpec extends SchemaBaseSpec {
           assert(obj.unwrap(JsonType.Boolean).isEmpty)(equalTo(true)) &&
           assert(obj.unwrap(JsonType.Null).isEmpty)(equalTo(true))
         },
-        test("unwrap for Number returns None when value is not parseable") {
-          val invalidNum: Json = Json.Number("not-a-number")
-          assert(invalidNum.unwrap(JsonType.Number).isEmpty)(equalTo(true))
-        },
         test("JsonType.apply works as a predicate function") {
           val obj: Json  = Json.Object.empty
           val arr: Json  = Json.Array.empty
           val str: Json  = Json.String("test")
-          val num: Json  = Json.Number("42")
+          val num: Json  = Json.Number(42)
           val bool: Json = Json.Boolean(true)
           val nul: Json  = Json.Null
           assert(JsonType.Object(obj))(equalTo(true)) &&
@@ -127,14 +123,14 @@ object JsonSpec extends SchemaBaseSpec {
           )
         },
         test("select(jsonType) returns selection when type matches") {
-          val json = Json.Object("a" -> Json.Number("1"))
+          val json = Json.Object("a" -> Json.Number(1))
           assertTrue(
             json.select(JsonType.Object).isSuccess,
             json.select(JsonType.Object).one == Right(json)
           )
         },
         test("select(jsonType) returns empty when type does not match") {
-          val json = Json.Object("a" -> Json.Number("1"))
+          val json = Json.Object("a" -> Json.Number(1))
           assertTrue(
             json.select(JsonType.Array).isEmpty,
             json.select(JsonType.String).isEmpty,
@@ -145,9 +141,9 @@ object JsonSpec extends SchemaBaseSpec {
       suite("prune/retain methods")(
         test("prune removes matching values from object") {
           val json = Json.Object(
-            "a" -> Json.Number("1"),
+            "a" -> Json.Number(1),
             "b" -> Json.Null,
-            "c" -> Json.Number("2")
+            "c" -> Json.Number(2)
           )
           val pruned  = json.prune(_.is(JsonType.Null))
           val pruned2 = pruned.as(JsonType.Object).get
@@ -160,15 +156,15 @@ object JsonSpec extends SchemaBaseSpec {
         },
         test("prune removes matching values from array") {
           val json = Json.Array(
-            Json.Number("1"),
+            Json.Number(1),
             Json.Null,
-            Json.Number("2"),
+            Json.Number(2),
             Json.Null
           )
           val pruned = json.prune(_.is(JsonType.Null))
           assertTrue(
             pruned.elements.length == 2,
-            pruned.elements == Chunk(Json.Number("1"), Json.Number("2"))
+            pruned.elements == Chunk(Json.Number(1), Json.Number(2))
           )
         },
         test("prune works recursively") {
@@ -186,8 +182,8 @@ object JsonSpec extends SchemaBaseSpec {
         },
         test("prunePath removes values at matching paths") {
           val json = Json.Object(
-            "keep" -> Json.Number("1"),
-            "drop" -> Json.Number("2")
+            "keep" -> Json.Number(1),
+            "drop" -> Json.Number(2)
           )
           val pruned = json.prunePath { path =>
             path.nodes.exists {
@@ -202,7 +198,7 @@ object JsonSpec extends SchemaBaseSpec {
         },
         test("pruneBoth removes values matching both path and value predicates") {
           val json = Json.Object(
-            "nums" -> Json.Array(Json.Number("1"), Json.Number("100"), Json.Number("5")),
+            "nums" -> Json.Array(Json.Number(1), Json.Number(100), Json.Number(5)),
             "strs" -> Json.Array(Json.String("a"))
           )
           val pruned = json.pruneBoth { (path, value) =>
@@ -220,9 +216,9 @@ object JsonSpec extends SchemaBaseSpec {
         },
         test("retain keeps only matching values in object") {
           val json = Json.Object(
-            "a" -> Json.Number("1"),
+            "a" -> Json.Number(1),
             "b" -> Json.String("hi"),
-            "c" -> Json.Number("2")
+            "c" -> Json.Number(2)
           )
           val retained = json.retain(_.is(JsonType.Number))
           val fields   = retained.as(JsonType.Object).get.fields
@@ -235,20 +231,20 @@ object JsonSpec extends SchemaBaseSpec {
         },
         test("retain keeps only matching values in array") {
           val json = Json.Array(
-            Json.Number("1"),
+            Json.Number(1),
             Json.String("x"),
-            Json.Number("2")
+            Json.Number(2)
           )
           val retained = json.retain(_.is(JsonType.Number))
           assertTrue(
             retained.elements.length == 2,
-            retained.elements == Chunk(Json.Number("1"), Json.Number("2"))
+            retained.elements == Chunk(Json.Number(1), Json.Number(2))
           )
         },
         test("retainPath keeps values at matching paths") {
           val json = Json.Object(
-            "keep" -> Json.Number("1"),
-            "drop" -> Json.Number("2")
+            "keep" -> Json.Number(1),
+            "drop" -> Json.Number(2)
           )
           val retained = json.retainPath { path =>
             path.nodes.exists {
@@ -263,8 +259,8 @@ object JsonSpec extends SchemaBaseSpec {
         },
         test("retainBoth keeps values matching both path and value predicates") {
           val json = Json.Object(
-            "keep" -> Json.Number("100"),
-            "drop" -> Json.Number("5")
+            "keep" -> Json.Number(100),
+            "drop" -> Json.Number(5)
           )
           val retained = json.retainBoth { (path, value) =>
             val hasKeepField = path.nodes.exists {
@@ -286,7 +282,7 @@ object JsonSpec extends SchemaBaseSpec {
             Json.Object.empty.jsonType == JsonType.Object,
             Json.Array.empty.jsonType == JsonType.Array,
             Json.String("test").jsonType == JsonType.String,
-            Json.Number("42").jsonType == JsonType.Number,
+            Json.Number(42).jsonType == JsonType.Number,
             Json.Boolean(true).jsonType == JsonType.Boolean,
             Json.Null.jsonType == JsonType.Null
           )
@@ -295,7 +291,7 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(
             Json.Null.typeIndex == JsonType.Null.typeIndex,
             Json.Boolean(true).typeIndex == JsonType.Boolean.typeIndex,
-            Json.Number("1").typeIndex == JsonType.Number.typeIndex,
+            Json.Number(1).typeIndex == JsonType.Number.typeIndex,
             Json.String("s").typeIndex == JsonType.String.typeIndex,
             Json.Array.empty.typeIndex == JsonType.Array.typeIndex,
             Json.Object.empty.typeIndex == JsonType.Object.typeIndex
@@ -313,20 +309,20 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("direct accessors")(
         test("fields returns non-empty Seq for objects") {
-          val json = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))
+          val json = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))
           assertTrue(json.fields.nonEmpty, json.fields.length == 2)
         },
         test("fields returns empty Seq for non-objects") {
           assertTrue(
             Json.Array().fields.isEmpty,
             Json.String("test").fields.isEmpty,
-            Json.Number("42").fields.isEmpty,
+            Json.Number(42).fields.isEmpty,
             Json.Boolean(true).fields.isEmpty,
             Json.Null.fields.isEmpty
           )
         },
         test("elements returns non-empty Seq for arrays") {
-          val json = Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
+          val json = Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
           assertTrue(json.elements.nonEmpty, json.elements.length == 3)
         }
       ),
@@ -342,10 +338,10 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(j.get(path).as[String] == Right("Bob"))
         },
         test("get retrieves field from object") {
-          val json = Json.Object("name" -> Json.String("Alice"), "age" -> Json.Number("30"))
+          val json = Json.Object("name" -> Json.String("Alice"), "age" -> Json.Number(30))
           assertTrue(
             json.get("name").one == Right(Json.String("Alice")),
-            json.get("age").one == Right(Json.Number("30"))
+            json.get("age").one == Right(Json.Number(30))
           )
         },
         test("get returns error for missing field") {
@@ -361,7 +357,7 @@ object JsonSpec extends SchemaBaseSpec {
           )
         },
         test("apply(index) returns error for out of bounds") {
-          val arr = Json.Array(Json.Number("1"))
+          val arr = Json.Array(Json.Number(1))
           assertTrue(arr.get(1).isFailure, arr.get(-1).isFailure)
         },
         test("chained navigation works") {
@@ -376,57 +372,57 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("modification with DynamicOptic")(
         test("set updates existing field in object") {
-          val json    = Json.Object("a" -> Json.Number("1"))
+          val json    = Json.Object("a" -> Json.Number(1))
           val path    = DynamicOptic.root.field("a")
-          val updated = json.set(path, Json.Number("99"))
-          assertTrue(updated.get("a").one == Right(Json.Number("99")))
+          val updated = json.set(path, Json.Number(99))
+          assertTrue(updated.get("a").one == Right(Json.Number(99)))
         },
         test("set returns unchanged json if field doesn't exist") {
-          val json    = Json.Object("a" -> Json.Number("1"))
+          val json    = Json.Object("a" -> Json.Number(1))
           val path    = DynamicOptic.root.field("b")
-          val updated = json.set(path, Json.Number("2"))
+          val updated = json.set(path, Json.Number(2))
           // set on non-existent path returns original unchanged
           assertTrue(updated == json)
         },
         test("set updates element in array") {
-          val arr     = Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
+          val arr     = Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
           val path    = DynamicOptic.root.at(1)
-          val updated = arr.set(path, Json.Number("99"))
-          assertTrue(updated.get(1).one == Right(Json.Number("99")))
+          val updated = arr.set(path, Json.Number(99))
+          assertTrue(updated.get(1).one == Right(Json.Number(99)))
         },
         test("setOrFail fails for non-existent path") {
-          val json   = Json.Object("a" -> Json.Number("1"))
+          val json   = Json.Object("a" -> Json.Number(1))
           val path   = DynamicOptic.root.field("b")
-          val result = json.setOrFail(path, Json.Number("2"))
+          val result = json.setOrFail(path, Json.Number(2))
           assertTrue(result.isLeft)
         },
         test("delete removes field from object") {
-          val json    = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))
+          val json    = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))
           val path    = DynamicOptic.root.field("a")
           val updated = json.delete(path)
           assertTrue(updated.get("a").isFailure, updated.get("b").isSuccess)
         },
         test("delete removes element from array") {
-          val arr     = Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
+          val arr     = Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
           val path    = DynamicOptic.root.at(1)
           val updated = arr.delete(path)
           assertTrue(
             updated.elements.length == 2,
-            updated.get(0).one == Right(Json.Number("1")),
-            updated.get(1).one == Right(Json.Number("3"))
+            updated.get(0).one == Right(Json.Number(1)),
+            updated.get(1).one == Right(Json.Number(3))
           )
         },
         test("deleteOrFail fails for non-existent path") {
-          val json   = Json.Object("a" -> Json.Number("1"))
+          val json   = Json.Object("a" -> Json.Number(1))
           val path   = DynamicOptic.root.field("missing")
           val result = json.deleteOrFail(path)
           assertTrue(result.isLeft)
         },
         test("modify transforms value at path") {
-          val json    = Json.Object("count" -> Json.Number("5"))
+          val json    = Json.Object("count" -> Json.Number(5))
           val path    = DynamicOptic.root.field("count")
           val updated = json.modify(path) {
-            case Json.Number(n) => Json.Number((BigDecimal(n) * 2).toString)
+            case Json.Number(n) => Json.Number(n * 2)
             case other          => other
           }
           assertTrue(updated.get("count").as[BigDecimal] == Right(BigDecimal(10)))
@@ -435,44 +431,44 @@ object JsonSpec extends SchemaBaseSpec {
           val json   = Json.Object("name" -> Json.String("Alice"))
           val path   = DynamicOptic.root.field("name")
           val result = json.modifyOrFail(path) { case Json.Number(n) =>
-            Json.Number((BigDecimal(n) * 2).toString)
+            Json.Number(n * 2)
           }
           assertTrue(result.isLeft)
         },
         test("insert adds new field to object") {
-          val json    = Json.Object("a" -> Json.Number("1"))
+          val json    = Json.Object("a" -> Json.Number(1))
           val path    = DynamicOptic.root.field("b")
-          val updated = json.insert(path, Json.Number("2"))
-          assertTrue(updated.get("b").one == Right(Json.Number("2")))
+          val updated = json.insert(path, Json.Number(2))
+          assertTrue(updated.get("b").one == Right(Json.Number(2)))
         },
         test("insert does nothing if field already exists") {
-          val json    = Json.Object("a" -> Json.Number("1"))
+          val json    = Json.Object("a" -> Json.Number(1))
           val path    = DynamicOptic.root.field("a")
-          val updated = json.insert(path, Json.Number("99"))
-          assertTrue(updated.get("a").one == Right(Json.Number("1"))) // Original value unchanged
+          val updated = json.insert(path, Json.Number(99))
+          assertTrue(updated.get("a").one == Right(Json.Number(1))) // Original value unchanged
         },
         test("insertOrFail fails if field already exists") {
-          val json   = Json.Object("a" -> Json.Number("1"))
+          val json   = Json.Object("a" -> Json.Number(1))
           val path   = DynamicOptic.root.field("a")
-          val result = json.insertOrFail(path, Json.Number("99"))
+          val result = json.insertOrFail(path, Json.Number(99))
           assertTrue(result.isLeft)
         },
         test("insert at array index shifts elements") {
-          val json    = Json.Array(Json.Number("1"), Json.Number("3"))
+          val json    = Json.Array(Json.Number(1), Json.Number(3))
           val path    = DynamicOptic.root.at(1)
-          val updated = json.insert(path, Json.Number("2"))
-          assertTrue(updated.elements == Chunk(Json.Number("1"), Json.Number("2"), Json.Number("3")))
+          val updated = json.insert(path, Json.Number(2))
+          assertTrue(updated.elements == Chunk(Json.Number(1), Json.Number(2), Json.Number(3)))
         },
         test("nested path modification works") {
           val json = Json.Object(
             "user" -> Json.Object(
               "profile" -> Json.Object(
-                "age" -> Json.Number("25")
+                "age" -> Json.Number(25)
               )
             )
           )
           val path    = DynamicOptic.root.field("user").field("profile").field("age")
-          val updated = json.set(path, Json.Number("26"))
+          val updated = json.set(path, Json.Number(26))
           assertTrue(updated.get("user").get("profile").get("age").as[BigDecimal] == Right(BigDecimal(26)))
         },
         test("get with DynamicOptic navigates nested structure") {
@@ -486,31 +482,31 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(json.get(path).as[String] == Right("Alice"))
         },
         test("get with elements returns all array elements") {
-          val json      = Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
+          val json      = Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
           val path      = DynamicOptic.elements
           val selection = json.get(path)
-          assertTrue(selection.either == Right(Vector(Json.Number("1"), Json.Number("2"), Json.Number("3"))))
+          assertTrue(selection.either == Right(Vector(Json.Number(1), Json.Number(2), Json.Number(3))))
         },
         test("modify with elements transforms all array elements") {
-          val json    = Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
+          val json    = Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
           val path    = DynamicOptic.elements
           val updated = json.modify(path) {
-            case Json.Number(n) => Json.Number((BigDecimal(n) * 10).toString)
+            case Json.Number(n) => Json.Number(n * 10)
             case other          => other
           }
-          assertTrue(updated.elements == Chunk(Json.Number("10"), Json.Number("20"), Json.Number("30")))
+          assertTrue(updated.elements == Chunk(Json.Number(10), Json.Number(20), Json.Number(30)))
         }
       ),
       suite("normalization")(
         test("sortKeys sorts object keys alphabetically") {
-          val json   = Json.Object("c" -> Json.Number("3"), "a" -> Json.Number("1"), "b" -> Json.Number("2"))
+          val json   = Json.Object("c" -> Json.Number(3), "a" -> Json.Number(1), "b" -> Json.Number(2))
           val sorted = json.sortKeys
           assertTrue(sorted.fields.map(_._1) == Chunk("a", "b", "c"))
         },
         test("sortKeys works recursively") {
           val json = Json.Object(
-            "z" -> Json.Object("b" -> Json.Number("1"), "a" -> Json.Number("2")),
-            "a" -> Json.Number("0")
+            "z" -> Json.Object("b" -> Json.Number(1), "a" -> Json.Number(2)),
+            "a" -> Json.Number(0)
           )
           val sorted = json.sortKeys
           sorted match {
@@ -526,16 +522,16 @@ object JsonSpec extends SchemaBaseSpec {
         },
         test("dropNulls removes null values") {
           val json = Json.Object(
-            "a" -> Json.Number("1"),
+            "a" -> Json.Number(1),
             "b" -> Json.Null,
-            "c" -> Json.Number("3")
+            "c" -> Json.Number(3)
           )
           val dropped = json.dropNulls
           assertTrue(dropped.fields.length == 2, dropped.get("b").isFailure)
         },
         test("dropEmpty removes empty objects and arrays") {
           val json = Json.Object(
-            "a" -> Json.Number("1"),
+            "a" -> Json.Number(1),
             "b" -> Json.Object(),
             "c" -> Json.Array()
           )
@@ -545,8 +541,8 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("merging")(
         test("merge with Auto strategy merges objects deeply") {
-          val left   = Json.Object("a" -> Json.Object("x" -> Json.Number("1")))
-          val right  = Json.Object("a" -> Json.Object("y" -> Json.Number("2")))
+          val left   = Json.Object("a" -> Json.Object("x" -> Json.Number(1)))
+          val right  = Json.Object("a" -> Json.Object("y" -> Json.Number(2)))
           val merged = left.merge(right)
           merged match {
             case Json.Object(fields) =>
@@ -560,53 +556,53 @@ object JsonSpec extends SchemaBaseSpec {
           }
         },
         test("merge with Replace strategy replaces completely") {
-          val left   = Json.Object("a" -> Json.Number("1"))
-          val right  = Json.Object("b" -> Json.Number("2"))
+          val left   = Json.Object("a" -> Json.Number(1))
+          val right  = Json.Object("b" -> Json.Number(2))
           val merged = left.merge(right, MergeStrategy.Replace)
           assertTrue(merged == right)
         },
         test("merge arrays by index with Auto") {
-          val left: Json  = Json.Array(Json.Number("1"), Json.Number("2"))
-          val right: Json = Json.Array(Json.Number("3"), Json.Number("4"))
+          val left: Json  = Json.Array(Json.Number(1), Json.Number(2))
+          val right: Json = Json.Array(Json.Number(3), Json.Number(4))
           val merged      = left.merge(right)
-          assertTrue(merged.elements == zio.blocks.chunk.Chunk(Json.Number("3"), Json.Number("4")))
+          assertTrue(merged.elements == zio.blocks.chunk.Chunk(Json.Number(3), Json.Number(4)))
         },
         test("merge arrays concatenates them with Concat") {
-          val left: Json  = Json.Array(Json.Number("1"), Json.Number("2"))
-          val right: Json = Json.Array(Json.Number("3"), Json.Number("4"))
+          val left: Json  = Json.Array(Json.Number(1), Json.Number(2))
+          val right: Json = Json.Array(Json.Number(3), Json.Number(4))
           val merged      = left.merge(right, MergeStrategy.Concat)
           assertTrue(merged.elements.length == 4)
         },
         test("merge arrays by index preserves extra elements from longer array") {
-          val left: Json  = Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
-          val right: Json = Json.Array(Json.Number("10"), Json.Number("20"))
+          val left: Json  = Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
+          val right: Json = Json.Array(Json.Number(10), Json.Number(20))
           val merged      = left.merge(right)
           assertTrue(
-            merged.elements == zio.blocks.chunk.Chunk(Json.Number("10"), Json.Number("20"), Json.Number("3"))
+            merged.elements == zio.blocks.chunk.Chunk(Json.Number(10), Json.Number(20), Json.Number(3))
           )
         },
         test("merge arrays by index with right longer than left") {
-          val left: Json  = Json.Array(Json.Number("1"))
-          val right: Json = Json.Array(Json.Number("10"), Json.Number("20"), Json.Number("30"))
+          val left: Json  = Json.Array(Json.Number(1))
+          val right: Json = Json.Array(Json.Number(10), Json.Number(20), Json.Number(30))
           val merged      = left.merge(right)
           assertTrue(
-            merged.elements == zio.blocks.chunk.Chunk(Json.Number("10"), Json.Number("20"), Json.Number("30"))
+            merged.elements == zio.blocks.chunk.Chunk(Json.Number(10), Json.Number(20), Json.Number(30))
           )
         },
         test("merge nested arrays recursively with Auto") {
-          val left   = Json.Object("arr" -> Json.Array(Json.Number("1"), Json.Number("2")))
-          val right  = Json.Object("arr" -> Json.Array(Json.Number("10")))
+          val left   = Json.Object("arr" -> Json.Array(Json.Number(1), Json.Number(2)))
+          val right  = Json.Object("arr" -> Json.Array(Json.Number(10)))
           val merged = left.merge(right)
           assertTrue(
-            merged.get("arr").one.map(_.elements) == Right(zio.blocks.chunk.Chunk(Json.Number("10"), Json.Number("2")))
+            merged.get("arr").one.map(_.elements) == Right(zio.blocks.chunk.Chunk(Json.Number(10), Json.Number(2)))
           )
         },
         test("merge with Shallow only merges at root level") {
           val left = Json.Object(
-            "a" -> Json.Object("x" -> Json.Number("1"), "y" -> Json.Number("2"))
+            "a" -> Json.Object("x" -> Json.Number(1), "y" -> Json.Number(2))
           )
           val right = Json.Object(
-            "a" -> Json.Object("z" -> Json.Number("3"))
+            "a" -> Json.Object("z" -> Json.Number(3))
           )
           val merged = left.merge(right, MergeStrategy.Shallow)
           assertTrue(
@@ -616,8 +612,8 @@ object JsonSpec extends SchemaBaseSpec {
           )
         },
         test("merge with Shallow on nested arrays replaces at root") {
-          val left: Json  = Json.Array(Json.Object("a" -> Json.Number("1")))
-          val right: Json = Json.Array(Json.Object("b" -> Json.Number("2")))
+          val left: Json  = Json.Array(Json.Object("a" -> Json.Number(1)))
+          val right: Json = Json.Array(Json.Object("b" -> Json.Number(2)))
           val merged      = left.merge(right, MergeStrategy.Shallow)
           assertTrue(merged.get(0).get("b").as[BigDecimal] == Right(BigDecimal(2)))
         }
@@ -638,7 +634,7 @@ object JsonSpec extends SchemaBaseSpec {
         test("parse JSON primitives") {
           assertTrue(
             Json.parse("\"hello\"").toOption.get == Json.String("hello"),
-            Json.parse("42").toOption.get == Json.Number("42"),
+            Json.parse("42").toOption.get == Json.Number(42),
             Json.parse("true").toOption.get == Json.Boolean(true),
             Json.parse("false").toOption.get == Json.Boolean(false),
             Json.parse("null").toOption.get == Json.Null
@@ -647,7 +643,7 @@ object JsonSpec extends SchemaBaseSpec {
         test("encode produces valid JSON") {
           val obj = Json.Object(
             "name"   -> Json.String("Alice"),
-            "scores" -> Json.Array(Json.Number("100"), Json.Number("95"))
+            "scores" -> Json.Array(Json.Number(100), Json.Number(95))
           )
           val encoded = obj.print
           assertTrue(encoded.contains("\"name\":\"Alice\"") || encoded.contains("\"name\": \"Alice\""))
@@ -655,11 +651,11 @@ object JsonSpec extends SchemaBaseSpec {
         test("roundtrip parsing and encoding") {
           val original = Json.Object(
             "string" -> Json.String("hello"),
-            "number" -> Json.Number("42.5"),
+            "number" -> Json.Number(42.5),
             "bool"   -> Json.Boolean(true),
             "null"   -> Json.Null,
-            "array"  -> Json.Array(Json.Number("1"), Json.Number("2")),
-            "nested" -> Json.Object("x" -> Json.Number("1"))
+            "array"  -> Json.Array(Json.Number(1), Json.Number(2)),
+            "nested" -> Json.Object("x" -> Json.Number(1))
           )
           val encoded = original.print
           val parsed  = Json.parse(encoded)
@@ -668,20 +664,20 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("equality and comparison")(
         test("object equality is order-independent") {
-          val obj1 = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))
-          val obj2 = Json.Object("b" -> Json.Number("2"), "a" -> Json.Number("1"))
+          val obj1 = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))
+          val obj2 = Json.Object("b" -> Json.Number(2), "a" -> Json.Number(1))
           assertTrue(obj1 == obj2, obj1.hashCode() == obj2.hashCode())
         },
         test("array equality is order-dependent") {
-          val arr1 = Json.Array(Json.Number("1"), Json.Number("2"))
-          val arr2 = Json.Array(Json.Number("2"), Json.Number("1"))
+          val arr1 = Json.Array(Json.Number(1), Json.Number(2))
+          val arr2 = Json.Array(Json.Number(2), Json.Number(1))
           assertTrue(arr1 != arr2)
         },
         test("compare orders by type then value") {
           assertTrue(
             Json.Null.compare(Json.Boolean(true)) < 0,
-            Json.Boolean(true).compare(Json.Number("1")) < 0,
-            Json.Number("1").compare(Json.String("a")) < 0,
+            Json.Boolean(true).compare(Json.Number(1)) < 0,
+            Json.Number(1).compare(Json.String("a")) < 0,
             Json.String("a").compare(Json.Array()) < 0,
             Json.Array().compare(Json.Object()) < 0
           )
@@ -696,7 +692,7 @@ object JsonSpec extends SchemaBaseSpec {
           )
         },
         test("toDynamicValue converts integers to Int when possible") {
-          val dv = Json.Number("42").toDynamicValue
+          val dv = Json.Number(42).toDynamicValue
           dv match {
             case DynamicValue.Primitive(pv: PrimitiveValue.Int) =>
               assertTrue(pv.value == 42)
@@ -720,13 +716,13 @@ object JsonSpec extends SchemaBaseSpec {
       suite("transformation methods")(
         test("transformUp applies function bottom-up") {
           val json = Json.Object(
-            "a" -> Json.Object("b" -> Json.Number("1")),
-            "c" -> Json.Number("2")
+            "a" -> Json.Object("b" -> Json.Number(1)),
+            "c" -> Json.Number(2)
           )
           // Double all numbers
           val transformed = json.transformUp { (_, j) =>
             j match {
-              case Json.Number(n) => Json.Number((BigDecimal(n) * 2).toString)
+              case Json.Number(n) => Json.Number(n * 2)
               case other          => other
             }
           }
@@ -736,7 +732,7 @@ object JsonSpec extends SchemaBaseSpec {
           )
         },
         test("transformDown applies function top-down") {
-          val json  = Json.Object("x" -> Json.Number("10"))
+          val json  = Json.Object("x" -> Json.Number(10))
           var order = Vector.empty[String]
           json.transformDown { (path, j) =>
             order = order :+ path.toString
@@ -746,7 +742,7 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(order.head == ".", order.contains(".x"))
         },
         test("transformKeys renames object keys") {
-          val json        = Json.Object("old_name" -> Json.Number("1"), "another_key" -> Json.Number("2"))
+          val json        = Json.Object("old_name" -> Json.Number(1), "another_key" -> Json.Number(2))
           val transformed = json.transformKeys { (_, key) =>
             key.replace("_", "-")
           }
@@ -759,45 +755,45 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("prune/retain methods")(
         test("retain keeps matching elements in arrays") {
-          val json     = Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"), Json.Number("4"))
+          val json     = Json.Array(Json.Number(1), Json.Number(2), Json.Number(3), Json.Number(4))
           val retained = json.retainBoth { (_, j) =>
             j match {
-              case Json.Number(n) => BigDecimal(n) > BigDecimal(2)
+              case Json.Number(n) => n > 2
               case _              => true
             }
           }
-          assertTrue(retained.elements == Chunk(Json.Number("3"), Json.Number("4")))
+          assertTrue(retained.elements == Chunk(Json.Number(3), Json.Number(4)))
         },
         test("retain keeps matching fields in objects") {
-          val json     = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"), "c" -> Json.Number("3"))
+          val json     = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2), "c" -> Json.Number(3))
           val retained = json.retainBoth { (_, j) =>
             j match {
-              case Json.Number(n) => BigDecimal(n) >= BigDecimal(2)
+              case Json.Number(n) => n >= 2
               case _              => true
             }
           }
           assertTrue(retained.get("a").isFailure, retained.get("b").isSuccess, retained.get("c").isSuccess)
         },
         test("prune removes matching elements") {
-          val json   = Json.Array(Json.Number("1"), Json.Null, Json.Number("2"), Json.Null)
+          val json   = Json.Array(Json.Number(1), Json.Null, Json.Number(2), Json.Null)
           val pruned = json.prune(j => j.is(JsonType.Null))
-          assertTrue(pruned.elements == Chunk(Json.Number("1"), Json.Number("2")))
+          assertTrue(pruned.elements == Chunk(Json.Number(1), Json.Number(2)))
         },
         test("partition splits by value predicate") {
-          val json          = Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"), Json.Number("4"))
+          val json          = Json.Array(Json.Number(1), Json.Number(2), Json.Number(3), Json.Number(4))
           val (evens, odds) = json.partition {
             case Json.Number(n) => n.toInt % 2 == 0
             case _              => false
           }
           assertTrue(
-            evens.elements == Chunk(Json.Number("2"), Json.Number("4")),
-            odds.elements == Chunk(Json.Number("1"), Json.Number("3"))
+            evens.elements == Chunk(Json.Number(2), Json.Number(4)),
+            odds.elements == Chunk(Json.Number(1), Json.Number(3))
           )
         },
         test("partitionPath splits by path predicate") {
           val json = Json.Object(
-            "keep" -> Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2")),
-            "drop" -> Json.Object("c" -> Json.Number("3"))
+            "keep" -> Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2)),
+            "drop" -> Json.Object("c" -> Json.Number(3))
           )
           val (kept, dropped) = json.partitionPath { path =>
             path.nodes.exists {
@@ -806,17 +802,17 @@ object JsonSpec extends SchemaBaseSpec {
             }
           }
           assertTrue(
-            kept.get("keep").get("a").one == Right(Json.Number("1")),
+            kept.get("keep").get("a").one == Right(Json.Number(1)),
             kept.get("drop").isFailure,
-            dropped.get("drop").get("c").one == Right(Json.Number("3")),
+            dropped.get("drop").get("c").one == Right(Json.Number(3)),
             dropped.get("keep").isFailure
           )
         },
         test("partitionBoth splits by path and value predicate") {
           val json = Json.Object(
-            "a" -> Json.Number("1"),
+            "a" -> Json.Number(1),
             "b" -> Json.String("x"),
-            "c" -> Json.Number("2")
+            "c" -> Json.Number(2)
           )
           val (matching, nonMatching) = json.partitionBoth { (path, j) =>
             path.nodes.lastOption.exists {
@@ -825,8 +821,8 @@ object JsonSpec extends SchemaBaseSpec {
             } && j.is(JsonType.Number)
           }
           assertTrue(
-            matching.get("a").one == Right(Json.Number("1")),
-            matching.get("c").one == Right(Json.Number("2")),
+            matching.get("a").one == Right(Json.Number(1)),
+            matching.get("c").one == Right(Json.Number(2)),
             matching.get("b").isFailure,
             nonMatching.get("b").one == Right(Json.String("x")),
             nonMatching.get("a").isFailure
@@ -836,7 +832,7 @@ object JsonSpec extends SchemaBaseSpec {
           val json = Json.Object(
             "user" -> Json.Object(
               "name"  -> Json.String("Alice"),
-              "age"   -> Json.Number("30"),
+              "age"   -> Json.Number(30),
               "email" -> Json.String("alice@example.com")
             ),
             "extra" -> Json.String("ignored")
@@ -855,20 +851,20 @@ object JsonSpec extends SchemaBaseSpec {
       suite("folding methods")(
         test("foldUp accumulates bottom-up") {
           val json = Json.Object(
-            "a" -> Json.Number("1"),
-            "b" -> Json.Object("c" -> Json.Number("2"), "d" -> Json.Number("3"))
+            "a" -> Json.Number(1),
+            "b" -> Json.Object("c" -> Json.Number(2), "d" -> Json.Number(3))
           )
           // Sum all numbers
           val sum = json.foldUp(BigDecimal(0)) { (_, j, acc) =>
             j match {
-              case Json.Number(n) => acc + BigDecimal(n)
+              case Json.Number(n) => acc + n
               case _              => acc
             }
           }
           assertTrue(sum == BigDecimal(6))
         },
         test("foldDown accumulates top-down") {
-          val json = Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
+          val json = Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
           // Collect paths in order
           val paths = json.foldDown(Vector.empty[String]) { (path, _, acc) =>
             acc :+ path.toString
@@ -877,10 +873,10 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(paths.head == ".", paths.length == 4) // root + 3 elements
         },
         test("foldUpOrFail stops on error") {
-          val json   = Json.Array(Json.Number("1"), Json.String("oops"), Json.Number("3"))
+          val json   = Json.Array(Json.Number(1), Json.String("oops"), Json.Number(3))
           val result = json.foldUpOrFail(BigDecimal(0)) { (_, j, acc) =>
             j match {
-              case Json.Number(n) => Right(acc + BigDecimal(n))
+              case Json.Number(n) => Right(acc + n)
               case Json.String(_) => Left(SchemaError("Found a string!"))
               case _              => Right(acc)
             }
@@ -888,7 +884,7 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(result.isLeft)
         },
         test("foldDownOrFail stops on error") {
-          val json   = Json.Object("a" -> Json.Number("1"), "b" -> Json.String("error"))
+          val json   = Json.Object("a" -> Json.Number(1), "b" -> Json.String("error"))
           val result = json.foldDownOrFail(0) { (_, j, acc) =>
             j match {
               case Json.String(s) if s == "error" => Left(SchemaError("Found error"))
@@ -914,22 +910,22 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(activeUsers.size == 2)
         },
         test("query returns empty selection when nothing matches") {
-          val json   = Json.Object("a" -> Json.Number("1"))
+          val json   = Json.Object("a" -> Json.Number(1))
           val result = json.select.query(JsonType.String)
           assertTrue(result.isEmpty)
         },
         test("toKV converts to path-value pairs") {
           val json = Json.Object(
-            "a" -> Json.Number("1"),
-            "b" -> Json.Object("c" -> Json.Number("2"))
+            "a" -> Json.Number(1),
+            "b" -> Json.Object("c" -> Json.Number(2))
           )
           val kvs = json.toKV
-          assertTrue(kvs.length == 2, kvs.exists(_._2 == Json.Number("1")), kvs.exists(_._2 == Json.Number("2")))
+          assertTrue(kvs.length == 2, kvs.exists(_._2 == Json.Number(1)), kvs.exists(_._2 == Json.Number(2)))
         },
         test("fromKV reconstructs JSON from path-value pairs") {
           val json = Json.Object(
-            "a" -> Json.Number("1"),
-            "b" -> Json.Object("c" -> Json.Number("2"))
+            "a" -> Json.Number(1),
+            "b" -> Json.Object("c" -> Json.Number(2))
           )
           val kvs           = json.toKV
           val reconstructed = Json.fromKV(kvs)
@@ -944,9 +940,9 @@ object JsonSpec extends SchemaBaseSpec {
         test("from creates Json from encodable value") {
           assertTrue(
             Json.from("hello") == Json.String("hello"),
-            Json.from(42) == Json.Number("42"),
+            Json.from(42) == Json.Number(42),
             Json.from(true) == Json.Boolean(true),
-            Json.from(Vector(1, 2, 3)) == Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
+            Json.from(Vector(1, 2, 3)) == Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
           )
         }
       )
@@ -956,8 +952,8 @@ object JsonSpec extends SchemaBaseSpec {
         val json = Json.Object(
           "data" -> Json.Object(
             "users" -> Json.Array(
-              Json.Object("name" -> Json.String("Alice"), "age" -> Json.Number("30")),
-              Json.Object("name" -> Json.String("Bob"), "age"   -> Json.Number("25"))
+              Json.Object("name" -> Json.String("Alice"), "age" -> Json.Number(30)),
+              Json.Object("name" -> Json.String("Bob"), "age"   -> Json.Number(25))
             )
           )
         )
@@ -987,47 +983,47 @@ object JsonSpec extends SchemaBaseSpec {
         )
       },
       test("++ combines selections") {
-        val sel1     = JsonSelection.succeed(Json.Number("1"))
-        val sel2     = JsonSelection.succeed(Json.Number("2"))
+        val sel1     = JsonSelection.succeed(Json.Number(1))
+        val sel2     = JsonSelection.succeed(Json.Number(2))
         val combined = sel1 ++ sel2
-        assertTrue(combined.either == Right(Vector(Json.Number("1"), Json.Number("2"))))
+        assertTrue(combined.either == Right(Vector(Json.Number(1), Json.Number(2))))
       },
       test("++ propagates errors") {
         val sel1      = JsonSelection.fail(SchemaError("error"))
-        val sel2      = JsonSelection.succeed(Json.Number("2"))
+        val sel2      = JsonSelection.succeed(Json.Number(2))
         val combined1 = sel1 ++ sel2
         val combined2 = sel2 ++ sel1
         assertTrue(combined1.isFailure, combined2.isFailure)
       },
       test("size operations") {
         val empty    = JsonSelection.empty
-        val single   = JsonSelection.succeed(Json.Number("1"))
-        val multiple = JsonSelection.succeedMany(Vector(Json.Number("1"), Json.Number("2"), Json.Number("3")))
+        val single   = JsonSelection.succeed(Json.Number(1))
+        val multiple = JsonSelection.succeedMany(Vector(Json.Number(1), Json.Number(2), Json.Number(3)))
         assertTrue(empty.isEmpty, empty.size == 0, single.nonEmpty, single.size == 1, multiple.size == 3)
       },
       test("all returns single value or wraps multiple in array") {
-        val single   = JsonSelection.succeed(Json.Number("1"))
-        val multiple = JsonSelection.succeedMany(Vector(Json.Number("1"), Json.Number("2")))
+        val single   = JsonSelection.succeed(Json.Number(1))
+        val multiple = JsonSelection.succeedMany(Vector(Json.Number(1), Json.Number(2)))
         assertTrue(
-          single.all == Right(Json.Number("1")),
-          multiple.all == Right(Json.Array(Json.Number("1"), Json.Number("2")))
+          single.all == Right(Json.Number(1)),
+          multiple.all == Right(Json.Array(Json.Number(1), Json.Number(2)))
         )
       },
       test("any returns first value") {
-        val multiple = JsonSelection.succeedMany(Vector(Json.Number("1"), Json.Number("2"), Json.Number("3")))
-        assertTrue(multiple.any == Right(Json.Number("1")))
+        val multiple = JsonSelection.succeedMany(Vector(Json.Number(1), Json.Number(2), Json.Number(3)))
+        assertTrue(multiple.any == Right(Json.Number(1)))
       },
       test("toArray wraps values in array") {
-        val selection = JsonSelection.succeedMany(Vector(Json.Number("1"), Json.Number("2")))
-        assertTrue(selection.toArray == Right(Json.Array(Json.Number("1"), Json.Number("2"))))
+        val selection = JsonSelection.succeedMany(Vector(Json.Number(1), Json.Number(2)))
+        assertTrue(selection.toArray == Right(Json.Array(Json.Number(1), Json.Number(2))))
       },
       test("objects/arrays filters by type") {
         val mixed = JsonSelection.succeedMany(
           Vector(
-            Json.Object("a" -> Json.Number("1")),
-            Json.Array(Json.Number("1")),
+            Json.Object("a" -> Json.Number(1)),
+            Json.Array(Json.Number(1)),
             Json.String("hello"),
-            Json.Object("b" -> Json.Number("2"))
+            Json.Object("b" -> Json.Number(2))
           )
         )
         assertTrue(mixed.objects.size == 2, mixed.arrays.size == 1)
@@ -1036,7 +1032,7 @@ object JsonSpec extends SchemaBaseSpec {
         val mixed = JsonSelection.succeedMany(
           Vector(
             Json.String("hello"),
-            Json.Number("42"),
+            Json.Number(42),
             Json.Boolean(true),
             Json.String("world")
           )
@@ -1048,7 +1044,7 @@ object JsonSpec extends SchemaBaseSpec {
       test("decode primitives") {
         assertTrue(
           Json.String("hello").as[String] == Right("hello"),
-          Json.Number("42").as[Int] == Right(42),
+          Json.Number(42).as[Int] == Right(42),
           Json.Boolean(true).as[Boolean] == Right(true)
         )
       },
@@ -1059,11 +1055,11 @@ object JsonSpec extends SchemaBaseSpec {
         )
       },
       test("decode Vector") {
-        val json = Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
+        val json = Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
         assertTrue(json.as[Vector[Int]] == Right(Vector(1, 2, 3)))
       },
       test("decode Map") {
-        val json = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))
+        val json = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))
         assertTrue(json.as[Map[String, Int]] == Right(Map("a" -> 1, "b" -> 2)))
       }
     ),
@@ -1071,7 +1067,7 @@ object JsonSpec extends SchemaBaseSpec {
       test("encode primitives") {
         assertTrue(
           JsonEncoder[String].encode("hello") == Json.String("hello"),
-          JsonEncoder[Int].encode(42) == Json.Number("42"),
+          JsonEncoder[Int].encode(42) == Json.Number(42),
           JsonEncoder[Boolean].encode(true) == Json.Boolean(true)
         )
       },
@@ -1084,7 +1080,7 @@ object JsonSpec extends SchemaBaseSpec {
       test("encode Vector") {
         assertTrue(
           JsonEncoder[Vector[Int]]
-            .encode(Vector(1, 2, 3)) == Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
+            .encode(Vector(1, 2, 3)) == Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
         )
       },
       test("encode Map") {
@@ -1099,8 +1095,8 @@ object JsonSpec extends SchemaBaseSpec {
     suite("additional coverage")(
       suite("merge strategies")(
         test("merge with Auto strategy merges objects deeply") {
-          val left   = Json.Object("a" -> Json.Object("x" -> Json.Number("1"), "y" -> Json.Number("2")))
-          val right  = Json.Object("a" -> Json.Object("y" -> Json.Number("3"), "z" -> Json.Number("4")))
+          val left   = Json.Object("a" -> Json.Object("x" -> Json.Number(1), "y" -> Json.Number(2)))
+          val right  = Json.Object("a" -> Json.Object("y" -> Json.Number(3), "z" -> Json.Number(4)))
           val merged = left.merge(right, MergeStrategy.Auto)
           assertTrue(
             merged.get("a").get("x").as[BigDecimal] == Right(BigDecimal(1)),
@@ -1109,8 +1105,8 @@ object JsonSpec extends SchemaBaseSpec {
           )
         },
         test("merge with Shallow strategy replaces nested objects") {
-          val left   = Json.Object("a" -> Json.Object("x" -> Json.Number("1"), "y" -> Json.Number("2")))
-          val right  = Json.Object("a" -> Json.Object("z" -> Json.Number("3")))
+          val left   = Json.Object("a" -> Json.Object("x" -> Json.Number(1), "y" -> Json.Number(2)))
+          val right  = Json.Object("a" -> Json.Object("z" -> Json.Number(3)))
           val merged = left.merge(right, MergeStrategy.Shallow)
           assertTrue(
             merged.get("a").get("x").isFailure,
@@ -1118,13 +1114,13 @@ object JsonSpec extends SchemaBaseSpec {
           )
         },
         test("merge with Concat strategy concatenates arrays") {
-          val left   = Json.Array(Json.Number("1"), Json.Number("2"))
-          val right  = Json.Array(Json.Number("3"), Json.Number("4"))
+          val left   = Json.Array(Json.Number(1), Json.Number(2))
+          val right  = Json.Array(Json.Number(3), Json.Number(4))
           val merged = left.merge(right, MergeStrategy.Concat)
-          assertTrue(merged.elements == Chunk(Json.Number("1"), Json.Number("2"), Json.Number("3"), Json.Number("4")))
+          assertTrue(merged.elements == Chunk(Json.Number(1), Json.Number(2), Json.Number(3), Json.Number(4)))
         },
         test("merge non-matching types replaces with right") {
-          val left   = Json.Number("1")
+          val left   = Json.Number(1)
           val right  = Json.String("hello")
           val merged = left.merge(right)
           assertTrue(merged == right)
@@ -1147,7 +1143,7 @@ object JsonSpec extends SchemaBaseSpec {
       suite("normalization")(
         test("normalize applies sortKeys, dropNulls, and dropEmpty") {
           val json = Json.Object(
-            "z" -> Json.Number("1"),
+            "z" -> Json.Number(1),
             "a" -> Json.Null,
             "m" -> Json.Object(),
             "b" -> Json.Array()
@@ -1159,9 +1155,9 @@ object JsonSpec extends SchemaBaseSpec {
           )
         },
         test("dropNulls works on arrays") {
-          val json    = Json.Array(Json.Number("1"), Json.Null, Json.Number("2"), Json.Null)
+          val json    = Json.Array(Json.Number(1), Json.Null, Json.Number(2), Json.Null)
           val dropped = json.dropNulls
-          assertTrue(dropped.elements == Chunk(Json.Number("1"), Json.Number("2")))
+          assertTrue(dropped.elements == Chunk(Json.Number(1), Json.Number(2)))
         },
         test("dropEmpty works recursively") {
           val json = Json.Object(
@@ -1173,24 +1169,24 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("DynamicOptic advanced operations")(
         test("get with mapValues returns all object values") {
-          val json      = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"), "c" -> Json.Number("3"))
+          val json      = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2), "c" -> Json.Number(3))
           val path      = DynamicOptic.mapValues
           val selection = json.get(path)
           assertTrue(
-            selection.either.toOption.get.toSet == Set[Json](Json.Number("1"), Json.Number("2"), Json.Number("3"))
+            selection.either.toOption.get.toSet == Set[Json](Json.Number(1), Json.Number(2), Json.Number(3))
           )
         },
         test("get with mapKeys returns all object keys as strings") {
-          val json      = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))
+          val json      = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))
           val path      = DynamicOptic.mapKeys
           val selection = json.get(path)
           assertTrue(selection.either.toOption.get.toSet == Set[Json](Json.String("a"), Json.String("b")))
         },
         test("modify with mapValues transforms all values") {
-          val json    = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))
+          val json    = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))
           val path    = DynamicOptic.mapValues
           val updated = json.modify(path) {
-            case Json.Number(n) => Json.Number((BigDecimal(n) * 10).toString)
+            case Json.Number(n) => Json.Number(n * 10)
             case other          => other
           }
           assertTrue(
@@ -1205,17 +1201,17 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(selection.either == Right(Vector(Json.String("a"), Json.String("c"))))
         },
         test("modify with atIndices transforms specific elements") {
-          val arr     = Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"), Json.Number("4"))
+          val arr     = Json.Array(Json.Number(1), Json.Number(2), Json.Number(3), Json.Number(4))
           val path    = DynamicOptic.root.atIndices(1, 3)
           val updated = arr.modify(path) {
-            case Json.Number(n) => Json.Number((BigDecimal(n) * 10).toString)
+            case Json.Number(n) => Json.Number(n * 10)
             case other          => other
           }
           assertTrue(
-            updated.get(0).one == Right(Json.Number("1")),
-            updated.get(1).one == Right(Json.Number("20")),
-            updated.get(2).one == Right(Json.Number("3")),
-            updated.get(3).one == Right(Json.Number("40"))
+            updated.get(0).one == Right(Json.Number(1)),
+            updated.get(1).one == Right(Json.Number(20)),
+            updated.get(2).one == Right(Json.Number(3)),
+            updated.get(3).one == Right(Json.Number(40))
           )
         }
       ),
@@ -1232,8 +1228,8 @@ object JsonSpec extends SchemaBaseSpec {
         },
         test("fromKVUnsafe works correctly") {
           val kvs = Seq(
-            (DynamicOptic.root.field("a"), Json.Number("1")),
-            (DynamicOptic.root.field("b").field("c"), Json.Number("2"))
+            (DynamicOptic.root.field("a"), Json.Number(1)),
+            (DynamicOptic.root.field("b").field("c"), Json.Number(2))
           )
           val json = Json.fromKVUnsafe(kvs)
           assertTrue(
@@ -1531,34 +1527,34 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(empty.one.isLeft)
         },
         test("one returns error for multiple values") {
-          val multiple = JsonSelection.succeedMany(Vector(Json.Number("1"), Json.Number("2")))
+          val multiple = JsonSelection.succeedMany(Vector(Json.Number(1), Json.Number(2)))
           assertTrue(multiple.one.isLeft)
         },
         test("one returns value for single element") {
-          val single = JsonSelection.succeed(Json.Number("42"))
-          assertTrue(single.one == Right(Json.Number("42")))
+          val single = JsonSelection.succeed(Json.Number(42))
+          assertTrue(single.one == Right(Json.Number(42)))
         },
         test("collect extracts matching values") {
-          val selection = JsonSelection.succeedMany(Vector(Json.Number("1"), Json.String("a"), Json.Number("2")))
+          val selection = JsonSelection.succeedMany(Vector(Json.Number(1), Json.String("a"), Json.Number(2)))
           val numbers   = selection.collect { case Json.Number(n) => n }
-          assertTrue(numbers == Right(Vector("1", "2")))
+          assertTrue(numbers == Right(Vector(BigDecimal(1), BigDecimal(2))))
         },
         test("orElse returns alternative on failure") {
           val failed   = JsonSelection.fail(SchemaError("error"))
-          val fallback = JsonSelection.succeed(Json.Number("42"))
+          val fallback = JsonSelection.succeed(Json.Number(42))
           val result   = failed.orElse(fallback)
-          assertTrue(result.one == Right(Json.Number("42")))
+          assertTrue(result.one == Right(Json.Number(42)))
         },
         test("orElse returns original on success") {
-          val success  = JsonSelection.succeed(Json.Number("1"))
-          val fallback = JsonSelection.succeed(Json.Number("2"))
+          val success  = JsonSelection.succeed(Json.Number(1))
+          val fallback = JsonSelection.succeed(Json.Number(2))
           val result   = success.orElse(fallback)
-          assertTrue(result.one == Right(Json.Number("1")))
+          assertTrue(result.one == Right(Json.Number(1)))
         },
         test("getOrElse returns values on success") {
-          val selection = JsonSelection.succeedMany(Vector(Json.Number("1"), Json.Number("2")))
+          val selection = JsonSelection.succeedMany(Vector(Json.Number(1), Json.Number(2)))
           val result    = selection.getOrElse(Vector(Json.Null))
-          assertTrue(result == Vector(Json.Number("1"), Json.Number("2")))
+          assertTrue(result == Vector(Json.Number(1), Json.Number(2)))
         },
         test("getOrElse returns default on failure") {
           val failed = JsonSelection.fail(SchemaError("error"))
@@ -1566,12 +1562,12 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(result == Vector(Json.Null))
         },
         test("map transforms all values") {
-          val selection = JsonSelection.succeedMany(Vector(Json.Number("1"), Json.Number("2")))
+          val selection = JsonSelection.succeedMany(Vector(Json.Number(1), Json.Number(2)))
           val mapped    = selection.map {
-            case Json.Number(n) => Json.Number((BigDecimal(n) * 2).toString)
+            case Json.Number(n) => Json.Number(n * 2)
             case other          => other
           }
-          assertTrue(mapped.either == Right(Vector(Json.Number("2"), Json.Number("4"))))
+          assertTrue(mapped.either == Right(Vector(Json.Number(2), Json.Number(4))))
         },
         test("flatMap chains selections") {
           val json = Json.Object(
@@ -1586,23 +1582,23 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(names.size == 2)
         },
         test("filter keeps matching values") {
-          val selection = JsonSelection.succeedMany(Vector(Json.Number("1"), Json.Number("2"), Json.Number("3")))
+          val selection = JsonSelection.succeedMany(Vector(Json.Number(1), Json.Number(2), Json.Number(3)))
           val filtered  = selection.filter {
-            case Json.Number(n) => BigDecimal(n) > BigDecimal(1)
+            case Json.Number(n) => n > 1
             case _              => false
           }
-          assertTrue(filtered.either == Right(Vector(Json.Number("2"), Json.Number("3"))))
+          assertTrue(filtered.either == Right(Vector(Json.Number(2), Json.Number(3))))
         },
         test("as decodes single value") {
-          val selection = JsonSelection.succeed(Json.Number("42"))
+          val selection = JsonSelection.succeed(Json.Number(42))
           assertTrue(selection.as[Int] == Right(42))
         },
         test("asAll decodes all values") {
-          val selection = JsonSelection.succeedMany(Vector(Json.Number("1"), Json.Number("2"), Json.Number("3")))
+          val selection = JsonSelection.succeedMany(Vector(Json.Number(1), Json.Number(2), Json.Number(3)))
           assertTrue(selection.asAll[Int] == Right(Vector(1, 2, 3)))
         },
         test("nulls filters to only nulls") {
-          val selection = JsonSelection.succeedMany(Vector(Json.Null, Json.Number("1"), Json.Null))
+          val selection = JsonSelection.succeedMany(Vector(Json.Null, Json.Number(1), Json.Null))
           assertTrue(selection.nulls.size == 2)
         },
         test("one fails on empty selection") {
@@ -1618,11 +1614,11 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(failed.error.isDefined, failed.error.get.message == "test error")
         },
         test("error returns None on success") {
-          val success = JsonSelection.succeed(Json.Number("1"))
+          val success = JsonSelection.succeed(Json.Number(1))
           assertTrue(success.error.isEmpty)
         },
         test("values returns Some on success") {
-          val success = JsonSelection.succeed(Json.Number("1"))
+          val success = JsonSelection.succeed(Json.Number(1))
           assertTrue(success.values.isDefined)
         },
         test("values returns None on failure") {
@@ -1630,8 +1626,8 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(failed.values.isEmpty)
         },
         test("any.toOption returns first value") {
-          val selection = JsonSelection.succeedMany(Vector(Json.Number("1"), Json.Number("2")))
-          assertTrue(selection.any.toOption.contains(Json.Number("1")))
+          val selection = JsonSelection.succeedMany(Vector(Json.Number(1), Json.Number(2)))
+          assertTrue(selection.any.toOption.contains(Json.Number(1)))
         },
         test("any.toOption returns None for empty") {
           val empty = JsonSelection.empty
@@ -1642,7 +1638,7 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(failed.toVector.isEmpty)
         },
         test("numbers/booleans/nulls type filtering") {
-          val numSel  = JsonSelection.succeed(Json.Number("42"))
+          val numSel  = JsonSelection.succeed(Json.Number(42))
           val boolSel = JsonSelection.succeed(Json.Boolean(true))
           val nullSel = JsonSelection.succeed(Json.Null)
           assertTrue(
@@ -1657,10 +1653,10 @@ object JsonSpec extends SchemaBaseSpec {
         test("query with predicate finds all matching values recursively") {
           val json = Json.Object(
             "name"  -> Json.String("Alice"),
-            "age"   -> Json.Number("30"),
+            "age"   -> Json.Number(30),
             "items" -> Json.Array(
               Json.String("apple"),
-              Json.Number("42"),
+              Json.Number(42),
               Json.String("banana")
             )
           )
@@ -1674,25 +1670,25 @@ object JsonSpec extends SchemaBaseSpec {
         },
         test("query with value predicate finds matching values") {
           val json = Json.Array(
-            Json.Number("1"),
-            Json.Number("10"),
-            Json.Number("5"),
-            Json.Number("20")
+            Json.Number(1),
+            Json.Number(10),
+            Json.Number(5),
+            Json.Number(20)
           )
           val largeNumbers = json.select.query { j =>
             j.unwrap(JsonType.Number).exists(_ > 5)
           }.toVector
           assertTrue(
             largeNumbers.length == 2,
-            largeNumbers.contains(Json.Number("10")),
-            largeNumbers.contains(Json.Number("20"))
+            largeNumbers.contains(Json.Number(10)),
+            largeNumbers.contains(Json.Number(20))
           )
         },
         test("queryPath finds values at paths matching predicate") {
           val json = Json.Object(
             "user" -> Json.Object(
               "name" -> Json.String("Alice"),
-              "age"  -> Json.Number("30")
+              "age"  -> Json.Number(30)
             ),
             "metadata" -> Json.Object(
               "created" -> Json.String("2024-01-01")
@@ -1723,9 +1719,9 @@ object JsonSpec extends SchemaBaseSpec {
         test("queryBoth finds values matching both path and value predicates") {
           val json = Json.Object(
             "numbers" -> Json.Array(
-              Json.Number("1"),
-              Json.Number("100"),
-              Json.Number("5")
+              Json.Number(1),
+              Json.Number(100),
+              Json.Number(5)
             ),
             "strings" -> Json.Array(
               Json.String("a"),
@@ -1740,10 +1736,10 @@ object JsonSpec extends SchemaBaseSpec {
             val isLargeNumber = value.unwrap(JsonType.Number).exists(_ > 10)
             inNumbersField && isLargeNumber
           }.toVector
-          assertTrue(largeNumbersInNumbersField == Vector(Json.Number("100")))
+          assertTrue(largeNumbersInNumbersField == Vector(Json.Number(100)))
         },
         test("queryBoth returns empty when no matches") {
-          val json    = Json.Object("a" -> Json.Number("1"))
+          val json    = Json.Object("a" -> Json.Number(1))
           val results = json.select.queryBoth { (_, value) =>
             value.is(JsonType.String)
           }.toVector
@@ -1764,7 +1760,7 @@ object JsonSpec extends SchemaBaseSpec {
             )
           )
           val json = Json.fromDynamicValue(dv)
-          assertTrue(json.elements == Chunk(Json.Number("1"), Json.Number("2")))
+          assertTrue(json.elements == Chunk(Json.Number(1), Json.Number(2)))
         },
         test("fromDynamicValue handles Map with string keys") {
           val dv = DynamicValue.Map(
@@ -1801,7 +1797,7 @@ object JsonSpec extends SchemaBaseSpec {
           }
         },
         test("toDynamicValue converts BigDecimal for decimals") {
-          val json = Json.Number("123.456")
+          val json = Json.Number(123.456)
           val dv   = json.toDynamicValue
           dv match {
             case DynamicValue.Primitive(pv: PrimitiveValue.BigDecimal) =>
@@ -1810,7 +1806,7 @@ object JsonSpec extends SchemaBaseSpec {
           }
         },
         test("toDynamicValue converts arrays") {
-          val json = Json.Array(Json.Number("1"), Json.Number("2"))
+          val json = Json.Array(Json.Number(1), Json.Number(2))
           val dv   = json.toDynamicValue
           dv match {
             case DynamicValue.Sequence(elems) =>
@@ -1819,7 +1815,7 @@ object JsonSpec extends SchemaBaseSpec {
           }
         },
         test("toDynamicValue converts objects") {
-          val json = Json.Object("a" -> Json.Number("1"))
+          val json = Json.Object("a" -> Json.Number(1))
           val dv   = json.toDynamicValue
           dv match {
             case DynamicValue.Record(fields) =>
@@ -1850,22 +1846,22 @@ object JsonSpec extends SchemaBaseSpec {
       suite("comparison edge cases")(
         test("compare same type values") {
           assertTrue(
-            Json.Number("1").compare(Json.Number("2")) < 0,
-            Json.Number("2").compare(Json.Number("1")) > 0,
-            Json.Number("1").compare(Json.Number("1")) == 0,
+            Json.Number(1).compare(Json.Number(2)) < 0,
+            Json.Number(2).compare(Json.Number(1)) > 0,
+            Json.Number(1).compare(Json.Number(1)) == 0,
             Json.String("a").compare(Json.String("b")) < 0,
             Json.Boolean(false).compare(Json.Boolean(true)) < 0
           )
         },
         test("compare arrays element by element") {
           assertTrue(
-            Json.Array(Json.Number("1")).compare(Json.Array(Json.Number("2"))) < 0,
-            Json.Array(Json.Number("1"), Json.Number("2")).compare(Json.Array(Json.Number("1"))) > 0
+            Json.Array(Json.Number(1)).compare(Json.Array(Json.Number(2))) < 0,
+            Json.Array(Json.Number(1), Json.Number(2)).compare(Json.Array(Json.Number(1))) > 0
           )
         },
         test("compare objects by sorted keys") {
-          val obj1 = Json.Object("a" -> Json.Number("1"))
-          val obj2 = Json.Object("b" -> Json.Number("1"))
+          val obj1 = Json.Object("a" -> Json.Number(1))
+          val obj2 = Json.Object("b" -> Json.Number(1))
           assertTrue(obj1.compare(obj2) < 0)
         }
       ),
@@ -1875,9 +1871,8 @@ object JsonSpec extends SchemaBaseSpec {
         },
         test("Json.Number with different representations") {
           assertTrue(
-            Json.Number("42") == Json.Number("42"),
-            Json.Number("42") == Json.Number("42"),
-            Json.Number("3.14") == Json.Number("3.14")
+            Json.Number(42) == Json.Number(42),
+            Json.Number(3.14) == Json.Number(3.14)
           )
         },
         test("Object.empty and Array.empty") {
@@ -1891,7 +1886,7 @@ object JsonSpec extends SchemaBaseSpec {
         test("transformKeys works on nested structures") {
           val json = Json.Object(
             "outer_key" -> Json.Object(
-              "inner_key" -> Json.Number("1")
+              "inner_key" -> Json.Number(1)
             )
           )
           val transformed = json.transformKeys((_, k) => k.toUpperCase)
@@ -1902,8 +1897,8 @@ object JsonSpec extends SchemaBaseSpec {
         },
         test("transformKeys works on arrays containing objects") {
           val arr = Json.Array(
-            Json.Object("snake_case"  -> Json.Number("1")),
-            Json.Object("another_key" -> Json.Number("2"))
+            Json.Object("snake_case"  -> Json.Number(1)),
+            Json.Object("another_key" -> Json.Number(2))
           )
           val transformed = arr.transformKeys((_, k) => k.replace("_", "-"))
           assertTrue(
@@ -1914,12 +1909,12 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("retain/prune/partition edge cases")(
         test("retain on primitives returns unchanged") {
-          val json     = Json.Number("42")
+          val json     = Json.Number(42)
           val retained = json.retainBoth((_, _) => true)
           assertTrue(retained == json)
         },
         test("prune on primitives returns unchanged") {
-          val json   = Json.Number("42")
+          val json   = Json.Number(42)
           val pruned = json.pruneBoth((_, _) => false)
           assertTrue(pruned == json)
         },
@@ -1931,12 +1926,12 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("project edge cases")(
         test("project with empty paths returns Null") {
-          val json      = Json.Object("a" -> Json.Number("1"))
+          val json      = Json.Object("a" -> Json.Number(1))
           val projected = json.project()
           assertTrue(projected == Json.Null)
         },
         test("project with non-existent paths") {
-          val json      = Json.Object("a" -> Json.Number("1"))
+          val json      = Json.Object("a" -> Json.Number(1))
           val path      = DynamicOptic.root.field("nonexistent")
           val projected = json.project(path)
           assertTrue(projected == Json.Null)
@@ -1944,22 +1939,22 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("AtMapKey operations")(
         test("get with atKey retrieves value by key") {
-          val json   = Json.Object("alice" -> Json.Number("1"), "bob" -> Json.Number("2"))
+          val json   = Json.Object("alice" -> Json.Number(1), "bob" -> Json.Number(2))
           val path   = DynamicOptic.root.atKey("alice")(Schema.string)
           val result = json.get(path)
-          assertTrue(result.one == Right(Json.Number("1")))
+          assertTrue(result.one == Right(Json.Number(1)))
         },
         test("get with atKey returns empty for missing key") {
-          val json   = Json.Object("alice" -> Json.Number("1"))
+          val json   = Json.Object("alice" -> Json.Number(1))
           val path   = DynamicOptic.root.atKey("missing")(Schema.string)
           val result = json.get(path)
           assertTrue(result.toVector.isEmpty)
         },
         test("modify with atKey updates value at key") {
-          val json    = Json.Object("alice" -> Json.Number("1"), "bob" -> Json.Number("2"))
+          val json    = Json.Object("alice" -> Json.Number(1), "bob" -> Json.Number(2))
           val path    = DynamicOptic.root.atKey("alice")(Schema.string)
           val updated = json.modify(path) {
-            case Json.Number(n) => Json.Number((BigDecimal(n) * 10).toString)
+            case Json.Number(n) => Json.Number(n * 10)
             case other          => other
           }
           assertTrue(
@@ -1968,30 +1963,30 @@ object JsonSpec extends SchemaBaseSpec {
           )
         },
         test("modify with atKey does nothing for missing key") {
-          val json    = Json.Object("alice" -> Json.Number("1"))
+          val json    = Json.Object("alice" -> Json.Number(1))
           val path    = DynamicOptic.root.atKey("missing")(Schema.string)
-          val updated = json.modify(path)(_ => Json.Number("99"))
+          val updated = json.modify(path)(_ => Json.Number(99))
           assertTrue(updated == json)
         }
       ),
       suite("AtMapKeys operations")(
         test("get with atKeys retrieves multiple values") {
-          val json   = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"), "c" -> Json.Number("3"))
+          val json   = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2), "c" -> Json.Number(3))
           val path   = DynamicOptic.root.atKeys("a", "c")(Schema.string)
           val result = json.get(path)
-          assertTrue(result.either == Right(Vector(Json.Number("1"), Json.Number("3"))))
+          assertTrue(result.either == Right(Vector(Json.Number(1), Json.Number(3))))
         },
         test("get with atKeys returns only existing keys") {
-          val json   = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))
+          val json   = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))
           val path   = DynamicOptic.root.atKeys("a", "missing", "b")(Schema.string)
           val result = json.get(path)
-          assertTrue(result.either == Right(Vector(Json.Number("1"), Json.Number("2"))))
+          assertTrue(result.either == Right(Vector(Json.Number(1), Json.Number(2))))
         },
         test("modify with atKeys updates multiple values") {
-          val json    = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"), "c" -> Json.Number("3"))
+          val json    = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2), "c" -> Json.Number(3))
           val path    = DynamicOptic.root.atKeys("a", "c")(Schema.string)
           val updated = json.modify(path) {
-            case Json.Number(n) => Json.Number((BigDecimal(n) * 10).toString)
+            case Json.Number(n) => Json.Number(n * 10)
             case other          => other
           }
           assertTrue(
@@ -2001,7 +1996,7 @@ object JsonSpec extends SchemaBaseSpec {
           )
         },
         test("get with atKeys on non-object returns empty") {
-          val json   = Json.Array(Json.Number("1"), Json.Number("2"))
+          val json   = Json.Array(Json.Number(1), Json.Number(2))
           val path   = DynamicOptic.root.atKeys("a")(Schema.string)
           val result = json.get(path)
           assertTrue(result.toVector.isEmpty)
@@ -2009,20 +2004,20 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("Elements delete operations")(
         test("delete with elements removes all array elements") {
-          val json    = Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
+          val json    = Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
           val path    = DynamicOptic.elements
           val deleted = json.delete(path)
           assertTrue(deleted == Json.Array())
         },
         test("delete with elements on non-array returns unchanged") {
-          val json    = Json.Object("a" -> Json.Number("1"))
+          val json    = Json.Object("a" -> Json.Number(1))
           val path    = DynamicOptic.elements
           val deleted = json.delete(path)
           assertTrue(deleted == json)
         },
         test("delete nested elements through field path") {
           val json = Json.Object(
-            "items" -> Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
+            "items" -> Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
           )
           val path    = DynamicOptic.root.field("items").elements
           val deleted = json.delete(path)
@@ -2034,7 +2029,7 @@ object JsonSpec extends SchemaBaseSpec {
           val json = Json.Object(
             "user" -> Json.Object(
               "name" -> Json.String("Alice"),
-              "age"  -> Json.Number("30")
+              "age"  -> Json.Number(30)
             )
           )
           val path    = DynamicOptic.root.field("user").field("name")
@@ -2046,20 +2041,20 @@ object JsonSpec extends SchemaBaseSpec {
         },
         test("delete nested element through array path") {
           val json = Json.Object(
-            "items" -> Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
+            "items" -> Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
           )
           val path    = DynamicOptic.root.field("items").at(1)
           val deleted = json.delete(path)
           assertTrue(
-            deleted.get("items").toVector == Vector(Json.Array(Json.Number("1"), Json.Number("3")))
+            deleted.get("items").toVector == Vector(Json.Array(Json.Number(1), Json.Number(3)))
           )
         },
         test("delete deeply nested field") {
           val json = Json.Object(
             "a" -> Json.Object(
               "b" -> Json.Object(
-                "c" -> Json.Number("1"),
-                "d" -> Json.Number("2")
+                "c" -> Json.Number(1),
+                "d" -> Json.Number(2)
               )
             )
           )
@@ -2073,26 +2068,26 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("modifyOrFail with Elements and MapValues")(
         test("modifyOrFail with elements succeeds when all match") {
-          val json   = Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))
+          val json   = Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))
           val path   = DynamicOptic.elements
           val result = json.modifyOrFail(path) { case Json.Number(n) =>
-            Json.Number((BigDecimal(n) * 2).toString)
+            Json.Number(n * 2)
           }
-          assertTrue(result == Right(Json.Array(Json.Number("2"), Json.Number("4"), Json.Number("6"))))
+          assertTrue(result == Right(Json.Array(Json.Number(2), Json.Number(4), Json.Number(6))))
         },
         test("modifyOrFail with elements fails when partial function not defined") {
-          val json   = Json.Array(Json.Number("1"), Json.String("not a number"), Json.Number("3"))
+          val json   = Json.Array(Json.Number(1), Json.String("not a number"), Json.Number(3))
           val path   = DynamicOptic.elements
           val result = json.modifyOrFail(path) { case Json.Number(n) =>
-            Json.Number((BigDecimal(n) * 2).toString)
+            Json.Number(n * 2)
           }
           assertTrue(result.isLeft)
         },
         test("modifyOrFail with mapValues succeeds when all match") {
-          val json   = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))
+          val json   = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))
           val path   = DynamicOptic.mapValues
           val result = json.modifyOrFail(path) { case Json.Number(n) =>
-            Json.Number((BigDecimal(n) * 10).toString)
+            Json.Number(n * 10)
           }
           assertTrue(
             result.map(_.get("a").as[BigDecimal]) == Right(Right(BigDecimal(10))),
@@ -2100,75 +2095,75 @@ object JsonSpec extends SchemaBaseSpec {
           )
         },
         test("modifyOrFail with mapValues fails when partial function not defined") {
-          val json   = Json.Object("a" -> Json.Number("1"), "b" -> Json.String("not a number"))
+          val json   = Json.Object("a" -> Json.Number(1), "b" -> Json.String("not a number"))
           val path   = DynamicOptic.mapValues
           val result = json.modifyOrFail(path) { case Json.Number(n) =>
-            Json.Number((BigDecimal(n) * 10).toString)
+            Json.Number(n * 10)
           }
           assertTrue(result.isLeft)
         },
         test("modifyOrFail with nested path and elements") {
           val json = Json.Object(
-            "items" -> Json.Array(Json.Number("1"), Json.Number("2"))
+            "items" -> Json.Array(Json.Number(1), Json.Number(2))
           )
           val path   = DynamicOptic.root.field("items").elements
           val result = json.modifyOrFail(path) { case Json.Number(n) =>
-            Json.Number((BigDecimal(n) + 100).toString)
+            Json.Number(n + 100)
           }
-          assertTrue(result == Right(Json.Object("items" -> Json.Array(Json.Number("101"), Json.Number("102")))))
+          assertTrue(result == Right(Json.Object("items" -> Json.Array(Json.Number(101), Json.Number(102)))))
         }
       ),
       suite("insertOrFail edge cases")(
         test("insertOrFail fails for non-existent nested path") {
           val json   = Json.Object()
           val path   = DynamicOptic.root.field("a").field("b")
-          val result = json.insertOrFail(path, Json.Number("42"))
+          val result = json.insertOrFail(path, Json.Number(42))
           assertTrue(result.isLeft)
         },
         test("insertOrFail at array index extends array") {
-          val json   = Json.Array(Json.Number("1"), Json.Number("2"))
+          val json   = Json.Array(Json.Number(1), Json.Number(2))
           val path   = DynamicOptic.root.at(2)
-          val result = json.insertOrFail(path, Json.Number("3"))
-          assertTrue(result == Right(Json.Array(Json.Number("1"), Json.Number("2"), Json.Number("3"))))
+          val result = json.insertOrFail(path, Json.Number(3))
+          assertTrue(result == Right(Json.Array(Json.Number(1), Json.Number(2), Json.Number(3))))
         },
         test("insertOrFail fails when field already exists") {
-          val json   = Json.Object("a" -> Json.Number("1"))
+          val json   = Json.Object("a" -> Json.Number(1))
           val path   = DynamicOptic.root.field("a")
-          val result = json.insertOrFail(path, Json.Number("99"))
+          val result = json.insertOrFail(path, Json.Number(99))
           assertTrue(result.isLeft)
         },
         test("insertOrFail succeeds for new field") {
-          val json   = Json.Object("a" -> Json.Number("1"))
+          val json   = Json.Object("a" -> Json.Number(1))
           val path   = DynamicOptic.root.field("b")
-          val result = json.insertOrFail(path, Json.Number("2"))
-          assertTrue(result == Right(Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))))
+          val result = json.insertOrFail(path, Json.Number(2))
+          assertTrue(result == Right(Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))))
         }
       ),
       suite("JSON ordering")(
         test("ordering sorts json values correctly") {
           val values = List(
-            Json.Number("3"),
-            Json.Number("1"),
-            Json.Number("2")
+            Json.Number(3),
+            Json.Number(1),
+            Json.Number(2)
           )
           val sorted = values.sorted(Json.ordering)
-          assertTrue(sorted == List(Json.Number("1"), Json.Number("2"), Json.Number("3")))
+          assertTrue(sorted == List(Json.Number(1), Json.Number(2), Json.Number(3)))
         },
         test("ordering handles mixed types by type order") {
           val values = List(
-            Json.Object("a" -> Json.Number("1")),
+            Json.Object("a" -> Json.Number(1)),
             Json.Null,
             Json.Boolean(true),
-            Json.Number("1"),
+            Json.Number(1),
             Json.String("hello"),
-            Json.Array(Json.Number("1"))
+            Json.Array(Json.Number(1))
           )
           val sorted = values.sorted(Json.ordering)
           // Null < Boolean < Number < String < Array < Object
           assertTrue(
             sorted(0) == Json.Null,
             sorted(1) == Json.Boolean(true),
-            sorted(2) == Json.Number("1"),
+            sorted(2) == Json.Number(1),
             sorted(3) == Json.String("hello")
           )
         },
@@ -2180,7 +2175,7 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("Config-based parse and encode")(
         test("print with custom config") {
-          val json   = Json.Object("a" -> Json.Number("1"))
+          val json   = Json.Object("a" -> Json.Number(1))
           val result = json.print
           assertTrue(result.contains("a") && result.contains("1"))
         },
@@ -2193,7 +2188,7 @@ object JsonSpec extends SchemaBaseSpec {
         test("parse handles whitespace correctly") {
           val input  = """  {  "a"  :  1  }  """
           val result = Json.parse(input)
-          assertTrue(result == Right(Json.Object("a" -> Json.Number("1"))))
+          assertTrue(result == Right(Json.Object("a" -> Json.Number(1))))
         },
         test("parse handles unicode escapes") {
           val input  = "{\"emoji\": \"\\u0048\\u0065\\u006c\\u006c\\u006f\"}"
@@ -2274,7 +2269,7 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("Chunk-based encoding and parsing")(
         test("printChunk produces valid Chunk[Byte]") {
-          val obj   = Json.Object("name" -> Json.String("Alice"), "age" -> Json.Number("30"))
+          val obj   = Json.Object("name" -> Json.String("Alice"), "age" -> Json.Number(30))
           val chunk = obj.printChunk
           assertTrue(chunk.length > 0)
         },
@@ -2287,10 +2282,10 @@ object JsonSpec extends SchemaBaseSpec {
         test("roundtrip printChunk and parse(Chunk) preserves data") {
           val obj = Json.Object(
             "users" -> Json.Array(
-              Json.Object("name" -> Json.String("Alice"), "age" -> Json.Number("30")),
-              Json.Object("name" -> Json.String("Bob"), "age"   -> Json.Number("25"))
+              Json.Object("name" -> Json.String("Alice"), "age" -> Json.Number(30)),
+              Json.Object("name" -> Json.String("Bob"), "age"   -> Json.Number(25))
             ),
-            "count"  -> Json.Number("2"),
+            "count"  -> Json.Number(2),
             "active" -> Json.Boolean(true)
           )
           val chunk  = obj.printChunk
@@ -2298,13 +2293,13 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(parsed == Right(obj))
         },
         test("printChunk with custom WriterConfig") {
-          val obj    = Json.Object("a" -> Json.Number("1"))
+          val obj    = Json.Object("a" -> Json.Number(1))
           val chunk  = obj.printChunk(WriterConfig)
           val parsed = Json.parse(chunk)
           assertTrue(parsed == Right(obj))
         },
         test("parse from Chunk[Byte] with custom ReaderConfig") {
-          val obj    = Json.Object("a" -> Json.Number("1"))
+          val obj    = Json.Object("a" -> Json.Number(1))
           val chunk  = obj.printChunk
           val parsed = Json.parse(chunk, ReaderConfig)
           assertTrue(parsed == Right(obj))
@@ -2324,25 +2319,25 @@ object JsonSpec extends SchemaBaseSpec {
       ),
       suite("MergeStrategy.Custom")(
         test("Custom merge strategy allows user-defined logic") {
-          val left           = Json.Object("a" -> Json.Number("1"), "b" -> Json.Number("2"))
-          val right          = Json.Object("a" -> Json.Number("10"), "c" -> Json.Number("3"))
+          val left           = Json.Object("a" -> Json.Number(1), "b" -> Json.Number(2))
+          val right          = Json.Object("a" -> Json.Number(10), "c" -> Json.Number(3))
           val customStrategy = MergeStrategy.Custom { (_, l, r) =>
             (l, r) match {
-              case (Json.Number(lv), Json.Number(rv)) => Json.Number((BigDecimal(lv) + BigDecimal(rv)).toString)
+              case (Json.Number(lv), Json.Number(rv)) => Json.Number(lv + rv)
               case _                                  => r
             }
           }
           val result = left.merge(right, customStrategy)
           assertTrue(
-            result.get("a").any == Right(Json.Number("11")),
-            result.get("b").any == Right(Json.Number("2")),
-            result.get("c").any == Right(Json.Number("3"))
+            result.get("a").any == Right(Json.Number(11)),
+            result.get("b").any == Right(Json.Number(2)),
+            result.get("c").any == Right(Json.Number(3))
           )
         },
         test("Custom merge strategy receives correct path") {
           var capturedPaths  = List.empty[String]
-          val left           = Json.Object("outer" -> Json.Object("inner" -> Json.Number("1")))
-          val right          = Json.Object("outer" -> Json.Object("inner" -> Json.Number("2")))
+          val left           = Json.Object("outer" -> Json.Object("inner" -> Json.Number(1)))
+          val right          = Json.Object("outer" -> Json.Object("inner" -> Json.Number(2)))
           val customStrategy = MergeStrategy.Custom { (path, _, r) =>
             capturedPaths = capturedPaths :+ path.toString
             r
@@ -2351,8 +2346,8 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(capturedPaths.exists(_.contains("inner")))
         },
         test("Custom merge strategy falls back to user function for non-objects") {
-          val left: Json     = Json.Array(Json.Number("1"))
-          val right: Json    = Json.Array(Json.Number("2"))
+          val left: Json     = Json.Array(Json.Number(1))
+          val right: Json    = Json.Array(Json.Number(2))
           val customStrategy = MergeStrategy.Custom(
             f = { (_, l, r) =>
               (l, r) match {
@@ -2363,14 +2358,14 @@ object JsonSpec extends SchemaBaseSpec {
             r = (_, _) => false
           )
           val result = left.merge(right, customStrategy)
-          assertTrue(result == Json.Array(Json.Number("1"), Json.Number("2")))
+          assertTrue(result == Json.Array(Json.Number(1), Json.Number(2)))
         },
         test("Custom merge strategy with default recursion behaves like Auto for arrays") {
-          val left: Json     = Json.Array(Json.Number("1"))
-          val right: Json    = Json.Array(Json.Number("2"))
+          val left: Json     = Json.Array(Json.Number(1))
+          val right: Json    = Json.Array(Json.Number(2))
           val customStrategy = MergeStrategy.Custom((_, _, r) => r)
           val result         = left.merge(right, customStrategy)
-          assertTrue(result == Json.Array(Json.Number("2")))
+          assertTrue(result == Json.Array(Json.Number(2)))
         }
       )
     ),
@@ -2383,16 +2378,16 @@ object JsonSpec extends SchemaBaseSpec {
           dynamicValueRoundTrip(Json.Boolean(true)) && dynamicValueRoundTrip(Json.Boolean(false))
         },
         test("Json.Number roundtrips") {
-          dynamicValueRoundTrip(Json.Number("123.456")) && dynamicValueRoundTrip(Json.Number("-42"))
+          dynamicValueRoundTrip(Json.Number(123.456)) && dynamicValueRoundTrip(Json.Number(-42))
         },
         test("Json.String roundtrips") {
           dynamicValueRoundTrip(Json.String("hello world"))
         },
         test("Json.Array roundtrips") {
-          dynamicValueRoundTrip(Json.Array(Json.Number("1"), Json.String("two"), Json.Null))
+          dynamicValueRoundTrip(Json.Array(Json.Number(1), Json.String("two"), Json.Null))
         },
         test("Json.Object roundtrips") {
-          dynamicValueRoundTrip(Json.Object("a" -> Json.Number("1"), "b" -> Json.String("two")))
+          dynamicValueRoundTrip(Json.Object("a" -> Json.Number(1), "b" -> Json.String("two")))
         },
         test("Json (Null) roundtrips as variant") {
           dynamicValueRoundTrip(Json.Null: Json)
@@ -2401,13 +2396,13 @@ object JsonSpec extends SchemaBaseSpec {
           dynamicValueRoundTrip(Json.Boolean(true): Json)
         },
         test("Json (Number) roundtrips as variant") {
-          dynamicValueRoundTrip(Json.Number("42"): Json)
+          dynamicValueRoundTrip(Json.Number(42): Json)
         },
         test("Json (String) roundtrips as variant") {
           dynamicValueRoundTrip(Json.String("test"): Json)
         },
         test("Json (Array) roundtrips as variant") {
-          dynamicValueRoundTrip(Json.Array(Json.Number("1")): Json)
+          dynamicValueRoundTrip(Json.Array(Json.Number(1)): Json)
         },
         test("Json (Object) roundtrips as variant") {
           dynamicValueRoundTrip(Json.Object("x" -> Json.Null): Json)
@@ -2415,10 +2410,10 @@ object JsonSpec extends SchemaBaseSpec {
         test("Nested Json roundtrips") {
           val nested: Json = Json.Object(
             "users" -> Json.Array(
-              Json.Object("name" -> Json.String("Alice"), "age" -> Json.Number("30")),
-              Json.Object("name" -> Json.String("Bob"), "age"   -> Json.Number("25"))
+              Json.Object("name" -> Json.String("Alice"), "age" -> Json.Number(30)),
+              Json.Object("name" -> Json.String("Bob"), "age"   -> Json.Number(25))
             ),
-            "meta" -> Json.Object("count" -> Json.Number("2"))
+            "meta" -> Json.Object("count" -> Json.Number(2))
           )
           dynamicValueRoundTrip(nested)
         }
@@ -2431,18 +2426,18 @@ object JsonSpec extends SchemaBaseSpec {
           JsonTestUtils.roundTrip(Json.Boolean(true), """{"value":true}""")
         },
         test("Json.Number serializes to JSON") {
-          JsonTestUtils.roundTrip(Json.Number("42"), """{"value":"42"}""")
+          JsonTestUtils.roundTrip(Json.Number(42), """{"value":42}""")
         },
         test("Json.String serializes to JSON") {
           JsonTestUtils.roundTrip(Json.String("hello"), """{"value":"hello"}""")
         },
         test("Json.Array serializes to JSON") {
-          JsonTestUtils.roundTrip(Json.Array(Json.Number("1")), """{"value":[{"Number":{"value":"1"}}]}""")
+          JsonTestUtils.roundTrip(Json.Array(Json.Number(1)), """{"value":[{"Number":{"value":1}}]}""")
         },
         test("Json (variant) serializes to JSON") {
           JsonTestUtils.roundTrip(Json.Null: Json, """{"Null":{}}""") &&
           JsonTestUtils.roundTrip(Json.Boolean(true): Json, """{"Boolean":{"value":true}}""") &&
-          JsonTestUtils.roundTrip(Json.Number("1"): Json, """{"Number":{"value":"1"}}""") &&
+          JsonTestUtils.roundTrip(Json.Number(1): Json, """{"Number":{"value":1}}""") &&
           JsonTestUtils.roundTrip(Json.String("x"): Json, """{"String":{"value":"x"}}""")
         }
       ),
@@ -2466,7 +2461,7 @@ object JsonSpec extends SchemaBaseSpec {
           assertTrue(back == Right(value))
         },
         test("Json.Number roundtrips") {
-          val value: Json = Json.Number("123.456")
+          val value: Json = Json.Number(123.456)
           val dyn         = Schema[Json].toDynamicValue(value)
           val back        = Schema[Json].fromDynamicValue(dyn)
           assertTrue(back == Right(value))
@@ -2640,7 +2635,7 @@ object JsonSpec extends SchemaBaseSpec {
       },
       test("bigIntEncoder encodes BigInt") {
         val result = JsonEncoder.bigIntEncoder.encode(BigInt("123456789012345678901234567890"))
-        assertTrue(result == Json.Number("123456789012345678901234567890"))
+        assertTrue(result == Json.Number(BigDecimal("123456789012345678901234567890")))
       }
     ),
     suite("JsonDecoder Java time types")(
@@ -2898,10 +2893,10 @@ object JsonSpec extends SchemaBaseSpec {
           (PrimitiveValue.Unit, _ == Json.Object.empty),
           (PrimitiveValue.Boolean(true), _ == Json.True),
           (PrimitiveValue.Boolean(false), _ == Json.False),
-          (PrimitiveValue.Byte(42.toByte), j => j.as(JsonType.Number).exists(_.value == "42")),
-          (PrimitiveValue.Short(100.toShort), j => j.as(JsonType.Number).exists(_.value == "100")),
-          (PrimitiveValue.Int(1000), j => j.as(JsonType.Number).exists(_.value == "1000")),
-          (PrimitiveValue.Long(10000L), j => j.as(JsonType.Number).exists(_.value == "10000")),
+          (PrimitiveValue.Byte(42.toByte), j => j.as(JsonType.Number).exists(_.value == BigDecimal(42))),
+          (PrimitiveValue.Short(100.toShort), j => j.as(JsonType.Number).exists(_.value == BigDecimal(100))),
+          (PrimitiveValue.Int(1000), j => j.as(JsonType.Number).exists(_.value == BigDecimal(1000))),
+          (PrimitiveValue.Long(10000L), j => j.as(JsonType.Number).exists(_.value == BigDecimal(10000))),
           (PrimitiveValue.Float(3.5f), j => j.as(JsonType.Number).isDefined),
           (PrimitiveValue.Double(3.14159), j => j.as(JsonType.Number).isDefined),
           (PrimitiveValue.Char('X'), j => j.as(JsonType.String).exists(_.value == "X")),
@@ -2948,7 +2943,7 @@ object JsonSpec extends SchemaBaseSpec {
     ),
     suite("JsonDecoder error branches")(
       test("stringDecoder fails on non-string Json values") {
-        assertTrue(JsonDecoder[String].decode(Json.Number("42")).isLeft) &&
+        assertTrue(JsonDecoder[String].decode(Json.Number(42)).isLeft) &&
         assertTrue(JsonDecoder[String].decode(Json.True).isLeft) &&
         assertTrue(JsonDecoder[String].decode(Json.Null).isLeft) &&
         assertTrue(JsonDecoder[String].decode(Json.Array.empty).isLeft) &&
@@ -2956,7 +2951,7 @@ object JsonSpec extends SchemaBaseSpec {
       },
       test("booleanDecoder fails on non-boolean Json values") {
         assertTrue(JsonDecoder[Boolean].decode(Json.String("true")).isLeft) &&
-        assertTrue(JsonDecoder[Boolean].decode(Json.Number("1")).isLeft) &&
+        assertTrue(JsonDecoder[Boolean].decode(Json.Number(1)).isLeft) &&
         assertTrue(JsonDecoder[Boolean].decode(Json.Null).isLeft)
       },
       test("intDecoder fails on non-number Json values") {
@@ -2965,7 +2960,7 @@ object JsonSpec extends SchemaBaseSpec {
         assertTrue(JsonDecoder[Int].decode(Json.Null).isLeft)
       },
       test("intDecoder fails on non-integer number") {
-        assertTrue(JsonDecoder[Int].decode(Json.Number("3.14")).isLeft)
+        assertTrue(JsonDecoder[Int].decode(Json.Number(3.14)).isLeft)
       },
       test("longDecoder fails on non-number Json values") {
         assertTrue(JsonDecoder[Long].decode(Json.String("42")).isLeft) &&
@@ -2979,18 +2974,18 @@ object JsonSpec extends SchemaBaseSpec {
         assertTrue(JsonDecoder[Float].decode(Json.String("3.14")).isLeft)
       },
       test("byteDecoder fails on out-of-range values") {
-        assertTrue(JsonDecoder[Byte].decode(Json.Number("128")).isLeft) &&
-        assertTrue(JsonDecoder[Byte].decode(Json.Number("-129")).isLeft)
+        assertTrue(JsonDecoder[Byte].decode(Json.Number(128)).isLeft) &&
+        assertTrue(JsonDecoder[Byte].decode(Json.Number(-129)).isLeft)
       },
       test("shortDecoder fails on out-of-range values") {
-        assertTrue(JsonDecoder[Short].decode(Json.Number("32768")).isLeft) &&
-        assertTrue(JsonDecoder[Short].decode(Json.Number("-32769")).isLeft)
+        assertTrue(JsonDecoder[Short].decode(Json.Number(32768)).isLeft) &&
+        assertTrue(JsonDecoder[Short].decode(Json.Number(-32769)).isLeft)
       },
       test("optionDecoder handles None for null") {
         assert(JsonDecoder[Option[Int]].decode(Json.Null))(isRight(equalTo(None)))
       },
       test("optionDecoder handles Some for non-null") {
-        assert(JsonDecoder[Option[Int]].decode(Json.Number("42")))(isRight(equalTo(Some(42))))
+        assert(JsonDecoder[Option[Int]].decode(Json.Number(42)))(isRight(equalTo(Some(42))))
       },
       test("listDecoder fails on non-array") {
         assertTrue(JsonDecoder[List[Int]].decode(Json.Object.empty).isLeft)
@@ -3003,21 +2998,21 @@ object JsonSpec extends SchemaBaseSpec {
       test("modify with DynamicOptic.root.field modifies nested value") {
         val json   = Json.parse("""{"a": {"x": 1}, "b": 2}""").getOrElse(Json.Null)
         val path   = DynamicOptic.root.field("a").field("x")
-        val result = json.modify(path)(_ => Json.Number("99"))
+        val result = json.modify(path)(_ => Json.Number(99))
 
-        assertTrue(result.get("a").get("x").one == Right(Json.Number("99")))
+        assertTrue(result.get("a").get("x").one == Right(Json.Number(99)))
       },
       test("modify returns original when path does not exist") {
         val json   = Json.parse("""{"a": 1}""").getOrElse(Json.Null)
         val path   = DynamicOptic.root.field("nonexistent")
-        val result = json.modify(path)(_ => Json.Number("99"))
+        val result = json.modify(path)(_ => Json.Number(99))
 
         assertTrue(result == json)
       },
       test("modifyOrFail fails when path does not exist") {
         val json   = Json.parse("""{"a": 1}""").getOrElse(Json.Null)
         val path   = DynamicOptic.root.field("nonexistent")
-        val result = json.modifyOrFail(path) { case _ => Json.Number("99") }
+        val result = json.modifyOrFail(path) { case _ => Json.Number(99) }
 
         assertTrue(result.isLeft)
       },
@@ -3048,7 +3043,7 @@ object JsonSpec extends SchemaBaseSpec {
       test("insert adds value at new path in object") {
         val json   = Json.parse("""{"a": 1}""").getOrElse(Json.Null)
         val path   = DynamicOptic.root.field("b")
-        val result = json.insert(path, Json.Number("2"))
+        val result = json.insert(path, Json.Number(2))
 
         assertTrue(
           result.get("a").isSuccess &&
@@ -3058,14 +3053,14 @@ object JsonSpec extends SchemaBaseSpec {
       test("insert adds value at array index") {
         val json   = Json.parse("""{"items": [1, 3]}""").getOrElse(Json.Null)
         val path   = DynamicOptic.root.field("items").at(1)
-        val result = json.insert(path, Json.Number("2"))
+        val result = json.insert(path, Json.Number(2))
 
         assertTrue(result.get("items").isSuccess)
       },
       test("insertOrFail fails when path already exists") {
         val json   = Json.parse("""{"a": 1}""").getOrElse(Json.Null)
         val path   = DynamicOptic.root.field("a")
-        val result = json.insertOrFail(path, Json.Number("99"))
+        val result = json.insertOrFail(path, Json.Number(99))
 
         // insertOrFail should fail because "a" already exists
         assertTrue(result.isLeft)
@@ -3079,15 +3074,15 @@ object JsonSpec extends SchemaBaseSpec {
         assertTrue(Json.Null.compare(Json.True) < 0) &&
         assertTrue(Json.True.compare(Json.False) > 0) &&
         assertTrue(Json.String("a").compare(Json.String("b")) < 0) &&
-        assertTrue(Json.Number("1").compare(Json.Number("2")) < 0)
+        assertTrue(Json.Number(1).compare(Json.Number(2)) < 0)
       },
       test("modify with Elements path modifies all array elements") {
         val json   = Json.parse("""[1, 2, 3]""").getOrElse(Json.Null)
         val path   = DynamicOptic.root.elements
-        val result = json.modify(path)(_ => Json.Number("0"))
+        val result = json.modify(path)(_ => Json.Number(0))
 
         result.as(JsonType.Array) match {
-          case Some(arr) => assertTrue(arr.value.forall(_ == Json.Number("0")))
+          case Some(arr) => assertTrue(arr.value.forall(_ == Json.Number(0)))
           case None      => assertTrue(false)
         }
       }

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/SchemaToJsonSchemaSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/SchemaToJsonSchemaSpec.scala
@@ -155,8 +155,8 @@ object SchemaToJsonSchemaSpec extends SchemaBaseSpec {
         val json   = schema.toJson
         assertTrue(
           json.get("type").one == Right(Json.String("integer")),
-          json.get("minimum").one == Right(Json.Number("-128")),
-          json.get("maximum").one == Right(Json.Number("127"))
+          json.get("minimum").one == Right(Json.Number(-128)),
+          json.get("maximum").one == Right(Json.Number(127))
         )
       },
       test("Short schema includes min/max constraints") {
@@ -164,8 +164,8 @@ object SchemaToJsonSchemaSpec extends SchemaBaseSpec {
         val json   = schema.toJson
         assertTrue(
           json.get("type").one == Right(Json.String("integer")),
-          json.get("minimum").one == Right(Json.Number("-32768")),
-          json.get("maximum").one == Right(Json.Number("32767"))
+          json.get("minimum").one == Right(Json.Number(-32768)),
+          json.get("maximum").one == Right(Json.Number(32767))
         )
       },
       test("Char schema includes length constraints") {
@@ -173,8 +173,8 @@ object SchemaToJsonSchemaSpec extends SchemaBaseSpec {
         val json   = schema.toJson
         assertTrue(
           json.get("type").one == Right(Json.String("string")),
-          json.get("minLength").one == Right(Json.Number("1")),
-          json.get("maxLength").one == Right(Json.Number("1"))
+          json.get("minLength").one == Right(Json.Number(1)),
+          json.get("maxLength").one == Right(Json.Number(1))
         )
       }
     ),

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonDifferSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonDifferSpec.scala
@@ -47,8 +47,8 @@ object JsonDifferSpec extends SchemaBaseSpec {
       )
     },
     test("diff handles decimal numbers") {
-      val source = Json.Number("1.5")
-      val target = Json.Number("2.75")
+      val source = Json.Number(1.5)
+      val target = Json.Number(2.75)
       val patch  = JsonDiffer.diff(source, target)
 
       assertTrue(
@@ -60,8 +60,8 @@ object JsonDifferSpec extends SchemaBaseSpec {
       )
     },
     test("diff handles large numbers") {
-      val source = Json.Number("999999999999999999")
-      val target = Json.Number("1000000000000000000")
+      val source = Json.Number(999999999999999999L)
+      val target = Json.Number(1000000000000000000L)
       val patch  = JsonDiffer.diff(source, target)
 
       assertTrue(
@@ -237,8 +237,8 @@ object JsonDifferSpec extends SchemaBaseSpec {
         patch.ops.head.operation match {
           case Op.ObjectEdit(ops) =>
             ops.exists {
-              case ObjectOp.Add("b", Json.Number("2")) => true
-              case _                                   => false
+              case ObjectOp.Add("b", Json.Number(n)) => n == BigDecimal(2)
+              case _                                 => false
             }
           case _ => false
         }
@@ -362,8 +362,8 @@ object JsonDifferSpec extends SchemaBaseSpec {
 
       assertTrue(
         patch.ops.head.operation match {
-          case Op.Set(Json.Number("1")) => true
-          case _                        => false
+          case Op.Set(Json.Number(n)) => n == BigDecimal(1)
+          case _                      => false
         },
         patch.apply(source) == Right(target)
       )

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonGen.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonGen.scala
@@ -13,9 +13,9 @@ object JsonGen {
   val genBoolean: Gen[Any, Json] = Gen.boolean.map(Json.Boolean(_))
 
   val genNumber: Gen[Any, Json] = Gen.oneOf(
-    Gen.const(Json.Number("0")),
-    Gen.int.map(i => Json.Number(i.toString)),
-    Gen.long.map(l => Json.Number(l.toString))
+    Gen.const(Json.Number(0)),
+    Gen.int.map(i => Json.Number(i)),
+    Gen.long.map(l => Json.Number(l))
   )
 
   val genString: Gen[Any, Json] = Gen.oneOf(
@@ -152,9 +152,9 @@ object JsonGen {
                  } yield (k, v)
                }
     } yield {
-      val fields1 = ((key, Json.Number(n1.toString)) :: extra).distinctBy(_._1)
+      val fields1 = ((key, Json.Number(n1)) :: extra).distinctBy(_._1)
       val fields2 = fields1.map {
-        case (k, _) if k == key => (k, Json.Number(n2.toString))
+        case (k, _) if k == key => (k, Json.Number(n2))
         case other              => other
       }
       (Json.Object(Chunk.from(fields1)), Json.Object(Chunk.from(fields2)))

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonPatchErrorSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonPatchErrorSpec.scala
@@ -406,7 +406,7 @@ object JsonPatchErrorSpec extends SchemaBaseSpec {
       val lenientResult = patch.apply(original, PatchMode.Lenient)
       val clobberResult = patch.apply(original, PatchMode.Clobber)
 
-      assertTrue(strictResult == Right(Json.Number("15"))) &&
+      assertTrue(strictResult == Right(Json.Number(15))) &&
       assertTrue(strictResult == lenientResult) &&
       assertTrue(strictResult == clobberResult)
     },

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonPatchIntegrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonPatchIntegrationSpec.scala
@@ -101,7 +101,7 @@ object JsonPatchIntegrationSpec extends SchemaBaseSpec {
       val json                              = Json.Number(10)
       val patch                             = JsonPatch.root(Op.PrimitiveDelta(PrimitiveOp.NumberDelta(BigDecimal(5))))
       val result: Either[SchemaError, Json] = json.patch(patch) // Type annotation proves return type
-      assertTrue(result == Right(Json.Number("15")))
+      assertTrue(result == Right(Json.Number(15)))
     }
   )
 

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonPatchOperationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonPatchOperationSpec.scala
@@ -54,7 +54,7 @@ object JsonPatchOperationSpec extends SchemaBaseSpec {
     },
     test("Set works on Json.Number") {
       val original = Json.Number(123)
-      val newValue = Json.Number("456.789")
+      val newValue = Json.Number(456.789)
       val patch    = JsonPatch.root(Op.Set(newValue))
       val result   = patch.apply(original, PatchMode.Strict)
       assertTrue(result == Right(newValue))
@@ -94,37 +94,37 @@ object JsonPatchOperationSpec extends SchemaBaseSpec {
       val original = Json.Number(5)
       val patch    = JsonPatch.root(Op.PrimitiveDelta(PrimitiveOp.NumberDelta(BigDecimal(3))))
       val result   = patch.apply(original, PatchMode.Strict)
-      assertTrue(result == Right(Json.Number("8")))
+      assertTrue(result == Right(Json.Number(8)))
     },
     test("NumberDelta with negative delta (10 - 3 = 7)") {
       val original = Json.Number(10)
       val patch    = JsonPatch.root(Op.PrimitiveDelta(PrimitiveOp.NumberDelta(BigDecimal(-3))))
       val result   = patch.apply(original, PatchMode.Strict)
-      assertTrue(result == Right(Json.Number("7")))
+      assertTrue(result == Right(Json.Number(7)))
     },
     test("NumberDelta with zero delta (value unchanged)") {
       val original = Json.Number(42)
       val patch    = JsonPatch.root(Op.PrimitiveDelta(PrimitiveOp.NumberDelta(BigDecimal(0))))
       val result   = patch.apply(original, PatchMode.Strict)
-      assertTrue(result == Right(Json.Number("42")))
+      assertTrue(result == Right(Json.Number(42)))
     },
     test("NumberDelta with decimal delta (1.5 + 0.5 = 2.0)") {
-      val original = Json.Number("1.5")
+      val original = Json.Number(1.5)
       val patch    = JsonPatch.root(Op.PrimitiveDelta(PrimitiveOp.NumberDelta(BigDecimal("0.5"))))
       val result   = patch.apply(original, PatchMode.Strict)
-      assertTrue(result == Right(Json.Number("2.0")))
+      assertTrue(result == Right(Json.Number(2.0)))
     },
     test("NumberDelta with large values") {
-      val original = Json.Number("999999999999999999")
+      val original = Json.Number(999999999999999999L)
       val patch    = JsonPatch.root(Op.PrimitiveDelta(PrimitiveOp.NumberDelta(BigDecimal(1))))
       val result   = patch.apply(original, PatchMode.Strict)
-      assertTrue(result == Right(Json.Number("1000000000000000000")))
+      assertTrue(result == Right(Json.Number(1000000000000000000L)))
     },
     test("NumberDelta with high precision decimals") {
-      val original = Json.Number("0.123456789")
+      val original = Json.Number(0.123456789)
       val patch    = JsonPatch.root(Op.PrimitiveDelta(PrimitiveOp.NumberDelta(BigDecimal("0.000000001"))))
       val result   = patch.apply(original, PatchMode.Strict)
-      assertTrue(result == Right(Json.Number("0.123456790")))
+      assertTrue(result == Right(Json.Number(0.123456790)))
     }
   )
 
@@ -325,7 +325,7 @@ object JsonPatchOperationSpec extends SchemaBaseSpec {
         Op.ArrayEdit(Vector(ArrayOp.Modify(1, Op.PrimitiveDelta(PrimitiveOp.NumberDelta(BigDecimal(5))))))
       )
       val result = patch.apply(original, PatchMode.Strict)
-      assertTrue(result == Right(Json.Array(Json.Number(10), Json.Number("25"), Json.Number(30))))
+      assertTrue(result == Right(Json.Array(Json.Number(10), Json.Number(25), Json.Number(30))))
     }
   )
 
@@ -403,7 +403,7 @@ object JsonPatchOperationSpec extends SchemaBaseSpec {
         )
       )
       val result = patch.apply(original, PatchMode.Strict)
-      assertTrue(result == Right(Json.Object("count" -> Json.Number("15"))))
+      assertTrue(result == Right(Json.Object("count" -> Json.Number(15))))
     },
     test("Modify nested object") {
       val original = Json.Object(
@@ -488,7 +488,7 @@ object JsonPatchOperationSpec extends SchemaBaseSpec {
           Json.Object(
             "level1" -> Json.Object(
               "level2" -> Json.Object(
-                "level3" -> Json.Number("150")
+                "level3" -> Json.Number(150)
               )
             )
           )
@@ -752,7 +752,7 @@ object JsonPatchOperationSpec extends SchemaBaseSpec {
       val path     = DynamicOptic.root.elements
       val patch    = JsonPatch(path, Op.PrimitiveDelta(PrimitiveOp.NumberDelta(BigDecimal(10))))
       val result   = patch.apply(original, PatchMode.Strict)
-      assertTrue(result == Right(Json.Array(Json.Number("11"), Json.Number("12"), Json.Number("13"))))
+      assertTrue(result == Right(Json.Array(Json.Number(11), Json.Number(12), Json.Number(13))))
     },
     test("Elements navigation on empty array succeeds in Lenient mode") {
       val original = Json.Array.empty
@@ -780,9 +780,9 @@ object JsonPatchOperationSpec extends SchemaBaseSpec {
       assertTrue(
         result == Right(
           Json.Array(
-            Json.Object("value" -> Json.Number("11")),
-            Json.Object("value" -> Json.Number("12")),
-            Json.Object("value" -> Json.Number("13"))
+            Json.Object("value" -> Json.Number(11)),
+            Json.Object("value" -> Json.Number(12)),
+            Json.Object("value" -> Json.Number(13))
           )
         )
       )
@@ -799,14 +799,14 @@ object JsonPatchOperationSpec extends SchemaBaseSpec {
       val path     = DynamicOptic.root.elements
       val patch    = JsonPatch(path, Op.PrimitiveDelta(PrimitiveOp.NumberDelta(BigDecimal(1))))
       val result   = patch.apply(original, PatchMode.Lenient)
-      assertTrue(result == Right(Json.Array(Json.Number("2"), Json.String("not a number"), Json.Number("4"))))
+      assertTrue(result == Right(Json.Array(Json.Number(2), Json.String("not a number"), Json.Number(4))))
     },
     test("applyToAllElements keeps original on error in Clobber mode") {
       val original = Json.Array(Json.Number(1), Json.String("not a number"), Json.Number(3))
       val path     = DynamicOptic.root.elements
       val patch    = JsonPatch(path, Op.PrimitiveDelta(PrimitiveOp.NumberDelta(BigDecimal(1))))
       val result   = patch.apply(original, PatchMode.Clobber)
-      assertTrue(result == Right(Json.Array(Json.Number("2"), Json.String("not a number"), Json.Number("4"))))
+      assertTrue(result == Right(Json.Array(Json.Number(2), Json.String("not a number"), Json.Number(4))))
     },
     test("navigateAllElements keeps original on error in Lenient mode") {
       val original = Json.Array(
@@ -853,8 +853,8 @@ object JsonPatchOperationSpec extends SchemaBaseSpec {
       assertTrue(
         result == Right(
           Json.Array(
-            Json.Object("outer" -> Json.Object("inner" -> Json.Number("101"))),
-            Json.Object("outer" -> Json.Object("inner" -> Json.Number("102")))
+            Json.Object("outer" -> Json.Object("inner" -> Json.Number(101))),
+            Json.Object("outer" -> Json.Object("inner" -> Json.Number(102)))
           )
         )
       )
@@ -876,14 +876,14 @@ object JsonPatchOperationSpec extends SchemaBaseSpec {
       val path     = DynamicOptic.root.wrapped.field("value")
       val patch    = JsonPatch(path, Op.PrimitiveDelta(PrimitiveOp.NumberDelta(BigDecimal(8))))
       val result   = patch.apply(original, PatchMode.Strict)
-      assertTrue(result == Right(Json.Object("value" -> Json.Number("50"))))
+      assertTrue(result == Right(Json.Object("value" -> Json.Number(50))))
     },
     test("Wrapped navigation with NumberDelta") {
       val original = Json.Number(10)
       val path     = DynamicOptic.root.wrapped
       val patch    = JsonPatch(path, Op.PrimitiveDelta(PrimitiveOp.NumberDelta(BigDecimal(5))))
       val result   = patch.apply(original, PatchMode.Strict)
-      assertTrue(result == Right(Json.Number("15")))
+      assertTrue(result == Right(Json.Number(15)))
     }
   )
 

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonPatchSerializationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonPatchSerializationSpec.scala
@@ -105,7 +105,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
     test("ArrayOp.Insert serializes") {
       roundTrip(
         ArrayOp.Insert(1, Chunk(Json.Number(42), Json.String("test"))): ArrayOp,
-        """{"Insert":{"index":1,"values":[{"Number":{"value":"42"}},{"String":{"value":"test"}}]}}"""
+        """{"Insert":{"index":1,"values":[{"Number":{"value":42}},{"String":{"value":"test"}}]}}"""
       )
     },
     test("ArrayOp.Append serializes") {
@@ -123,7 +123,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
     test("ArrayOp.Modify with Set operation") {
       roundTrip(
         ArrayOp.Modify(0, Op.Set(Json.Number(100))): ArrayOp,
-        """{"Modify":{"index":0,"op":{"Set":{"value":{"Number":{"value":"100"}}}}}}"""
+        """{"Modify":{"index":0,"op":{"Set":{"value":{"Number":{"value":100}}}}}}"""
       )
     },
     test("ArrayOp.Modify with nested PrimitiveDelta") {
@@ -154,7 +154,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
       roundTrip(
         ObjectOp.Modify("counter", innerPatch): ObjectOp,
         // Empty path serializes as empty object
-        """{"Modify":{"key":"counter","patch":{"ops":[{"path":{},"operation":{"Set":{"value":{"Number":{"value":"42"}}}}}]}}}"""
+        """{"Modify":{"key":"counter","patch":{"ops":[{"path":{},"operation":{"Set":{"value":{"Number":{"value":42}}}}}]}}}"""
       )
     },
     test("ObjectOp with unicode keys") {
@@ -177,7 +177,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
     test("Op.Set with complex object") {
       roundTrip(
         Op.Set(Json.Object("a" -> Json.Number(1), "b" -> Json.Array(Json.Boolean(true)))): Op,
-        """{"Set":{"value":{"Object":{"value":[["a",{"Number":{"value":"1"}}],["b",{"Array":{"value":[{"Boolean":{"value":true}}]}}]]}}}}"""
+        """{"Set":{"value":{"Object":{"value":[["a",{"Number":{"value":1}}],["b",{"Array":{"value":[{"Boolean":{"value":true}}]}}]]}}}}"""
       )
     },
     test("Op.PrimitiveDelta with NumberDelta") {
@@ -200,7 +200,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
             ArrayOp.Delete(0, 1)
           )
         ): Op,
-        """{"ArrayEdit":{"ops":[{"Append":{"values":[{"Number":{"value":"1"}}]}},{"Delete":{"index":0,"count":1}}]}}"""
+        """{"ArrayEdit":{"ops":[{"Append":{"values":[{"Number":{"value":1}}]}},{"Delete":{"index":0,"count":1}}]}}"""
       )
     },
     test("Op.ObjectEdit serializes") {
@@ -211,7 +211,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
             ObjectOp.Remove("y")
           )
         ): Op,
-        """{"ObjectEdit":{"ops":[{"Add":{"key":"x","value":{"Number":{"value":"10"}}}},{"Remove":{"key":"y"}}]}}"""
+        """{"ObjectEdit":{"ops":[{"Add":{"key":"x","value":{"Number":{"value":10}}}},{"Remove":{"key":"y"}}]}}"""
       )
     },
     test("Op.Nested serializes") {
@@ -231,7 +231,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
       roundTrip(
         JsonPatchOp(DynamicOptic.root, Op.Set(Json.Number(42))),
         // Empty path serializes as empty object
-        """{"path":{},"operation":{"Set":{"value":{"Number":{"value":"42"}}}}}"""
+        """{"path":{},"operation":{"Set":{"value":{"Number":{"value":42}}}}}"""
       )
     },
     test("JsonPatchOp with single field path") {
@@ -311,7 +311,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
       // Empty paths serialize as empty objects
       roundTrip(
         level1,
-        """{"ops":[{"path":{},"operation":{"Nested":{"patch":{"ops":[{"path":{},"operation":{"Nested":{"patch":{"ops":[{"path":{},"operation":{"Set":{"value":{"Number":{"value":"42"}}}}}]}}}}]}}}}]}"""
+        """{"ops":[{"path":{},"operation":{"Nested":{"patch":{"ops":[{"path":{},"operation":{"Nested":{"patch":{"ops":[{"path":{},"operation":{"Set":{"value":{"Number":{"value":42}}}}}]}}}}]}}}}]}"""
       )
     },
     test("ObjectOp.Modify with deeply nested patches") {
@@ -329,7 +329,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
       // Empty paths serialize as empty objects
       roundTrip(
         ObjectOp.Modify("outer", innerPatch): ObjectOp,
-        """{"Modify":{"key":"outer","patch":{"ops":[{"path":{},"operation":{"ObjectEdit":{"ops":[{"Add":{"key":"nested","value":{"Object":{"value":[["a",{"Number":{"value":"1"}}]]}}}},{"Modify":{"key":"other","patch":{"ops":[{"path":{},"operation":{"Set":{"value":{"String":{"value":"deep"}}}}}]}}}]}}}]}}}"""
+        """{"Modify":{"key":"outer","patch":{"ops":[{"path":{},"operation":{"ObjectEdit":{"ops":[{"Add":{"key":"nested","value":{"Object":{"value":[["a",{"Number":{"value":1}}]]}}}},{"Modify":{"key":"other","patch":{"ops":[{"path":{},"operation":{"Set":{"value":{"String":{"value":"deep"}}}}}]}}}]}}}]}}}"""
       )
     },
     test("ArrayOp.Modify containing ObjectEdit containing ArrayEdit") {

--- a/schema/shared/src/test/scala/zio/blocks/schema/tostring/JsonPatchToStringSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/tostring/JsonPatchToStringSpec.scala
@@ -97,7 +97,7 @@ object JsonPatchToStringSpec extends ZIOSpecDefault {
     },
     test("renders array append") {
       val patch = JsonPatch.root(
-        JsonPatch.Op.ArrayEdit(Vector(JsonPatch.ArrayOp.Append(Chunk(Json.Number("1"), Json.Number("2")))))
+        JsonPatch.Op.ArrayEdit(Vector(JsonPatch.ArrayOp.Append(Chunk(Json.Number(1), Json.Number(2)))))
       )
       assertTrue(
         patch.toString ==
@@ -110,7 +110,7 @@ object JsonPatchToStringSpec extends ZIOSpecDefault {
     },
     test("renders array insert") {
       val patch = JsonPatch.root(
-        JsonPatch.Op.ArrayEdit(Vector(JsonPatch.ArrayOp.Insert(1, Chunk(Json.Number("42"), Json.Number("43")))))
+        JsonPatch.Op.ArrayEdit(Vector(JsonPatch.ArrayOp.Insert(1, Chunk(Json.Number(42), Json.Number(43)))))
       )
       assertTrue(
         patch.toString ==
@@ -147,7 +147,7 @@ object JsonPatchToStringSpec extends ZIOSpecDefault {
     },
     test("renders array modify with set") {
       val patch = JsonPatch.root(
-        JsonPatch.Op.ArrayEdit(Vector(JsonPatch.ArrayOp.Modify(0, JsonPatch.Op.Set(Json.Number("99")))))
+        JsonPatch.Op.ArrayEdit(Vector(JsonPatch.ArrayOp.Modify(0, JsonPatch.Op.Set(Json.Number(99)))))
       )
       assertTrue(
         patch.toString ==
@@ -219,8 +219,8 @@ object JsonPatchToStringSpec extends ZIOSpecDefault {
       )
     },
     test("renders diff-generated patch for number change") {
-      val source = Json.Number("10")
-      val target = Json.Number("15")
+      val source = Json.Number(10)
+      val target = Json.Number(15)
       val patch  = JsonPatch.diff(source, target)
       assertTrue(
         patch.toString ==
@@ -230,8 +230,8 @@ object JsonPatchToStringSpec extends ZIOSpecDefault {
       )
     },
     test("renders diff-generated patch for object field changes") {
-      val source = Json.Object(Chunk("name" -> Json.String("Alice"), "age" -> Json.Number("30")))
-      val target = Json.Object(Chunk("name" -> Json.String("Bob"), "age" -> Json.Number("30")))
+      val source = Json.Object(Chunk("name" -> Json.String("Alice"), "age" -> Json.Number(30)))
+      val target = Json.Object(Chunk("name" -> Json.String("Bob"), "age" -> Json.Number(30)))
       val patch  = JsonPatch.diff(source, target)
       assertTrue(
         patch.toString ==
@@ -243,8 +243,8 @@ object JsonPatchToStringSpec extends ZIOSpecDefault {
       )
     },
     test("renders diff-generated patch for array changes") {
-      val source = Json.Array(Chunk(Json.Number("1"), Json.Number("2"), Json.Number("3")))
-      val target = Json.Array(Chunk(Json.Number("1"), Json.Number("2"), Json.Number("3"), Json.Number("4")))
+      val source = Json.Array(Chunk(Json.Number(1), Json.Number(2), Json.Number(3)))
+      val target = Json.Array(Chunk(Json.Number(1), Json.Number(2), Json.Number(3), Json.Number(4)))
       val patch  = JsonPatch.diff(source, target)
       assertTrue(
         patch.toString ==
@@ -264,7 +264,7 @@ object JsonPatchToStringSpec extends ZIOSpecDefault {
       )
     },
     test("renders nested operation") {
-      val innerPatch = JsonPatch.root(JsonPatch.Op.Set(Json.Number("42")))
+      val innerPatch = JsonPatch.root(JsonPatch.Op.Set(Json.Number(42)))
       val patch      = JsonPatch.root(JsonPatch.Op.Nested(innerPatch))
       assertTrue(
         patch.toString ==
@@ -282,7 +282,7 @@ object JsonPatchToStringSpec extends ZIOSpecDefault {
         Vector(
           JsonPatch.JsonPatchOp(
             DynamicOptic.root.field("items").at(0),
-            JsonPatch.Op.Set(Json.Number("1"))
+            JsonPatch.Op.Set(Json.Number(1))
           )
         )
       )
@@ -314,7 +314,7 @@ object JsonPatchToStringSpec extends ZIOSpecDefault {
         Vector(
           JsonPatch.JsonPatchOp(
             DynamicOptic.root.at(0).at(1),
-            JsonPatch.Op.Set(Json.Number("42"))
+            JsonPatch.Op.Set(Json.Number(42))
           )
         )
       )


### PR DESCRIPTION
These days `scala.BigDecimal` is much handy and safer than `java.math.BigDecimal` that was used in zio-json, no more DoS vulnerability on arithmetic operations (see https://github.com/scala/bug/issues/10882):

```
$ scala-cli
Welcome to Scala 3.7.4 (25.0.1, Java Java HotSpot(TM) 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                                                                                                                              
scala> def timed[A](f: => A): A = { val t = System.nanoTime(); val r = f; println(s"${System.nanoTime() - t} ns"); r }
def timed[A](f: => A): A
                                                                                                                                                                                                                                                              
scala> timed(BigDecimal("1e1000000000", java.math.MathContext.DECIMAL128) + 1)
62149 ns
val res0: BigDecimal = 1.000000000000000000000000000000000E+1000000000
                                                                                                                                                                                                                                                              
scala> timed(BigDecimal("1e1000000000", java.math.MathContext.DECIMAL128) + 1)
45599 ns
val res1: BigDecimal = 1.000000000000000000000000000000000E+1000000000
                                                                                                                                                                                                                                                              
scala> timed(BigDecimal("1e1000000000", java.math.MathContext.DECIMAL128) + 1)
46976 ns
val res2: BigDecimal = 1.000000000000000000000000000000000E+1000000000
```

Also, this PR provides `Json.Number.apply` with `Float` and `Double` arguments to be much faster than corresponding `BigDecimal.apply` from the Scala library.

Results of benchmarks for `Json` parsing and serialization with Scala 3 and JDK 25 on Intel® Core™ Ultra 9 285K CPU @ 3.7GHz (max 5.7GHz, 200S Boost), RAM 64Gb DDR5-6400:

#### Before
```txt
Benchmark                                                     (size)   Mode  Cnt        Score     Error   Units
JsonListOfJsonsBenchmark.readingZioBlocks                       1000  thrpt    5     5183.994 ±  97.674   ops/s
JsonListOfJsonsBenchmark.readingZioBlocks:gc.alloc.rate         1000  thrpt    5     7177.635 ± 135.872  MB/sec
JsonListOfJsonsBenchmark.readingZioBlocks:gc.alloc.rate.norm    1000  thrpt    5  1452385.136 ±   0.021    B/op
JsonListOfJsonsBenchmark.readingZioBlocks:gc.count              1000  thrpt    5       23.000            counts
JsonListOfJsonsBenchmark.readingZioBlocks:gc.time               1000  thrpt    5       22.000                ms
JsonListOfJsonsBenchmark.writingZioBlocks                       1000  thrpt    5     7369.679 ±  63.667   ops/s
JsonListOfJsonsBenchmark.writingZioBlocks:gc.alloc.rate         1000  thrpt    5     3137.016 ±  27.603  MB/sec
JsonListOfJsonsBenchmark.writingZioBlocks:gc.alloc.rate.norm    1000  thrpt    5   446448.800 ±   0.008    B/op
JsonListOfJsonsBenchmark.writingZioBlocks:gc.count              1000  thrpt    5       10.000            counts
JsonListOfJsonsBenchmark.writingZioBlocks:gc.time               1000  thrpt    5       14.000                ms
```

#### After
```txt
Benchmark                                                     (size)   Mode  Cnt        Score     Error   Units
JsonListOfJsonsBenchmark.readingZioBlocks                       1000  thrpt    5     7246.757 ± 135.401   ops/s
JsonListOfJsonsBenchmark.readingZioBlocks:gc.alloc.rate         1000  thrpt    5     7435.857 ± 139.660  MB/sec
JsonListOfJsonsBenchmark.readingZioBlocks:gc.alloc.rate.norm    1000  thrpt    5  1076389.622 ±  27.572    B/op
JsonListOfJsonsBenchmark.readingZioBlocks:gc.count              1000  thrpt    5       24.000            counts
JsonListOfJsonsBenchmark.readingZioBlocks:gc.time               1000  thrpt    5       22.000                ms
JsonListOfJsonsBenchmark.writingZioBlocks                       1000  thrpt    5     7329.897 ± 175.682   ops/s
JsonListOfJsonsBenchmark.writingZioBlocks:gc.alloc.rate         1000  thrpt    5     3120.357 ±  74.101  MB/sec
JsonListOfJsonsBenchmark.writingZioBlocks:gc.alloc.rate.norm    1000  thrpt    5   446448.811 ±   0.062    B/op
JsonListOfJsonsBenchmark.writingZioBlocks:gc.count              1000  thrpt    5       10.000            counts
JsonListOfJsonsBenchmark.writingZioBlocks:gc.time               1000  thrpt    5       14.000                ms
```


