### PR TITLE
fix: throw IllegalStateException on closed-scope operations instead of returning null

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -227,6 +227,7 @@ Scope.global.scoped { scope =>
 - **Built-in Dependency Injection**: Wire up your application with `Resource.from[T](wires*)` for automatic constructor-based DI.
 - **AutoCloseable Integration**: Resources implementing `AutoCloseable` have `close()` registered automatically.
 - **Unscoped Constraint**: The `scoped` method requires `Unscoped[A]` evidence on the return type, ensuring only pure data (not resources or closures) can escape.
+- **Actionable Runtime Errors**: If a scope reference escapes and is used after closing, `allocate`, `open()`, and `$` throw `IllegalStateException` with a detailed message explaining what went wrong, the common causes, and how to fix it—no silent null returns.
 
 ### Installation
 

--- a/scope/shared/src/main/scala-2/zio/blocks/scope/ScopeMacros.scala
+++ b/scope/shared/src/main/scala-2/zio/blocks/scope/ScopeMacros.scala
@@ -87,13 +87,21 @@ private[scope] object ScopeMacros {
     if (hasUnscoped) {
       // B is Unscoped — return B directly (auto-unwrap)
       q"""
-        if ($self.isClosed) null.asInstanceOf[$returnType]
+        if ($self.isClosed)
+          throw new _root_.java.lang.IllegalStateException(
+            _root_.zio.blocks.scope.internal.ErrorMessages
+              .renderUseOnClosedScope($self.scopeDisplayName, color = false)
+          )
         else $fTyped($sa.asInstanceOf[$inputType])
       """
     } else {
       // B is not Unscoped — return $[B]
       q"""
-        if ($self.isClosed) null.asInstanceOf[$returnType].asInstanceOf[$self.$$[$returnType]]
+        if ($self.isClosed)
+          throw new _root_.java.lang.IllegalStateException(
+            _root_.zio.blocks.scope.internal.ErrorMessages
+              .renderUseOnClosedScope($self.scopeDisplayName, color = false)
+          )
         else $fTyped($sa.asInstanceOf[$inputType]).asInstanceOf[$self.$$[$returnType]]
       """
     }

--- a/scope/shared/src/main/scala-2/zio/blocks/scope/ScopeVersionSpecific.scala
+++ b/scope/shared/src/main/scala-2/zio/blocks/scope/ScopeVersionSpecific.scala
@@ -79,7 +79,9 @@ private[scope] trait ScopeVersionSpecific { self: Scope =>
    *   the output value type
    * @return
    *   the result as `B` if `B` has an `Unscoped` instance (auto-unwrapped),
-   *   otherwise as `$[B]`; returns a default value if the scope is closed
+   *   otherwise as `$[B]`
+   * @throws java.lang.IllegalStateException
+   *   if this scope is already closed
    */
   def $[A, B](sa: $[A])(f: A => B): Any = macro ScopeMacros.useImpl
 


### PR DESCRIPTION
## Summary

- `allocate`, `open()`, and `$` previously returned `null.asInstanceOf[T]` when called on a closed scope, silently causing `NullPointerException` on first use — especially dangerous on `Scope.global` where `$[A] = A` and no wrapper type stood between the null and the call site.
- Each operation now throws `IllegalStateException` with a rich, ASCII-rendered error message (via `ErrorMessages` RE1–RE3) that names the scope type, explains what went wrong, lists common escape-pattern causes, and shows a correct usage example.
- The `isClosed` guard in `open()` is moved to the top of the method, preventing spurious `Finalizers` / `Child` / `defer` allocations when the scope is already closed.

## What's unchanged

- `defer` on a closed scope remains a documented no-op.
- `lower` is a zero-cost cast and requires no closed check.
- `scoped` on a closed scope still creates a born-closed child (existing behaviour, not a hazard).

## Tests

Tests assert the **full rendered message** via `==` rather than loose `contains` checks, keeping tests and message copy in sync across Scala 2.13 and Scala 3. 299/298 tests pass.

## Docs

- `docs/scope.md`: replaces the old "closed-scope defense returns defaults" section with the new throw behaviour and shows all three error messages verbatim. Adds a "Common runtime errors" section before the existing "Common compile errors" section.
- `docs/index.md`: adds an "Actionable Runtime Errors" key-feature bullet to the Scope block summary.