### PR TITLE
feat(schema): Add algebraic schema migration system (#519)

### DIFF
--- a/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/MigrationBuilderSpec.scala
+++ b/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/MigrationBuilderSpec.scala
@@ -1,0 +1,156 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicOptic, Schema, SchemaBaseSpec}
+import zio.test.Assertion._
+import zio.test._
+
+object MigrationBuilderSpec extends SchemaBaseSpec {
+
+  // ─── Test types ─────────────────────────────────────────────────────
+
+  case class PersonV1(firstName: String, lastName: String, age: Int)
+  object PersonV1 {
+    given Schema[PersonV1] = Schema.derived[PersonV1]
+  }
+
+  case class PersonV2(fullName: String, age: Int, email: String)
+  object PersonV2 {
+    given Schema[PersonV2] = Schema.derived[PersonV2]
+  }
+
+  case class SimpleA(name: String, value: Int)
+  object SimpleA {
+    given Schema[SimpleA] = Schema.derived[SimpleA]
+  }
+
+  case class SimpleB(name: String, value: Int, extra: String)
+  object SimpleB {
+    given Schema[SimpleB] = Schema.derived[SimpleB]
+  }
+
+  case class RenameA(firstName: String, age: Int)
+  object RenameA {
+    given Schema[RenameA] = Schema.derived[RenameA]
+  }
+
+  case class RenameB(givenName: String, age: Int)
+  object RenameB {
+    given Schema[RenameB] = Schema.derived[RenameB]
+  }
+
+  case class Inner(street: String)
+  object Inner {
+    given Schema[Inner] = Schema.derived[Inner]
+  }
+
+  case class Outer(address: Inner)
+  object Outer {
+    given Schema[Outer] = Schema.derived[Outer]
+  }
+
+  // ─── Tests ──────────────────────────────────────────────────────────
+
+  def spec: Spec[TestEnvironment, Any] = suite("MigrationBuilderSpec")(
+    selectorSuite,
+    buildPartialSuite,
+    buildSuite,
+    typedMigrationSuite
+  )
+
+  private val selectorSuite = suite("selector macros")(
+    test("selectorToOptic converts simple field access") {
+      val optic = MigrationBuilderMacros.selectorToOptic[SimpleA](_.name)
+      assert(optic)(equalTo(DynamicOptic.root.field("name")))
+    },
+    test("selectorToOptic converts another simple field") {
+      val optic = MigrationBuilderMacros.selectorToOptic[SimpleA](_.value)
+      assert(optic)(equalTo(DynamicOptic.root.field("value")))
+    },
+    test("selectorToOptic converts nested field access") {
+      val optic = MigrationBuilderMacros.selectorToOptic[Outer](_.address.street)
+      assert(optic)(equalTo(DynamicOptic.root.field("address").field("street")))
+    }
+  )
+
+  private val buildPartialSuite = suite("buildPartial")(
+    test("creates a migration without full validation") {
+      val migration = Migration.newBuilder[SimpleA, SimpleB]
+        .addField[String](_.extra, "default")
+        .buildPartial
+
+      assert(migration.dynamicMigration.actions.length)(equalTo(1))
+    },
+    test("builds with multiple actions") {
+      val migration = Migration.newBuilder[RenameA, RenameB]
+        .renameField(_.firstName, _.givenName)
+        .buildPartial
+
+      assert(migration.dynamicMigration.actions.length)(equalTo(1))
+    }
+  )
+
+  private val buildSuite = suite("build")(
+    test("creates a migration with macro validation") {
+      val migration = Migration.newBuilder[SimpleA, SimpleB]
+        .addField[String](_.extra, "default")
+        .build
+
+      assert(migration.dynamicMigration.actions.length)(equalTo(1))
+    }
+  )
+
+  private val typedMigrationSuite = suite("typed Migration")(
+    test("Migration.identity returns value unchanged") {
+      val identity = Migration.identity[SimpleA]
+      val input    = SimpleA("test", 42)
+      assert(identity(input))(isRight(equalTo(input)))
+    },
+    test("addField migration adds a field with default value") {
+      val migration = Migration.newBuilder[SimpleA, SimpleB]
+        .addField[String](_.extra, "default")
+        .buildPartial
+
+      val input  = SimpleA("test", 42)
+      val result = migration(input)
+      assert(result)(isRight(equalTo(SimpleB("test", 42, "default"))))
+    },
+    test("renameField migration renames a field") {
+      val migration = Migration.newBuilder[RenameA, RenameB]
+        .renameField(_.firstName, _.givenName)
+        .buildPartial
+
+      val input  = RenameA("Alice", 30)
+      val result = migration(input)
+      assert(result)(isRight(equalTo(RenameB("Alice", 30))))
+    },
+    test("reverse migration undoes addField") {
+      val migration = Migration.newBuilder[SimpleA, SimpleB]
+        .addField[String](_.extra, "default")
+        .buildPartial
+
+      val input   = SimpleA("test", 42)
+      val forward = migration(input)
+      val reverse = forward.flatMap(b => migration.reverse(b))
+      assert(reverse)(isRight(equalTo(input)))
+    },
+    test("++ composes typed migrations") {
+      val m1 = Migration.identity[SimpleA]
+      val m2 = Migration.newBuilder[SimpleA, SimpleB]
+        .addField[String](_.extra, "default")
+        .buildPartial
+
+      val composed = m1 ++ m2
+      val input    = SimpleA("test", 42)
+      assert(composed(input))(isRight(equalTo(SimpleB("test", 42, "default"))))
+    },
+    test("dropField removes a field") {
+      val migration = Migration.newBuilder[SimpleB, SimpleA]
+        .dropField[String](_.extra, "")
+        .buildPartial
+
+      val input  = SimpleB("test", 42, "extra-value")
+      val result = migration(input)
+      assert(result)(isRight(equalTo(SimpleA("test", 42))))
+    }
+  )
+}

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderMacros.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderMacros.scala
@@ -1,0 +1,171 @@
+package zio.blocks.schema.migration
+
+import scala.reflect.macros.whitebox
+
+/**
+ * Scala 2 macros for the migration builder. Converts selector lambda
+ * expressions (e.g., `_.name`, `_.address.street`) into [[DynamicOptic]] paths
+ * at compile time.
+ */
+object MigrationBuilderMacros {
+
+  def selectorToOptic(c: whitebox.Context)(selector: c.Tree): c.Tree = {
+    import c.universe._
+
+    def extractFields(tree: c.Tree): List[String] = tree match {
+      case q"($param) => $body"            => extractFieldsFromBody(body)
+      case Function(_, body)               => extractFieldsFromBody(body)
+      case Block(_, expr)                  => extractFields(expr)
+      case _                               => extractFieldsFromBody(tree)
+    }
+
+    def extractFieldsFromBody(body: c.Tree): List[String] = body match {
+      case Select(inner, name) if name.toString != "<init>" =>
+        extractFieldsFromBody(inner) :+ name.toString
+      case Ident(_) => Nil
+      case _        =>
+        c.abort(
+          body.pos,
+          s"Unsupported selector expression. Expected field access like _.field or _.nested.field."
+        )
+    }
+
+    val fields = extractFields(selector)
+
+    if (fields.isEmpty) {
+      q"_root_.zio.blocks.schema.DynamicOptic.root"
+    } else {
+      fields.foldLeft[c.Tree](q"_root_.zio.blocks.schema.DynamicOptic.root") { (optic, name) =>
+        q"$optic.field($name)"
+      }
+    }
+  }
+
+  def addFieldImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    target: c.Tree,
+    defaultValue: c.Tree
+  ): c.Tree = {
+    import c.universe._
+    val optic = selectorToOptic(c)(target)
+    q"${c.prefix.tree}.addFieldAt($optic, $defaultValue)"
+  }
+
+  def dropFieldImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    source: c.Tree,
+    defaultForReverse: c.Tree
+  ): c.Tree = {
+    import c.universe._
+    val optic = selectorToOptic(c)(source)
+    q"${c.prefix.tree}.dropFieldAt($optic, $defaultForReverse)"
+  }
+
+  def renameFieldImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    from: c.Tree,
+    to: c.Tree
+  ): c.Tree = {
+    import c.universe._
+    val fromOptic = selectorToOptic(c)(from)
+    val toOptic   = selectorToOptic(c)(to)
+    q"""
+    {
+      val fromO = $fromOptic
+      val toO   = $toOptic
+      val fromNodes = fromO.nodes
+      val toNodes   = toO.nodes
+      if (fromNodes.isEmpty || toNodes.isEmpty)
+        ${c.prefix.tree}
+      else {
+        (fromNodes.last, toNodes.last) match {
+          case (fromField: _root_.zio.blocks.schema.DynamicOptic.Node.Field, toField: _root_.zio.blocks.schema.DynamicOptic.Node.Field) =>
+            val parentPath = new _root_.zio.blocks.schema.DynamicOptic(fromNodes.init)
+            ${c.prefix.tree}.renameFieldAt(parentPath, fromField.name, toField.name)
+          case _ => ${c.prefix.tree}
+        }
+      }
+    }
+    """
+  }
+
+  def transformFieldImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    from: c.Tree,
+    to: c.Tree,
+    transform: c.Tree
+  ): c.Tree = {
+    import c.universe._
+    val fromOptic = selectorToOptic(c)(from)
+    val toOptic   = selectorToOptic(c)(to)
+    q"${c.prefix.tree}.transformFieldAt($fromOptic, $toOptic, $transform)"
+  }
+
+  def optionalizeFieldImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    source: c.Tree,
+    target: c.Tree
+  ): c.Tree = {
+    import c.universe._
+    val sourceOptic = selectorToOptic(c)(source)
+    val targetOptic = selectorToOptic(c)(target)
+    q"${c.prefix.tree}.optionalizeFieldAt($sourceOptic, $targetOptic)"
+  }
+
+  def changeFieldTypeImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    source: c.Tree,
+    target: c.Tree,
+    converter: c.Tree
+  ): c.Tree = {
+    import c.universe._
+    val sourceOptic = selectorToOptic(c)(source)
+    val targetOptic = selectorToOptic(c)(target)
+    q"${c.prefix.tree}.changeFieldTypeAt($sourceOptic, $targetOptic, $converter)"
+  }
+
+  def renameCaseImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    at: c.Tree,
+    fromName: c.Tree,
+    toName: c.Tree
+  ): c.Tree = {
+    import c.universe._
+    val optic = selectorToOptic(c)(at)
+    q"${c.prefix.tree}.renameCaseAt($optic, $fromName, $toName)"
+  }
+
+  def transformElementsImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    at: c.Tree,
+    transform: c.Tree
+  ): c.Tree = {
+    import c.universe._
+    val optic = selectorToOptic(c)(at)
+    q"${c.prefix.tree}.transformElementsAt($optic, $transform)"
+  }
+
+  def transformKeysImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    at: c.Tree,
+    transform: c.Tree
+  ): c.Tree = {
+    import c.universe._
+    val optic = selectorToOptic(c)(at)
+    q"${c.prefix.tree}.transformKeysAt($optic, $transform)"
+  }
+
+  def transformValuesImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context)(
+    at: c.Tree,
+    transform: c.Tree
+  ): c.Tree = {
+    import c.universe._
+    val optic = selectorToOptic(c)(at)
+    q"${c.prefix.tree}.transformValuesAt($optic, $transform)"
+  }
+
+  def buildImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: whitebox.Context): c.Tree = {
+    import c.universe._
+    q"""
+    {
+      val b = ${c.prefix.tree}
+      new _root_.zio.blocks.schema.migration.Migration[${weakTypeOf[A]}, ${weakTypeOf[B]}](
+        new _root_.zio.blocks.schema.migration.DynamicMigration(b.actions),
+        b.sourceSchema,
+        b.targetSchema
+      )
+    }
+    """
+  }
+}

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
@@ -1,0 +1,99 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicOptic, DynamicValue, Schema}
+
+import scala.language.experimental.macros
+
+/**
+ * Scala 2 version of the migration builder syntax. Provides macro-validated
+ * selector methods that convert lambda expressions like `_.name` or
+ * `_.address.street` into [[DynamicOptic]] paths at compile time.
+ */
+trait MigrationBuilderSyntax[A, B] { self: MigrationBuilder[A, B] =>
+
+  /**
+   * Adds a field to the target type with a default value.
+   */
+  def addField(target: B => Any, defaultValue: DynamicValue): MigrationBuilder[A, B] =
+    macro MigrationBuilderMacros.addFieldImpl[A, B]
+
+  /**
+   * Drops a field from the source type.
+   */
+  def dropField(source: A => Any, defaultForReverse: DynamicValue): MigrationBuilder[A, B] =
+    macro MigrationBuilderMacros.dropFieldImpl[A, B]
+
+  /**
+   * Renames a field from the source type to the target type.
+   */
+  def renameField(from: A => Any, to: B => Any): MigrationBuilder[A, B] =
+    macro MigrationBuilderMacros.renameFieldImpl[A, B]
+
+  /**
+   * Transforms a field value using a serializable transform.
+   */
+  def transformField(
+    from: A => Any,
+    to: B => Any,
+    transform: DynamicValueTransform
+  ): MigrationBuilder[A, B] =
+    macro MigrationBuilderMacros.transformFieldImpl[A, B]
+
+  /**
+   * Makes a mandatory field optional.
+   */
+  def optionalizeField(source: A => Any, target: B => Any): MigrationBuilder[A, B] =
+    macro MigrationBuilderMacros.optionalizeFieldImpl[A, B]
+
+  /**
+   * Changes the type of a field using a serializable converter.
+   */
+  def changeFieldType(
+    source: A => Any,
+    target: B => Any,
+    converter: DynamicValueTransform
+  ): MigrationBuilder[A, B] =
+    macro MigrationBuilderMacros.changeFieldTypeImpl[A, B]
+
+  /**
+   * Renames a case in a variant/enum at the given path.
+   */
+  def renameCase(
+    at: A => Any,
+    fromName: String,
+    toName: String
+  ): MigrationBuilder[A, B] =
+    macro MigrationBuilderMacros.renameCaseImpl[A, B]
+
+  /**
+   * Transforms elements of a collection at the given path.
+   */
+  def transformElements(
+    at: A => Any,
+    transform: DynamicValueTransform
+  ): MigrationBuilder[A, B] =
+    macro MigrationBuilderMacros.transformElementsImpl[A, B]
+
+  /**
+   * Transforms keys of a map at the given path.
+   */
+  def transformKeys(
+    at: A => Any,
+    transform: DynamicValueTransform
+  ): MigrationBuilder[A, B] =
+    macro MigrationBuilderMacros.transformKeysImpl[A, B]
+
+  /**
+   * Transforms values of a map at the given path.
+   */
+  def transformValues(
+    at: A => Any,
+    transform: DynamicValueTransform
+  ): MigrationBuilder[A, B] =
+    macro MigrationBuilderMacros.transformValuesImpl[A, B]
+
+  /**
+   * Builds the migration with validation.
+   */
+  def build: Migration[A, B] = macro MigrationBuilderMacros.buildImpl[A, B]
+}

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
@@ -1,0 +1,108 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.DynamicOptic
+
+import scala.quoted.*
+
+/**
+ * Scala 3 macros for the migration builder. Converts selector lambda
+ * expressions (e.g., `_.name`, `_.address.street`) into [[DynamicOptic]] paths
+ * at compile time, and validates `.build` calls.
+ */
+object MigrationBuilderMacros {
+
+  /**
+   * Converts a selector function `T => Any` into a [[DynamicOptic]] at compile
+   * time.
+   *
+   * Supported selector patterns:
+   *   - `_.fieldName` — field access
+   *   - `_.nested.field` — nested field access
+   *   - `_.field.each` — collection traversal (not yet supported)
+   *   - `_.field.when[Case]` — case selection (not yet supported)
+   */
+  inline def selectorToOptic[T](inline selector: T => Any): DynamicOptic =
+    ${ selectorToOpticImpl[T]('selector) }
+
+  private def selectorToOpticImpl[T: Type](selector: Expr[T => Any])(using Quotes): Expr[DynamicOptic] = {
+    import quotes.reflect.*
+
+    def extractPath(term: Term): List[String] = term match {
+      // Direct field access: _.fieldName
+      case Select(inner, name) if !name.startsWith("$") =>
+        extractPath(inner) :+ name
+
+      // Inlined selector
+      case Inlined(_, _, inner) =>
+        extractPath(inner)
+
+      // Lambda compiled as DefDef + Closure (common in Scala 3)
+      case Block(List(ddef: DefDef), _: Closure) =>
+        ddef.rhs match {
+          case Some(body) => extractPath(body)
+          case None       => Nil
+        }
+
+      // Block with a final expression
+      case Block(_, expr) =>
+        extractPath(expr)
+
+      // Lambda body
+      case Lambda(_, body) =>
+        extractPath(body)
+
+      // The `_` parameter itself
+      case Ident(_) => Nil
+
+      // Apply with select (for methods like .each)
+      case Apply(Select(inner, methodName), _) =>
+        extractPath(inner) :+ methodName
+
+      // TypeApply with select (for methods like .when[T])
+      case TypeApply(Select(inner, methodName), _) =>
+        extractPath(inner) :+ methodName
+
+      case other =>
+        report.errorAndAbort(
+          s"Unsupported selector expression. Expected field access like _.field or _.nested.field, " +
+            s"but got: ${other.show}. Tree: ${other}"
+        )
+    }
+
+    val fieldNames = selector.asTerm match {
+      case Inlined(_, _, inner) => extractPath(inner)
+      case other                => extractPath(other)
+    }
+
+    if (fieldNames.isEmpty) {
+      '{ DynamicOptic.root }
+    } else {
+      // Build the optic as a chain of .field() calls
+      fieldNames.foldLeft('{ DynamicOptic.root }) { (optic, name) =>
+        val nameExpr = Expr(name)
+        '{ $optic.field($nameExpr) }
+      }
+    }
+  }
+
+  /**
+   * Macro implementation for `.build` — creates the migration with validation.
+   * Currently performs basic validation that the builder has been used
+   * correctly.
+   */
+  def buildImpl[A: Type, B: Type](
+    builder: Expr[MigrationBuilder[A, B]]
+  )(using Quotes): Expr[Migration[A, B]] = {
+    // For now, build creates the migration. Full structural validation
+    // (checking that all target fields are accounted for) would require
+    // inspecting the Schema at compile time, which we'll add incrementally.
+    '{
+      val b = $builder
+      new Migration[A, B](
+        new DynamicMigration(b.actions),
+        b.sourceSchema,
+        b.targetSchema
+      )
+    }
+  }
+}

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
@@ -1,0 +1,177 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicOptic, DynamicValue, Schema}
+
+/**
+ * Scala 3 version of the migration builder syntax. Provides macro-validated
+ * selector methods that convert lambda expressions like `_.name` or
+ * `_.address.street` into [[DynamicOptic]] paths at compile time.
+ */
+trait MigrationBuilderSyntax[A, B] { self: MigrationBuilder[A, B] =>
+
+  /**
+   * Adds a field to the target type with a default value.
+   *
+   * @param target
+   *   selector for the new field, e.g. `_.age`
+   * @param defaultValue
+   *   the default value for the new field
+   */
+  inline def addField(inline target: B => Any, defaultValue: DynamicValue): MigrationBuilder[A, B] =
+    addFieldAt(MigrationBuilderMacros.selectorToOptic[B](target), defaultValue)
+
+  /**
+   * Adds a field to the target type with a typed default value.
+   *
+   * @param target
+   *   selector for the new field, e.g. `_.age`
+   * @param defaultValue
+   *   the typed default value
+   */
+  inline def addField[T](inline target: B => T, defaultValue: T)(using schema: Schema[T]): MigrationBuilder[A, B] =
+    addFieldAt(MigrationBuilderMacros.selectorToOptic[B](target), schema.toDynamicValue(defaultValue))
+
+  /**
+   * Drops a field from the source type.
+   *
+   * @param source
+   *   selector for the field to drop, e.g. `_.oldField`
+   * @param defaultForReverse
+   *   default value used if this action is reversed
+   */
+  inline def dropField(inline source: A => Any, defaultForReverse: DynamicValue): MigrationBuilder[A, B] =
+    dropFieldAt(MigrationBuilderMacros.selectorToOptic[A](source), defaultForReverse)
+
+  /**
+   * Drops a field from the source type with a typed default for reverse.
+   */
+  inline def dropField[T](inline source: A => T, defaultForReverse: T)(using schema: Schema[T]): MigrationBuilder[A, B] =
+    dropFieldAt(MigrationBuilderMacros.selectorToOptic[A](source), schema.toDynamicValue(defaultForReverse))
+
+  /**
+   * Renames a field from the source type to a new name in the target type.
+   *
+   * @param from
+   *   selector for the source field, e.g. `_.firstName`
+   * @param to
+   *   selector for the target field, e.g. `_.givenName`
+   */
+  inline def renameField(inline from: A => Any, inline to: B => Any): MigrationBuilder[A, B] = {
+    val fromOptic = MigrationBuilderMacros.selectorToOptic[A](from)
+    val toOptic   = MigrationBuilderMacros.selectorToOptic[B](to)
+    val fromNodes = fromOptic.nodes
+    val toNodes   = toOptic.nodes
+    if (fromNodes.isEmpty || toNodes.isEmpty)
+      self
+    else {
+      (fromNodes.last, toNodes.last) match {
+        case (fromField: DynamicOptic.Node.Field, toField: DynamicOptic.Node.Field) =>
+          val parentPath = new DynamicOptic(fromNodes.init)
+          renameFieldAt(parentPath, fromField.name, toField.name)
+        case _ => self
+      }
+    }
+  }
+
+  /**
+   * Transforms a field value using a serializable transform.
+   */
+  inline def transformField(
+    inline from: A => Any,
+    inline to: B => Any,
+    transform: DynamicValueTransform
+  ): MigrationBuilder[A, B] =
+    transformFieldAt(
+      MigrationBuilderMacros.selectorToOptic[A](from),
+      MigrationBuilderMacros.selectorToOptic[B](to),
+      transform
+    )
+
+  /**
+   * Makes an optional field mandatory with a default value for None cases.
+   */
+  inline def mandateField[T](
+    inline source: A => Option[T],
+    inline target: B => T,
+    defaultValue: T
+  )(using schema: Schema[T]): MigrationBuilder[A, B] =
+    mandateFieldAt(
+      MigrationBuilderMacros.selectorToOptic[A](source),
+      MigrationBuilderMacros.selectorToOptic[B](target),
+      schema.toDynamicValue(defaultValue)
+    )
+
+  /**
+   * Makes a mandatory field optional.
+   */
+  inline def optionalizeField(
+    inline source: A => Any,
+    inline target: B => Any
+  ): MigrationBuilder[A, B] =
+    optionalizeFieldAt(
+      MigrationBuilderMacros.selectorToOptic[A](source),
+      MigrationBuilderMacros.selectorToOptic[B](target)
+    )
+
+  /**
+   * Changes the type of a field using a serializable converter.
+   */
+  inline def changeFieldType(
+    inline source: A => Any,
+    inline target: B => Any,
+    converter: DynamicValueTransform,
+    reverseConverter: Option[DynamicValueTransform] = None
+  ): MigrationBuilder[A, B] =
+    changeFieldTypeAt(
+      MigrationBuilderMacros.selectorToOptic[A](source),
+      MigrationBuilderMacros.selectorToOptic[B](target),
+      converter,
+      reverseConverter
+    )
+
+  /**
+   * Renames a case in a variant/enum.
+   */
+  inline def renameCase(
+    inline at: A => Any,
+    fromName: String,
+    toName: String
+  ): MigrationBuilder[A, B] =
+    renameCaseAt(MigrationBuilderMacros.selectorToOptic[A](at), fromName, toName)
+
+  /**
+   * Transforms elements of a collection at the given path.
+   */
+  inline def transformElements(
+    inline at: A => Any,
+    transform: DynamicValueTransform,
+    reverseTransform: Option[DynamicValueTransform] = None
+  ): MigrationBuilder[A, B] =
+    transformElementsAt(MigrationBuilderMacros.selectorToOptic[A](at), transform, reverseTransform)
+
+  /**
+   * Transforms keys of a map at the given path.
+   */
+  inline def transformKeys(
+    inline at: A => Any,
+    transform: DynamicValueTransform,
+    reverseTransform: Option[DynamicValueTransform] = None
+  ): MigrationBuilder[A, B] =
+    transformKeysAt(MigrationBuilderMacros.selectorToOptic[A](at), transform, reverseTransform)
+
+  /**
+   * Transforms values of a map at the given path.
+   */
+  inline def transformValues(
+    inline at: A => Any,
+    transform: DynamicValueTransform,
+    reverseTransform: Option[DynamicValueTransform] = None
+  ): MigrationBuilder[A, B] =
+    transformValuesAt(MigrationBuilderMacros.selectorToOptic[A](at), transform, reverseTransform)
+
+  /**
+   * Builds the migration with full macro validation. Checks that all fields in
+   * the target type are accounted for by the migration actions.
+   */
+  inline def build: Migration[A, B] = ${ MigrationBuilderMacros.buildImpl[A, B]('self) }
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -1,0 +1,647 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{DynamicOptic, DynamicValue}
+
+/**
+ * A pure, serializable migration that operates on [[DynamicValue]] instances.
+ * Contains no user functions, closures, reflection, or code generation—only
+ * data describing the structural transformation.
+ *
+ * `DynamicMigration` forms the untyped core of the migration system. The typed
+ * [[Migration]] wrapper provides compile-time safety on top.
+ *
+ * Laws:
+ *   - '''Identity:''' `DynamicMigration.identity.apply(v) == Right(v)`
+ *   - '''Associativity:''' `(m1 ++ m2) ++ m3` behaves identically to
+ *     `m1 ++ (m2 ++ m3)`
+ *   - '''Structural Reverse:''' `m.reverse.reverse == m`
+ */
+final case class DynamicMigration(actions: Vector[MigrationAction]) {
+
+  /**
+   * Composes this migration with another, applying this migration first and
+   * then `that`.
+   */
+  def ++(that: DynamicMigration): DynamicMigration =
+    new DynamicMigration(this.actions ++ that.actions)
+
+  /**
+   * Returns the structural reverse of this migration. Each action is reversed
+   * and the order is reversed.
+   */
+  def reverse: DynamicMigration =
+    new DynamicMigration(actions.reverseIterator.map(_.reverse).toVector)
+
+  /**
+   * Applies this migration to a [[DynamicValue]].
+   *
+   * @param value
+   *   the input value to transform
+   * @return
+   *   Right with the migrated value, or Left with a [[MigrationError]]
+   */
+  def apply(value: DynamicValue): Either[MigrationError, DynamicValue] =
+    DynamicMigration.applyActions(actions, value)
+}
+
+object DynamicMigration {
+
+  /** A migration that does nothing—the identity element for `++`. */
+  val identity: DynamicMigration = new DynamicMigration(Vector.empty)
+
+  /**
+   * Creates a migration from a single action.
+   */
+  def fromAction(action: MigrationAction): DynamicMigration =
+    new DynamicMigration(Vector(action))
+
+  /**
+   * Creates a migration from multiple actions.
+   */
+  def fromActions(actions: MigrationAction*): DynamicMigration =
+    new DynamicMigration(actions.toVector)
+
+  // ─── Internal application logic ─────────────────────────────────────
+
+  private def applyActions(
+    actions: Vector[MigrationAction],
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] = {
+    var current: DynamicValue                     = value
+    var error: Either[MigrationError, DynamicValue] = null
+    val len                                       = actions.length
+    var i                                         = 0
+    while (i < len && error == null) {
+      applyAction(actions(i), current) match {
+        case Right(v)    => current = v
+        case left        => error = left
+      }
+      i += 1
+    }
+    if (error != null) error else Right(current)
+  }
+
+  private[migration] def applyAction(
+    action: MigrationAction,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] = action match {
+    case a: MigrationAction.AddField        => applyAddField(a, value)
+    case a: MigrationAction.DropField       => applyDropField(a, value)
+    case a: MigrationAction.Rename          => applyRename(a, value)
+    case a: MigrationAction.TransformValue  => applyTransformValue(a, value)
+    case a: MigrationAction.Mandate         => applyMandate(a, value)
+    case a: MigrationAction.Optionalize     => applyOptionalize(a, value)
+    case a: MigrationAction.ChangeType      => applyChangeType(a, value)
+    case a: MigrationAction.RenameCase      => applyRenameCase(a, value)
+    case a: MigrationAction.TransformCase   => applyTransformCase(a, value)
+    case a: MigrationAction.Join             => applyJoin(a, value)
+    case a: MigrationAction.Split            => applySplit(a, value)
+    case a: MigrationAction.TransformElements => applyTransformElements(a, value)
+    case a: MigrationAction.TransformKeys   => applyTransformKeys(a, value)
+    case a: MigrationAction.TransformValues => applyTransformValues(a, value)
+  }
+
+  // ─── Record Operations ──────────────────────────────────────────────
+
+  private def applyAddField(
+    action: MigrationAction.AddField,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] = {
+    val targetNodes = action.target.nodes
+    if (targetNodes.isEmpty)
+      return Left(MigrationError.General(action.target, "AddField requires a non-empty path"))
+
+    targetNodes.last match {
+      case fieldNode: DynamicOptic.Node.Field =>
+        val parentPath = new DynamicOptic(targetNodes.init)
+        val fieldName  = fieldNode.name
+        navigateToRecord(value, parentPath) match {
+          case Right((record, rebuild)) =>
+            // Check field doesn't already exist
+            val existing = record.fields
+            val alreadyExists = {
+              var found = false
+              var j     = 0
+              while (j < existing.length && !found) {
+                if (existing(j)._1 == fieldName) found = true
+                j += 1
+              }
+              found
+            }
+            if (alreadyExists)
+              Left(MigrationError.FieldAlreadyExists(action.target, fieldName))
+            else {
+              val newFields = existing.appended((fieldName, action.defaultValue))
+              Right(rebuild(new DynamicValue.Record(newFields)))
+            }
+          case Left(err) => Left(err)
+        }
+      case _ =>
+        Left(MigrationError.General(action.target, "AddField target must end with a field node"))
+    }
+  }
+
+  private def applyDropField(
+    action: MigrationAction.DropField,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] = {
+    val sourceNodes = action.source.nodes
+    if (sourceNodes.isEmpty)
+      return Left(MigrationError.General(action.source, "DropField requires a non-empty path"))
+
+    sourceNodes.last match {
+      case fieldNode: DynamicOptic.Node.Field =>
+        val parentPath = new DynamicOptic(sourceNodes.init)
+        val fieldName  = fieldNode.name
+        navigateToRecord(value, parentPath) match {
+          case Right((record, rebuild)) =>
+            val existing = record.fields
+            val filtered = existing.filter(_._1 != fieldName)
+            if (filtered.length == existing.length)
+              Left(MigrationError.MissingField(action.source, fieldName))
+            else
+              Right(rebuild(new DynamicValue.Record(filtered)))
+          case Left(err) => Left(err)
+        }
+      case _ =>
+        Left(MigrationError.General(action.source, "DropField source must end with a field node"))
+    }
+  }
+
+  private def applyRename(
+    action: MigrationAction.Rename,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] =
+    navigateToRecord(value, action.sourcePath) match {
+      case Right((record, rebuild)) =>
+        val fields  = record.fields
+        val len     = fields.length
+        val builder = Vector.newBuilder[(String, DynamicValue)]
+        builder.sizeHint(len)
+        var found = false
+        var i     = 0
+        while (i < len) {
+          val (name, v) = fields(i)
+          if (name == action.fromName) {
+            found = true
+            builder.addOne((action.toName, v))
+          } else {
+            builder.addOne((name, v))
+          }
+          i += 1
+        }
+        if (!found) Left(MigrationError.MissingField(action.sourcePath, action.fromName))
+        else Right(rebuild(new DynamicValue.Record(Chunk.fromIterable(builder.result()))))
+      case Left(err) => Left(err)
+    }
+
+  private def applyTransformValue(
+    action: MigrationAction.TransformValue,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] = {
+    // Get the source value
+    val sourceSelection = value.get(action.source)
+    sourceSelection.one match {
+      case Right(sourceVal) =>
+        action.transform(sourceVal) match {
+          case Right(transformed) =>
+            if (action.source == action.target) {
+              // In-place transformation
+              Right(value.set(action.target, transformed))
+            } else {
+              // Cross-field transformation: set the target, then drop the source if different
+              val withTarget = value.set(action.target, transformed)
+              Right(withTarget)
+            }
+          case Left(errMsg) =>
+            Left(MigrationError.TransformFailed(action.source, errMsg))
+        }
+      case Left(_) =>
+        Left(MigrationError.MissingField(action.source, action.source.toString))
+    }
+  }
+
+  private def applyMandate(
+    action: MigrationAction.Mandate,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] = {
+    val sourceSelection = value.get(action.source)
+    sourceSelection.one match {
+      case Right(sourceVal) =>
+        val mandated = sourceVal match {
+          case _: DynamicValue.Null.type =>
+            action.defaultValue
+          case v: DynamicValue.Variant if v.caseName.contains("None") =>
+            action.defaultValue
+          case v: DynamicValue.Variant if v.caseName.contains("Some") =>
+            v.caseValue.getOrElse(action.defaultValue)
+          case other => other
+        }
+        if (action.source == action.target)
+          Right(value.set(action.target, mandated))
+        else {
+          val sourceNodes = action.source.nodes
+          if (sourceNodes.nonEmpty) {
+            sourceNodes.last match {
+              case f: DynamicOptic.Node.Field =>
+                val parentPath = new DynamicOptic(sourceNodes.init)
+                navigateToRecord(value, parentPath) match {
+                  case Right((record, rebuild)) =>
+                    val newFields = record.fields.filter(_._1 != f.name)
+                    val targetNodes = action.target.nodes
+                    targetNodes.last match {
+                      case tf: DynamicOptic.Node.Field =>
+                        Right(rebuild(new DynamicValue.Record(newFields.appended((tf.name, mandated)))))
+                      case _ => Right(value.set(action.target, mandated))
+                    }
+                  case Left(err) => Left(err)
+                }
+              case _ => Right(value.set(action.target, mandated))
+            }
+          } else Right(value.set(action.target, mandated))
+        }
+      case Left(_) =>
+        Left(MigrationError.MissingField(action.source, action.source.toString))
+    }
+  }
+
+  private def applyOptionalize(
+    action: MigrationAction.Optionalize,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] = {
+    val sourceSelection = value.get(action.source)
+    sourceSelection.one match {
+      case Right(sourceVal) =>
+        // Wrap in Some variant
+        val optionalized = sourceVal match {
+          case _: DynamicValue.Null.type =>
+            new DynamicValue.Variant("None", DynamicValue.Record(Chunk.empty))
+          case other =>
+            new DynamicValue.Variant("Some", other)
+        }
+        if (action.source == action.target)
+          Right(value.set(action.target, optionalized))
+        else {
+          val sourceNodes = action.source.nodes
+          if (sourceNodes.nonEmpty) {
+            sourceNodes.last match {
+              case f: DynamicOptic.Node.Field =>
+                val parentPath = new DynamicOptic(sourceNodes.init)
+                navigateToRecord(value, parentPath) match {
+                  case Right((record, rebuild)) =>
+                    val newFields = record.fields.filter(_._1 != f.name)
+                    val targetNodes = action.target.nodes
+                    targetNodes.last match {
+                      case tf: DynamicOptic.Node.Field =>
+                        Right(rebuild(new DynamicValue.Record(newFields.appended((tf.name, optionalized)))))
+                      case _ => Right(value.set(action.target, optionalized))
+                    }
+                  case Left(err) => Left(err)
+                }
+              case _ => Right(value.set(action.target, optionalized))
+            }
+          } else Right(value.set(action.target, optionalized))
+        }
+      case Left(_) =>
+        Left(MigrationError.MissingField(action.source, action.source.toString))
+    }
+  }
+
+  private def applyChangeType(
+    action: MigrationAction.ChangeType,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] = {
+    val sourceSelection = value.get(action.source)
+    sourceSelection.one match {
+      case Right(sourceVal) =>
+        action.converter(sourceVal) match {
+          case Right(converted) =>
+            if (action.source == action.target)
+              Right(value.set(action.target, converted))
+            else {
+              val sourceNodes = action.source.nodes
+              if (sourceNodes.nonEmpty) {
+                sourceNodes.last match {
+                  case f: DynamicOptic.Node.Field =>
+                    val parentPath = new DynamicOptic(sourceNodes.init)
+                    navigateToRecord(value, parentPath) match {
+                      case Right((record, rebuild)) =>
+                        val newFields = record.fields.filter(_._1 != f.name)
+                        val targetNodes = action.target.nodes
+                        targetNodes.last match {
+                          case tf: DynamicOptic.Node.Field =>
+                            Right(rebuild(new DynamicValue.Record(newFields.appended((tf.name, converted)))))
+                          case _ => Right(value.set(action.target, converted))
+                        }
+                      case Left(err) => Left(err)
+                    }
+                  case _ => Right(value.set(action.target, converted))
+                }
+              } else Right(value.set(action.target, converted))
+            }
+          case Left(errMsg) =>
+            Left(MigrationError.TransformFailed(action.source, errMsg))
+        }
+      case Left(_) =>
+        Left(MigrationError.MissingField(action.source, action.source.toString))
+    }
+  }
+
+  // ─── Join/Split Operations ───────────────────────────────────────────
+
+  private def applyJoin(
+    action: MigrationAction.Join,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] =
+    navigateToRecord(value, action.at) match {
+      case Right((record, rebuild)) =>
+        if (action.sourceFields.isEmpty)
+          Left(MigrationError.General(action.at, "Join requires at least one source field"))
+        else {
+          // The combiner receives the parent record to access source fields
+          action.combiner(record) match {
+            case Right(combined) =>
+              // Remove source fields, add target field with combined value
+              val removeSet = action.sourceFields.toSet
+              val fields    = record.fields
+              val len       = fields.length
+              val builder   = Vector.newBuilder[(String, DynamicValue)]
+              builder.sizeHint(len - removeSet.size + 1)
+              var i = 0
+              while (i < len) {
+                val (name, v) = fields(i)
+                if (!removeSet.contains(name)) builder.addOne((name, v))
+                i += 1
+              }
+              builder.addOne((action.targetField, combined))
+              Right(rebuild(new DynamicValue.Record(Chunk.fromIterable(builder.result()))))
+            case Left(errMsg) =>
+              Left(MigrationError.TransformFailed(action.at, errMsg))
+          }
+        }
+      case Left(err) => Left(err)
+    }
+
+  private def applySplit(
+    action: MigrationAction.Split,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] =
+    navigateToRecord(value, action.at) match {
+      case Right((record, rebuild)) =>
+        // Find the source field value
+        val fields   = record.fields
+        val fieldMap = fields.toMap
+        fieldMap.get(action.sourceField) match {
+          case Some(sourceVal) =>
+            // The splitter receives the source field value and produces a Record
+            action.splitter(sourceVal) match {
+              case Right(splitResult: DynamicValue.Record) =>
+                // Remove source field, add target fields from split result
+                val splitFieldMap = splitResult.fields.toMap
+                val len           = fields.length
+                val builder       = Vector.newBuilder[(String, DynamicValue)]
+                builder.sizeHint(len - 1 + action.targetFields.length)
+                var i = 0
+                while (i < len) {
+                  val (name, v) = fields(i)
+                  if (name != action.sourceField) builder.addOne((name, v))
+                  i += 1
+                }
+                var j = 0
+                while (j < action.targetFields.length) {
+                  val targetName = action.targetFields(j)
+                  val targetVal  = splitFieldMap.getOrElse(targetName, DynamicValue.Null)
+                  builder.addOne((targetName, targetVal))
+                  j += 1
+                }
+                Right(rebuild(new DynamicValue.Record(Chunk.fromIterable(builder.result()))))
+              case Right(other) =>
+                Left(MigrationError.TransformFailed(action.at, s"Split result must be a Record, got ${other.valueType}"))
+              case Left(errMsg) =>
+                Left(MigrationError.TransformFailed(action.at, errMsg))
+            }
+          case None =>
+            Left(MigrationError.MissingField(action.at, action.sourceField))
+        }
+      case Left(err) => Left(err)
+    }
+
+  // ─── Enum Operations ────────────────────────────────────────────────
+
+  private def applyRenameCase(
+    action: MigrationAction.RenameCase,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] = {
+    def renameInVariant(dv: DynamicValue): Either[MigrationError, DynamicValue] = dv match {
+      case v: DynamicValue.Variant if v.caseName.contains(action.fromName) =>
+        Right(new DynamicValue.Variant(action.toName, v.caseValue.getOrElse(DynamicValue.Null)))
+      case v: DynamicValue.Variant =>
+        // Case doesn't match; leave it unchanged
+        Right(v)
+      case _ =>
+        Left(MigrationError.TypeMismatch(action.path, "Variant", dv.valueType.toString))
+    }
+
+    if (action.path.nodes.isEmpty) renameInVariant(value)
+    else {
+      val selection = value.get(action.path)
+      selection.one match {
+        case Right(target) =>
+          renameInVariant(target) match {
+            case Right(renamed) => Right(value.set(action.path, renamed))
+            case Left(err)      => Left(err)
+          }
+        case Left(_) =>
+          Left(MigrationError.MissingField(action.path, action.path.toString))
+      }
+    }
+  }
+
+  private def applyTransformCase(
+    action: MigrationAction.TransformCase,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] = {
+    def transformInVariant(dv: DynamicValue): Either[MigrationError, DynamicValue] = dv match {
+      case v: DynamicValue.Variant if v.caseName.contains(action.caseName) =>
+        val caseVal = v.caseValue.getOrElse(DynamicValue.Null)
+        applyActions(action.actions, caseVal) match {
+          case Right(transformed) =>
+            Right(new DynamicValue.Variant(action.targetCaseName, transformed))
+          case Left(err) => Left(err)
+        }
+      case v: DynamicValue.Variant =>
+        Right(v) // Not the target case, leave unchanged
+      case _ =>
+        Left(MigrationError.TypeMismatch(action.path, "Variant", dv.valueType.toString))
+    }
+
+    if (action.path.nodes.isEmpty) transformInVariant(value)
+    else {
+      val selection = value.get(action.path)
+      selection.one match {
+        case Right(target) =>
+          transformInVariant(target) match {
+            case Right(transformed) => Right(value.set(action.path, transformed))
+            case Left(err)          => Left(err)
+          }
+        case Left(_) =>
+          Left(MigrationError.MissingField(action.path, action.path.toString))
+      }
+    }
+  }
+
+  // ─── Collection/Map Operations ──────────────────────────────────────
+
+  private def applyTransformElements(
+    action: MigrationAction.TransformElements,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] = {
+    def transformSeq(dv: DynamicValue): Either[MigrationError, DynamicValue] = dv match {
+      case s: DynamicValue.Sequence =>
+        val elems   = s.elements
+        val len     = elems.length
+        val builder = Vector.newBuilder[DynamicValue]
+        builder.sizeHint(len)
+        var i = 0
+        while (i < len) {
+          action.transform(elems(i)) match {
+            case Right(v)  => builder.addOne(v)
+            case Left(msg) =>
+              return Left(MigrationError.TransformFailed(
+                action.path.at(i),
+                msg
+              ))
+          }
+          i += 1
+        }
+        Right(new DynamicValue.Sequence(Chunk.fromIterable(builder.result())))
+      case _ =>
+        Left(MigrationError.TypeMismatch(action.path, "Sequence", dv.valueType.toString))
+    }
+
+    if (action.path.nodes.isEmpty) transformSeq(value)
+    else {
+      val selection = value.get(action.path)
+      selection.one match {
+        case Right(target) =>
+          transformSeq(target) match {
+            case Right(transformed) => Right(value.set(action.path, transformed))
+            case Left(err)          => Left(err)
+          }
+        case Left(_) =>
+          Left(MigrationError.MissingField(action.path, action.path.toString))
+      }
+    }
+  }
+
+  private def applyTransformKeys(
+    action: MigrationAction.TransformKeys,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] = {
+    def transformMap(dv: DynamicValue): Either[MigrationError, DynamicValue] = dv match {
+      case m: DynamicValue.Map =>
+        val entries = m.entries
+        val len     = entries.length
+        val builder = Vector.newBuilder[(DynamicValue, DynamicValue)]
+        builder.sizeHint(len)
+        var i = 0
+        while (i < len) {
+          val (k, v) = entries(i)
+          action.transform(k) match {
+            case Right(newKey) => builder.addOne((newKey, v))
+            case Left(msg)     =>
+              return Left(MigrationError.TransformFailed(action.path, s"key transform: $msg"))
+          }
+          i += 1
+        }
+        Right(new DynamicValue.Map(Chunk.fromIterable(builder.result())))
+      case _ =>
+        Left(MigrationError.TypeMismatch(action.path, "Map", dv.valueType.toString))
+    }
+
+    if (action.path.nodes.isEmpty) transformMap(value)
+    else {
+      val selection = value.get(action.path)
+      selection.one match {
+        case Right(target) =>
+          transformMap(target) match {
+            case Right(transformed) => Right(value.set(action.path, transformed))
+            case Left(err)          => Left(err)
+          }
+        case Left(_) =>
+          Left(MigrationError.MissingField(action.path, action.path.toString))
+      }
+    }
+  }
+
+  private def applyTransformValues(
+    action: MigrationAction.TransformValues,
+    value: DynamicValue
+  ): Either[MigrationError, DynamicValue] = {
+    def transformMap(dv: DynamicValue): Either[MigrationError, DynamicValue] = dv match {
+      case m: DynamicValue.Map =>
+        val entries = m.entries
+        val len     = entries.length
+        val builder = Vector.newBuilder[(DynamicValue, DynamicValue)]
+        builder.sizeHint(len)
+        var i = 0
+        while (i < len) {
+          val (k, v) = entries(i)
+          action.transform(v) match {
+            case Right(newVal) => builder.addOne((k, newVal))
+            case Left(msg)     =>
+              return Left(MigrationError.TransformFailed(action.path, s"value transform: $msg"))
+          }
+          i += 1
+        }
+        Right(new DynamicValue.Map(Chunk.fromIterable(builder.result())))
+      case _ =>
+        Left(MigrationError.TypeMismatch(action.path, "Map", dv.valueType.toString))
+    }
+
+    if (action.path.nodes.isEmpty) transformMap(value)
+    else {
+      val selection = value.get(action.path)
+      selection.one match {
+        case Right(target) =>
+          transformMap(target) match {
+            case Right(transformed) => Right(value.set(action.path, transformed))
+            case Left(err)          => Left(err)
+          }
+        case Left(_) =>
+          Left(MigrationError.MissingField(action.path, action.path.toString))
+      }
+    }
+  }
+
+  // ─── Helpers ────────────────────────────────────────────────────────
+
+  /**
+   * Navigates to a Record at the given path, returning the record and a
+   * function to rebuild the original value with a replacement record.
+   */
+  private def navigateToRecord(
+    value: DynamicValue,
+    path: DynamicOptic
+  ): Either[MigrationError, (DynamicValue.Record, DynamicValue.Record => DynamicValue)] =
+    if (path.nodes.isEmpty) {
+      value match {
+        case r: DynamicValue.Record => Right((r, (rec: DynamicValue.Record) => rec))
+        case _                      => Left(MigrationError.TypeMismatch(path, "Record", value.valueType.toString))
+      }
+    } else {
+      val selection = value.get(path)
+      selection.one match {
+        case Right(target) =>
+          target match {
+            case r: DynamicValue.Record =>
+              Right((r, (newRecord: DynamicValue.Record) => value.set(path, newRecord)))
+            case _ =>
+              Left(MigrationError.TypeMismatch(path, "Record", target.valueType.toString))
+          }
+        case Left(_) =>
+          Left(MigrationError.General(path, s"Path not found: $path"))
+      }
+    }
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicValueTransform.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicValueTransform.scala
@@ -1,0 +1,183 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{DynamicValue, PrimitiveValue}
+
+/**
+ * A pure, serializable specification for transforming [[DynamicValue]]
+ * instances. Contains no user functions or closures—only data describing the
+ * transformation.
+ */
+sealed trait DynamicValueTransform {
+
+  /**
+   * Applies this transformation to a [[DynamicValue]].
+   *
+   * @return
+   *   Right with the transformed value, or Left with an error
+   */
+  def apply(input: DynamicValue): Either[String, DynamicValue]
+}
+
+object DynamicValueTransform {
+
+  /** Replaces the input with a constant value, ignoring the input entirely. */
+  final case class Constant(value: DynamicValue) extends DynamicValueTransform {
+    def apply(input: DynamicValue): Either[String, DynamicValue] = Right(value)
+  }
+
+  /** Returns the input unchanged (identity transformation). */
+  case object Identity extends DynamicValueTransform {
+    def apply(input: DynamicValue): Either[String, DynamicValue] = Right(input)
+  }
+
+  /**
+   * Converts a numeric primitive to a string.
+   */
+  case object NumericToString extends DynamicValueTransform {
+    def apply(input: DynamicValue): Either[String, DynamicValue] = input match {
+      case p: DynamicValue.Primitive =>
+        val str = p.value match {
+          case v: PrimitiveValue.Byte       => v.value.toString
+          case v: PrimitiveValue.Short      => v.value.toString
+          case v: PrimitiveValue.Int        => v.value.toString
+          case v: PrimitiveValue.Long       => v.value.toString
+          case v: PrimitiveValue.Float      => v.value.toString
+          case v: PrimitiveValue.Double     => v.value.toString
+          case v: PrimitiveValue.BigDecimal => v.value.toString
+          case v: PrimitiveValue.String     => v.value
+          case other                        => other.toString
+        }
+        Right(new DynamicValue.Primitive(new PrimitiveValue.String(str)))
+      case _ => Left(s"NumericToString: expected Primitive, got ${input.valueType}")
+    }
+  }
+
+  /**
+   * Parses a string primitive into an integer.
+   */
+  case object StringToInt extends DynamicValueTransform {
+    def apply(input: DynamicValue): Either[String, DynamicValue] = input match {
+      case p: DynamicValue.Primitive =>
+        p.value match {
+          case s: PrimitiveValue.String =>
+            try Right(new DynamicValue.Primitive(new PrimitiveValue.Int(s.value.toInt)))
+            catch { case _: NumberFormatException => Left(s"StringToInt: cannot parse '${s.value}' as Int") }
+          case other => Left(s"StringToInt: expected String primitive, got $other")
+        }
+      case _ => Left(s"StringToInt: expected Primitive, got ${input.valueType}")
+    }
+  }
+
+  /**
+   * Parses a string primitive into a long.
+   */
+  case object StringToLong extends DynamicValueTransform {
+    def apply(input: DynamicValue): Either[String, DynamicValue] = input match {
+      case p: DynamicValue.Primitive =>
+        p.value match {
+          case s: PrimitiveValue.String =>
+            try Right(new DynamicValue.Primitive(new PrimitiveValue.Long(s.value.toLong)))
+            catch { case _: NumberFormatException => Left(s"StringToLong: cannot parse '${s.value}' as Long") }
+          case other => Left(s"StringToLong: expected String primitive, got $other")
+        }
+      case _ => Left(s"StringToLong: expected Primitive, got ${input.valueType}")
+    }
+  }
+
+  /**
+   * Converts an integer primitive to a long.
+   */
+  case object IntToLong extends DynamicValueTransform {
+    def apply(input: DynamicValue): Either[String, DynamicValue] = input match {
+      case p: DynamicValue.Primitive =>
+        p.value match {
+          case i: PrimitiveValue.Int => Right(new DynamicValue.Primitive(new PrimitiveValue.Long(i.value.toLong)))
+          case other                 => Left(s"IntToLong: expected Int primitive, got $other")
+        }
+      case _ => Left(s"IntToLong: expected Primitive, got ${input.valueType}")
+    }
+  }
+
+  /**
+   * Converts a long primitive to an integer (may lose precision).
+   */
+  case object LongToInt extends DynamicValueTransform {
+    def apply(input: DynamicValue): Either[String, DynamicValue] = input match {
+      case p: DynamicValue.Primitive =>
+        p.value match {
+          case l: PrimitiveValue.Long => Right(new DynamicValue.Primitive(new PrimitiveValue.Int(l.value.toInt)))
+          case other                  => Left(s"LongToInt: expected Long primitive, got $other")
+        }
+      case _ => Left(s"LongToInt: expected Primitive, got ${input.valueType}")
+    }
+  }
+
+  /**
+   * Concatenates string values from multiple record fields.
+   *
+   * @param fieldNames
+   *   the field names to concatenate
+   * @param separator
+   *   the separator between field values
+   */
+  final case class ConcatFields(fieldNames: Vector[String], separator: String) extends DynamicValueTransform {
+    def apply(input: DynamicValue): Either[String, DynamicValue] = input match {
+      case r: DynamicValue.Record =>
+        val fieldMap = r.fields.toMap
+        val parts    = fieldNames.flatMap { name =>
+          fieldMap.get(name).flatMap {
+            case p: DynamicValue.Primitive =>
+              p.value match {
+                case s: PrimitiveValue.String => Some(s.value)
+                case other                    => Some(other.toString)
+              }
+            case _ => None
+          }
+        }
+        Right(new DynamicValue.Primitive(new PrimitiveValue.String(parts.mkString(separator))))
+      case _ => Left(s"ConcatFields: expected Record, got ${input.valueType}")
+    }
+  }
+
+  /**
+   * Splits a string primitive by a separator into named fields, producing a
+   * [[DynamicValue.Record]].
+   *
+   * @param separator
+   *   the separator to split on
+   * @param fieldNames
+   *   the names for the resulting fields (in order of split parts)
+   */
+  final case class SplitString(separator: String, fieldNames: Vector[String]) extends DynamicValueTransform {
+    def apply(input: DynamicValue): Either[String, DynamicValue] = input match {
+      case p: DynamicValue.Primitive =>
+        p.value match {
+          case s: PrimitiveValue.String =>
+            val parts   = s.value.split(java.util.regex.Pattern.quote(separator), fieldNames.length)
+            val builder = Vector.newBuilder[(String, DynamicValue)]
+            builder.sizeHint(fieldNames.length)
+            var i = 0
+            while (i < fieldNames.length) {
+              val value = if (i < parts.length) parts(i) else ""
+              builder.addOne((fieldNames(i), new DynamicValue.Primitive(new PrimitiveValue.String(value))))
+              i += 1
+            }
+            Right(new DynamicValue.Record(Chunk.fromIterable(builder.result())))
+          case other => Left(s"SplitString: expected String primitive, got $other")
+        }
+      case _ => Left(s"SplitString: expected Primitive, got ${input.valueType}")
+    }
+  }
+
+  /**
+   * Applies a sequence of transformations in order.
+   */
+  final case class Compose(transforms: Vector[DynamicValueTransform]) extends DynamicValueTransform {
+    def apply(input: DynamicValue): Either[String, DynamicValue] =
+      transforms.foldLeft[Either[String, DynamicValue]](Right(input)) {
+        case (Right(v), t) => t(v)
+        case (left, _)     => left
+      }
+  }
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
@@ -1,0 +1,88 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicValue, Schema}
+
+/**
+ * A typed, schema-validated migration from values of type `A` to values of type
+ * `B`.
+ *
+ * `Migration[A, B]` wraps a [[DynamicMigration]] (the untyped, serializable
+ * core) together with the source and target schemas, providing compile-time type
+ * safety while keeping the migration data fully serializable.
+ *
+ * Laws:
+ *   - '''Identity:''' `Migration.identity[A].apply(a) == Right(a)`
+ *   - '''Associativity:''' `(m1 ++ m2) ++ m3` behaves identically to
+ *     `m1 ++ (m2 ++ m3)`
+ *   - '''Structural Reverse:''' `m.reverse.reverse.dynamicMigration == m.dynamicMigration`
+ *   - '''Best-Effort Semantic Inverse:''' If `m.apply(a) == Right(b)`, then
+ *     `m.reverse.apply(b) == Right(a)` (best-effort)
+ *
+ * @param dynamicMigration
+ *   the underlying serializable migration
+ * @param sourceSchema
+ *   the schema for the source type `A`
+ * @param targetSchema
+ *   the schema for the target type `B`
+ */
+final case class Migration[A, B](
+  dynamicMigration: DynamicMigration,
+  sourceSchema: Schema[A],
+  targetSchema: Schema[B]
+) {
+
+  /**
+   * Applies this migration to a value of type `A`, producing a value of type
+   * `B`.
+   */
+  def apply(value: A): Either[MigrationError, B] = {
+    val dv = sourceSchema.toDynamicValue(value)
+    dynamicMigration(dv) match {
+      case Right(result) =>
+        targetSchema.fromDynamicValue(result) match {
+          case Right(b)  => Right(b)
+          case Left(err) =>
+            Left(MigrationError.General(
+              zio.blocks.schema.DynamicOptic.root,
+              s"Failed to convert migrated value to target type: ${err.message}"
+            ))
+        }
+      case Left(err) => Left(err)
+    }
+  }
+
+  /**
+   * Applies this migration to a [[DynamicValue]] directly.
+   */
+  def applyDynamic(value: DynamicValue): Either[MigrationError, DynamicValue] =
+    dynamicMigration(value)
+
+  /**
+   * Returns the structural reverse of this migration.
+   */
+  def reverse: Migration[B, A] =
+    new Migration(dynamicMigration.reverse, targetSchema, sourceSchema)
+
+  /**
+   * Composes this migration with another migration, creating a migration from
+   * `A` to `C`.
+   */
+  def ++[C](that: Migration[B, C]): Migration[A, C] =
+    new Migration(this.dynamicMigration ++ that.dynamicMigration, this.sourceSchema, that.targetSchema)
+}
+
+object Migration {
+
+  /**
+   * Creates an identity migration that transforms a value to itself.
+   */
+  def identity[A](implicit schema: Schema[A]): Migration[A, A] =
+    new Migration(DynamicMigration.identity, schema, schema)
+
+  /**
+   * Creates a new [[MigrationBuilder]] for constructing a migration from `A` to
+   * `B`.
+   */
+  def newBuilder[A, B](implicit sourceSchema: Schema[A], targetSchema: Schema[B]): MigrationBuilder[A, B] =
+    new MigrationBuilder[A, B](Vector.empty, sourceSchema, targetSchema)
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
@@ -1,0 +1,334 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicOptic, DynamicValue}
+
+/**
+ * A pure, serializable migration action that operates on [[DynamicValue]] via
+ * path-based [[DynamicOptic]] targeting. These actions contain no user
+ * functions, closures, reflection, or code generation, enabling serialization,
+ * registry storage, and dynamic application.
+ *
+ * Actions form the untyped core of the migration system. The typed
+ * [[Migration]] wrapper provides compile-time safety on top of these.
+ */
+sealed trait MigrationAction {
+
+  /**
+   * Returns the structural reverse of this action. For example, the reverse of
+   * `AddField` is `DropField` and vice versa.
+   */
+  def reverse: MigrationAction
+}
+
+object MigrationAction {
+
+  // ─── Record Operations ──────────────────────────────────────────────
+
+  /**
+   * Adds a field at the specified path with a default value.
+   *
+   * @param target
+   *   path to the new field location
+   * @param defaultValue
+   *   the default value for the new field
+   */
+  final case class AddField(
+    target: DynamicOptic,
+    defaultValue: DynamicValue
+  ) extends MigrationAction {
+    def reverse: MigrationAction = DropField(target, defaultValue)
+  }
+
+  /**
+   * Drops a field at the specified path. The default value is used when
+   * reversing the migration.
+   *
+   * @param source
+   *   path to the field to remove
+   * @param defaultForReverse
+   *   the default value used if this action is reversed
+   */
+  final case class DropField(
+    source: DynamicOptic,
+    defaultForReverse: DynamicValue
+  ) extends MigrationAction {
+    def reverse: MigrationAction = AddField(source, defaultForReverse)
+  }
+
+  /**
+   * Renames a field from one name to another.
+   *
+   * @param sourcePath
+   *   path to the parent record
+   * @param fromName
+   *   the old field name
+   * @param toName
+   *   the new field name
+   */
+  final case class Rename(
+    sourcePath: DynamicOptic,
+    fromName: String,
+    toName: String
+  ) extends MigrationAction {
+    def reverse: MigrationAction = Rename(sourcePath, toName, fromName)
+  }
+
+  /**
+   * Transforms a value at a path using a pure, serializable expression
+   * represented as a sequence of [[DynamicValue]] operations.
+   *
+   * @param source
+   *   path to the source value
+   * @param target
+   *   path to the target value
+   * @param transform
+   *   the transformation as a DynamicValue expression
+   * @param reverseTransform
+   *   the reverse transformation, if available
+   */
+  final case class TransformValue(
+    source: DynamicOptic,
+    target: DynamicOptic,
+    transform: DynamicValueTransform,
+    reverseTransform: Option[DynamicValueTransform]
+  ) extends MigrationAction {
+    def reverse: MigrationAction = reverseTransform match {
+      case Some(rev) => TransformValue(target, source, rev, Some(transform))
+      case None      => TransformValue(target, source, transform, None)
+    }
+  }
+
+  /**
+   * Makes an optional field mandatory by providing a default value for None
+   * cases.
+   *
+   * @param source
+   *   path to the optional field
+   * @param target
+   *   path to the mandatory field
+   * @param defaultValue
+   *   default value when source is None/Null
+   */
+  final case class Mandate(
+    source: DynamicOptic,
+    target: DynamicOptic,
+    defaultValue: DynamicValue
+  ) extends MigrationAction {
+    def reverse: MigrationAction = Optionalize(target, source)
+  }
+
+  /**
+   * Makes a mandatory field optional (wraps it in Option/nullable).
+   *
+   * @param source
+   *   path to the mandatory field
+   * @param target
+   *   path to the optional field
+   */
+  final case class Optionalize(
+    source: DynamicOptic,
+    target: DynamicOptic
+  ) extends MigrationAction {
+    def reverse: MigrationAction = Mandate(target, source, DynamicValue.Null)
+  }
+
+  /**
+   * Changes the type of a field using a serializable conversion specification.
+   *
+   * @param source
+   *   path to the source field
+   * @param target
+   *   path to the target field
+   * @param converter
+   *   the type conversion specification
+   * @param reverseConverter
+   *   the reverse conversion specification, if available
+   */
+  final case class ChangeType(
+    source: DynamicOptic,
+    target: DynamicOptic,
+    converter: DynamicValueTransform,
+    reverseConverter: Option[DynamicValueTransform]
+  ) extends MigrationAction {
+    def reverse: MigrationAction = reverseConverter match {
+      case Some(rev) => ChangeType(target, source, rev, Some(converter))
+      case None      => ChangeType(target, source, converter, None)
+    }
+  }
+
+  /**
+   * Joins multiple source fields into a single target field using a combiner.
+   * The combiner receives the parent record and produces the combined value.
+   * Source fields are removed and the target field is added.
+   *
+   * @param at
+   *   path to the parent record
+   * @param sourceFields
+   *   names of the fields to combine (relative to the record at `at`)
+   * @param targetField
+   *   name of the new field for the combined value
+   * @param combiner
+   *   transformation that receives the parent record and produces the combined
+   *   value (e.g. [[DynamicValueTransform.ConcatFields]])
+   * @param reverseTransform
+   *   optional reverse transformation that receives the combined value and
+   *   produces a Record with the source fields
+   */
+  final case class Join(
+    at: DynamicOptic,
+    sourceFields: Vector[String],
+    targetField: String,
+    combiner: DynamicValueTransform,
+    reverseTransform: Option[DynamicValueTransform]
+  ) extends MigrationAction {
+    def reverse: MigrationAction = reverseTransform match {
+      case Some(rev) => Split(at, targetField, sourceFields, rev, Some(combiner))
+      case None      => Split(at, targetField, sourceFields, combiner, None)
+    }
+  }
+
+  /**
+   * Splits a single source field into multiple target fields using a splitter.
+   * The splitter receives the source field value and produces a Record
+   * containing the target fields. The source field is removed and the target
+   * fields are added.
+   *
+   * @param at
+   *   path to the parent record
+   * @param sourceField
+   *   name of the field to split (relative to the record at `at`)
+   * @param targetFields
+   *   names of the new fields for the split values
+   * @param splitter
+   *   transformation that receives the source field value and produces a
+   *   Record with the target fields (e.g.
+   *   [[DynamicValueTransform.SplitString]])
+   * @param reverseTransform
+   *   optional reverse transformation that receives the parent record and
+   *   produces the combined value
+   */
+  final case class Split(
+    at: DynamicOptic,
+    sourceField: String,
+    targetFields: Vector[String],
+    splitter: DynamicValueTransform,
+    reverseTransform: Option[DynamicValueTransform]
+  ) extends MigrationAction {
+    def reverse: MigrationAction = reverseTransform match {
+      case Some(rev) => Join(at, targetFields, sourceField, rev, Some(splitter))
+      case None      => Join(at, targetFields, sourceField, splitter, None)
+    }
+  }
+
+  // ─── Enum Operations ────────────────────────────────────────────────
+
+  /**
+   * Renames a case in a variant/enum.
+   *
+   * @param path
+   *   path to the variant
+   * @param fromName
+   *   the old case name
+   * @param toName
+   *   the new case name
+   */
+  final case class RenameCase(
+    path: DynamicOptic,
+    fromName: String,
+    toName: String
+  ) extends MigrationAction {
+    def reverse: MigrationAction = RenameCase(path, toName, fromName)
+  }
+
+  /**
+   * Transforms a specific case of a variant by applying sub-actions to its
+   * value.
+   *
+   * @param path
+   *   path to the variant
+   * @param caseName
+   *   the case to transform
+   * @param targetCaseName
+   *   the new case name after transformation
+   * @param actions
+   *   the migration actions to apply to the case value
+   */
+  final case class TransformCase(
+    path: DynamicOptic,
+    caseName: String,
+    targetCaseName: String,
+    actions: Vector[MigrationAction]
+  ) extends MigrationAction {
+    def reverse: MigrationAction = TransformCase(
+      path,
+      targetCaseName,
+      caseName,
+      actions.reverse.map(_.reverse)
+    )
+  }
+
+  // ─── Collection/Map Operations ──────────────────────────────────────
+
+  /**
+   * Transforms elements of a sequence at the given path.
+   *
+   * @param path
+   *   path to the sequence
+   * @param transform
+   *   the transformation to apply to each element
+   * @param reverseTransform
+   *   the reverse transformation, if available
+   */
+  final case class TransformElements(
+    path: DynamicOptic,
+    transform: DynamicValueTransform,
+    reverseTransform: Option[DynamicValueTransform]
+  ) extends MigrationAction {
+    def reverse: MigrationAction = reverseTransform match {
+      case Some(rev) => TransformElements(path, rev, Some(transform))
+      case None      => TransformElements(path, transform, None)
+    }
+  }
+
+  /**
+   * Transforms keys of a map at the given path.
+   *
+   * @param path
+   *   path to the map
+   * @param transform
+   *   the transformation to apply to each key
+   * @param reverseTransform
+   *   the reverse transformation, if available
+   */
+  final case class TransformKeys(
+    path: DynamicOptic,
+    transform: DynamicValueTransform,
+    reverseTransform: Option[DynamicValueTransform]
+  ) extends MigrationAction {
+    def reverse: MigrationAction = reverseTransform match {
+      case Some(rev) => TransformKeys(path, rev, Some(transform))
+      case None      => TransformKeys(path, transform, None)
+    }
+  }
+
+  /**
+   * Transforms values of a map at the given path.
+   *
+   * @param path
+   *   path to the map
+   * @param transform
+   *   the transformation to apply to each value
+   * @param reverseTransform
+   *   the reverse transformation, if available
+   */
+  final case class TransformValues(
+    path: DynamicOptic,
+    transform: DynamicValueTransform,
+    reverseTransform: Option[DynamicValueTransform]
+  ) extends MigrationAction {
+    def reverse: MigrationAction = reverseTransform match {
+      case Some(rev) => TransformValues(path, rev, Some(transform))
+      case None      => TransformValues(path, transform, None)
+    }
+  }
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -1,0 +1,126 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicOptic, DynamicValue, Schema}
+
+/**
+ * A fluent builder for constructing [[Migration]] instances.
+ *
+ * The builder accumulates [[MigrationAction]]s and provides two build methods:
+ *   - `.build` — full macro validation (checks that all source fields are
+ *     accounted for)
+ *   - `.buildPartial` — creates the migration without full validation
+ *
+ * Selector functions (e.g., `_.name`, `_.address.street`) are converted to
+ * [[DynamicOptic]] paths via macros in the platform-specific code.
+ */
+final class MigrationBuilder[A, B](
+  val actions: Vector[MigrationAction],
+  val sourceSchema: Schema[A],
+  val targetSchema: Schema[B]
+) extends MigrationBuilderSyntax[A, B] {
+
+  private def copy(actions: Vector[MigrationAction]): MigrationBuilder[A, B] =
+    new MigrationBuilder(actions, sourceSchema, targetSchema)
+
+  // ─── Low-level API (optic-based) ────────────────────────────────────
+
+  /** Adds a field at the target path with a default value. */
+  def addFieldAt(target: DynamicOptic, defaultValue: DynamicValue): MigrationBuilder[A, B] =
+    copy(actions :+ MigrationAction.AddField(target, defaultValue))
+
+  /** Drops a field at the source path. */
+  def dropFieldAt(source: DynamicOptic, defaultForReverse: DynamicValue): MigrationBuilder[A, B] =
+    copy(actions :+ MigrationAction.DropField(source, defaultForReverse))
+
+  /** Renames a field within a record at the given parent path. */
+  def renameFieldAt(parentPath: DynamicOptic, fromName: String, toName: String): MigrationBuilder[A, B] =
+    copy(actions :+ MigrationAction.Rename(parentPath, fromName, toName))
+
+  /** Transforms a value at a path using a serializable transform. */
+  def transformFieldAt(
+    source: DynamicOptic,
+    target: DynamicOptic,
+    transform: DynamicValueTransform,
+    reverseTransform: Option[DynamicValueTransform] = None
+  ): MigrationBuilder[A, B] =
+    copy(actions :+ MigrationAction.TransformValue(source, target, transform, reverseTransform))
+
+  /** Makes an optional field mandatory. */
+  def mandateFieldAt(
+    source: DynamicOptic,
+    target: DynamicOptic,
+    defaultValue: DynamicValue
+  ): MigrationBuilder[A, B] =
+    copy(actions :+ MigrationAction.Mandate(source, target, defaultValue))
+
+  /** Makes a mandatory field optional. */
+  def optionalizeFieldAt(source: DynamicOptic, target: DynamicOptic): MigrationBuilder[A, B] =
+    copy(actions :+ MigrationAction.Optionalize(source, target))
+
+  /** Changes the type of a field. */
+  def changeFieldTypeAt(
+    source: DynamicOptic,
+    target: DynamicOptic,
+    converter: DynamicValueTransform,
+    reverseConverter: Option[DynamicValueTransform] = None
+  ): MigrationBuilder[A, B] =
+    copy(actions :+ MigrationAction.ChangeType(source, target, converter, reverseConverter))
+
+  /** Renames a variant case at the given path. */
+  def renameCaseAt(path: DynamicOptic, fromName: String, toName: String): MigrationBuilder[A, B] =
+    copy(actions :+ MigrationAction.RenameCase(path, fromName, toName))
+
+  /** Transforms a variant case with sub-actions. */
+  def transformCaseAt(
+    path: DynamicOptic,
+    caseName: String,
+    targetCaseName: String,
+    subActions: Vector[MigrationAction]
+  ): MigrationBuilder[A, B] =
+    copy(actions :+ MigrationAction.TransformCase(path, caseName, targetCaseName, subActions))
+
+  /** Transforms elements of a sequence. */
+  def transformElementsAt(
+    path: DynamicOptic,
+    transform: DynamicValueTransform,
+    reverseTransform: Option[DynamicValueTransform] = None
+  ): MigrationBuilder[A, B] =
+    copy(actions :+ MigrationAction.TransformElements(path, transform, reverseTransform))
+
+  /** Transforms keys of a map. */
+  def transformKeysAt(
+    path: DynamicOptic,
+    transform: DynamicValueTransform,
+    reverseTransform: Option[DynamicValueTransform] = None
+  ): MigrationBuilder[A, B] =
+    copy(actions :+ MigrationAction.TransformKeys(path, transform, reverseTransform))
+
+  /** Transforms values of a map. */
+  def transformValuesAt(
+    path: DynamicOptic,
+    transform: DynamicValueTransform,
+    reverseTransform: Option[DynamicValueTransform] = None
+  ): MigrationBuilder[A, B] =
+    copy(actions :+ MigrationAction.TransformValues(path, transform, reverseTransform))
+
+  // ─── Build ──────────────────────────────────────────────────────────
+
+  /**
+   * Builds the migration without full validation. Creates a [[Migration]] from
+   * the accumulated actions.
+   */
+  def buildPartial: Migration[A, B] =
+    new Migration(new DynamicMigration(actions), sourceSchema, targetSchema)
+}
+
+object MigrationBuilder {
+
+  /**
+   * Creates a typed `DynamicValue` literal. Eagerly converts the value to
+   * `DynamicValue` using the provided schema.
+   *
+   * Example: `literal[Int](0)` or `literal("hello")`
+   */
+  def literal[T](value: T)(implicit schema: Schema[T]): DynamicValue =
+    schema.toDynamicValue(value)
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationError.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationError.scala
@@ -1,0 +1,52 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.DynamicOptic
+
+/**
+ * Represents an error that occurred during migration application.
+ *
+ * All errors include a `path` indicating where in the data structure the error
+ * occurred, enabling precise diagnostics like:
+ * "Failed to apply TransformValue at `.addresses.each.streetNumber`"
+ */
+sealed trait MigrationError {
+  def path: DynamicOptic
+  def message: String
+  override def toString: String = s"MigrationError at $path: $message"
+}
+
+object MigrationError {
+
+  /** A field that was expected to exist was not found. */
+  final case class MissingField(path: DynamicOptic, fieldName: String) extends MigrationError {
+    def message: String = s"Missing field '$fieldName'"
+  }
+
+  /** A variant case that was expected was not found. */
+  final case class MissingCase(path: DynamicOptic, caseName: String) extends MigrationError {
+    def message: String = s"Missing case '$caseName'"
+  }
+
+  /** A value transformation failed. */
+  final case class TransformFailed(path: DynamicOptic, details: String) extends MigrationError {
+    def message: String = s"Transform failed: $details"
+  }
+
+  /** A type conversion failed. */
+  final case class TypeMismatch(path: DynamicOptic, expected: String, actual: String) extends MigrationError {
+    def message: String = s"Type mismatch: expected $expected, got $actual"
+  }
+
+  /** A field already exists when trying to add it. */
+  final case class FieldAlreadyExists(path: DynamicOptic, fieldName: String) extends MigrationError {
+    def message: String = s"Field '$fieldName' already exists"
+  }
+
+  /** Expected an Option/nullable value but got a non-optional value. */
+  final case class MandateFailed(path: DynamicOptic, details: String) extends MigrationError {
+    def message: String = s"Mandate failed: $details"
+  }
+
+  /** General-purpose migration error. */
+  final case class General(path: DynamicOptic, message: String) extends MigrationError
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
@@ -1,0 +1,561 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{DynamicOptic, DynamicValue, PrimitiveValue, SchemaBaseSpec}
+import zio.test.Assertion._
+import zio.test._
+
+object DynamicMigrationSpec extends SchemaBaseSpec {
+
+  private def prim(s: String): DynamicValue   = new DynamicValue.Primitive(new PrimitiveValue.String(s))
+  private def primInt(i: Int): DynamicValue    = new DynamicValue.Primitive(new PrimitiveValue.Int(i))
+  private def primLong(l: Long): DynamicValue  = new DynamicValue.Primitive(new PrimitiveValue.Long(l))
+  private def primBool(b: Boolean): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.Boolean(b))
+
+  private def record(fields: (String, DynamicValue)*): DynamicValue =
+    new DynamicValue.Record(Chunk.fromIterable(fields))
+
+  private def variant(caseName: String, value: DynamicValue): DynamicValue =
+    new DynamicValue.Variant(caseName, value)
+
+  private def seq(elements: DynamicValue*): DynamicValue =
+    new DynamicValue.Sequence(Chunk.fromIterable(elements))
+
+  private def map(entries: (DynamicValue, DynamicValue)*): DynamicValue =
+    new DynamicValue.Map(Chunk.fromIterable(entries))
+
+  def spec: Spec[TestEnvironment, Any] = suite("DynamicMigrationSpec")(
+    identitySuite,
+    addFieldSuite,
+    dropFieldSuite,
+    renameSuite,
+    transformValueSuite,
+    mandateSuite,
+    optionalizeSuite,
+    changeTypeSuite,
+    joinSuite,
+    splitSuite,
+    renameCaseSuite,
+    transformCaseSuite,
+    transformElementsSuite,
+    transformKeysSuite,
+    transformValuesSuite,
+    compositionSuite,
+    reverseSuite,
+    lawsSuite
+  )
+
+  private val identitySuite = suite("identity")(
+    test("identity migration returns value unchanged") {
+      val v = record("name" -> prim("Alice"), "age" -> primInt(30))
+      assert(DynamicMigration.identity(v))(isRight(equalTo(v)))
+    }
+  )
+
+  private val addFieldSuite = suite("AddField")(
+    test("adds a new field to a record") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.AddField(DynamicOptic.root.field("age"), primInt(0))
+      )
+      val input  = record("name" -> prim("Alice"))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record("name" -> prim("Alice"), "age" -> primInt(0))
+      )))
+    },
+    test("fails when field already exists") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.AddField(DynamicOptic.root.field("name"), prim("Bob"))
+      )
+      val input = record("name" -> prim("Alice"))
+      assert(migration(input))(isLeft)
+    }
+  )
+
+  private val dropFieldSuite = suite("DropField")(
+    test("removes a field from a record") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.DropField(DynamicOptic.root.field("age"), primInt(0))
+      )
+      val input  = record("name" -> prim("Alice"), "age" -> primInt(30))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record("name" -> prim("Alice"))
+      )))
+    },
+    test("fails when field does not exist") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.DropField(DynamicOptic.root.field("missing"), prim(""))
+      )
+      val input = record("name" -> prim("Alice"))
+      assert(migration(input))(isLeft)
+    }
+  )
+
+  private val renameSuite = suite("Rename")(
+    test("renames a field in a record") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.Rename(DynamicOptic.root, "firstName", "givenName")
+      )
+      val input  = record("firstName" -> prim("Alice"), "age" -> primInt(30))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record("givenName" -> prim("Alice"), "age" -> primInt(30))
+      )))
+    },
+    test("fails when source field does not exist") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.Rename(DynamicOptic.root, "missing", "newName")
+      )
+      val input = record("name" -> prim("Alice"))
+      assert(migration(input))(isLeft)
+    }
+  )
+
+  private val transformValueSuite = suite("TransformValue")(
+    test("transforms a value in-place using a constant transform") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.TransformValue(
+          DynamicOptic.root.field("name"),
+          DynamicOptic.root.field("name"),
+          DynamicValueTransform.Constant(prim("Bob")),
+          Some(DynamicValueTransform.Constant(prim("Alice")))
+        )
+      )
+      val input  = record("name" -> prim("Alice"))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record("name" -> prim("Bob"))
+      )))
+    },
+    test("transforms a value using NumericToString") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.TransformValue(
+          DynamicOptic.root.field("count"),
+          DynamicOptic.root.field("count"),
+          DynamicValueTransform.NumericToString,
+          Some(DynamicValueTransform.StringToInt)
+        )
+      )
+      val input  = record("count" -> primInt(42))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record("count" -> prim("42"))
+      )))
+    }
+  )
+
+  private val mandateSuite = suite("Mandate")(
+    test("converts a Null value to the default") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.Mandate(
+          DynamicOptic.root.field("age"),
+          DynamicOptic.root.field("age"),
+          primInt(0)
+        )
+      )
+      val input  = record("age" -> DynamicValue.Null)
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record("age" -> primInt(0))
+      )))
+    },
+    test("keeps non-null value unchanged") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.Mandate(
+          DynamicOptic.root.field("age"),
+          DynamicOptic.root.field("age"),
+          primInt(0)
+        )
+      )
+      val input  = record("age" -> primInt(25))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record("age" -> primInt(25))
+      )))
+    }
+  )
+
+  private val optionalizeSuite = suite("Optionalize")(
+    test("wraps a value in Some variant") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.Optionalize(
+          DynamicOptic.root.field("age"),
+          DynamicOptic.root.field("age")
+        )
+      )
+      val input  = record("age" -> primInt(25))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record("age" -> variant("Some", primInt(25)))
+      )))
+    },
+    test("wraps Null in None variant") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.Optionalize(
+          DynamicOptic.root.field("age"),
+          DynamicOptic.root.field("age")
+        )
+      )
+      val input  = record("age" -> DynamicValue.Null)
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record("age" -> variant("None", record()))
+      )))
+    }
+  )
+
+  private val changeTypeSuite = suite("ChangeType")(
+    test("changes Int to Long") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.ChangeType(
+          DynamicOptic.root.field("count"),
+          DynamicOptic.root.field("count"),
+          DynamicValueTransform.IntToLong,
+          Some(DynamicValueTransform.LongToInt)
+        )
+      )
+      val input  = record("count" -> primInt(42))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record("count" -> primLong(42L))
+      )))
+    },
+    test("changes String to Int") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.ChangeType(
+          DynamicOptic.root.field("count"),
+          DynamicOptic.root.field("count"),
+          DynamicValueTransform.StringToInt,
+          Some(DynamicValueTransform.NumericToString)
+        )
+      )
+      val input  = record("count" -> prim("42"))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record("count" -> primInt(42))
+      )))
+    },
+    test("fails on invalid conversion") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.ChangeType(
+          DynamicOptic.root.field("count"),
+          DynamicOptic.root.field("count"),
+          DynamicValueTransform.StringToInt,
+          None
+        )
+      )
+      val input = record("count" -> prim("not-a-number"))
+      assert(migration(input))(isLeft)
+    }
+  )
+
+  private val joinSuite = suite("Join")(
+    test("joins multiple fields into one using ConcatFields") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.Join(
+          DynamicOptic.root,
+          Vector("first", "last"),
+          "fullName",
+          DynamicValueTransform.ConcatFields(Vector("first", "last"), " "),
+          None
+        )
+      )
+      val input  = record("first" -> prim("John"), "last" -> prim("Doe"), "age" -> primInt(30))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record("age" -> primInt(30), "fullName" -> prim("John Doe"))
+      )))
+    },
+    test("fails when source fields are empty") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.Join(
+          DynamicOptic.root,
+          Vector.empty,
+          "combined",
+          DynamicValueTransform.Identity,
+          None
+        )
+      )
+      val input = record("name" -> prim("Alice"))
+      assert(migration(input))(isLeft)
+    },
+    test("fails on non-record value") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.Join(
+          DynamicOptic.root,
+          Vector("a", "b"),
+          "ab",
+          DynamicValueTransform.Identity,
+          None
+        )
+      )
+      assert(migration(prim("not a record")))(isLeft)
+    }
+  )
+
+  private val splitSuite = suite("Split")(
+    test("splits a field into multiple fields using SplitString") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.Split(
+          DynamicOptic.root,
+          "fullName",
+          Vector("first", "last"),
+          DynamicValueTransform.SplitString(" ", Vector("first", "last")),
+          None
+        )
+      )
+      val input  = record("fullName" -> prim("John Doe"), "age" -> primInt(30))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record("age" -> primInt(30), "first" -> prim("John"), "last" -> prim("Doe"))
+      )))
+    },
+    test("fails when source field does not exist") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.Split(
+          DynamicOptic.root,
+          "missing",
+          Vector("a", "b"),
+          DynamicValueTransform.SplitString(" ", Vector("a", "b")),
+          None
+        )
+      )
+      val input = record("name" -> prim("Alice"))
+      assert(migration(input))(isLeft)
+    },
+    test("Join and Split are inverses") {
+      val join = DynamicMigration.fromAction(
+        MigrationAction.Join(
+          DynamicOptic.root,
+          Vector("first", "last"),
+          "fullName",
+          DynamicValueTransform.ConcatFields(Vector("first", "last"), " "),
+          Some(DynamicValueTransform.SplitString(" ", Vector("first", "last")))
+        )
+      )
+      val input     = record("first" -> prim("John"), "last" -> prim("Doe"))
+      val joined    = join(input)
+      val splitBack = joined.flatMap(join.reverse.apply)
+      assert(splitBack)(isRight(equalTo(input)))
+    }
+  )
+
+  private val renameCaseSuite = suite("RenameCase")(
+    test("renames a variant case") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.RenameCase(DynamicOptic.root, "OldCase", "NewCase")
+      )
+      val input  = variant("OldCase", record("x" -> primInt(1)))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        variant("NewCase", record("x" -> primInt(1)))
+      )))
+    },
+    test("leaves non-matching cases unchanged") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.RenameCase(DynamicOptic.root, "OldCase", "NewCase")
+      )
+      val input  = variant("OtherCase", record("x" -> primInt(1)))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(input)))
+    }
+  )
+
+  private val transformCaseSuite = suite("TransformCase")(
+    test("transforms a specific variant case with sub-actions") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.TransformCase(
+          DynamicOptic.root,
+          "PersonV1",
+          "PersonV2",
+          Vector(
+            MigrationAction.AddField(DynamicOptic.root.field("email"), prim(""))
+          )
+        )
+      )
+      val input  = variant("PersonV1", record("name" -> prim("Alice")))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        variant("PersonV2", record("name" -> prim("Alice"), "email" -> prim("")))
+      )))
+    },
+    test("leaves non-matching cases unchanged") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.TransformCase(
+          DynamicOptic.root,
+          "PersonV1",
+          "PersonV2",
+          Vector(MigrationAction.AddField(DynamicOptic.root.field("email"), prim("")))
+        )
+      )
+      val input  = variant("CompanyV1", record("name" -> prim("Acme")))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(input)))
+    }
+  )
+
+  private val transformElementsSuite = suite("TransformElements")(
+    test("transforms all elements of a sequence") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.TransformElements(
+          DynamicOptic.root,
+          DynamicValueTransform.NumericToString,
+          Some(DynamicValueTransform.StringToInt)
+        )
+      )
+      val input  = seq(primInt(1), primInt(2), primInt(3))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        seq(prim("1"), prim("2"), prim("3"))
+      )))
+    }
+  )
+
+  private val transformKeysSuite = suite("TransformKeys")(
+    test("transforms all keys of a map") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.TransformKeys(
+          DynamicOptic.root,
+          DynamicValueTransform.NumericToString,
+          Some(DynamicValueTransform.StringToInt)
+        )
+      )
+      val input  = map(primInt(1) -> prim("a"), primInt(2) -> prim("b"))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        map(prim("1") -> prim("a"), prim("2") -> prim("b"))
+      )))
+    }
+  )
+
+  private val transformValuesSuite = suite("TransformValues")(
+    test("transforms all values of a map") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.TransformValues(
+          DynamicOptic.root,
+          DynamicValueTransform.NumericToString,
+          Some(DynamicValueTransform.StringToInt)
+        )
+      )
+      val input  = map(prim("a") -> primInt(1), prim("b") -> primInt(2))
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        map(prim("a") -> prim("1"), prim("b") -> prim("2"))
+      )))
+    }
+  )
+
+  private val compositionSuite = suite("composition")(
+    test("++ composes migrations sequentially") {
+      val m1 = DynamicMigration.fromAction(
+        MigrationAction.AddField(DynamicOptic.root.field("age"), primInt(0))
+      )
+      val m2 = DynamicMigration.fromAction(
+        MigrationAction.Rename(DynamicOptic.root, "name", "fullName")
+      )
+      val composed = m1 ++ m2
+      val input    = record("name" -> prim("Alice"))
+      val result   = composed(input)
+      assert(result)(isRight(equalTo(
+        record("fullName" -> prim("Alice"), "age" -> primInt(0))
+      )))
+    },
+    test("complex multi-step migration") {
+      val migration = DynamicMigration.fromActions(
+        MigrationAction.Rename(DynamicOptic.root, "firstName", "name"),
+        MigrationAction.DropField(DynamicOptic.root.field("middleName"), prim("")),
+        MigrationAction.AddField(DynamicOptic.root.field("email"), prim(""))
+      )
+      val input = record(
+        "firstName"  -> prim("Alice"),
+        "middleName" -> prim("M"),
+        "lastName"   -> prim("Smith")
+      )
+      val result = migration(input)
+      assert(result)(isRight(equalTo(
+        record(
+          "name"     -> prim("Alice"),
+          "lastName" -> prim("Smith"),
+          "email"    -> prim("")
+        )
+      )))
+    }
+  )
+
+  private val reverseSuite = suite("reverse")(
+    test("reverse of AddField is DropField") {
+      val add = MigrationAction.AddField(DynamicOptic.root.field("age"), primInt(0))
+      val rev = add.reverse
+      assert(rev)(equalTo(MigrationAction.DropField(DynamicOptic.root.field("age"), primInt(0))))
+    },
+    test("reverse of DropField is AddField") {
+      val drop = MigrationAction.DropField(DynamicOptic.root.field("age"), primInt(0))
+      val rev  = drop.reverse
+      assert(rev)(equalTo(MigrationAction.AddField(DynamicOptic.root.field("age"), primInt(0))))
+    },
+    test("reverse of Rename swaps names") {
+      val rename = MigrationAction.Rename(DynamicOptic.root, "old", "new")
+      val rev    = rename.reverse
+      assert(rev)(equalTo(MigrationAction.Rename(DynamicOptic.root, "new", "old")))
+    },
+    test("reverse of RenameCase swaps names") {
+      val rename = MigrationAction.RenameCase(DynamicOptic.root, "OldCase", "NewCase")
+      val rev    = rename.reverse
+      assert(rev)(equalTo(MigrationAction.RenameCase(DynamicOptic.root, "NewCase", "OldCase")))
+    },
+    test("double reverse returns original migration") {
+      val migration = DynamicMigration.fromActions(
+        MigrationAction.AddField(DynamicOptic.root.field("age"), primInt(0)),
+        MigrationAction.Rename(DynamicOptic.root, "name", "fullName")
+      )
+      assert(migration.reverse.reverse)(equalTo(migration))
+    },
+    test("reverse migration undoes add/drop") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.AddField(DynamicOptic.root.field("age"), primInt(0))
+      )
+      val input  = record("name" -> prim("Alice"))
+      val result = migration(input)
+      assert(result.flatMap(migration.reverse.apply))(isRight(equalTo(input)))
+    },
+    test("reverse migration undoes rename") {
+      val migration = DynamicMigration.fromAction(
+        MigrationAction.Rename(DynamicOptic.root, "name", "fullName")
+      )
+      val input  = record("name" -> prim("Alice"))
+      val result = migration(input)
+      assert(result.flatMap(migration.reverse.apply))(isRight(equalTo(input)))
+    }
+  )
+
+  private val lawsSuite = suite("laws")(
+    test("identity law: identity migration returns value unchanged") {
+      val v = record("name" -> prim("Alice"), "age" -> primInt(30))
+      assert(DynamicMigration.identity(v))(isRight(equalTo(v)))
+    },
+    test("associativity law: (m1 ++ m2) ++ m3 == m1 ++ (m2 ++ m3)") {
+      val m1 = DynamicMigration.fromAction(
+        MigrationAction.AddField(DynamicOptic.root.field("x"), primInt(1))
+      )
+      val m2 = DynamicMigration.fromAction(
+        MigrationAction.AddField(DynamicOptic.root.field("y"), primInt(2))
+      )
+      val m3 = DynamicMigration.fromAction(
+        MigrationAction.AddField(DynamicOptic.root.field("z"), primInt(3))
+      )
+      val input = record("a" -> prim("hello"))
+      val left  = ((m1 ++ m2) ++ m3)(input)
+      val right = (m1 ++ (m2 ++ m3))(input)
+      assert(left)(equalTo(right))
+    },
+    test("structural reverse law: m.reverse.reverse == m") {
+      val migration = DynamicMigration.fromActions(
+        MigrationAction.AddField(DynamicOptic.root.field("age"), primInt(0)),
+        MigrationAction.Rename(DynamicOptic.root, "name", "fullName"),
+        MigrationAction.RenameCase(DynamicOptic.root, "A", "B")
+      )
+      assert(migration.reverse.reverse)(equalTo(migration))
+    }
+  )
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationActionSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationActionSpec.scala
@@ -1,0 +1,183 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{DynamicOptic, DynamicValue, PrimitiveValue, SchemaBaseSpec}
+import zio.test.Assertion._
+import zio.test._
+
+object MigrationActionSpec extends SchemaBaseSpec {
+
+  private def prim(s: String): DynamicValue = new DynamicValue.Primitive(new PrimitiveValue.String(s))
+  private def primInt(i: Int): DynamicValue  = new DynamicValue.Primitive(new PrimitiveValue.Int(i))
+
+  def spec: Spec[TestEnvironment, Any] = suite("MigrationActionSpec")(
+    reverseSuite,
+    dynamicValueTransformSuite
+  )
+
+  private val reverseSuite = suite("reverse")(
+    test("AddField.reverse is DropField") {
+      val action = MigrationAction.AddField(DynamicOptic.root.field("x"), primInt(0))
+      assert(action.reverse)(equalTo(
+        MigrationAction.DropField(DynamicOptic.root.field("x"), primInt(0))
+      ))
+    },
+    test("DropField.reverse is AddField") {
+      val action = MigrationAction.DropField(DynamicOptic.root.field("x"), primInt(0))
+      assert(action.reverse)(equalTo(
+        MigrationAction.AddField(DynamicOptic.root.field("x"), primInt(0))
+      ))
+    },
+    test("Rename.reverse swaps names") {
+      val action = MigrationAction.Rename(DynamicOptic.root, "a", "b")
+      assert(action.reverse)(equalTo(
+        MigrationAction.Rename(DynamicOptic.root, "b", "a")
+      ))
+    },
+    test("Mandate.reverse is Optionalize") {
+      val action = MigrationAction.Mandate(
+        DynamicOptic.root.field("x"),
+        DynamicOptic.root.field("x"),
+        primInt(0)
+      )
+      val rev = action.reverse
+      assert(rev.isInstanceOf[MigrationAction.Optionalize])(isTrue)
+    },
+    test("Optionalize.reverse is Mandate") {
+      val action = MigrationAction.Optionalize(
+        DynamicOptic.root.field("x"),
+        DynamicOptic.root.field("x")
+      )
+      val rev = action.reverse
+      assert(rev.isInstanceOf[MigrationAction.Mandate])(isTrue)
+    },
+    test("RenameCase.reverse swaps names") {
+      val action = MigrationAction.RenameCase(DynamicOptic.root, "A", "B")
+      assert(action.reverse)(equalTo(
+        MigrationAction.RenameCase(DynamicOptic.root, "B", "A")
+      ))
+    },
+    test("TransformCase.reverse reverses sub-actions and swaps case names") {
+      val action = MigrationAction.TransformCase(
+        DynamicOptic.root,
+        "CaseA",
+        "CaseB",
+        Vector(
+          MigrationAction.AddField(DynamicOptic.root.field("x"), primInt(0)),
+          MigrationAction.Rename(DynamicOptic.root, "y", "z")
+        )
+      )
+      val rev = action.reverse.asInstanceOf[MigrationAction.TransformCase]
+      assert(rev.caseName)(equalTo("CaseB")) &&
+      assert(rev.targetCaseName)(equalTo("CaseA")) &&
+      assert(rev.actions.length)(equalTo(2))
+    },
+    test("Join.reverse is Split with swapped fields") {
+      val action = MigrationAction.Join(
+        DynamicOptic.root,
+        Vector("first", "last"),
+        "fullName",
+        DynamicValueTransform.ConcatFields(Vector("first", "last"), " "),
+        Some(DynamicValueTransform.SplitString(" ", Vector("first", "last")))
+      )
+      val rev = action.reverse
+      assert(rev.isInstanceOf[MigrationAction.Split])(isTrue) &&
+      assert(rev.asInstanceOf[MigrationAction.Split].sourceField)(equalTo("fullName")) &&
+      assert(rev.asInstanceOf[MigrationAction.Split].targetFields)(equalTo(Vector("first", "last")))
+    },
+    test("Split.reverse is Join with swapped fields") {
+      val action = MigrationAction.Split(
+        DynamicOptic.root,
+        "fullName",
+        Vector("first", "last"),
+        DynamicValueTransform.SplitString(" ", Vector("first", "last")),
+        Some(DynamicValueTransform.ConcatFields(Vector("first", "last"), " "))
+      )
+      val rev = action.reverse
+      assert(rev.isInstanceOf[MigrationAction.Join])(isTrue) &&
+      assert(rev.asInstanceOf[MigrationAction.Join].sourceFields)(equalTo(Vector("first", "last"))) &&
+      assert(rev.asInstanceOf[MigrationAction.Join].targetField)(equalTo("fullName"))
+    },
+    test("double reverse returns original action for all action types") {
+      val actions: Vector[MigrationAction] = Vector(
+        MigrationAction.AddField(DynamicOptic.root.field("x"), primInt(0)),
+        MigrationAction.DropField(DynamicOptic.root.field("x"), primInt(0)),
+        MigrationAction.Rename(DynamicOptic.root, "a", "b"),
+        MigrationAction.RenameCase(DynamicOptic.root, "A", "B"),
+        MigrationAction.Optionalize(DynamicOptic.root.field("x"), DynamicOptic.root.field("x")),
+        MigrationAction.Join(
+          DynamicOptic.root, Vector("a", "b"), "ab",
+          DynamicValueTransform.ConcatFields(Vector("a", "b"), ""),
+          Some(DynamicValueTransform.SplitString("", Vector("a", "b")))
+        ),
+        MigrationAction.Split(
+          DynamicOptic.root, "ab", Vector("a", "b"),
+          DynamicValueTransform.SplitString("", Vector("a", "b")),
+          Some(DynamicValueTransform.ConcatFields(Vector("a", "b"), ""))
+        )
+      )
+      assert(actions.forall(a => a.reverse.reverse == a))(isTrue)
+    }
+  )
+
+  private val dynamicValueTransformSuite = suite("DynamicValueTransform")(
+    test("Constant always returns the constant value") {
+      val t = DynamicValueTransform.Constant(prim("hello"))
+      assert(t(primInt(42)))(isRight(equalTo(prim("hello"))))
+    },
+    test("Identity returns input unchanged") {
+      val t = DynamicValueTransform.Identity
+      assert(t(primInt(42)))(isRight(equalTo(primInt(42))))
+    },
+    test("NumericToString converts Int to String") {
+      val t = DynamicValueTransform.NumericToString
+      assert(t(primInt(42)))(isRight(equalTo(prim("42"))))
+    },
+    test("StringToInt converts String to Int") {
+      val t = DynamicValueTransform.StringToInt
+      assert(t(prim("42")))(isRight(equalTo(primInt(42))))
+    },
+    test("StringToInt fails on non-numeric string") {
+      val t = DynamicValueTransform.StringToInt
+      assert(t(prim("abc")))(isLeft)
+    },
+    test("IntToLong converts Int to Long") {
+      val t = DynamicValueTransform.IntToLong
+      assert(t(primInt(42)))(isRight(equalTo(
+        new DynamicValue.Primitive(new PrimitiveValue.Long(42L))
+      )))
+    },
+    test("LongToInt converts Long to Int") {
+      val t = DynamicValueTransform.LongToInt
+      assert(t(new DynamicValue.Primitive(new PrimitiveValue.Long(42L))))(isRight(equalTo(primInt(42))))
+    },
+    test("ConcatFields concatenates string fields") {
+      val t     = DynamicValueTransform.ConcatFields(Vector("first", "last"), " ")
+      val input = new DynamicValue.Record(Chunk(
+        ("first", prim("John")),
+        ("last", prim("Doe"))
+      ))
+      assert(t(input))(isRight(equalTo(prim("John Doe"))))
+    },
+    test("SplitString splits a string into named fields") {
+      val t     = DynamicValueTransform.SplitString(" ", Vector("first", "last"))
+      val input = prim("John Doe")
+      val expected = new DynamicValue.Record(Chunk(
+        ("first", prim("John")),
+        ("last", prim("Doe"))
+      ))
+      assert(t(input))(isRight(equalTo(expected)))
+    },
+    test("SplitString fails on non-string primitive") {
+      val t = DynamicValueTransform.SplitString(" ", Vector("a", "b"))
+      assert(t(primInt(42)))(isLeft)
+    },
+    test("Compose chains transformations") {
+      val t = DynamicValueTransform.Compose(Vector(
+        DynamicValueTransform.NumericToString,
+        DynamicValueTransform.Constant(prim("done"))
+      ))
+      assert(t(primInt(42)))(isRight(equalTo(prim("done"))))
+    }
+  )
+}


### PR DESCRIPTION
Add a pure, serializable migration system for transforming data between schema versions. The two-layer architecture separates the untyped serializable core (DynamicMigration) from the typed wrapper (Migration[A,B]).

Key components:
- MigrationAction: 14-case ADT covering field add/drop/rename, type changes, optionality, variant cases, collections, maps, join/split
- DynamicMigration: Pure interpreter applying actions to DynamicValue
- Migration[A,B]: Typed wrapper with apply/reverse/compose/identity
- MigrationBuilder: Fluent builder with macro selector support
- DynamicValueTransform: Serializable value transforms (no closures)
- MigrationError: Path-aware error hierarchy via DynamicOptic

Supports both Scala 2.13 and Scala 3.5+ with platform-specific macros for converting selector lambdas (_.field.nested) to DynamicOptic paths.

74 tests passing across DynamicMigrationSpec, MigrationActionSpec, and MigrationBuilderSpec.