### PR TITLE
fix: use sbt-git console git runner to support git worktrees

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,8 @@ inThisBuild(
   )
 )
 
+com.github.sbt.git.SbtGit.useReadableConsoleGit
+
 addCommandAlias("build", "; fmt; coverage; root/test; coverageReport")
 addCommandAlias("fmt", "all root/scalafmtSbt root/scalafmtAll")
 addCommandAlias("fmtCheck", "all root/scalafmtSbtCheck root/scalafmtCheckAll")


### PR DESCRIPTION
## Summary

- JGit 5.x (bundled transitively via `sbt-ci-release` → `sbt-git` 2.1.0) cannot follow the `gitdir:` pointer file used by git worktrees, causing a `RepositoryNotFoundException` at sbt startup before any task runs.
- Native worktree support only landed in JGit 7.0.0 (Sep 2024); `sbt-git` has not yet upgraded (open issue: sbt/sbt-git#264).
- Enable `SbtGit.useReadableConsoleGit` — an official sbt-git 2.0.0+ opt-in that delegates all read-only git operations to the system `git` binary instead of JGit, bypassing the incompatibility entirely.

## Change

One line added to `build.sbt`, immediately after the `inThisBuild` block:

```scala
com.github.sbt.git.SbtGit.useReadableConsoleGit
```

No new dependencies, no imports required — `sbt-git` is already on the plugin classpath via `sbt-ci-release`.

## Verification

`sbt --client` now starts cleanly against a git worktree checkout without any JGit / `RepositoryNotFoundException` errors.