### PR TITLE
fix(Allows): harden Scala 2 macro type extraction and add regression test for #1145

### DIFF
--- a/schema/shared/src/main/scala-2/zio/blocks/schema/comptime/AllowsCompanionVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/comptime/AllowsCompanionVersionSpecific.scala
@@ -37,9 +37,52 @@ private[comptime] object AllowsMacroImpl {
 
     // In Scala 2 whitebox macros, weakTypeOf[S] and weakTypeOf[A] are abstract type
     // variables. Extract the concrete types from the macro application's return type.
-    val appTpe   = c.macroApplication.tpe
-    val sTpe     = appTpe.typeArgs.last // Allows[A, S] — S is second type arg
-    val rootTpe0 = appTpe.typeArgs.head // Allows[A, S] — A is first type arg
+    //
+    // c.macroApplication.tpe is the primary source: it holds the return type of the
+    // macro call as determined by the typer before expansion.  When the macro is
+    // used as an implicit and Scala 2's typer has already committed the expected
+    // type (which is the normal case), this gives us Allows[ConcreteA, ConcreteS]
+    // with both type arguments fully resolved.
+    //
+    // In rare cases c.macroApplication.tpe can be null (e.g. some incremental
+    // compilation states) or its type arguments can contain unresolved type variables
+    // (isAbstract type parameters or existential skolems).  The fallback reads
+    // c.enclosingImplicits: when the macro is triggered as part of an implicit
+    // search, c.enclosingImplicits.head.pt is the "point type" — the expected
+    // type the search is trying to satisfy — which is always concrete.
+    val allowsTypeCon = typeOf[Allows[_, _]].typeConstructor
+
+    // Returns Some((A, S)) only when both type arguments are fully concrete —
+    // i.e. neither is an unresolved type parameter (typeSymbol.isParameter is true
+    // for type-parameter symbols such as the A and S in derived[S, A], but false
+    // for concrete types including abstract classes used as grammar nodes).
+    def isConcrete(t: Type): Boolean =
+      !t.typeSymbol.isParameter
+
+    def typeArgsFromPt(pt: Type): Option[(Type, Type)] = {
+      val dealiased = pt.dealias
+      if (dealiased.typeConstructor =:= allowsTypeCon && dealiased.typeArgs.length == 2) {
+        val a = dealiased.typeArgs.head
+        val s = dealiased.typeArgs.last
+        if (isConcrete(a) && isConcrete(s)) Some((a, s)) else None
+      } else None
+    }
+
+    val (rootTpe0, sTpe): (Type, Type) = {
+      val fromApp: Option[(Type, Type)] =
+        Option(c.macroApplication.tpe).flatMap(t => typeArgsFromPt(t))
+      val fromImplicits: Option[(Type, Type)] =
+        c.enclosingImplicits.headOption.flatMap(ic => typeArgsFromPt(ic.pt))
+      fromApp
+        .orElse(fromImplicits)
+        .getOrElse(
+          c.abort(
+            c.enclosingPosition,
+            "Allows macro: could not determine concrete type arguments A and S. " +
+              "Make sure the full Allows[A, S] type is fully inferred at the call site."
+          )
+        )
+    }
 
     val primitiveBase = typeOf[Allows.Primitive]
     val dynamicBase   = typeOf[Allows.Dynamic]

--- a/schema/shared/src/test/scala/zio/blocks/schema/comptime/AllowsSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/comptime/AllowsSpec.scala
@@ -154,6 +154,28 @@ object AllowsFixtures {
 }
 
 // ---------------------------------------------------------------------------
+// Regression: issue #1145
+// Reproduced verbatim from the bug report. DO NOT MODIFY THIS OBJECT.
+// Allows must be derivable when A is inferred at a call site in a user object
+// that imports Allows._ (wildcard) from an external namespace.
+// ---------------------------------------------------------------------------
+
+object Issue1145Reproducer {
+  import zio.blocks.schema.Schema
+  import zio.blocks.schema.comptime.Allows
+  import Allows._
+
+  def writeCsv[A: Schema](rows: Seq[A])(implicit ev: Allows[A, Record[Primitive | Optional[Primitive]]]): Unit = ()
+
+  final case class Person(age: Int)
+  object Person {
+    implicit val schema: Schema[Person] = Schema.derived
+  }
+
+  val result: Unit = writeCsv(Seq(Person(42)))
+}
+
+// ---------------------------------------------------------------------------
 // Positive tests (positive evidence derivation must compile)
 // Use `implicitly` which works on both Scala 2 and Scala 3.
 // ---------------------------------------------------------------------------
@@ -400,6 +422,12 @@ object AllowsSpec extends SchemaBaseSpec {
         val nilUUID                                                                    = new java.util.UUID(0L, 0L)
         val event: DomainEvent                                                         = AccountOpened(nilUUID, "Alice")
         assertTrue(publish(event) == "ok")
+      },
+      // Regression test for https://github.com/zio/zio-blocks/issues/1145
+      // Issue1145Reproducer is a top-level object with `import Allows._` (wildcard),
+      // exactly matching the reporter's code. The val initialiser is evaluated here.
+      test("Allows is derivable with inferred A under wildcard import (issue #1145)") {
+        assertTrue(Issue1145Reproducer.result == (()))
       }
     )
   )


### PR DESCRIPTION
## Summary

- Hardens the Scala 2 whitebox macro in `AllowsCompanionVersionSpecific` with a fallback to `c.enclosingImplicits.head.pt` when `c.macroApplication.tpe` is null or unresolved, so that `A` and `S` are always resolved from the implicit search's expected type.
- Adds `Issue1145Reproducer` — a top-level object with `import Allows._` (wildcard), matching the reporter's exact code — as a permanent regression guard for #1145.

## Notes

The bug could not be reproduced locally under Scala 2.13.18 in the same sbt build. The regression test compiles and passes, confirming the pattern works in the current environment. The `c.enclosingImplicits` fallback defends against environments (older Scala 2.13.x patches, or separate compilation) where `c.macroApplication.tpe` may not yet be resolved when the macro fires.

Closes #1145