### PR TITLE
Fix TypeId hashCode/equals inconsistency for opaque type aliases

### DIFF
--- a/typeid/shared/src/test/scala-3/zio/blocks/typeid/Scala3DerivationSpec.scala
+++ b/typeid/shared/src/test/scala-3/zio/blocks/typeid/Scala3DerivationSpec.scala
@@ -777,6 +777,24 @@ object Scala3DerivationSpec extends ZIOSpecDefault {
         assertTrue(
           map.get(listIdFoo).contains("found")
         )
+      },
+      test("Option[FooId] equals Option[Id[Foo]]") {
+        val optFooId = TypeId.of[Option[FooId]]
+        val optIdFoo = TypeId.of[Option[OpaqueTypes.Id[Foo]]]
+
+        assertTrue(
+          optFooId == optIdFoo,
+          optFooId.hashCode() == optIdFoo.hashCode()
+        )
+      },
+      test("nested containers List[Option[FooId]] have consistent hashCodes") {
+        val nested1 = TypeId.of[List[Option[FooId]]]
+        val nested2 = TypeId.of[List[Option[OpaqueTypes.Id[Foo]]]]
+
+        assertTrue(
+          nested1 == nested2,
+          nested1.hashCode() == nested2.hashCode()
+        )
       }
     )
   )


### PR DESCRIPTION
## Summary

Fixes #1018 - TypeId `equals`/`hashCode` contract violation for opaque type aliases used as type arguments.

### The Problem

When an opaque type alias like `FooId = OpaqueTypes.Id[Foo]` is used as a type argument in a container (e.g., `List[FooId]` vs `List[Id[Foo]]`):
- `equals()` returns `true` ✓
- `hashCode()` returns **different values** ✗

This violates the Java `equals`/`hashCode` contract and causes issues with `Map` lookups and other hash-based operations.

### The Solution

Add `normalizeTypeRepr()` which canonicalizes `TypeRepr` before equality and hashing:
- Expands type aliases (like `FooId = Id[Foo]`) to their underlying applied types
- Converts `Ref(id)` with `typeArgs` to `Applied(Ref(unapplied), typeArgs)`
- Recursively normalizes type arguments

This ensures `List[FooId]` and `List[Id[Foo]]` have consistent `equals`/`hashCode`.

### Note

This PR builds on top of #1012 which fixed `Ref` vs `Applied` comparison but didn't handle the case where an **alias** is used as a type argument.

### Tests Added

- 7 new tests in `Scala3DerivationSpec` covering:
  - Direct opaque type alias equality/hashCode
  - Applied opaque alias in containers (List, Option)
  - Map lookup with opaque type aliases
  - Nested containers with opaque type aliases