### PR TITLE
feat(scope): Add Wireable.apply and Wireable.fromWire convenience constructors

### DIFF
--- a/scope/shared/src/main/scala/zio/blocks/scope/Wireable.scala
+++ b/scope/shared/src/main/scala/zio/blocks/scope/Wireable.scala
@@ -52,4 +52,35 @@ object Wireable extends WireableVersionSpecific {
    * }}}
    */
   type Typed[-In0, +Out] = Wireable[Out] { type In >: In0 }
+
+  /**
+   * Creates a [[Wireable]] from a pre-existing value.
+   *
+   * The value is wrapped in a shared wire with no dependencies.
+   *
+   * @example
+   *   {{{
+   *   object Config {
+   *     given Wireable[Config] = Wireable(Config("jdbc://localhost", 8080))
+   *   }
+   *   }}}
+   */
+  def apply[T](value: T)(implicit ev: zio.blocks.context.IsNominalType[T]): Wireable.Typed[Any, T] =
+    fromWire(Wire(value))
+
+  /**
+   * Creates a [[Wireable]] from an existing [[Wire]].
+   *
+   * @example
+   *   {{{
+   *   object Database {
+   *     given Wireable[Database] = Wireable.fromWire(shared[PostgresDatabase])
+   *   }
+   *   }}}
+   */
+  def fromWire[In0, Out](w: Wire[In0, Out]): Wireable.Typed[In0, Out] =
+    new Wireable[Out] {
+      type In = In0
+      def wire: Wire[In0, Out] = w
+    }
 }

--- a/scope/shared/src/test/scala/zio/blocks/scope/WireableSpec.scala
+++ b/scope/shared/src/test/scala/zio/blocks/scope/WireableSpec.scala
@@ -5,6 +5,8 @@ import zio.test._
 object WireableSpec extends ZIOSpecDefault {
 
   case class Config(debug: Boolean)
+  case class DbConfig(url: String)
+  class Database(@annotation.unused config: DbConfig)
 
   def spec = suite("Wireable")(
     test("trait exists") {
@@ -13,6 +15,17 @@ object WireableSpec extends ZIOSpecDefault {
         def wire: Wire[Any, Config] = Wire(Config(true))
       }
       assertTrue(wireable.wire != null)
+    },
+    test("Wireable.apply creates wireable from value") {
+      val wireable: Wireable.Typed[Any, Config] = Wireable(Config(true))
+      val wire: Wire[Any, Config]               = wireable.wire
+      assertTrue(wire.isShared)
+    },
+    test("Wireable.fromWire creates wireable from wire") {
+      val wire                                         = shared[Database]
+      val wireable: Wireable.Typed[DbConfig, Database] = Wireable.fromWire(wire)
+      val w: Wire[DbConfig, Database]                  = wireable.wire
+      assertTrue(w eq wire)
     }
   )
 }


### PR DESCRIPTION
Adds convenience constructors to make defining Wireable instances more ergonomic:

- `Wireable(value)` - create a Wireable from a pre-existing value
- `Wireable.fromWire(wire)` - create a Wireable from an existing Wire

**Example usage:**
```scala
case class Config(dbUrl: String, port: Int)
object Config {
  given Wireable[Config] = Wireable(Config("jdbc://prod/mydb", 8080))
}

trait Database
object Database {
  given Wireable[Database] = Wireable.fromWire(shared[PostgresDatabase])
}
```

100% statement and branch coverage on Scala 2 and 3.