### PR TITLE
fix: enable explicit type annotations with schema.derive(Format) (#1023)

### DIFF
--- a/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaVersionSpecific.scala
@@ -6,6 +6,31 @@ package zio.blocks.schema
 trait SchemaVersionSpecific[A] { self: Schema[A] =>
 
   /**
+   * Derives a type class instance for this schema using the given format.
+   *
+   * In Scala 2, when using an explicit type annotation, you need to help the
+   * compiler select the correct overload by either:
+   *
+   * 1. Specifying the type parameter explicitly:
+   * {{{
+   * implicit val jsonCodec: JsonBinaryCodec[Person] = schema.derive[JsonFormat.type](JsonFormat)
+   * }}}
+   *
+   * 2. Or using the deriver directly:
+   * {{{
+   * implicit val jsonCodec: JsonBinaryCodec[Person] = schema.derive(JsonFormat.deriver)
+   * }}}
+   *
+   * Without explicit type annotation, it works as expected:
+   * {{{
+   * implicit val jsonCodec = schema.derive(JsonFormat)
+   * }}}
+   *
+   * In Scala 3, explicit type annotations work without these workarounds.
+   */
+  def derive[F <: codec.Format](format: F): format.TypeClass[A] = deriving(format.deriver).derive
+
+  /**
    * Convert this schema to a structural type schema.
    *
    * The structural type represents the "shape" of A without its nominal

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaVersionSpecific.scala
@@ -6,6 +6,24 @@ package zio.blocks.schema
 trait SchemaVersionSpecific[A] { self: Schema[A] =>
 
   /**
+   * Derives a type class instance for this schema using the given format.
+   *
+   * This method uses `transparent inline` to resolve the path-dependent type
+   * `format.TypeClass[A]` at compile time, enabling explicit type annotations:
+   *
+   * {{{
+   * implicit val jsonCodec: JsonBinaryCodec[Person] = schema.derive(JsonFormat)
+   * }}}
+   *
+   * @param format
+   *   The format to derive a codec for
+   * @return
+   *   A type class instance for encoding/decoding values of type A
+   */
+  transparent inline def derive[F <: codec.Format](format: F): format.TypeClass[A] =
+    self.deriving(format.deriver).derive
+
+  /**
    * Convert this schema to a structural type schema.
    *
    * The structural type represents the "shape" of A without its nominal

--- a/schema/shared/src/test/scala-2/zio/blocks/schema/SchemaVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-2/zio/blocks/schema/SchemaVersionSpecificSpec.scala
@@ -5,6 +5,51 @@ import zio.test._
 
 object SchemaVersionSpecificSpec extends SchemaBaseSpec {
   def spec: Spec[TestEnvironment, Any] = suite("SchemaVersionSpecificSpec")(
+    test("compiles when explicit type annotation is used with schema.derive[F](format)") {
+      typeCheck {
+        """
+        import zio.blocks.schema._
+        import zio.blocks.schema.json.{JsonBinaryCodec, JsonFormat}
+
+        case class Person(name: String, age: Int)
+
+        object Person {
+          implicit val schema: Schema[Person] = Schema.derived[Person]
+          implicit val jsonCodec: JsonBinaryCodec[Person] = schema.derive[JsonFormat.type](JsonFormat)
+        }
+        """
+      }.map(result => assert(result)(isRight))
+    },
+    test("compiles when explicit type annotation is used with schema.derive(format.deriver)") {
+      typeCheck {
+        """
+        import zio.blocks.schema._
+        import zio.blocks.schema.json.{JsonBinaryCodec, JsonFormat}
+
+        case class Person(name: String, age: Int)
+
+        object Person {
+          implicit val schema: Schema[Person] = Schema.derived[Person]
+          implicit val jsonCodec: JsonBinaryCodec[Person] = schema.derive(JsonFormat.deriver)
+        }
+        """
+      }.map(result => assert(result)(isRight))
+    },
+    test("compiles without explicit type annotation using schema.derive(Format)") {
+      typeCheck {
+        """
+        import zio.blocks.schema._
+        import zio.blocks.schema.json.JsonFormat
+
+        case class Person(name: String, age: Int)
+
+        object Person {
+          implicit val schema: Schema[Person] = Schema.derived[Person]
+          val jsonCodec = schema.derive(JsonFormat)
+        }
+        """
+      }.map(result => assert(result)(isRight))
+    },
     test("doesn't generate schema for unsupported classes") {
       typeCheck {
         "Schema.derived[scala.concurrent.duration.Duration]"

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
@@ -793,6 +793,21 @@ object SchemaVersionSpecificSpec extends SchemaBaseSpec {
         )
       }
     ),
+    suite("derive with Format")(
+      test("compiles when explicit type annotation is used with schema.derive(Format)") {
+        typeCheck {
+          """
+          import zio.blocks.schema._
+          import zio.blocks.schema.json.{JsonBinaryCodec, JsonFormat}
+
+          case class Person(name: String, age: Int) derives Schema
+
+          val schema = Schema[Person]
+          val jsonCodec: JsonBinaryCodec[Person] = schema.derive(JsonFormat)
+          """
+        }.map(result => assertTrue(result.isRight))
+      }
+    ),
     suite("transform captures TypeId")(
       test("transform captures the correct TypeId automatically") {
         case class Age(value: Int)


### PR DESCRIPTION
## Summary

Fixes #1023 - Explicit type annotations now work with `schema.derive(Format)` in Scala 3.

### Scala 3 (Full Fix)

Uses `transparent inline` to resolve the path-dependent type `format.TypeClass[A]` at compile time:

```scala
implicit val jsonCodec: JsonBinaryCodec[Person] = schema.derive(JsonFormat)  // ✅ Works!
```

### Scala 2 (Workarounds Documented)

Due to Scala 2's overload resolution limitations (the `derive[TC[_]](deriver)` method is selected before `derive[F <: Format](format)` when an explicit return type is provided), the following workarounds are documented:

```scala
// Option 1: Specify the type parameter explicitly
implicit val jsonCodec: JsonBinaryCodec[Person] = schema.derive[JsonFormat.type](JsonFormat)

// Option 2: Use the deriver directly
implicit val jsonCodec: JsonBinaryCodec[Person] = schema.derive(JsonFormat.deriver)

// Without explicit type annotation, it works as expected
implicit val jsonCodec = schema.derive(JsonFormat)  // Type inferred correctly
```

### Changes

1. **Scala 3 `SchemaVersionSpecific`**: Added `transparent inline def derive[F <: codec.Format](format: F): format.TypeClass[A]`

2. **Scala 2 `SchemaVersionSpecific`**: Added `def derive[F <: codec.Format](format: F): format.TypeClass[A]` with documentation explaining the limitations and workarounds

3. **Shared `Schema.scala`**: Removed the `derive[F <: codec.Format]` method (moved to version-specific traits) and updated internal usages to call `deriving(format.deriver).derive` directly

4. **Tests**: Added typeCheck-based tests verifying compilation behavior in both Scala 2 and Scala 3