### PR TITLE
Add Permissions for id-token and contents in CI Configuration‌ (OpenID Connect)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ on:
   release:
     types:
       - published
-permissions:
-  id-token: write
-  contents: read
 concurrency:
   group: ci-pr-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -168,6 +165,9 @@ jobs:
     needs:
       - release
     if: ${{ ((github.event_name == 'release') && (github.event.action == 'published')) || (github.event_name == 'workflow_dispatch') }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
This pull request makes a small but important update to the GitHub Actions workflow configuration by adding explicit permissions for the workflow. Specifically, it grants write access to `id-token` and read access to `contents`, which may be required for certain actions (such as authentication or accessing repository contents).

* Added explicit workflow permissions: `id-token: write` and `contents: read` to the `.github/workflows/ci.yml` file.