### PR TITLE
fix(schema): add Derivable type class for unified schema.derive method

### DIFF
--- a/docs/reference/codec.md
+++ b/docs/reference/codec.md
@@ -32,8 +32,8 @@ case class Person(name: String, age: Int)
 object Person {
   // Derive a schema for Person (required for codec derivation)
   implicit val schema: Schema[Person] = Schema.derived
-  // Derive a JSON codec from the schema
-  implicit val codec: JsonBinaryCodec[Person] = schema.derive[JsonFormat.type](JsonFormat)
+   // Derive a JSON codec from the schema
+   implicit val codec: JsonBinaryCodec[Person] = schema.derive(JsonFormat)
 }
 
 // Encode
@@ -116,7 +116,7 @@ object Person {
 }
 
 // Pass a Format object to get a codec for that format
-val jsonCodec: JsonBinaryCodec[Person] = Schema[Person].derive[JsonFormat.type](JsonFormat)
+val jsonCodec: JsonBinaryCodec[Person] = Schema[Person].derive(JsonFormat)
 ```
 
 This works with any format:

--- a/docs/reference/modifier.md
+++ b/docs/reference/modifier.md
@@ -38,12 +38,12 @@ object User extends CompanionOptics[User] {
     .derived[User]
     .modifier(Modifier.config("db.table-name", "users"))
 
-  implicit val jsonCodec: JsonBinaryCodec[User] =
-    schema
-      .deriving[JsonBinaryCodec](JsonBinaryCodecDeriver)
-      .modifier(User.name, Modifier.rename("username"))
-      .modifier(User.cache, Modifier.transient())
-      .derive
+   implicit val jsonCodec: JsonBinaryCodec[User] =
+     schema
+       .deriving(JsonBinaryCodecDeriver)
+       .modifier(User.name, Modifier.rename("username"))
+       .modifier(User.cache, Modifier.transient())
+       .derive
 
   lazy val id   : Lens[User, String]              = $(_.id)
   lazy val name : Lens[User, String]              = $(_.name)
@@ -86,9 +86,9 @@ object User extends CompanionOptics[User] {
   implicit val schema: Schema[User] =
     Schema.derived[User]
 
-  implicit val jsonCodec: JsonBinaryCodec[User] =
-    schema
-      .derive[JsonBinaryCodec](JsonBinaryCodecDeriver)
+   implicit val jsonCodec: JsonBinaryCodec[User] =
+     schema
+       .derive(JsonBinaryCodecDeriver)
 }
 ```
 

--- a/docs/reference/type-class-derivation.md
+++ b/docs/reference/type-class-derivation.md
@@ -128,7 +128,7 @@ Given a `Schema[A]`, you can call the `derive` method to get an instance of the 
 
 ```scala
 case class Schema[A](reflect: Reflect.Bound[A]) {
-  def derive[TC[_]](deriver: Deriver[TC]): TC[A] = ???
+   def derive[D, TC[_]](d: D)(implicit ev: Derivable[D, TC]): TC[A] = ???
 }
 ```
 
@@ -158,13 +158,7 @@ val result: Either[SchemaError, Person] =
   )
 ```
 
-There is another overloaded version of the `Schema#derive` method that takes a `Format` instead of a `Deriver`:
-
-```scala
-case class Schema[A](reflect: Reflect.Bound[A]) {
-  def derive[F <: codec.Format](format: F): format.TypeClass[A] = derive(format.deriver)
-}
-```
+There is a `Derivable` type class that enables seamless overloading between `Deriver[TC]` and `Format` arguments, allowing the same `derive` method to work with both:
 
 For example, by calling `Person.schema.derive(JsonFormat)`, we can derive a `JsonCodec[Person]` instance:
 

--- a/schema-avro/src/test/scala/zio/blocks/schema/avro/AvroTestUtils.scala
+++ b/schema-avro/src/test/scala/zio/blocks/schema/avro/AvroTestUtils.scala
@@ -16,7 +16,9 @@ object AvroTestUtils {
   private[this] val codecs = new ConcurrentHashMap[Schema[?], AvroBinaryCodec[?]]()
 
   private[this] def codec[A](schema: Schema[A]): AvroBinaryCodec[A] =
-    codecs.computeIfAbsent(schema, (s: Schema[?]) => s.derive(AvroFormat.deriver)).asInstanceOf[AvroBinaryCodec[A]]
+    codecs
+      .computeIfAbsent(schema, (s: Schema[?]) => s.deriving(AvroFormat.deriver).derive)
+      .asInstanceOf[AvroBinaryCodec[A]]
 
   def avroSchema[A](expectedAvroSchemaJson: String)(implicit schema: Schema[A]): TestResult =
     avroSchema(expectedAvroSchemaJson, codec(schema))

--- a/schema-toon/src/test/scala/zio/blocks/schema/toon/ToonTestUtils.scala
+++ b/schema-toon/src/test/scala/zio/blocks/schema/toon/ToonTestUtils.scala
@@ -218,7 +218,7 @@ object ToonTestUtils {
   private[this] def writerConfig = WriterConfig
 
   private[this] def getOrDeriveCodec[A](schema: Schema[A]): ToonBinaryCodec[A] =
-    codecs.computeIfAbsent(schema, _.derive(ToonBinaryCodecDeriver)).asInstanceOf[ToonBinaryCodec[A]]
+    codecs.computeIfAbsent(schema, _.deriving(ToonBinaryCodecDeriver).derive).asInstanceOf[ToonBinaryCodec[A]]
 
   def deriveCodec[A: Schema](deriverModifier: ToonBinaryCodecDeriver => ToonBinaryCodecDeriver): ToonBinaryCodec[A] =
     Schema[A].derive(deriverModifier(ToonBinaryCodecDeriver))

--- a/schema/shared/src/main/scala/zio/blocks/schema/codec/Format.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/codec/Format.scala
@@ -40,6 +40,11 @@ abstract class BinaryFormat[TC[A] <: BinaryCodec[A]](val mimeType: String, val d
 
   type DecodeInput  = ByteBuffer
   type EncodeOutput = ByteBuffer
+
+  implicit final def derivable: Derivable[this.type, TC] =
+    new Derivable[this.type, TC] {
+      def deriver(d: BinaryFormat.this.type): Deriver[TC] = BinaryFormat.this.deriver
+    }
 }
 
 /**
@@ -58,4 +63,9 @@ abstract class TextFormat[TC[A] <: TextCodec[A]](val mimeType: String, val deriv
 
   type DecodeInput  = CharBuffer
   type EncodeOutput = CharBuffer
+
+  implicit final def derivable: Derivable[this.type, TC] =
+    new Derivable[this.type, TC] {
+      def deriver(d: TextFormat.this.type): Deriver[TC] = TextFormat.this.deriver
+    }
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/Derivable.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/Derivable.scala
@@ -1,0 +1,12 @@
+package zio.blocks.schema.derive
+
+trait Derivable[-D, TC[_]] {
+  def deriver(d: D): Deriver[TC]
+}
+
+object Derivable {
+  implicit def deriverDerivable[TC[_]]: Derivable[Deriver[TC], TC] =
+    new Derivable[Deriver[TC], TC] {
+      def deriver(d: Deriver[TC]): Deriver[TC] = d
+    }
+}

--- a/schema/shared/src/test/scala-2/zio/blocks/schema/SchemaVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-2/zio/blocks/schema/SchemaVersionSpecificSpec.scala
@@ -5,6 +5,51 @@ import zio.test._
 
 object SchemaVersionSpecificSpec extends SchemaBaseSpec {
   def spec: Spec[TestEnvironment, Any] = suite("SchemaVersionSpecificSpec")(
+    test("compiles when explicit type annotation is used with schema.derive(Format)") {
+      typeCheck {
+        """
+        import zio.blocks.schema._
+        import zio.blocks.schema.json.{JsonBinaryCodec, JsonFormat}
+
+        case class Person(name: String, age: Int)
+
+        object Person {
+          implicit val schema: Schema[Person] = Schema.derived[Person]
+          implicit val jsonCodec: JsonBinaryCodec[Person] = schema.derive(JsonFormat)
+        }
+        """
+      }.map(result => assert(result)(isRight))
+    },
+    test("compiles when explicit type annotation is used with schema.derive(deriver)") {
+      typeCheck {
+        """
+        import zio.blocks.schema._
+        import zio.blocks.schema.json.{JsonBinaryCodec, JsonBinaryCodecDeriver}
+
+        case class Person(name: String, age: Int)
+
+        object Person {
+          implicit val schema: Schema[Person] = Schema.derived[Person]
+          implicit val jsonCodec: JsonBinaryCodec[Person] = schema.derive(JsonBinaryCodecDeriver)
+        }
+        """
+      }.map(result => assert(result)(isRight))
+    },
+    test("compiles without explicit type annotation using schema.derive(Format)") {
+      typeCheck {
+        """
+        import zio.blocks.schema._
+        import zio.blocks.schema.json.JsonFormat
+
+        case class Person(name: String, age: Int)
+
+        object Person {
+          implicit val schema: Schema[Person] = Schema.derived[Person]
+          val jsonCodec = schema.derive(JsonFormat)
+        }
+        """
+      }.map(result => assert(result)(isRight))
+    },
     test("doesn't generate schema for unsupported classes") {
       typeCheck {
         "Schema.derived[scala.concurrent.duration.Duration]"

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
@@ -798,6 +798,21 @@ object SchemaVersionSpecificSpec extends SchemaBaseSpec {
         )
       }
     ),
+    suite("derive with Format")(
+      test("compiles when explicit type annotation is used with schema.derive(Format)") {
+        typeCheck {
+          """
+          import zio.blocks.schema._
+          import zio.blocks.schema.json.{JsonBinaryCodec, JsonFormat}
+
+          case class Person(name: String, age: Int) derives Schema
+
+          val schema = Schema[Person]
+          val jsonCodec: JsonBinaryCodec[Person] = schema.derive(JsonFormat)
+          """
+        }.map(result => assertTrue(result.isRight))
+      }
+    ),
     suite("transform captures TypeId")(
       test("transform captures the correct TypeId automatically") {
         case class Age(value: Int)

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSchemaToSchemaSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSchemaToSchemaSpec.scala
@@ -813,7 +813,8 @@ object JsonSchemaToSchemaSpec extends SchemaBaseSpec {
         )
       },
       test("exclusiveMinimum constraint survives roundtrip") {
-        val codec = Schema.fromJsonSchema(JsonSchema.integer(exclusiveMinimum = Some(BigDecimal(0)))).derive(JsonFormat)
+        val codec =
+          Schema.fromJsonSchema(JsonSchema.integer(exclusiveMinimum = Some(BigDecimal(0)))).derive(JsonFormat)
         assertTrue(
           codec.decode("1").isRight,
           codec.decode("100").isRight,

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonTestUtils.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonTestUtils.scala
@@ -190,7 +190,9 @@ object JsonTestUtils {
   private[this] def writerConfig = WriterConfig.withPreferredBufSize(random.nextInt(11) + 1)
 
   private[this] def getOrDeriveCodec[A](schema: Schema[A]): JsonBinaryCodec[A] =
-    codecs.computeIfAbsent(schema, _.derive(JsonBinaryCodecDeriver)).asInstanceOf[JsonBinaryCodec[A]]
+    codecs
+      .computeIfAbsent(schema, (s: Schema[_]) => s.deriving(JsonBinaryCodecDeriver).derive)
+      .asInstanceOf[JsonBinaryCodec[A]]
 
   private[this] def toInputStream(bs: Array[Byte]): java.io.InputStream = new java.io.ByteArrayInputStream(bs)
 


### PR DESCRIPTION
## Summary

Fixes #1023 — `schema.derive(Format)` fails to compile with explicit type annotations in Scala 2 due to overload ambiguity with `schema.derive(Deriver[TC])`.

## Solution

Introduces a `Derivable[D, TC[_]]` type class that unifies both `Deriver[TC]` and `Format` arguments under a single `derive` method:

```scala
// Single method handles both:
schema.derive(JsonFormat)             // Format → Derivable[JsonFormat.type, JsonBinaryCodec]
schema.derive(JsonBinaryCodecDeriver) // Deriver[TC] → Derivable[Deriver[TC], TC]
```

### Design

- **`Derivable[-D, TC[_]]`** — type class that extracts a `Deriver[TC]` from any derivation source `D`
- **`Derivable.deriverDerivable`** — identity instance for `Deriver[TC]` (in `Derivable` companion)
- **`BinaryFormat.derivable` / `TextFormat.derivable`** — implicit `Derivable` instances on format classes (uses `this.type` for precise type inference)

### Key change

```diff
- def derive[TC[_]](deriver: Deriver[TC]): TC[A] = deriving(deriver).derive
+ def derive[D, TC[_]](d: D)(implicit ev: Derivable[D, TC]): TC[A] = deriving(ev.deriver(d)).derive
```

### Breaking change

The `derive` method signature changed. Code that passed a `Deriver[TC]` directly still works via the `deriverDerivable` instance. Code that passed a `Format` also still works via the format's own `derivable` implicit.

## Files changed

- **New**: `schema/.../derive/Derivable.scala` — the type class
- **Modified**: `Schema.scala` — unified `derive` method
- **Modified**: `Format.scala` — `derivable` implicits on `BinaryFormat`/`TextFormat`
- **Removed**: `deriveFormat` from `SchemaVersionSpecific` (Scala 2 & 3)
- **Updated**: All call sites reverted from `deriveFormat` back to `derive`
- **Updated**: Tests, docs, benchmarks, downstream modules

## Testing

- ✅ Schema JVM tests pass (Scala 2.13 + Scala 3)
- ✅ Downstream modules pass (avro, messagepack, toon, thrift) in both Scala versions
- ✅ Benchmarks compile
- ✅ Docs compile
- ✅ Type-check tests verify explicit type annotations work in both Scala versions