### PR TITLE
fix: swap regex and string operands in StringRegexMatch eval

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
@@ -276,13 +276,13 @@ object SchemaExpr {
       for {
         xs <- regex.eval(input)
         ys <- string.eval(input)
-      } yield for { x <- xs; y <- ys } yield x.matches(y)
+      } yield for { x <- xs; y <- ys } yield y.matches(x)
 
     def evalDynamic(input: A): Either[OpticCheck, Seq[DynamicValue]] =
       for {
         xs <- regex.eval(input)
         ys <- string.eval(input)
-      } yield for { x <- xs; y <- ys } yield toDynamicValue(x.matches(y))
+      } yield for { x <- xs; y <- ys } yield toDynamicValue(y.matches(x))
 
     private[this] def toDynamicValue(value: Boolean): DynamicValue =
       new DynamicValue.Primitive(new PrimitiveValue.Boolean(value))

--- a/schema/shared/src/test/scala/zio/blocks/schema/OpticSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/OpticSpec.scala
@@ -2402,6 +2402,13 @@ object OpticSpec extends SchemaBaseSpec {
         assert((Collections.abi + BigInt(1)).eval(Array(BigInt(1))))(isRight(equalTo(Seq(BigInt(2))))) &&
         assert((Collections.abd + BigDecimal(1)).eval(Array(BigDecimal(1))))(isRight(equalTo(Seq(BigDecimal(2))))) &&
         assert(Case5.as.matches("a").eval(Case5(Set(), Array("a", "b"))))(isRight(equalTo(Seq(true, false)))) &&
+        assert(Case5.as.matches("[a-z]+").eval(Case5(Set(), Array("hello", "123"))))(
+          isRight(equalTo(Seq(true, false)))
+        ) &&
+        assert(Case5.as.matches("\\d+").eval(Case5(Set(), Array("abc", "42"))))(isRight(equalTo(Seq(false, true)))) &&
+        assert(Case5.as.matches("he.*").eval(Case5(Set(), Array("hello", "world"))))(
+          isRight(equalTo(Seq(true, false)))
+        ) &&
         assert(Case5.as.concat("x").eval(Case5(Set(), Array("a", "b"))))(isRight(equalTo(Seq("ax", "bx")))) &&
         assert(Case5.as.length.eval(Case5(Set(), Array("a", "b"))))(isRight(equalTo(Seq(1, 1)))) &&
         assert(Case5.as.length.eval(Case5(Set(), emptyArray)))(
@@ -2435,6 +2442,26 @@ object OpticSpec extends SchemaBaseSpec {
               Seq(
                 DynamicValue.Primitive(PrimitiveValue.Boolean(true)),
                 DynamicValue.Primitive(PrimitiveValue.Boolean(false))
+              )
+            )
+          )
+        ) &&
+        assert(Case5.as.matches("[a-z]+").evalDynamic(Case5(Set(), Array("hello", "123"))))(
+          isRight(
+            equalTo(
+              Seq(
+                DynamicValue.Primitive(PrimitiveValue.Boolean(true)),
+                DynamicValue.Primitive(PrimitiveValue.Boolean(false))
+              )
+            )
+          )
+        ) &&
+        assert(Case5.as.matches("\\d+").evalDynamic(Case5(Set(), Array("abc", "42"))))(
+          isRight(
+            equalTo(
+              Seq(
+                DynamicValue.Primitive(PrimitiveValue.Boolean(false)),
+                DynamicValue.Primitive(PrimitiveValue.Boolean(true))
               )
             )
           )


### PR DESCRIPTION
## Summary
- `StringRegexMatch.eval` and `evalDynamic` had the regex and string operands swapped when calling `String.matches(regex)`, causing regex matching to be applied in the wrong direction
- Swapped `x.matches(y)` to `y.matches(x)` so the string is the receiver and the regex is the argument
- Added tests with actual regex patterns (`[a-z]+`, `\d+`, `he.*`) for both `eval` and `evalDynamic` to prevent regression

## Test plan
- [x] Added regex pattern tests for `eval` (character classes, digit patterns, wildcards)
- [x] Added regex pattern tests for `evalDynamic` with same patterns
- [x] All 98 OpticSpec tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)