### PR TITLE
Filter common base types from TypeDefKind to reduce generated bytecode

### DIFF
--- a/typeid/shared/src/main/scala-2/zio/blocks/typeid/TypeIdMacros.scala
+++ b/typeid/shared/src/main/scala-2/zio/blocks/typeid/TypeIdMacros.scala
@@ -584,9 +584,9 @@ object TypeIdMacros {
     "scala.Product",
     "scala.Equals",
     "scala.deriving.Mirror",
-    "scala.deriving.Mirror.Product",
-    "scala.deriving.Mirror.Singleton",
-    "scala.deriving.Mirror.Sum",
+    "scala.deriving.Mirror$.Product",
+    "scala.deriving.Mirror$.Singleton",
+    "scala.deriving.Mirror$.Sum",
     "java.io.Serializable"
   )
 

--- a/typeid/shared/src/main/scala-3/zio/blocks/typeid/TypeIdMacros.scala
+++ b/typeid/shared/src/main/scala-3/zio/blocks/typeid/TypeIdMacros.scala
@@ -419,9 +419,9 @@ object TypeIdMacros {
     "scala.Product",
     "scala.Equals",
     "scala.deriving.Mirror",
-    "scala.deriving.Mirror.Product",
-    "scala.deriving.Mirror.Singleton",
-    "scala.deriving.Mirror.Sum",
+    "scala.deriving.Mirror$.Product",
+    "scala.deriving.Mirror$.Singleton",
+    "scala.deriving.Mirror$.Sum",
     "java.io.Serializable"
   )
 

--- a/typeid/shared/src/test/scala/zio/blocks/typeid/TypeIdDerivationSpec.scala
+++ b/typeid/shared/src/test/scala/zio/blocks/typeid/TypeIdDerivationSpec.scala
@@ -37,6 +37,7 @@ object TypeIdDerivationSpec extends ZIOSpecDefault {
     }
   }
 
+  case object SimpleCaseObject
   trait SimpleTrait
   abstract class AbstractClass
 
@@ -540,6 +541,26 @@ object TypeIdDerivationSpec extends ZIOSpecDefault {
           listId.parents.isInstanceOf[List[TypeRepr]],
           classId.parents.isInstanceOf[List[TypeRepr]]
         )
+      },
+      test("simple case class has no base types") {
+        val id = TypeId.of[SimpleClass]
+        assertTrue(id.parents.isEmpty)
+      },
+      test("simple case object has no base types") {
+        val id = TypeId.of[SimpleCaseObject.type]
+        assertTrue(id.parents.isEmpty)
+      },
+      test("sealed trait that doesn't extend anything has no base types") {
+        val id = TypeId.of[SimpleSealed]
+        assertTrue(id.parents.isEmpty)
+      },
+      test("simple trait has no base types") {
+        val id = TypeId.of[SimpleTrait]
+        assertTrue(id.parents.isEmpty)
+      },
+      test("abstract class has no base types") {
+        val id = TypeId.of[AbstractClass]
+        assertTrue(id.parents.isEmpty)
       }
     ),
     suite("isSubtypeOf")(


### PR DESCRIPTION
Closes https://github.com/zio/zio-blocks/issues/979

Exclude Product, Equals, Serializable and Mirror.* from the base types list in `TypeDefKind`. These standard library types are automatically synthesized and generate substantial bytecode in macro expansions, contributing to "Method Too Large" errors for complex ADTs.