### PR TITLE
Simplify Deriver binding parameter types

### DIFF
--- a/docs/reference/type-class-derivation.md
+++ b/docs/reference/type-class-derivation.md
@@ -107,7 +107,7 @@ trait Deriver[TC[_]] {
   def deriveRecord[F[_, _], A](
     fields: IndexedSeq[Term[F, A, ?]],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Record, A],
+    binding: Binding.Record[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -200,7 +200,7 @@ object DeriveShow extends Deriver[Show] {
   override def derivePrimitive[A](
     primitiveType: PrimitiveType[A],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Primitive, A],
+    binding: Binding.Primitive[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -219,7 +219,7 @@ object DeriveShow extends Deriver[Show] {
   override def deriveRecord[F[_, _], A](
     fields: IndexedSeq[Term[F, A, ?]],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Record, A],
+    binding: Binding.Record[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -269,7 +269,7 @@ object DeriveShow extends Deriver[Show] {
   override def deriveVariant[F[_, _], A](
     cases: IndexedSeq[Term[F, A, ?]],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Variant, A],
+    binding: Binding.Variant[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -304,7 +304,7 @@ object DeriveShow extends Deriver[Show] {
   override def deriveSequence[F[_, _], C[_], A](
     element: Reflect[F, A],
     typeId: TypeId[C[A]],
-    binding: Binding[BindingType.Seq[C], C[A]],
+    binding: Binding.Seq[C, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[C[A]],
@@ -332,7 +332,7 @@ object DeriveShow extends Deriver[Show] {
     key: Reflect[F, K],
     value: Reflect[F, V],
     typeId: TypeId[M[K, V]],
-    binding: Binding[BindingType.Map[M], M[K, V]],
+    binding: Binding.Map[M, K, V],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[M[K, V]],
@@ -362,7 +362,7 @@ object DeriveShow extends Deriver[Show] {
   }
 
   override def deriveDynamic[F[_, _]](
-    binding: Binding[BindingType.Dynamic, DynamicValue],
+    binding: Binding.Dynamic,
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[DynamicValue],
@@ -401,7 +401,7 @@ object DeriveShow extends Deriver[Show] {
   override def deriveWrapper[F[_, _], A, B](
     wrapped: Reflect[F, B],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Wrapper[A, B], A],
+    binding: Binding.Wrapper[A, B],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -443,7 +443,7 @@ import zio.blocks.docs.Doc
 def derivePrimitive[A](
   primitiveType: PrimitiveType[A],
   typeId: TypeId[A],
-  binding: Binding[BindingType.Primitive, A],
+  binding: Binding.Primitive[A],
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[A],
@@ -476,7 +476,7 @@ import DeriveShow._
 def deriveRecord[F[_, _], A](
   fields: IndexedSeq[Term[F, A, ?]],
   typeId: TypeId[A],
-  binding: Binding[BindingType.Record, A],
+  binding: Binding.Record[A],
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[A],
@@ -551,7 +551,7 @@ When the derivation process encounters a variant type (e.g., a sealed trait with
 def deriveVariant[F[_, _], A](
   cases: IndexedSeq[Term[F, A, ?]],
   typeId: TypeId[A],
-  binding: Binding[BindingType.Variant, A],
+  binding: Binding.Variant[A],
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[A],
@@ -592,7 +592,7 @@ When the derivation process encounters a sequence type (e.g., `List[A]`), it cal
 def deriveSequence[F[_, _], C[_], A](
   element: Reflect[F, A],
   typeId: TypeId[C[A]],
-  binding: Binding[BindingType.Seq[C], C[A]],
+  binding: Binding.Seq[C, A],
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[C[A]],
@@ -626,7 +626,7 @@ def deriveMap[F[_, _], M[_, _], K, V](
   key: Reflect[F, K],
   value: Reflect[F, V],
   typeId: TypeId[M[K, V]],
-  binding: Binding[BindingType.Map[M], M[K, V]],
+  binding: Binding.Map[M, K, V],
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[M[K, V]],
@@ -660,11 +660,11 @@ The derivation process for maps is similar to sequences, but we have to handle b
 
 ### Dynamic Derivation
 
-When the derivation process encounters a dynamic type (e.g., `DynamicValue`), it calls the `deriveDynamic` method of the `Deriver`. This method receives a `Binding[BindingType.Dynamic, DynamicValue]` representing the dynamic type, along with other metadata such as documentation, modifiers, default values, and examples:
+When the derivation process encounters a dynamic type (e.g., `DynamicValue`), it calls the `deriveDynamic` method of the `Deriver`. This method receives a `Binding.Dynamic` representing the dynamic type, along with other metadata such as documentation, modifiers, default values, and examples:
 
 ```scala mdoc:compile-only
 def deriveDynamic[F[_, _]](
-  binding: Binding[BindingType.Dynamic, DynamicValue],
+  binding: Binding.Dynamic,
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[DynamicValue],
@@ -707,7 +707,7 @@ When the derivation process encounters a wrapper type (e.g., a value class, opaq
 def deriveWrapper[F[_, _], A, B](
   wrapped: Reflect[F, B],
   typeId: TypeId[A],
-  binding: Binding[BindingType.Wrapper[A, B], A],
+  binding: Binding.Wrapper[A, B],
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[A],
@@ -886,7 +886,7 @@ object DeriveGen extends Deriver[Gen] {
   override def derivePrimitive[A](
     primitiveType: PrimitiveType[A],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Primitive, A],
+    binding: Binding.Primitive[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -924,7 +924,7 @@ object DeriveGen extends Deriver[Gen] {
   override def deriveRecord[F[_, _], A](
     fields: IndexedSeq[Term[F, A, ?]],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Record, A],
+    binding: Binding.Record[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -967,7 +967,7 @@ object DeriveGen extends Deriver[Gen] {
   override def deriveVariant[F[_, _], A](
     cases: IndexedSeq[Term[F, A, ?]],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Variant, A],
+    binding: Binding.Variant[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -996,7 +996,7 @@ object DeriveGen extends Deriver[Gen] {
   override def deriveSequence[F[_, _], C[_], A](
     element: Reflect[F, A],
     typeId: TypeId[C[A]],
-    binding: Binding[BindingType.Seq[C], C[A]],
+    binding: Binding.Seq[C, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[C[A]],
@@ -1034,7 +1034,7 @@ object DeriveGen extends Deriver[Gen] {
     key: Reflect[F, K],
     value: Reflect[F, V],
     typeId: TypeId[M[K, V]],
-    binding: Binding[BindingType.Map[M], M[K, V]],
+    binding: Binding.Map[M, K, V],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[M[K, V]],
@@ -1068,7 +1068,7 @@ object DeriveGen extends Deriver[Gen] {
    * content.
    */
   override def deriveDynamic[F[_, _]](
-    binding: Binding[BindingType.Dynamic, DynamicValue],
+    binding: Binding.Dynamic,
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[DynamicValue],
@@ -1123,7 +1123,7 @@ object DeriveGen extends Deriver[Gen] {
   override def deriveWrapper[F[_, _], A, B](
     wrapped: Reflect[F, B],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Wrapper[A, B], A],
+    binding: Binding.Wrapper[A, B],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -1148,7 +1148,7 @@ The `derivePrimitive` method is responsible for deriving a `Gen` instance for pr
 def derivePrimitive[A](
   primitiveType: PrimitiveType[A],
   typeId: TypeId[A],
-  binding: Binding[BindingType.Primitive, A],
+  binding: Binding.Primitive[A],
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[A],
@@ -1182,7 +1182,7 @@ The `deriveRecord` method is responsible for deriving a `Gen` instance for recor
 def deriveRecord[F[_, _], A](
   fields: IndexedSeq[Term[F, A, ?]],
   typeId: TypeId[A],
-  binding: Binding[BindingType.Record, A],
+  binding: Binding.Record[A],
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[A],
@@ -1227,7 +1227,7 @@ The `deriveVariant` method is responsible for deriving a `Gen` instance for vari
 def deriveVariant[F[_, _], A](
   cases: IndexedSeq[Term[F, A, ?]],
   typeId: TypeId[A],
-  binding: Binding[BindingType.Variant, A],
+  binding: Binding.Variant[A],
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[A],
@@ -1258,7 +1258,7 @@ The `deriveSequence` method is responsible for deriving a `Gen` instance for seq
 def deriveSequence[F[_, _], C[_], A](
   element: Reflect[F, A],
   typeId: TypeId[C[A]],
-  binding: Binding[BindingType.Seq[C], C[A]],
+  binding: Binding.Seq[C, A],
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[C[A]],
@@ -1298,7 +1298,7 @@ def deriveMap[F[_, _], M[_, _], K, V](
   key: Reflect[F, K],
   value: Reflect[F, V],
   typeId: TypeId[M[K, V]],
-  binding: Binding[BindingType.Map[M], M[K, V]],
+  binding: Binding.Map[M, K, V],
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[M[K, V]],
@@ -1335,7 +1335,7 @@ The `deriveDynamic` method is responsible for deriving a `Gen` instance for dyna
 
 ```scala mdoc:silent
 def deriveDynamic[F[_, _]](
-  binding: Binding[BindingType.Dynamic, DynamicValue],
+  binding: Binding.Dynamic,
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[DynamicValue],
@@ -1398,7 +1398,7 @@ The `deriveWrapper` method is responsible for deriving a `Gen` instance for wrap
 def deriveWrapper[F[_, _], A, B](
   wrapped: Reflect[F, B],
   typeId: TypeId[A],
-  binding: Binding[BindingType.Wrapper[A, B], A],
+  binding: Binding.Wrapper[A, B],
   doc: Doc,
   modifiers: Seq[Modifier.Reflect],
   defaultValue: Option[A],

--- a/schema-avro/src/main/scala/zio/blocks/schema/avro/AvroFormat.scala
+++ b/schema-avro/src/main/scala/zio/blocks/schema/avro/AvroFormat.scala
@@ -3,7 +3,7 @@ package zio.blocks.schema.avro
 import org.apache.avro.io.{BinaryDecoder, BinaryEncoder}
 import org.apache.avro.{Schema => AvroSchema}
 import zio.blocks.docs.Doc
-import zio.blocks.schema.binding.{Binding, BindingType, HasBinding, Registers, RegisterOffset}
+import zio.blocks.schema.binding.{Binding, HasBinding, Registers, RegisterOffset}
 import zio.blocks.schema.binding.SeqDeconstructor._
 import zio.blocks.schema._
 import zio.blocks.chunk.ChunkBuilder
@@ -20,7 +20,7 @@ object AvroFormat
         override def derivePrimitive[A](
           primitiveType: PrimitiveType[A],
           typeId: TypeId[A],
-          binding: Binding[BindingType.Primitive, A],
+          binding: Binding.Primitive[A],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[A],
@@ -31,7 +31,7 @@ object AvroFormat
         override def deriveRecord[F[_, _], A](
           fields: IndexedSeq[Term[F, A, ?]],
           typeId: TypeId[A],
-          binding: Binding[BindingType.Record, A],
+          binding: Binding.Record[A],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[A],
@@ -51,7 +51,7 @@ object AvroFormat
         override def deriveVariant[F[_, _], A](
           cases: IndexedSeq[Term[F, A, ?]],
           typeId: TypeId[A],
-          binding: Binding[BindingType.Variant, A],
+          binding: Binding.Variant[A],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[A],
@@ -71,7 +71,7 @@ object AvroFormat
         override def deriveSequence[F[_, _], C[_], A](
           element: Reflect[F, A],
           typeId: TypeId[C[A]],
-          binding: Binding[BindingType.Seq[C], C[A]],
+          binding: Binding.Seq[C, A],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[C[A]],
@@ -86,7 +86,7 @@ object AvroFormat
           key: Reflect[F, K],
           value: Reflect[F, V],
           typeId: TypeId[M[K, V]],
-          binding: Binding[BindingType.Map[M], M[K, V]],
+          binding: Binding.Map[M, K, V],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[M[K, V]],
@@ -105,7 +105,7 @@ object AvroFormat
         }
 
         override def deriveDynamic[F[_, _]](
-          binding: Binding[BindingType.Dynamic, DynamicValue],
+          binding: Binding.Dynamic,
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[DynamicValue],
@@ -116,7 +116,7 @@ object AvroFormat
         def deriveWrapper[F[_, _], A, B](
           wrapped: Reflect[F, B],
           typeId: TypeId[A],
-          binding: Binding[BindingType.Wrapper[A, B], A],
+          binding: Binding.Wrapper[A, B],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[A],

--- a/schema-messagepack/src/main/scala/zio/blocks/schema/msgpack/MessagePackBinaryCodecDeriver.scala
+++ b/schema-messagepack/src/main/scala/zio/blocks/schema/msgpack/MessagePackBinaryCodecDeriver.scala
@@ -1,7 +1,7 @@
 package zio.blocks.schema.msgpack
 
 import zio.blocks.docs.Doc
-import zio.blocks.schema.binding.{Binding, BindingType, HasBinding, Registers, RegisterOffset}
+import zio.blocks.schema.binding.{Binding, HasBinding, Registers, RegisterOffset}
 import zio.blocks.schema._
 import zio.blocks.chunk.Chunk
 import zio.blocks.schema.derive.{BindingInstance, Deriver, InstanceOverride}
@@ -14,7 +14,7 @@ object MessagePackBinaryCodecDeriver extends Deriver[MessagePackBinaryCodec] {
   override def derivePrimitive[A](
     primitiveType: PrimitiveType[A],
     typeId: zio.blocks.typeid.TypeId[A],
-    binding: Binding[BindingType.Primitive, A],
+    binding: Binding.Primitive[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -25,7 +25,7 @@ object MessagePackBinaryCodecDeriver extends Deriver[MessagePackBinaryCodec] {
   override def deriveRecord[F[_, _], A](
     fields: IndexedSeq[Term[F, A, ?]],
     typeId: zio.blocks.typeid.TypeId[A],
-    binding: Binding[BindingType.Record, A],
+    binding: Binding.Record[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -45,7 +45,7 @@ object MessagePackBinaryCodecDeriver extends Deriver[MessagePackBinaryCodec] {
   override def deriveVariant[F[_, _], A](
     cases: IndexedSeq[Term[F, A, ?]],
     typeId: zio.blocks.typeid.TypeId[A],
-    binding: Binding[BindingType.Variant, A],
+    binding: Binding.Variant[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -65,7 +65,7 @@ object MessagePackBinaryCodecDeriver extends Deriver[MessagePackBinaryCodec] {
   override def deriveSequence[F[_, _], C[_], A](
     element: Reflect[F, A],
     typeId: zio.blocks.typeid.TypeId[C[A]],
-    binding: Binding[BindingType.Seq[C], C[A]],
+    binding: Binding.Seq[C, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[C[A]],
@@ -80,7 +80,7 @@ object MessagePackBinaryCodecDeriver extends Deriver[MessagePackBinaryCodec] {
     key: Reflect[F, K],
     value: Reflect[F, V],
     typeId: zio.blocks.typeid.TypeId[M[K, V]],
-    binding: Binding[BindingType.Map[M], M[K, V]],
+    binding: Binding.Map[M, K, V],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[M[K, V]],
@@ -99,7 +99,7 @@ object MessagePackBinaryCodecDeriver extends Deriver[MessagePackBinaryCodec] {
   }
 
   override def deriveDynamic[F[_, _]](
-    binding: Binding[BindingType.Dynamic, DynamicValue],
+    binding: Binding.Dynamic,
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[DynamicValue],
@@ -110,7 +110,7 @@ object MessagePackBinaryCodecDeriver extends Deriver[MessagePackBinaryCodec] {
   def deriveWrapper[F[_, _], A, B](
     wrapped: Reflect[F, B],
     typeId: zio.blocks.typeid.TypeId[A],
-    binding: Binding[BindingType.Wrapper[A, B], A],
+    binding: Binding.Wrapper[A, B],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],

--- a/schema-thrift/src/main/scala/zio/blocks/schema/thrift/ThriftFormat.scala
+++ b/schema-thrift/src/main/scala/zio/blocks/schema/thrift/ThriftFormat.scala
@@ -4,7 +4,7 @@ import org.apache.thrift.protocol._
 import scala.reflect.ClassTag
 import zio.blocks.docs.Doc
 import zio.blocks.schema._
-import zio.blocks.schema.binding.{Binding, BindingType, HasBinding, RegisterOffset, Registers}
+import zio.blocks.schema.binding.{Binding, HasBinding, RegisterOffset, Registers}
 import zio.blocks.schema.codec.BinaryFormat
 import zio.blocks.schema.derive.{BindingInstance, Deriver, InstanceOverride}
 import zio.blocks.typeid.TypeId
@@ -70,7 +70,7 @@ object ThriftFormat
         override def derivePrimitive[A](
           primitiveType: PrimitiveType[A],
           typeId: TypeId[A],
-          binding: Binding[BindingType.Primitive, A],
+          binding: Binding.Primitive[A],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[A],
@@ -81,7 +81,7 @@ object ThriftFormat
         override def deriveRecord[F[_, _], A](
           fields: IndexedSeq[Term[F, A, ?]],
           typeId: TypeId[A],
-          binding: Binding[BindingType.Record, A],
+          binding: Binding.Record[A],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[A],
@@ -101,7 +101,7 @@ object ThriftFormat
         override def deriveVariant[F[_, _], A](
           cases: IndexedSeq[Term[F, A, ?]],
           typeId: TypeId[A],
-          binding: Binding[BindingType.Variant, A],
+          binding: Binding.Variant[A],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[A],
@@ -121,7 +121,7 @@ object ThriftFormat
         override def deriveSequence[F[_, _], C[_], A](
           element: Reflect[F, A],
           typeId: TypeId[C[A]],
-          binding: Binding[BindingType.Seq[C], C[A]],
+          binding: Binding.Seq[C, A],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[C[A]],
@@ -136,7 +136,7 @@ object ThriftFormat
           key: Reflect[F, K],
           value: Reflect[F, V],
           typeId: TypeId[M[K, V]],
-          binding: Binding[BindingType.Map[M], M[K, V]],
+          binding: Binding.Map[M, K, V],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[M[K, V]],
@@ -155,7 +155,7 @@ object ThriftFormat
         }
 
         override def deriveDynamic[F[_, _]](
-          binding: Binding[BindingType.Dynamic, DynamicValue],
+          binding: Binding.Dynamic,
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[DynamicValue],
@@ -166,7 +166,7 @@ object ThriftFormat
         override def deriveWrapper[F[_, _], A, B](
           wrapped: Reflect[F, B],
           typeId: TypeId[A],
-          binding: Binding[BindingType.Wrapper[A, B], A],
+          binding: Binding.Wrapper[A, B],
           doc: Doc,
           modifiers: Seq[Modifier.Reflect],
           defaultValue: Option[A],

--- a/schema-toon/src/main/scala/zio/blocks/schema/toon/ToonBinaryCodecDeriver.scala
+++ b/schema-toon/src/main/scala/zio/blocks/schema/toon/ToonBinaryCodecDeriver.scala
@@ -2,7 +2,7 @@ package zio.blocks.schema.toon
 
 import zio.blocks.docs.Doc
 import zio.blocks.schema.toon.ToonBinaryCodec._
-import zio.blocks.schema.binding.{Binding, BindingType, HasBinding}
+import zio.blocks.schema.binding.{Binding, HasBinding}
 import zio.blocks.schema._
 import zio.blocks.schema.derive.{BindingInstance, Deriver, InstanceOverride}
 import zio.blocks.schema.toon.codec._
@@ -116,7 +116,7 @@ class ToonBinaryCodecDeriver private[toon] (
   override def derivePrimitive[A](
     primitiveType: PrimitiveType[A],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Primitive, A],
+    binding: Binding.Primitive[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -127,7 +127,7 @@ class ToonBinaryCodecDeriver private[toon] (
   override def deriveRecord[F[_, _], A](
     fields: IndexedSeq[Term[F, A, ?]],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Record, A],
+    binding: Binding.Record[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -147,7 +147,7 @@ class ToonBinaryCodecDeriver private[toon] (
   override def deriveVariant[F[_, _], A](
     cases: IndexedSeq[Term[F, A, ?]],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Variant, A],
+    binding: Binding.Variant[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -167,7 +167,7 @@ class ToonBinaryCodecDeriver private[toon] (
   override def deriveSequence[F[_, _], C[_], A](
     element: Reflect[F, A],
     typeId: TypeId[C[A]],
-    binding: Binding[BindingType.Seq[C], C[A]],
+    binding: Binding.Seq[C, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[C[A]],
@@ -182,7 +182,7 @@ class ToonBinaryCodecDeriver private[toon] (
     key: Reflect[F, K],
     value: Reflect[F, V],
     typeId: TypeId[M[K, V]],
-    binding: Binding[BindingType.Map[M], M[K, V]],
+    binding: Binding.Map[M, K, V],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[M[K, V]],
@@ -201,7 +201,7 @@ class ToonBinaryCodecDeriver private[toon] (
   }
 
   override def deriveDynamic[F[_, _]](
-    binding: Binding[BindingType.Dynamic, DynamicValue],
+    binding: Binding.Dynamic,
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[DynamicValue],
@@ -212,7 +212,7 @@ class ToonBinaryCodecDeriver private[toon] (
   override def deriveWrapper[F[_, _], A, B](
     wrapped: Reflect[F, B],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Wrapper[A, B], A],
+    binding: Binding.Wrapper[A, B],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],

--- a/schema/shared/src/main/scala/zio/blocks/schema/binding/HasBinding.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/binding/HasBinding.scala
@@ -1,6 +1,6 @@
 package zio.blocks.schema.binding
 
-import zio.blocks.schema.{Lazy, ReflectTransformer}
+import zio.blocks.schema.{DynamicValue, Lazy, ReflectTransformer}
 
 trait HasBinding[F[_, _]] extends ReflectTransformer.OnlyMetadata[F, Binding] {
   override def transformMetadata[T, A](f: F[T, A]): Lazy[Binding[T, A]] = Lazy(binding(f))
@@ -144,5 +144,11 @@ trait HasBinding[F[_, _]] extends ReflectTransformer.OnlyMetadata[F, Binding] {
     binding(fa) match {
       case wrapper: Binding.Wrapper[A, B] @scala.unchecked => wrapper
       case _                                               => sys.error("Expected Binding.Wrapper")
+    }
+
+  final def dynamic(fa: F[BindingType.Dynamic, DynamicValue]): Binding.Dynamic =
+    binding(fa) match {
+      case dynamic: Binding.Dynamic => dynamic
+      case _                        => sys.error("Expected Binding.Dynamic")
     }
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
@@ -159,7 +159,7 @@ final case class DerivationBuilder[TC[_], A](
                 .deriveRecord(
                   updatedFields,
                   typeId,
-                  metadata,
+                  Binding.bindingHasBinding.record(metadata),
                   doc,
                   prependCombinedModifiers(modifiers, path, typeId),
                   defaultValue,
@@ -221,7 +221,7 @@ final case class DerivationBuilder[TC[_], A](
                 .deriveVariant(
                   updatedCases,
                   typeId,
-                  metadata,
+                  Binding.bindingHasBinding.variant(metadata),
                   doc,
                   prependCombinedModifiers(modifiers, path, typeId),
                   defaultValue,
@@ -268,7 +268,7 @@ final case class DerivationBuilder[TC[_], A](
                 .deriveSequence(
                   element,
                   typeId,
-                  metadata,
+                  Binding.bindingHasBinding.seq(metadata),
                   doc,
                   prependCombinedModifiers(modifiers, path, typeId),
                   defaultValue,
@@ -318,7 +318,7 @@ final case class DerivationBuilder[TC[_], A](
                   key,
                   value,
                   typeId,
-                  metadata,
+                  Binding.bindingHasBinding.map(metadata),
                   doc,
                   prependCombinedModifiers(modifiers, path, typeId),
                   defaultValue,
@@ -349,7 +349,7 @@ final case class DerivationBuilder[TC[_], A](
             val instance = getCustomInstance[DynamicValue](path, TypeId.of[DynamicValue])
               .getOrElse(
                 deriver.deriveDynamic[G](
-                  metadata,
+                  Binding.bindingHasBinding.dynamic(metadata),
                   doc,
                   prependCombinedModifiers(modifiers, path, typeId),
                   storedDefaultValue,
@@ -383,7 +383,7 @@ final case class DerivationBuilder[TC[_], A](
                 .derivePrimitive(
                   primitiveType,
                   typeId,
-                  metadata,
+                  Binding.bindingHasBinding.primitive(metadata),
                   doc,
                   prependCombinedModifiers(modifiers, path, typeId),
                   defaultValue,
@@ -430,7 +430,7 @@ final case class DerivationBuilder[TC[_], A](
                 deriver.deriveWrapper(
                   wrapped,
                   typeId,
-                  metadata,
+                  Binding.bindingHasBinding.wrapper(metadata),
                   doc,
                   prependCombinedModifiers(modifiers, path, typeId),
                   defaultValue,

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/Deriver.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/Deriver.scala
@@ -16,7 +16,7 @@ trait Deriver[TC[_]] { self =>
   def derivePrimitive[A](
     primitiveType: PrimitiveType[A],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Primitive, A],
+    binding: Binding.Primitive[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -26,7 +26,7 @@ trait Deriver[TC[_]] { self =>
   def deriveRecord[F[_, _], A](
     fields: IndexedSeq[Term[F, A, ?]],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Record, A],
+    binding: Binding.Record[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -36,7 +36,7 @@ trait Deriver[TC[_]] { self =>
   def deriveVariant[F[_, _], A](
     cases: IndexedSeq[Term[F, A, ?]],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Variant, A],
+    binding: Binding.Variant[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -46,7 +46,7 @@ trait Deriver[TC[_]] { self =>
   def deriveSequence[F[_, _], C[_], A](
     element: Reflect[F, A],
     typeId: TypeId[C[A]],
-    binding: Binding[BindingType.Seq[C], C[A]],
+    binding: Binding.Seq[C, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[C[A]],
@@ -57,7 +57,7 @@ trait Deriver[TC[_]] { self =>
     key: Reflect[F, K],
     value: Reflect[F, V],
     typeId: TypeId[M[K, V]],
-    binding: Binding[BindingType.Map[M], M[K, V]],
+    binding: Binding.Map[M, K, V],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[M[K, V]],
@@ -65,7 +65,7 @@ trait Deriver[TC[_]] { self =>
   )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TC[M[K, V]]]
 
   def deriveDynamic[F[_, _]](
-    binding: Binding[BindingType.Dynamic, DynamicValue],
+    binding: Binding.Dynamic,
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[DynamicValue],
@@ -75,7 +75,7 @@ trait Deriver[TC[_]] { self =>
   def deriveWrapper[F[_, _], A, B](
     wrapped: Reflect[F, B],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Wrapper[A, B], A],
+    binding: Binding.Wrapper[A, B],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonBinaryCodecDeriver.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonBinaryCodecDeriver.scala
@@ -4,7 +4,7 @@ import zio.blocks.chunk.{Chunk, ChunkBuilder, ChunkMap, NonEmptyChunk}
 import zio.blocks.docs.Doc
 import zio.blocks.schema.json._
 import zio.blocks.schema.json.JsonBinaryCodec._
-import zio.blocks.schema.binding.{Binding, BindingType, HasBinding, RegisterOffset, Registers}
+import zio.blocks.schema.binding.{Binding, HasBinding, RegisterOffset, Registers}
 import zio.blocks.schema._
 import zio.blocks.schema.binding.{Constructor, Discriminator}
 import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
@@ -271,7 +271,7 @@ class JsonBinaryCodecDeriver private[json] (
   override def derivePrimitive[A](
     primitiveType: PrimitiveType[A],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Primitive, A],
+    binding: Binding.Primitive[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -282,7 +282,7 @@ class JsonBinaryCodecDeriver private[json] (
   override def deriveRecord[F[_, _], A](
     fields: IndexedSeq[Term[F, A, ?]],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Record, A],
+    binding: Binding.Record[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -302,7 +302,7 @@ class JsonBinaryCodecDeriver private[json] (
   override def deriveVariant[F[_, _], A](
     cases: IndexedSeq[Term[F, A, ?]],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Variant, A],
+    binding: Binding.Variant[A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],
@@ -322,7 +322,7 @@ class JsonBinaryCodecDeriver private[json] (
   override def deriveSequence[F[_, _], C[_], A](
     element: Reflect[F, A],
     typeId: TypeId[C[A]],
-    binding: Binding[BindingType.Seq[C], C[A]],
+    binding: Binding.Seq[C, A],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[C[A]],
@@ -337,7 +337,7 @@ class JsonBinaryCodecDeriver private[json] (
     key: Reflect[F, K],
     value: Reflect[F, V],
     typeId: TypeId[M[K, V]],
-    binding: Binding[BindingType.Map[M], M[K, V]],
+    binding: Binding.Map[M, K, V],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[M[K, V]],
@@ -356,7 +356,7 @@ class JsonBinaryCodecDeriver private[json] (
   }
 
   override def deriveDynamic[F[_, _]](
-    binding: Binding[BindingType.Dynamic, DynamicValue],
+    binding: Binding.Dynamic,
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[DynamicValue],
@@ -367,7 +367,7 @@ class JsonBinaryCodecDeriver private[json] (
   def deriveWrapper[F[_, _], A, B](
     wrapped: Reflect[F, B],
     typeId: TypeId[A],
-    binding: Binding[BindingType.Wrapper[A, B], A],
+    binding: Binding.Wrapper[A, B],
     doc: Doc,
     modifiers: Seq[Modifier.Reflect],
     defaultValue: Option[A],

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
@@ -2036,7 +2036,7 @@ object SchemaSpec extends SchemaBaseSpec {
           override def derivePrimitive[A](
             primitiveType: PrimitiveType[A],
             typeId: zio.blocks.typeid.TypeId[A],
-            binding: Binding[BindingType.Primitive, A],
+            binding: Binding.Primitive[A],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect],
             defaultValue: Option[A],
@@ -2051,7 +2051,7 @@ object SchemaSpec extends SchemaBaseSpec {
           override def deriveRecord[F[_, _], A](
             fields: IndexedSeq[Term[F, A, ?]],
             typeId: zio.blocks.typeid.TypeId[A],
-            binding: Binding[BindingType.Record, A],
+            binding: Binding.Record[A],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect],
             defaultValue: Option[A],
@@ -2066,7 +2066,7 @@ object SchemaSpec extends SchemaBaseSpec {
           override def deriveVariant[F[_, _], A](
             cases: IndexedSeq[Term[F, A, ?]],
             typeId: zio.blocks.typeid.TypeId[A],
-            binding: Binding[BindingType.Variant, A],
+            binding: Binding.Variant[A],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect],
             defaultValue: Option[A],
@@ -2081,7 +2081,7 @@ object SchemaSpec extends SchemaBaseSpec {
           override def deriveSequence[F[_, _], C[_], A](
             element: Reflect[F, A],
             typeId: zio.blocks.typeid.TypeId[C[A]],
-            binding: Binding[BindingType.Seq[C], C[A]],
+            binding: Binding.Seq[C, A],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect],
             defaultValue: Option[C[A]],
@@ -2097,7 +2097,7 @@ object SchemaSpec extends SchemaBaseSpec {
             key: Reflect[F, K],
             value: Reflect[F, V],
             typeId: zio.blocks.typeid.TypeId[M[K, V]],
-            binding: Binding[BindingType.Map[M], M[K, V]],
+            binding: Binding.Map[M, K, V],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect],
             defaultValue: Option[M[K, V]],
@@ -2110,7 +2110,7 @@ object SchemaSpec extends SchemaBaseSpec {
             })
 
           override def deriveDynamic[F[_, _]](
-            binding: Binding[BindingType.Dynamic, DynamicValue],
+            binding: Binding.Dynamic,
             doc: Doc,
             modifiers: Seq[Modifier.Reflect],
             defaultValue: Option[DynamicValue],
@@ -2128,7 +2128,7 @@ object SchemaSpec extends SchemaBaseSpec {
           override def deriveWrapper[F[_, _], A, B](
             wrapped: Reflect[F, B],
             typeId: zio.blocks.typeid.TypeId[A],
-            binding: Binding[BindingType.Wrapper[A, B], A],
+            binding: Binding.Wrapper[A, B],
             doc: Doc,
             modifiers: Seq[Modifier.Reflect],
             defaultValue: Option[A],

--- a/schema/shared/src/test/scala/zio/blocks/schema/derive/DeriverDefaultValueSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/derive/DeriverDefaultValueSpec.scala
@@ -77,7 +77,7 @@ object DeriverDefaultValueSpec extends SchemaBaseSpec {
     override def derivePrimitive[A](
       primitiveType: PrimitiveType[A],
       typeId: TypeId[A],
-      binding: Binding[BindingType.Primitive, A],
+      binding: Binding.Primitive[A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[A],
@@ -91,7 +91,7 @@ object DeriverDefaultValueSpec extends SchemaBaseSpec {
     override def deriveRecord[F[_, _], A](
       fields: IndexedSeq[Term[F, A, ?]],
       typeId: TypeId[A],
-      binding: Binding[BindingType.Record, A],
+      binding: Binding.Record[A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[A],
@@ -104,7 +104,7 @@ object DeriverDefaultValueSpec extends SchemaBaseSpec {
     override def deriveVariant[F[_, _], A](
       cases: IndexedSeq[Term[F, A, ?]],
       typeId: TypeId[A],
-      binding: Binding[BindingType.Variant, A],
+      binding: Binding.Variant[A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[A],
@@ -117,7 +117,7 @@ object DeriverDefaultValueSpec extends SchemaBaseSpec {
     override def deriveSequence[F[_, _], C[_], A](
       element: Reflect[F, A],
       typeId: TypeId[C[A]],
-      binding: Binding[BindingType.Seq[C], C[A]],
+      binding: Binding.Seq[C, A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[C[A]],
@@ -131,7 +131,7 @@ object DeriverDefaultValueSpec extends SchemaBaseSpec {
       key: Reflect[F, K],
       value: Reflect[F, V],
       typeId: TypeId[M[K, V]],
-      binding: Binding[BindingType.Map[M], M[K, V]],
+      binding: Binding.Map[M, K, V],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[M[K, V]],
@@ -142,7 +142,7 @@ object DeriverDefaultValueSpec extends SchemaBaseSpec {
     }
 
     override def deriveDynamic[F[_, _]](
-      binding: Binding[BindingType.Dynamic, DynamicValue],
+      binding: Binding.Dynamic,
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[DynamicValue],
@@ -155,7 +155,7 @@ object DeriverDefaultValueSpec extends SchemaBaseSpec {
     override def deriveWrapper[F[_, _], A, B](
       wrapped: Reflect[F, B],
       typeId: TypeId[A],
-      binding: Binding[BindingType.Wrapper[A, B], A],
+      binding: Binding.Wrapper[A, B],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[A],

--- a/zio-blocks-examples/src/main/scala/typeclassderivation/DeriveGenExample.scala
+++ b/zio-blocks-examples/src/main/scala/typeclassderivation/DeriveGenExample.scala
@@ -36,7 +36,7 @@ object DeriveGenExample extends App {
     override def derivePrimitive[A](
       primitiveType: PrimitiveType[A],
       typeId: TypeId[A],
-      binding: Binding[BindingType.Primitive, A],
+      binding: Binding.Primitive[A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[A],
@@ -74,7 +74,7 @@ object DeriveGenExample extends App {
     override def deriveRecord[F[_, _], A](
       fields: IndexedSeq[Term[F, A, _]],
       typeId: TypeId[A],
-      binding: Binding[BindingType.Record, A],
+      binding: Binding.Record[A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[A],
@@ -88,7 +88,7 @@ object DeriveGenExample extends App {
 
         // Build Reflect.Record to access registers and constructor
         val recordFields  = fields.asInstanceOf[IndexedSeq[Term[Binding, A, _]]]
-        val recordBinding = binding.asInstanceOf[Binding.Record[A]]
+        val recordBinding = binding
         val recordReflect = new Reflect.Record[Binding, A](recordFields, typeId, recordBinding, doc, modifiers)
 
         new Gen[A] {
@@ -117,7 +117,7 @@ object DeriveGenExample extends App {
     override def deriveVariant[F[_, _], A](
       cases: IndexedSeq[Term[F, A, _]],
       typeId: TypeId[A],
-      binding: Binding[BindingType.Variant, A],
+      binding: Binding.Variant[A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[A],
@@ -146,14 +146,14 @@ object DeriveGenExample extends App {
     override def deriveSequence[F[_, _], C[_], A](
       element: Reflect[F, A],
       typeId: TypeId[C[A]],
-      binding: Binding[BindingType.Seq[C], C[A]],
+      binding: Binding.Seq[C, A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[C[A]],
       examples: Seq[C[A]]
     )(implicit F: HasBinding[F], D: DeriveGen.HasInstance[F]): Lazy[Gen[C[A]]] = Lazy {
       val elementGen   = D.instance(element.metadata)
-      val seqBinding   = binding.asInstanceOf[Binding.Seq[C, A]]
+      val seqBinding   = binding
       val constructor  = seqBinding.constructor
       val elemClassTag = element.typeId.classTag.asInstanceOf[ClassTag[A]]
 
@@ -185,7 +185,7 @@ object DeriveGenExample extends App {
       key: Reflect[F, K],
       value: Reflect[F, V],
       typeId: TypeId[M[K, V]],
-      binding: Binding[BindingType.Map[M], M[K, V]],
+      binding: Binding.Map[M, K, V],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[M[K, V]],
@@ -193,7 +193,7 @@ object DeriveGenExample extends App {
     )(implicit F: HasBinding[F], D: DeriveGen.HasInstance[F]): Lazy[Gen[M[K, V]]] = Lazy {
       val keyGen      = D.instance(key.metadata)
       val valueGen    = D.instance(value.metadata)
-      val mapBinding  = binding.asInstanceOf[Binding.Map[M, K, V]]
+      val mapBinding  = binding
       val constructor = mapBinding.constructor
 
       new Gen[M[K, V]] {
@@ -219,7 +219,7 @@ object DeriveGenExample extends App {
      * content.
      */
     override def deriveDynamic[F[_, _]](
-      binding: Binding[BindingType.Dynamic, DynamicValue],
+      binding: Binding.Dynamic,
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[DynamicValue],
@@ -274,14 +274,14 @@ object DeriveGenExample extends App {
     override def deriveWrapper[F[_, _], A, B](
       wrapped: Reflect[F, B],
       typeId: TypeId[A],
-      binding: Binding[BindingType.Wrapper[A, B], A],
+      binding: Binding.Wrapper[A, B],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[A],
       examples: Seq[A]
     )(implicit F: HasBinding[F], D: DeriveGen.HasInstance[F]): Lazy[Gen[A]] = Lazy {
       val wrappedGen     = D.instance(wrapped.metadata)
-      val wrapperBinding = binding.asInstanceOf[Binding.Wrapper[A, B]]
+      val wrapperBinding = binding
 
       new Gen[A] {
         def generate(random: Random): A =

--- a/zio-blocks-examples/src/main/scala/typeclassderivation/DeriveShowExample.scala
+++ b/zio-blocks-examples/src/main/scala/typeclassderivation/DeriveShowExample.scala
@@ -25,7 +25,7 @@ object DeriveShowExample extends App {
     override def derivePrimitive[A](
       primitiveType: PrimitiveType[A],
       typeId: TypeId[A],
-      binding: Binding[BindingType.Primitive, A],
+      binding: Binding.Primitive[A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[A],
@@ -44,7 +44,7 @@ object DeriveShowExample extends App {
     override def deriveRecord[F[_, _], A](
       fields: IndexedSeq[Term[F, A, _]],
       typeId: TypeId[A],
-      binding: Binding[BindingType.Record, A],
+      binding: Binding.Record[A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[A],
@@ -64,7 +64,7 @@ object DeriveShowExample extends App {
         val recordFields = fields.asInstanceOf[IndexedSeq[Term[Binding, A, _]]]
 
         // Cast to Binding.Record to access constructor/deconstructor
-        val recordBinding = binding.asInstanceOf[Binding.Record[A]]
+        val recordBinding = binding
 
         // Build a Reflect.Record to get access to the computed registers for each field
         val recordReflect = new Reflect.Record[Binding, A](recordFields, typeId, recordBinding, doc, modifiers)
@@ -94,7 +94,7 @@ object DeriveShowExample extends App {
     override def deriveVariant[F[_, _], A](
       cases: IndexedSeq[Term[F, A, _]],
       typeId: TypeId[A],
-      binding: Binding[BindingType.Variant, A],
+      binding: Binding.Variant[A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[A],
@@ -106,7 +106,7 @@ object DeriveShowExample extends App {
       }
 
       // Cast binding to Binding.Variant to access discriminator and matchers
-      val variantBinding = binding.asInstanceOf[Binding.Variant[A]]
+      val variantBinding = binding
       val discriminator  = variantBinding.discriminator
       val matchers       = variantBinding.matchers
 
@@ -129,7 +129,7 @@ object DeriveShowExample extends App {
     override def deriveSequence[F[_, _], C[_], A](
       element: Reflect[F, A],
       typeId: TypeId[C[A]],
-      binding: Binding[BindingType.Seq[C], C[A]],
+      binding: Binding.Seq[C, A],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[C[A]],
@@ -139,7 +139,7 @@ object DeriveShowExample extends App {
       val elementShowLazy: Lazy[Show[A]] = D.instance(element.metadata)
 
       // Cast binding to Binding.Seq to access the deconstructor
-      val seqBinding    = binding.asInstanceOf[Binding.Seq[C, A]]
+      val seqBinding    = binding
       val deconstructor = seqBinding.deconstructor
 
       new Show[C[A]] {
@@ -157,7 +157,7 @@ object DeriveShowExample extends App {
       key: Reflect[F, K],
       value: Reflect[F, V],
       typeId: TypeId[M[K, V]],
-      binding: Binding[BindingType.Map[M], M[K, V]],
+      binding: Binding.Map[M, K, V],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[M[K, V]],
@@ -168,7 +168,7 @@ object DeriveShowExample extends App {
       val valueShowLazy: Lazy[Show[V]] = D.instance(value.metadata)
 
       // Cast binding to Binding.Map to access the deconstructor
-      val mapBinding    = binding.asInstanceOf[Binding.Map[M, K, V]]
+      val mapBinding    = binding
       val deconstructor = mapBinding.deconstructor
 
       new Show[M[K, V]] {
@@ -187,7 +187,7 @@ object DeriveShowExample extends App {
     }
 
     override def deriveDynamic[F[_, _]](
-      binding: Binding[BindingType.Dynamic, DynamicValue],
+      binding: Binding.Dynamic,
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[DynamicValue],
@@ -226,7 +226,7 @@ object DeriveShowExample extends App {
     override def deriveWrapper[F[_, _], A, B](
       wrapped: Reflect[F, B],
       typeId: TypeId[A],
-      binding: Binding[BindingType.Wrapper[A, B], A],
+      binding: Binding.Wrapper[A, B],
       doc: Doc,
       modifiers: Seq[Modifier.Reflect],
       defaultValue: Option[A],
@@ -236,7 +236,7 @@ object DeriveShowExample extends App {
       val wrappedShowLazy: Lazy[Show[B]] = D.instance(wrapped.metadata)
 
       // Cast binding to Binding.Wrapper to access unwrap function
-      val wrapperBinding = binding.asInstanceOf[Binding.Wrapper[A, B]]
+      val wrapperBinding = binding
 
       new Show[A] {
         def show(value: A): String = {


### PR DESCRIPTION
## Summary

Resolves #908 — narrows `Deriver` method binding parameters from generic `Binding[BindingType.X, A]` to concrete subtypes like `Binding.Record[A]`, `Binding.Variant[A]`, etc.

## Motivation

The previous signatures forced every deriver implementation to receive a generic `Binding[BindingType.X, A]` and then immediately cast it to the concrete subtype they actually needed (e.g. `binding.asInstanceOf[Binding.Record[A]]`). Since the framework always passes the correct concrete type anyway, the signatures can just reflect that directly and remove the unnecessary casts.

## Changes

**Core API** (`Deriver.scala`):
- All 7 `derive*` methods now take concrete binding types (`Binding.Primitive[A]`, `Binding.Record[A]`, `Binding.Seq[C, A]`, `Binding.Map[M, K, V]`, `Binding.Dynamic`, `Binding.Wrapper[A, B]`)

**DerivationBuilder** (`DerivationBuilder.scala`):
- Updated internal call sites to extract concrete binding types via `HasBinding` helpers before passing them to deriver methods

**HasBinding** (`HasBinding.scala`):
- Added `dynamic` extractor method — the other 6 shapes already had one, this was the missing piece

**Production derivers** (5 files):
- `JsonBinaryCodecDeriver`, `MessagePackBinaryCodecDeriver`, `ToonBinaryCodecDeriver`, `AvroFormat`, `ThriftFormat` — updated override signatures, removed now-unnecessary `BindingType` imports

**Tests, examples, docs**:
- Updated test derivers in `DeriverDefaultValueSpec` and `SchemaSpec`
- Updated `DeriveShowExample` and `DeriveGenExample` — also removed redundant `.asInstanceOf` casts that are no longer needed
- Updated all signature snippets in `docs/reference/type-class-derivation.md`
