### PR TITLE
docs: add Scaladoc review instructions for public API changes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,7 +58,7 @@ When Scaladoc is missing or incomplete, leave a **suggestion** comment on the li
   * @tparam A    the target type
   * @return      a `DecodeResult` containing either the decoded value or an error
   *
-  * Example:
+  * @example
   * {{{
   * val result = Codec.decode[Person](bytes)
   * result match {


### PR DESCRIPTION
## Summary
- Add Scaladoc requirements to GitHub reviewer agent instructions so it suggests Scaladoc comments on new/changed public APIs
- Require usage examples (in `{{{ }}}` blocks) for non-obvious APIs (higher-kinded types, implicits, macros, etc.)
- Update the review checklist to include Scaladoc verification

## Test plan
- [ ] Verify the reviewer agent suggests Scaladoc on PRs that introduce new public APIs
- [ ] Verify examples are suggested for non-obvious APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)