### PR TITLE
feat: infix syntax for $ method

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ Scope.global.scoped { scope =>
   val db: Database @@ scope.Tag = scope.allocate(Resource(openDatabase()))
   
   // Methods are hidden - can't call db.query() directly
-  // Must use scope.$ to access:
-  val result = scope.$(db)(_.query("SELECT 1"))
+  // Must use (scope $ ...) to access:
+  val result = (scope $ db)(_.query("SELECT 1"))
   
   // Trying to return `db` would be a compile error!
   result  // Only pure data escapes
@@ -245,8 +245,8 @@ Scope.global.scoped { scope =>
   // Allocate returns Database @@ scope.Tag (scoped value)
   val db = scope.allocate(Resource(new Database))
   
-  // Access via scope.$ - result (String) escapes, db does not
-  val result = scope.$(db)(_.query("SELECT * FROM users"))
+  // Access via (scope $ ...) - result (String) escapes, db does not
+  val result = (scope $ db)(_.query("SELECT * FROM users"))
   println(result)
 }
 // Output: Result: SELECT * FROM users
@@ -271,7 +271,7 @@ val serviceResource: Resource[UserService] = Resource.from[UserService](
 
 Scope.global.scoped { scope =>
   val service = scope.allocate(serviceResource)
-  scope.$(service)(_.createUser("Alice"))
+  (scope $ service)(_.createUser("Alice"))
 }
 // Cleanup runs LIFO: UserService → Database (UserRepo has no cleanup)
 ```
@@ -285,8 +285,8 @@ Scope.global.scoped { connScope =>
   // Transaction lives in child scope - cleaned up before connection
   val result = connScope.scoped { txScope =>
     val tx = txScope.allocate(conn.beginTransaction())  // Returns Resource!
-    txScope.$(tx)(_.execute("INSERT INTO users VALUES (1, 'Alice')"))
-    txScope.$(tx)(_.commit())
+    (txScope $ tx)(_.execute("INSERT INTO users VALUES (1, 'Alice')"))
+    (txScope $ tx)(_.commit())
     "success"
   }
   // Transaction closed here, connection still open

--- a/scope-examples/src/main/scala/scope/examples/CachingSharedLoggerExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/CachingSharedLoggerExample.scala
@@ -116,7 +116,7 @@ object CachingSharedLoggerExample {
       println("\n─── Verification ───")
       println(s"  Logger instances created: ${loggerInstances.get()} (expected: 1)")
       println(s"  Cache instances created:  ${cacheInstances.get()} (expected: 2)")
-      scope.$(app) { a =>
+      (scope $ app) { a =>
         println(s"  ProductService.logger eq OrderService.logger: ${a.productService.logger eq a.orderService.logger}")
         println(s"  ProductService.cache  eq OrderService.cache:  ${a.productService.cache eq a.orderService.cache}")
 

--- a/scope-examples/src/main/scala/scope/examples/CircularDependencyDemoExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/CircularDependencyDemoExample.scala
@@ -96,7 +96,7 @@ class Application(a: ServiceAImpl, @annotation.unused b: ServiceBApi) {
       )
     )
 
-    println(s"Result: ${scope.$(app)(_.run())}")
+    println(s"Result: ${(scope $ app)(_.run())}")
     println("\nThe dependency graph was validated at compile time.")
     println("No cycles detected - application wired successfully.")
   }

--- a/scope-examples/src/main/scala/scope/examples/ConfigReaderExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/ConfigReaderExample.scala
@@ -94,7 +94,7 @@ class SecretStore extends AutoCloseable {
   Scope.global.scoped { scope =>
     val reader = scope.allocate(Resource(new ConfigReader))
 
-    scope.$(reader) { r =>
+    (scope $ reader) { r =>
       escapedConfig = r.readConfig("/etc/app/config.json")
     }
   }
@@ -108,7 +108,7 @@ class SecretStore extends AutoCloseable {
   Scope.global.scoped { scope =>
     val secrets = scope.allocate(Resource(new SecretStore))
 
-    scope.$(secrets) { s =>
+    (scope $ secrets) { s =>
       val dbPassword = s.getSecret("database.password")
       println(s"  Retrieved secret: $dbPassword")
     }

--- a/scope-examples/src/main/scala/scope/examples/ConnectionPoolExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/ConnectionPoolExample.scala
@@ -99,9 +99,9 @@ final class ConnectionPool(config: PoolConfig) extends AutoCloseable {
 
     println("--- ServiceA doing work (connection scoped to this block) ---")
     appScope.scoped { workScope =>
-      appScope.$(pool) { p =>
+      (appScope $ pool) { p =>
         val conn = workScope.allocate(p.acquire)
-        workScope.$(conn) { c =>
+        (workScope $ conn) { c =>
           val result = c.execute("SELECT * FROM service_a_table")
           println(s"  [ServiceA] Got: $result")
         }
@@ -111,9 +111,9 @@ final class ConnectionPool(config: PoolConfig) extends AutoCloseable {
 
     println("--- ServiceB doing work ---")
     appScope.scoped { workScope =>
-      appScope.$(pool) { p =>
+      (appScope $ pool) { p =>
         val conn = workScope.allocate(p.acquire)
-        workScope.$(conn) { c =>
+        (workScope $ conn) { c =>
           val result = c.execute("SELECT * FROM service_b_table")
           println(s"  [ServiceB] Got: $result")
         }
@@ -123,12 +123,12 @@ final class ConnectionPool(config: PoolConfig) extends AutoCloseable {
 
     println("--- Multiple connections in same scope ---")
     appScope.scoped { workScope =>
-      appScope.$(pool) { p =>
+      (appScope $ pool) { p =>
         val connA = workScope.allocate(p.acquire)
         val connB = workScope.allocate(p.acquire)
 
-        workScope.$(connA) { a =>
-          workScope.$(connB) { b =>
+        (workScope $ connA) { a =>
+          (workScope $ connB) { b =>
             println(s"  [Parallel] Using connections ${a.id} and ${b.id}")
             a.execute("UPDATE table_a SET x = 1")
             b.execute("UPDATE table_b SET y = 2")

--- a/scope-examples/src/main/scala/scope/examples/DatabaseConnectionExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/DatabaseConnectionExample.scala
@@ -80,7 +80,7 @@ final class Database(config: DbConfig) extends AutoCloseable {
  *
  * This example shows:
  *   - Allocating an AutoCloseable resource with automatic cleanup
- *   - Using `scope.$` to access scoped values and execute queries
+ *   - Using `(scope $ value)` to access scoped values and execute queries
  *   - LIFO finalizer ordering (last allocated = first closed)
  *
  * When the scope exits, all registered finalizers run in reverse order,
@@ -102,9 +102,9 @@ final class Database(config: DbConfig) extends AutoCloseable {
       database
     })
 
-    // Use scope.$ to access the scoped value and execute queries.
+    // Use (scope $ value) to access the scoped value and execute queries.
     // $ executes immediately, so we can capture results via side effects or use directly.
-    scope.$(db) { database =>
+    (scope $ db) { database =>
       val users = database.query("SELECT * FROM users")
       println(s"[Result] Found ${users.size} users: ${users.rows.map(_("name")).mkString(", ")}\n")
 

--- a/scope-examples/src/main/scala/scope/examples/HttpClientPipelineExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/HttpClientPipelineExample.scala
@@ -62,7 +62,7 @@ final class HttpClient(config: ApiConfig) extends AutoCloseable {
  * Key concepts:
  *   - `(scopedValue).map(f)` builds a `Scoped` computation lazily
  *   - `(scopedValue).flatMap(f)` chains scoped computations
- *   - `scope.$(scopedValue) { v => ... }` executes and applies a function
+ *   - `(scope $ scopedValue) { v => ... }` executes and applies a function
  *   - The computation only runs when explicitly executed
  */
 @main def httpClientPipelineExample(): Unit = {
@@ -100,22 +100,22 @@ final class HttpClient(config: ApiConfig) extends AutoCloseable {
 
     println("Pipeline definitions built. Now executing each step...\n")
 
-    // Step 3: Execute each computation using scope.$
-    // Use scope.$ to apply a function to the scoped value
+    // Step 3: Execute each computation using (scope $ value)
+    // Use (scope $ value) to apply a function to the scoped value
     println("--- Executing: fetchUsers ---")
-    scope.$(scope.execute(fetchUsers)) { users =>
+    (scope $ scope.execute(fetchUsers)) { users =>
       println(s"\n=== Users Result ===")
       println(s"Users data: ${users.values}")
     }
 
     println("\n--- Executing: fetchOrders ---")
-    scope.$(scope.execute(fetchOrders)) { orders =>
+    (scope $ scope.execute(fetchOrders)) { orders =>
       println(s"\n=== Orders Result ===")
       println(s"Orders data: ${orders.values}")
     }
 
     println("\n--- Executing: postAnalytics ---")
-    scope.$(scope.execute(postAnalytics)) { analytics =>
+    (scope $ scope.execute(postAnalytics)) { analytics =>
       println(s"\n=== Analytics Result ===")
       println(s"Analytics: ${analytics.values}")
     }

--- a/scope-examples/src/main/scala/scope/examples/IntegrationTestHarnessExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/IntegrationTestHarnessExample.scala
@@ -110,7 +110,7 @@ object IntegrationTestHarnessExample {
 
       // Run test scenarios - access the tuple components via scope.$
       println("Running test scenarios:")
-      scope.$(harness) { case (fixture, app) =>
+      (scope $ harness) { case (fixture, app) =>
         println(s"  GET user:1 -> ${app.handleRequest("user:1")}")
         println(s"  GET user:2 -> ${app.handleRequest("user:2")}")
         println(s"  GET user:3 -> ${app.handleRequest("user:3")}")

--- a/scope-examples/src/main/scala/scope/examples/LayeredWebServiceExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/LayeredWebServiceExample.scala
@@ -96,8 +96,8 @@ class UserController(repo: UserRepository) extends AutoCloseable {
     val controller = scope.allocate(controllerResource)
 
     println("\n=== Handling requests ===")
-    println(s"  GET /users/1  → ${scope.$(controller)(_.getUser(1))}")
-    println(s"  POST /users   → ${scope.$(controller)(_.createUser("Bob", "bob@example.com"))}")
+    println(s"  GET /users/1  → ${(scope $ controller)(_.getUser(1))}")
+    println(s"  POST /users   → ${(scope $ controller)(_.createUser("Bob", "bob@example.com"))}")
 
     println("\n=== Scope closing (LIFO cleanup: controller → database) ===")
   }

--- a/scope-examples/src/main/scala/scope/examples/PluginArchitectureExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/PluginArchitectureExample.scala
@@ -88,7 +88,7 @@ final class CheckoutService(gateway: PaymentGateway) extends AutoCloseable {
 
   Scope.global.scoped { scope =>
     val checkout = scope.allocate(stripeResource)
-    scope.$(checkout) { c =>
+    (scope $ checkout) { c =>
       val result = c.processOrder("ORD-001", BigDecimal("99.99"))
       println(s"Result: ${result.message}")
     }
@@ -102,7 +102,7 @@ final class CheckoutService(gateway: PaymentGateway) extends AutoCloseable {
 
   Scope.global.scoped { scope =>
     val checkout = scope.allocate(paypalResource)
-    scope.$(checkout) { c =>
+    (scope $ checkout) { c =>
       val result = c.processOrder("ORD-002", BigDecimal("149.99"))
       println(s"Result: ${result.message}")
     }

--- a/scope-examples/src/main/scala/scope/examples/TransactionBoundaryExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/TransactionBoundaryExample.scala
@@ -88,10 +88,10 @@ object TransactionBoundaryExample {
       // Transaction 1: Successful insert
       println("--- Transaction 1: Insert user ---")
       val result1 = connScope.scoped { txScope =>
-        connScope.$(conn) { rawConn =>
+        (connScope $ conn) { rawConn =>
           // beginTransaction returns Resource[DbTransaction] - must allocate it!
           val tx = txScope.allocate(rawConn.beginTransaction("tx-001"))
-          txScope.$(tx) { t =>
+          (txScope $ tx) { t =>
             val rows = t.execute("INSERT INTO users VALUES (1, 'Alice')")
             t.commit()
             TxResult(success = true, affectedRows = rows)
@@ -103,9 +103,9 @@ object TransactionBoundaryExample {
       // Transaction 2: Transfer funds (multiple operations)
       println("--- Transaction 2: Transfer funds ---")
       val result2 = connScope.scoped { txScope =>
-        connScope.$(conn) { rawConn =>
+        (connScope $ conn) { rawConn =>
           val tx = txScope.allocate(rawConn.beginTransaction("tx-002"))
-          txScope.$(tx) { t =>
+          (txScope $ tx) { t =>
             val rows1 = t.execute("UPDATE accounts SET balance = balance - 100 WHERE id = 1")
             val rows2 = t.execute("UPDATE accounts SET balance = balance + 100 WHERE id = 2")
             t.commit()
@@ -118,9 +118,9 @@ object TransactionBoundaryExample {
       // Transaction 3: Demonstrates auto-rollback on scope exit without commit
       println("--- Transaction 3: Auto-rollback (no explicit commit) ---")
       val result3 = connScope.scoped { txScope =>
-        connScope.$(conn) { rawConn =>
+        (connScope $ conn) { rawConn =>
           val tx = txScope.allocate(rawConn.beginTransaction("tx-003"))
-          txScope.$(tx) { t =>
+          (txScope $ tx) { t =>
             t.execute("DELETE FROM audit_log")
             println("    [App] Not committing - scope exit will trigger auto-rollback...")
             // Returning without commit - the Resource's release will call close(),

--- a/scope/shared/src/main/scala-2/zio/blocks/scope/package.scala
+++ b/scope/shared/src/main/scala-2/zio/blocks/scope/package.scala
@@ -13,7 +13,7 @@ import scala.language.experimental.macros
  *
  * Scope.global.scoped { scope =>
  *   val db = scope.allocate(Resource[Database])
- *   val result = scope.$(db)(_.query("SELECT 1"))
+ *   val result = (scope $ db)(_.query("SELECT 1"))
  *   println(result)
  * }
  * }}}
@@ -23,7 +23,7 @@ import scala.language.experimental.macros
  *   - '''Scoped values''' (`A @@ S`): Values tagged with a scope, preventing
  *     escape
  *   - '''`scope.allocate(resource)`''': Allocate a value in a scope
- *   - '''`scope.$(value)(f)`''': Apply a function to a scoped value
+ *   - '''`(scope $ value)(f)`''': Apply a function to a scoped value
  *   - '''`scope.scoped { s => ... }`''': Create a child scope with existential
  *     tag
  *   - '''`scope.defer { ... }`''': Register cleanup to run when scope closes

--- a/scope/shared/src/main/scala-3/zio/blocks/scope/ScopeVersionSpecific.scala
+++ b/scope/shared/src/main/scala-3/zio/blocks/scope/ScopeVersionSpecific.scala
@@ -28,8 +28,19 @@ private[scope] trait ScopeVersionSpecific[ParentTag, Tag0 <: ParentTag] {
    *   the function result type
    * @return
    *   B @@ Tag (result is always scoped)
+   *
+   * @example
+   *   {{{
+   *   // Infix syntax (preferred)
+   *   (scope $ database)(_.query("SELECT 1"))
+   *
+   *   // Multi-line with braces
+   *   (scope $ database) { db =>
+   *     db.query("SELECT 1")
+   *   }
+   *   }}}
    */
-  def $[A, B](scoped: A @@ self.Tag)(f: A => B): B @@ self.Tag =
+  infix def $[A, B](scoped: A @@ self.Tag)(f: A => B): B @@ self.Tag =
     // NOTE: This isClosed check is racy - a proper synchronization mechanism
     // is needed to fully prevent use-after-close in concurrent scenarios.
     if (self.isClosed) {

--- a/scope/shared/src/main/scala-3/zio/blocks/scope/package.scala
+++ b/scope/shared/src/main/scala-3/zio/blocks/scope/package.scala
@@ -11,7 +11,7 @@ package zio.blocks
  *
  * Scope.global.scoped { scope =>
  *   val db = scope.allocate(Resource[Database])
- *   val result = scope.$(db)(_.query("SELECT 1"))
+ *   val result = (scope $ db)(_.query("SELECT 1"))
  *   println(result)
  * }
  * }}}
@@ -21,7 +21,7 @@ package zio.blocks
  *   - '''Scoped values''' (`A @@ S`): Values tagged with a scope, preventing
  *     escape
  *   - '''`scope.allocate(resource)`''': Allocate a value in a scope
- *   - '''`scope.$(value)(f)`''': Apply a function to a scoped value
+ *   - '''`(scope $ value)(f)`''': Apply a function to a scoped value
  *   - '''`scope.scoped { s => ... }`''': Create a child scope with existential
  *     tag
  *   - '''`scope.defer { ... }`''': Register cleanup to run when scope closes

--- a/scope/shared/src/main/scala/zio/blocks/scope/Resource.scala
+++ b/scope/shared/src/main/scala/zio/blocks/scope/Resource.scala
@@ -26,7 +26,7 @@ import zio.blocks.scope.internal.ProxyFinalizer
  *   {{{
  *   Scope.global.scoped { scope =>
  *     val db = scope.allocate(Resource.fromAutoCloseable(new Database()))
- *     scope.$(db)(_.query("SELECT 1"))
+ *     (scope $ db)(_.query("SELECT 1"))
  *   }
  *   }}}
  *

--- a/scope/shared/src/main/scala/zio/blocks/scope/Scope.scala
+++ b/scope/shared/src/main/scala/zio/blocks/scope/Scope.scala
@@ -30,7 +30,7 @@ import zio.blocks.scope.internal.Finalizers
  *   {{{
  *   Scope.global.scoped { scope =>
  *     val db = scope.allocate(Resource[Database])
- *     val result = scope.$(db)(_.query("SELECT 1"))
+ *     val result = (scope $ db)(_.query("SELECT 1"))
  *     println(result)
  *   }
  *   }}}
@@ -145,7 +145,7 @@ object Scope {
    *   {{{
    *   Scope.global.scoped { scope =>
    *     val app = scope.allocate(Resource[App])
-   *     scope.$(app)(_.run())
+   *     (scope $ app)(_.run())
    *   }
    *   }}}
    */

--- a/scope/shared/src/test/scala-3/zio/blocks/scope/ScopeLiftSpec.scala
+++ b/scope/shared/src/test/scala-3/zio/blocks/scope/ScopeLiftSpec.scala
@@ -171,7 +171,7 @@ object ScopeLiftSpec extends ZIOSpecDefault {
 
           Scope.global.scoped { scope =>
             val db = scope.allocate(Resource("test"))
-            val result: String = scope.$(db)(identity) // Should fail - $ returns String @@ scope.Tag
+            val result: String = (scope $ db)(identity) // Should fail - $ returns String @@ scope.Tag
             result
           }
         """))(isLeft)

--- a/scope/shared/src/test/scala-3/zio/blocks/scope/ScopeScala3Spec.scala
+++ b/scope/shared/src/test/scala-3/zio/blocks/scope/ScopeScala3Spec.scala
@@ -73,7 +73,7 @@ object ScopeScala3Spec extends ZIOSpecDefault {
         Scope.global.scoped { scope =>
           val db: Database @@ scope.Tag = scope.allocate(Resource.from[Database])
           // $ executes immediately, so side effect happens now
-          scope.$(db) { d =>
+          (scope $ db) { d =>
             val result = d.query("SELECT 1")
             captured = result
             result
@@ -87,7 +87,7 @@ object ScopeScala3Spec extends ZIOSpecDefault {
         var captured: Boolean | Null = null
         Scope.global.scoped { scope =>
           val config: Config @@ scope.Tag = scope.allocate(Resource(Config(true)))
-          scope.$(config) { c =>
+          (scope $ config) { c =>
             val debug = c.debug
             captured = debug
             debug
@@ -99,7 +99,7 @@ object ScopeScala3Spec extends ZIOSpecDefault {
         var captured: String | Null = null
         Scope.global.scoped { scope =>
           val db: Database @@ scope.Tag = scope.allocate(Resource.from[Database])
-          scope.$(db) { d =>
+          (scope $ db) { d =>
             val result = d.query("test")
             captured = result
             result
@@ -115,7 +115,7 @@ object ScopeScala3Spec extends ZIOSpecDefault {
           val db: Database @@ parentScope.Tag = parentScope.allocate(Resource.from[Database])
 
           parentScope.scoped { childScope =>
-            childScope.$(db) { d =>
+            (childScope $ db) { d =>
               val result = d.query("child")
               captured = result
               result
@@ -314,7 +314,7 @@ object ScopeScala3Spec extends ZIOSpecDefault {
           }
           parent.scoped { child2 =>
             val db = leaked.asInstanceOf[Database @@ child2.Tag]
-            child2.$(db) { d =>
+            (child2 $ db) { d =>
               val result = d.query("test")
               captured = result
               result
@@ -358,7 +358,7 @@ object ScopeScala3Spec extends ZIOSpecDefault {
         leaked.scope.scoped { newChild =>
           // newChild is created as already-closed (because parent is closed)
           // newChild.$ checks isClosed → true → stays lazy, doesn't execute
-          newChild.$(leaked.value) { r =>
+          (newChild $ leaked.value) { r =>
             result = r.read() // This never executes!
           }
           ()

--- a/scope/shared/src/test/scala/zio/blocks/scope/ScopeEscapeSpec.scala
+++ b/scope/shared/src/test/scala/zio/blocks/scope/ScopeEscapeSpec.scala
@@ -46,7 +46,7 @@ object ScopeEscapeSpec extends ZIOSpecDefault {
         var captured: String = null
         Scope.global.scoped { scope =>
           val str: String @@ scope.Tag = scope.allocate(zio.blocks.scope.Resource("test"))
-          scope.$(str) { s =>
+          (scope $ str) { s =>
             captured = s
             s
           }
@@ -77,7 +77,7 @@ object ScopeEscapeSpec extends ZIOSpecDefault {
           parent.scoped { child =>
             var captured: String         = null
             val str: String @@ child.Tag = child.allocate(zio.blocks.scope.Resource("hello"))
-            child.$(str) { s =>
+            (child $ str) { s =>
               captured = s.toUpperCase
               s.toUpperCase
             }

--- a/scope/shared/src/test/scala/zio/blocks/scope/ScopeSpec.scala
+++ b/scope/shared/src/test/scala/zio/blocks/scope/ScopeSpec.scala
@@ -74,7 +74,7 @@ object ScopeSpec extends ZIOSpecDefault {
         val resource = scope.allocate(new TestCloseable)
         // Capture result via side effect in the function passed to $
         var captured: String = null
-        scope.$(resource) { r =>
+        (scope $ resource) { r =>
           captured = r.value
           r.value
         }
@@ -110,7 +110,7 @@ object ScopeSpec extends ZIOSpecDefault {
             // Capture a thunk that uses the child scope's $ method
             capturedThunk = () => {
               // This calls child.$ on a CLOSED scope - should stay lazy
-              child.$(resource)(_.read())
+              (child $ resource)(_.read())
               ()
             }
 
@@ -183,9 +183,9 @@ object ScopeSpec extends ZIOSpecDefault {
 
             capturedThunk = () => {
               // All these should stay lazy on a closed scope
-              child.$(counter)(_.inc())
-              child.$(counter)(_.inc())
-              child.$(counter)(_.inc())
+              (child $ counter)(_.inc())
+              (child $ counter)(_.inc())
+              (child $ counter)(_.inc())
               ()
             }
 
@@ -209,7 +209,7 @@ object ScopeSpec extends ZIOSpecDefault {
         }
 
         val resource = scope.allocate(Resource(new TrackedResource))
-        scope.$(resource)(_.doWork())
+        (scope $ resource)(_.doWork())
         close()
         assertTrue(executed)
       },


### PR DESCRIPTION
## Summary

Adds the `infix` modifier to the `$` method in Scala 3, enabling cleaner syntax for accessing scoped values.

### Before
```scala
scope.$(database)(_.query("SELECT 1"))
```

### After (infix)
```scala
(scope $ database)(_.query("SELECT 1"))

// Multi-line with braces
(scope $ database) { db =>
  db.query("SELECT 1")
}
```

### Changes

- Add `infix` modifier to `$` method in `ScopeVersionSpecific` (Scala 3)
- Add example syntax to the method's scaladoc
- Update all examples in `scope-examples` to use infix syntax
- Update all Scala 3 tests to use infix syntax
- Update cross-platform tests to use infix syntax
- Update README.md and docs/scope.md
- Update doc comments in Scope.scala, Resource.scala, package.scala

### Notes

- The infix syntax works in both Scala 2 and 3
- The `infix` modifier is Scala 3 only (avoids deprecation warnings in Scala 3.4+)
- Scala 2 tests left unchanged (they still compile with infix syntax)