### PR TITLE
feat(rpc): add zio-blocks-rpc descriptor foundation (#1143)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,28 +97,28 @@ addCommandAlias(
   "golemTest3; golemTest2"
 )
 lazy val testJVMScala2Command =
-  "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
+  "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; rpcJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
     "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; muxJVM/test; mediatypeJVM/test; " +
     "endpointJVM/test; openapiJVM/test; smithy/test; codegen/test; htmlJVM/test"
 
 lazy val testJVMScala3Command =
-  "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
+  "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; rpcJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
     "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; muxJVM/test; mediatypeJVM/test; http-modelJVM/test; " +
     "http-model-schemaJVM/test; endpointJVM/test; openapiJVM/test; smithy/test; codegen/test; htmlJVM/test; datastarJVM/test; htmxJVM/test"
 
 lazy val testJSScala2Command =
-  "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
+  "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; rpcJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
     "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; muxJS/test; mediatypeJS/test; endpointJS/test; htmlJS/test"
 
 lazy val testJSScala3Command =
-  "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
+  "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; rpcJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
     "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; muxJS/test; mediatypeJS/test; http-modelJS/test; http-model-schemaJS/test; endpointJS/test; htmlJS/test; datastarJS/test; htmxJS/test"
 
 lazy val testJS1Scala2Command =
-  "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test"
+  "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; rpcJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test"
 
 lazy val testJS1Scala3Command =
-  "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test"
+  "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; rpcJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test"
 
 lazy val testJS2Scala2Command =
   "openapiJS/test; schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; htmlJS/test"
@@ -127,31 +127,31 @@ lazy val testJS2Scala3Command =
   "openapiJS/test; schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; http-modelJS/test; http-model-schemaJS/test; endpointJS/test; htmlJS/test; datastarJS/test; htmxJS/test"
 
 lazy val docJVMScala2Command =
-  "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
+  "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; rpcJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
     "schema-thrift/doc; schema-bson/doc; schema-xmlJVM/doc; schema-yamlJVM/doc; schema-csvJVM/doc; contextJVM/doc; scopeJVM/doc; muxJVM/doc; mediatypeJVM/doc; " +
     "endpointJVM/doc; openapiJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc"
 
 lazy val docJVMScala3Command =
-  "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
+  "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; rpcJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
     "schema-thrift/doc; schema-bson/doc; schema-xmlJVM/doc; schema-yamlJVM/doc; schema-csvJVM/doc; contextJVM/doc; scopeJVM/doc; muxJVM/doc; mediatypeJVM/doc; http-modelJVM/doc; " +
     "http-model-schemaJVM/doc; openapiJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc; datastarJVM/doc; htmxJVM/doc"
 
 lazy val docJSScala2Command =
-  "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
+  "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; rpcJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
     "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; muxJS/doc; mediatypeJS/doc; endpointJS/doc; htmlJS/doc"
 
 lazy val docJSScala2Batch1Command =
-  "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc"
+  "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; rpcJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc"
 
 lazy val docJSScala2Batch2Command =
   "openapiJS/doc; schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; htmlJS/doc"
 
 lazy val docJSScala3Command =
-  "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
+  "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; rpcJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
     "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; muxJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; htmlJS/doc; datastarJS/doc; htmxJS/doc"
 
 lazy val docJSScala3Batch1Command =
-  "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc"
+  "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; rpcJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc"
 
 lazy val docJSScala3Batch2Command =
   "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; htmlJS/doc; datastarJS/doc"
@@ -200,6 +200,8 @@ lazy val root = project
     `scope-examples`,
     schema.jvm,
     schema.js,
+    rpc.jvm,
+    rpc.js,
     `schema-avro`,
     `schema-messagepack`.jvm,
     `schema-messagepack`.js,
@@ -502,6 +504,27 @@ lazy val schema = crossProject(JSPlatform, JVMPlatform)
           "io.github.kitlangton" %%% "neotype" % "0.5.0" % Test
         )
     })
+  )
+
+lazy val rpc = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Full)
+  .dependsOn(schema)
+  .settings(stdSettings("zio-blocks-rpc"))
+  .settings(crossProjectSettings)
+  .settings(buildInfoSettings("zio.blocks.rpc"))
+  .enablePlugins(BuildInfoPlugin)
+  .jsSettings(jsSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "dev.zio" %%% "zio-test"     % "2.1.24" % Test,
+      "dev.zio" %%% "zio-test-sbt" % "2.1.24" % Test
+    ),
+    coverageMinimumStmtTotal   := 80,
+    coverageMinimumBranchTotal := 70,
+    coverageExcludedFiles      := Seq(
+      ".*scala-3/zio/blocks/rpc/.*",
+      ".*BuildInfo.*"
+    ).mkString(";")
   )
 
 lazy val streams = crossProject(JSPlatform, JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -97,39 +97,39 @@ addCommandAlias(
   "golemTest3; golemTest2"
 )
 lazy val testJVMScala2Command =
-  "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
+  "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; rpcJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
     "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; mediatypeJVM/test; " +
     "openapiJVM/test; smithy/test; codegen/test; htmlJVM/test"
 
 lazy val testJVMScala3Command =
-  "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
+  "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; rpcJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
     "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; mediatypeJVM/test; http-modelJVM/test; " +
     "http-model-schemaJVM/test; endpointJVM/test; openapiJVM/test; smithy/test; codegen/test; htmlJVM/test; datastarJVM/test"
 
 lazy val testJSScala2Command =
-  "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
+  "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; rpcJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
     "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; htmlJS/test"
 
 lazy val testJSScala3Command =
-  "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
+  "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; rpcJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
     "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; http-modelJS/test; http-model-schemaJS/test; endpointJS/test; htmlJS/test; datastarJS/test"
 
 lazy val docJVMScala2Command =
-  "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
+  "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; rpcJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
     "schema-thrift/doc; schema-bson/doc; schema-xmlJVM/doc; schema-yamlJVM/doc; schema-csvJVM/doc; contextJVM/doc; scopeJVM/doc; mediatypeJVM/doc; " +
     "openapiJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc"
 
 lazy val docJVMScala3Command =
-  "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
+  "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; rpcJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
     "schema-thrift/doc; schema-bson/doc; schema-xmlJVM/doc; schema-yamlJVM/doc; schema-csvJVM/doc; contextJVM/doc; scopeJVM/doc; mediatypeJVM/doc; http-modelJVM/doc; " +
     "http-model-schemaJVM/doc; openapiJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc; datastarJVM/doc"
 
 lazy val docJSScala2Command =
-  "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
+  "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; rpcJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
     "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; htmlJS/doc"
 
 lazy val docJSScala3Command =
-  "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
+  "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; rpcJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
     "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; htmlJS/doc; datastarJS/doc"
 
 def commandForScalaVersion(name: String, scala2Command: String, scala3Command: String): Command =
@@ -172,6 +172,8 @@ lazy val root = project
     `scope-examples`,
     schema.jvm,
     schema.js,
+    rpc.jvm,
+    rpc.js,
     `schema-avro`,
     `schema-messagepack`.jvm,
     `schema-messagepack`.js,
@@ -445,6 +447,27 @@ lazy val schema = crossProject(JSPlatform, JVMPlatform)
           "io.github.kitlangton" %%% "neotype" % "0.4.10" % Test
         )
     })
+  )
+
+lazy val rpc = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Full)
+  .dependsOn(schema)
+  .settings(stdSettings("zio-blocks-rpc"))
+  .settings(crossProjectSettings)
+  .settings(buildInfoSettings("zio.blocks.rpc"))
+  .enablePlugins(BuildInfoPlugin)
+  .jsSettings(jsSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "dev.zio" %%% "zio-test"     % "2.1.24" % Test,
+      "dev.zio" %%% "zio-test-sbt" % "2.1.24" % Test
+    ),
+    coverageMinimumStmtTotal   := 80,
+    coverageMinimumBranchTotal := 70,
+    coverageExcludedFiles      := Seq(
+      ".*scala-3/zio/blocks/rpc/.*",
+      ".*BuildInfo.*"
+    ).mkString(";")
   )
 
 lazy val streams = crossProject(JSPlatform, JVMPlatform)

--- a/rpc/shared/src/main/scala-2/zio/blocks/rpc/RPCCompanionVersionSpecific.scala
+++ b/rpc/shared/src/main/scala-2/zio/blocks/rpc/RPCCompanionVersionSpecific.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc
+
+trait RPCCompanionVersionSpecific

--- a/rpc/shared/src/main/scala-2/zio/blocks/rpc/RPCVersionSpecific.scala
+++ b/rpc/shared/src/main/scala-2/zio/blocks/rpc/RPCVersionSpecific.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc
+
+trait RPCVersionSpecific[T]

--- a/rpc/shared/src/main/scala-3/zio/blocks/rpc/RPCCompanionVersionSpecific.scala
+++ b/rpc/shared/src/main/scala-3/zio/blocks/rpc/RPCCompanionVersionSpecific.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc
+
+trait RPCCompanionVersionSpecific {
+  inline def derived[T]: RPC[T] = ${ RPCMacros.derived[T] }
+}

--- a/rpc/shared/src/main/scala-3/zio/blocks/rpc/RPCMacros.scala
+++ b/rpc/shared/src/main/scala-3/zio/blocks/rpc/RPCMacros.scala
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc
+
+import scala.quoted.*
+
+object RPCMacros {
+
+  def derived[T: Type](using Quotes): Expr[RPC[T]] = {
+    import quotes.reflect.*
+
+    val tpe    = TypeRepr.of[T]
+    val tpeSym = tpe.typeSymbol
+
+    if (!tpeSym.isClassDef || !tpeSym.flags.is(Flags.Trait))
+      report.errorAndAbort(s"RPC.derived requires a trait, got: ${tpe.show}")
+
+    val abstractMethods = {
+      val allMethods = tpeSym.methodMembers.filter(_.flags.is(Flags.Deferred))
+      allMethods.filterNot { m =>
+        val owner = m.owner
+        owner == defn.AnyClass || owner == defn.ObjectClass
+      }
+    }
+
+    abstractMethods.foreach { method =>
+      if (abstractMethods.count(_.name == method.name) > 1)
+        report.errorAndAbort(
+          s"Overloaded method '${method.name}' is not supported in RPC traits"
+        )
+
+      method.paramSymss match {
+        case tps :: _ if tps.exists(_.isTypeParam) =>
+          report.errorAndAbort(
+            s"Generic/polymorphic method '${method.name}' is not supported in RPC traits"
+          )
+        case _ => ()
+      }
+
+      val termParamLists = method.paramSymss.filterNot(_.exists(_.isTypeParam))
+      if (termParamLists.size > 1)
+        report.errorAndAbort(
+          s"Curried method '${method.name}' is not supported in RPC traits"
+        )
+    }
+
+    val schemaTpe        = TypeRepr.of[zio.blocks.schema.Schema]
+    val metaAnnotationTR = TypeRepr.of[MetaAnnotation]
+    val decomposerTR     = TypeRepr.of[ReturnTypeDecomposer]
+
+    def summonSchema(paramType: TypeRepr): Term =
+      Implicits.search(schemaTpe.appliedTo(paramType)) match {
+        case s: ImplicitSearchSuccess => s.tree
+        case _                        =>
+          report.errorAndAbort(
+            s"No Schema instance found for ${paramType.show}. Add 'derives Schema' to the type."
+          )
+      }
+
+    val traitAnnotations: List[Term] =
+      tpeSym.annotations.filter(ann => ann.tpe <:< metaAnnotationTR)
+
+    val traitAnnotationsExpr: Expr[zio.blocks.chunk.Chunk[MetaAnnotation]] = {
+      val annExprs = traitAnnotations.map(_.asExpr.asInstanceOf[Expr[MetaAnnotation]])
+      if (annExprs.isEmpty) '{ zio.blocks.chunk.Chunk.empty[MetaAnnotation] }
+      else '{ zio.blocks.chunk.Chunk(${ Varargs(annExprs) }*) }
+    }
+
+    val metadataExpr: Expr[RPC.ServiceMetadata] =
+      '{ RPC.ServiceMetadata($traitAnnotationsExpr) }
+
+    /**
+     * Decompose a return type into (successType, errorType).
+     *
+     *   1. Fast path for Either: extracts type args directly from the dealiased
+     *      type. This is necessary because Scala 3 macro implicit search with
+     *      `ReturnTypeDecomposer` produces refinement types with unresolved
+     *      type variables, causing compiler assertion failures when extracting
+     *      type members via pattern matching.
+     *   2. General fallback via `Implicits.search(ReturnTypeDecomposer[F])` —
+     *      provides extensibility for effect types (ZIO, cats IO, Kyo) added by
+     *      integration modules.
+     *   3. Plain type: success = returnType, error = Nothing.
+     */
+    def decomposeReturnType(returnType: TypeRepr): (TypeRepr, TypeRepr) = {
+      val dealiased = returnType.dealias
+
+      // Fast path: Either is handled directly because extracting type members
+      // from ReturnTypeDecomposer refinement types triggers GADT assertion
+      // failures in the Scala 3 compiler (dotty TypeBounds constraint issue).
+      if (dealiased.typeSymbol.fullName == "scala.util.Either") {
+        val typeArgs = dealiased.typeArgs
+        if (typeArgs.length == 2) {
+          return (typeArgs(1), typeArgs(0)) // (success, error)
+        }
+      }
+
+      // General path: find a ReturnTypeDecomposer instance for non-Either types
+      // (e.g. ZIO, cats IO, Kyo provided by integration modules)
+      val searchType = decomposerTR.appliedTo(returnType)
+      Implicits.search(searchType) match {
+        case s: ImplicitSearchSuccess =>
+          val decompTpe     = s.tree.tpe.dealias
+          val errorMember   = decompTpe.typeSymbol.typeMember("Error")
+          val successMember = decompTpe.typeSymbol.typeMember("Success")
+          if (errorMember != Symbol.noSymbol && successMember != Symbol.noSymbol) {
+            val errorType   = decompTpe.memberType(errorMember).dealias
+            val successType = decompTpe.memberType(successMember).dealias
+            (successType, errorType)
+          } else {
+            (returnType, TypeRepr.of[Nothing])
+          }
+        case _ =>
+          (returnType, TypeRepr.of[Nothing])
+      }
+    }
+
+    val operationExprs: List[Expr[RPC.Operation[?, ?]]] = abstractMethods.map { method =>
+      val methodName = method.name
+
+      val methodType = tpe.memberType(method)
+
+      val (termParams, paramTypes) = methodType match {
+        case MethodType(_, pts, _) =>
+          val paramSyms = method.paramSymss.filterNot(_.exists(_.isTypeParam))
+          val syms      = if (paramSyms.isEmpty) Nil else paramSyms.head
+          (syms, pts)
+        case _ =>
+          (Nil, Nil)
+      }
+
+      val returnType: TypeRepr = methodType match {
+        case MethodType(_, _, rt) => rt
+        case ByNameType(rt)       => rt
+        case other                => other
+      }
+
+      val (aType, eType) = decomposeReturnType(returnType)
+
+      val paramNames: List[String] = termParams.map(_.name)
+
+      val methodAnnotations: List[Expr[MetaAnnotation]] =
+        method.annotations
+          .filter(ann => ann.tpe <:< metaAnnotationTR)
+          .map(_.asExpr.asInstanceOf[Expr[MetaAnnotation]])
+
+      val methodAnnotationsExpr: Expr[zio.blocks.chunk.Chunk[MetaAnnotation]] =
+        if (methodAnnotations.isEmpty) '{ zio.blocks.chunk.Chunk.empty[MetaAnnotation] }
+        else '{ zio.blocks.chunk.Chunk(${ Varargs(methodAnnotations) }*) }
+
+      val paramAnnotationsExpr: Expr[zio.blocks.chunk.Chunk[zio.blocks.chunk.Chunk[MetaAnnotation]]] = {
+        val perParam = termParams.map { p =>
+          val anns = p.annotations
+            .filter(ann => ann.tpe <:< metaAnnotationTR)
+            .map(_.asExpr.asInstanceOf[Expr[MetaAnnotation]])
+          if (anns.isEmpty) '{ zio.blocks.chunk.Chunk.empty[MetaAnnotation] }
+          else '{ zio.blocks.chunk.Chunk(${ Varargs(anns) }*) }
+        }
+        if (perParam.isEmpty) '{ zio.blocks.chunk.Chunk.empty[zio.blocks.chunk.Chunk[MetaAnnotation]] }
+        else '{ zio.blocks.chunk.Chunk(${ Varargs(perParam) }*) }
+      }
+
+      val paramNamesExpr: Expr[zio.blocks.chunk.Chunk[String]] = {
+        val nameExprs = paramNames.map(n => Expr(n))
+        if (nameExprs.isEmpty) '{ zio.blocks.chunk.Chunk.empty[String] }
+        else '{ zio.blocks.chunk.Chunk(${ Varargs(nameExprs) }*) }
+      }
+
+      val opErrorSchemaExpr: Expr[Option[zio.blocks.schema.Schema[?]]] =
+        if (eType =:= TypeRepr.of[Nothing]) '{ None }
+        else {
+          val schemaTree = summonSchema(eType)
+          eType.asType match {
+            case '[e] =>
+              val se = schemaTree.asExpr.asInstanceOf[Expr[zio.blocks.schema.Schema[e]]]
+              '{ Some($se) }
+          }
+        }
+
+      val outputSchemaTree = summonSchema(aType)
+
+      aType.asType match {
+        case '[a] =>
+          val outputSchemaExpr =
+            outputSchemaTree.asExpr.asInstanceOf[Expr[zio.blocks.schema.Schema[a]]]
+
+          buildOperation[a](
+            paramTypes,
+            methodName,
+            outputSchemaExpr,
+            opErrorSchemaExpr,
+            paramNamesExpr,
+            methodAnnotationsExpr,
+            paramAnnotationsExpr,
+            schemaTpe
+          )
+      }
+    }
+
+    val operationsExpr: Expr[zio.blocks.chunk.Chunk[RPC.Operation[?, ?]]] =
+      if (operationExprs.isEmpty) '{ zio.blocks.chunk.Chunk.empty[RPC.Operation[?, ?]] }
+      else '{ zio.blocks.chunk.Chunk(${ Varargs(operationExprs) }*) }
+
+    val labelExpr  = Expr(tpeSym.name)
+    val typeIdExpr = '{ zio.blocks.typeid.TypeId.of[T] }
+
+    '{ RPC[T]($labelExpr, $typeIdExpr, $operationsExpr, $metadataExpr) }
+  }
+
+  private def buildOperation[A: Type](using
+    Quotes
+  )(
+    paramTypes: List[quotes.reflect.TypeRepr],
+    methodName: String,
+    outputSchemaExpr: Expr[zio.blocks.schema.Schema[A]],
+    errorSchemaExpr: Expr[Option[zio.blocks.schema.Schema[?]]],
+    paramNamesExpr: Expr[zio.blocks.chunk.Chunk[String]],
+    methodAnnotationsExpr: Expr[zio.blocks.chunk.Chunk[MetaAnnotation]],
+    paramAnnotationsExpr: Expr[zio.blocks.chunk.Chunk[zio.blocks.chunk.Chunk[MetaAnnotation]]],
+    schemaTpe: quotes.reflect.TypeRepr
+  ): Expr[RPC.Operation[?, ?]] = {
+    import quotes.reflect.*
+
+    def summonSchemaLocal(paramType: TypeRepr): Term =
+      Implicits.search(schemaTpe.appliedTo(paramType)) match {
+        case s: ImplicitSearchSuccess => s.tree
+        case _                        =>
+          report.errorAndAbort(
+            s"No Schema instance found for ${paramType.show}. Add 'derives Schema' to the type."
+          )
+      }
+
+    paramTypes.size match {
+      case 0 =>
+        val inputSchemaExpr = '{ zio.blocks.schema.Schema.unit }
+        '{
+          RPC.Operation[Unit, A](
+            ${ Expr(methodName) },
+            $inputSchemaExpr,
+            $outputSchemaExpr,
+            $errorSchemaExpr,
+            $paramNamesExpr,
+            $methodAnnotationsExpr,
+            $paramAnnotationsExpr
+          )
+        }
+
+      case 1 =>
+        val pt              = paramTypes.head
+        val inputSchemaTree = summonSchemaLocal(pt)
+        pt.asType match {
+          case '[p] =>
+            val inputSchemaExpr =
+              inputSchemaTree.asExpr.asInstanceOf[Expr[zio.blocks.schema.Schema[p]]]
+            '{
+              RPC.Operation[p, A](
+                ${ Expr(methodName) },
+                $inputSchemaExpr,
+                $outputSchemaExpr,
+                $errorSchemaExpr,
+                $paramNamesExpr,
+                $methodAnnotationsExpr,
+                $paramAnnotationsExpr
+              )
+            }
+        }
+
+      case n =>
+        val tupleTypeRepr = defn.TupleClass(n).typeRef.appliedTo(paramTypes)
+        tupleTypeRepr.asType match {
+          case '[t] =>
+            val inputSchemaExpr: Expr[zio.blocks.schema.Schema[t]] =
+              Implicits.search(schemaTpe.appliedTo(tupleTypeRepr)) match {
+                case s: ImplicitSearchSuccess =>
+                  s.tree.asExpr.asInstanceOf[Expr[zio.blocks.schema.Schema[t]]]
+                case _ =>
+                  '{ zio.blocks.schema.Schema.derived[t] }
+              }
+            '{
+              RPC.Operation[t, A](
+                ${ Expr(methodName) },
+                $inputSchemaExpr,
+                $outputSchemaExpr,
+                $errorSchemaExpr,
+                $paramNamesExpr,
+                $methodAnnotationsExpr,
+                $paramAnnotationsExpr
+              )
+            }
+        }
+    }
+  }
+}

--- a/rpc/shared/src/main/scala-3/zio/blocks/rpc/RPCVersionSpecific.scala
+++ b/rpc/shared/src/main/scala-3/zio/blocks/rpc/RPCVersionSpecific.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc
+
+trait RPCVersionSpecific[T]

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/RPC.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/RPC.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc
+
+import zio.blocks.schema.Schema
+import zio.blocks.chunk.Chunk
+import zio.blocks.typeid.TypeId
+
+/**
+ * A `RPC` is a data type that contains reified information on the structure of
+ * a service trait, together with schemas for its operations' input and output
+ * types.
+ *
+ * @tparam T
+ *   The service trait type
+ */
+final case class RPC[T](
+  label: String,
+  typeId: TypeId[T],
+  operations: Chunk[RPC.Operation[?, ?]],
+  metadata: RPC.ServiceMetadata
+) {
+
+  /**
+   * Derives a protocol-specific implementation from this RPC descriptor.
+   *
+   * @tparam P
+   *   The protocol type constructor
+   * @param deriver
+   *   The protocol-specific deriver
+   * @return
+   *   A protocol-specific implementation for this service
+   */
+  def derive[P[_]](deriver: RpcDeriver[P]): P[T] = deriver.deriveService(this)
+}
+
+object RPC extends RPCCompanionVersionSpecific {
+
+  /**
+   * Describes a single operation (method) of a service trait.
+   *
+   * @tparam Input
+   *   The combined input type (product of all parameters)
+   * @tparam Output
+   *   The success type
+   */
+  final case class Operation[Input, Output](
+    name: String,
+    inputSchema: Schema[Input],
+    outputSchema: Schema[Output],
+    errorSchema: Option[Schema[?]],
+    parameterNames: Chunk[String],
+    annotations: Chunk[MetaAnnotation],
+    parameterAnnotations: Chunk[Chunk[MetaAnnotation]]
+  )
+
+  /**
+   * Service-level metadata extracted from trait annotations.
+   */
+  final case class ServiceMetadata(
+    annotations: Chunk[MetaAnnotation]
+  )
+}

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/RPC.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/RPC.scala
@@ -36,14 +36,14 @@ final case class RPC[T](
 ) {
 
   /**
-   * Derives a protocol-specific implementation from this RPC descriptor.
+   * Derives a protocol-specific artifact from this RPC descriptor.
    *
    * @tparam P
    *   The protocol type constructor
    * @param deriver
    *   The protocol-specific deriver
    * @return
-   *   A protocol-specific implementation for this service
+   *   A protocol-specific artifact for this service descriptor
    */
   def derive[P[_]](deriver: RpcDeriver[P]): P[T] = deriver.deriveService(this)
 }

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/ReturnTypeDecomposer.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/ReturnTypeDecomposer.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc
+
+/**
+ * Compile-time type class that decomposes a method return type into error and
+ * success components.
+ *
+ * The RPC derivation macro summons this via implicit search to determine how to
+ * extract error and success types from service trait method return types.
+ *
+ * Built-in instance: `Either[E, A]` decomposes to error=E, success=A.
+ *
+ * Plain return types (not wrapped in Either or an effect) do not require a
+ * `ReturnTypeDecomposer` instance — the macro handles them directly as
+ * success-only with `error = Nothing`.
+ *
+ * For effect types (ZIO, cats IO, Kyo), add a dependency on the corresponding
+ * rpc integration module which provides the appropriate decomposer instance.
+ */
+trait ReturnTypeDecomposer[F] {
+  type Error
+  type Success
+}
+
+object ReturnTypeDecomposer {
+  type Aux[F, E, S] = ReturnTypeDecomposer[F] { type Error = E; type Success = S }
+
+  implicit def eitherDecomposer[E, A]: Aux[Either[E, A], E, A] =
+    new ReturnTypeDecomposer[Either[E, A]] {
+      type Error   = E
+      type Success = A
+    }
+}

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/RpcDeriver.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/RpcDeriver.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc
+
+/**
+ * Trait for protocol-specific derivation from an RPC descriptor. Analogous to
+ * Schema's `Deriver[TC[_]]`, but operates at service level.
+ *
+ * @tparam Protocol
+ *   The protocol-specific type class to derive
+ */
+trait RpcDeriver[Protocol[_]] {
+
+  /**
+   * Derives a protocol-specific implementation from an RPC service descriptor.
+   *
+   * @tparam T
+   *   The service trait type
+   * @param rpc
+   *   The RPC descriptor for the service
+   * @return
+   *   A protocol-specific implementation for the service
+   */
+  def deriveService[T](rpc: RPC[T]): Protocol[T]
+}

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/RpcDeriver.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/RpcDeriver.scala
@@ -21,19 +21,19 @@ package zio.blocks.rpc
  * Schema's `Deriver[TC[_]]`, but operates at service level.
  *
  * @tparam Protocol
- *   The protocol-specific type class to derive
+ *   The protocol-specific artifact to derive
  */
 trait RpcDeriver[Protocol[_]] {
 
   /**
-   * Derives a protocol-specific implementation from an RPC service descriptor.
+   * Derives a protocol-specific artifact from an RPC service descriptor.
    *
    * @tparam T
    *   The service trait type
    * @param rpc
    *   The RPC descriptor for the service
    * @return
-   *   A protocol-specific implementation for the service
+   *   A protocol-specific artifact for the service descriptor
    */
   def deriveService[T](rpc: RPC[T]): Protocol[T]
 }

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/RpcFormat.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/RpcFormat.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc
+
+/**
+ * A format that associates a protocol with its deriver. Analogous to Schema's
+ * `Format` trait.
+ *
+ * {{{
+ * // Example usage:
+ * object JsonRpcFormat extends RpcFormat {
+ *   type Protocol[T] = JsonRpcCodec[T]
+ *   def deriver: RpcDeriver[Protocol] = JsonRpcDeriver
+ * }
+ * }}}
+ */
+trait RpcFormat {
+  type Protocol[_]
+  def deriver: RpcDeriver[Protocol]
+}

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/RpcFormat.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/RpcFormat.scala
@@ -23,7 +23,7 @@ package zio.blocks.rpc
  * {{{
  * // Example usage:
  * object JsonRpcFormat extends RpcFormat {
- *   type Protocol[T] = JsonRpcCodec[T]
+ *   type Protocol[T] = JsonRpcProtocol[T]
  *   def deriver: RpcDeriver[Protocol] = JsonRpcDeriver
  * }
  * }}}

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/annotations.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/annotations.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc
+
+import scala.annotation.StaticAnnotation
+
+/**
+ * Base class for user-defined RPC service annotations. Extend this to create
+ * custom annotations for service traits and methods.
+ */
+class MetaAnnotation extends StaticAnnotation

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcCodec.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcCodec.scala
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc.jsonrpc
+
+import scala.util.control.NonFatal
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.json.Json
+
+/**
+ * A JSON-RPC 2.0 handler derived from an RPC service descriptor.
+ * Transport-agnostic: operates on `String => Option[String]`.
+ */
+final class JsonRpcCodec[T](
+  private val operationHandlers: Map[String, JsonRpcCodec.OperationHandler]
+) {
+
+  /**
+   * Handles a JSON-RPC 2.0 request string and returns an optional response
+   * string. Returns `None` for notifications (requests without an `id` field),
+   * as the JSON-RPC 2.0 spec requires no response for notifications.
+   */
+  def handleRequest(request: String): Option[String] =
+    Json.parse(request) match {
+      case Left(_) =>
+        Some(JsonRpcCodec.errorResponse(Json.Null, -32700, "Parse error"))
+      case Right(parsed) =>
+        parsed match {
+          case obj: Json.Object =>
+            val jsonrpcField    = obj.get("jsonrpc").values.flatMap(_.headOption)
+            val hasValidJsonrpc = jsonrpcField.exists {
+              case s: Json.String => s.value == "2.0"
+              case _              => false
+            }
+            if (!hasValidJsonrpc) {
+              Some(
+                JsonRpcCodec
+                  .errorResponse(Json.Null, -32600, "Invalid Request: missing or invalid 'jsonrpc' field")
+              )
+            } else {
+              val rawId          = obj.get("id").values.flatMap(_.headOption)
+              val isNotification = rawId.isEmpty
+              val idJson         = rawId.map {
+                case s: Json.String => s
+                case n: Json.Number => n
+                case _              => Json.Null
+              }
+                .getOrElse(Json.Null)
+
+              val response = obj.get("method").values.flatMap(_.headOption) match {
+                case None =>
+                  JsonRpcCodec.errorResponse(idJson, -32600, "Invalid Request: missing 'method'")
+                case Some(methodJson) =>
+                  methodJson match {
+                    case str: Json.String =>
+                      val methodName = str.value
+                      operationHandlers.get(methodName) match {
+                        case None =>
+                          JsonRpcCodec.errorResponse(idJson, -32601, s"Method not found: $methodName")
+                        case Some(handler) =>
+                          val params = obj.get("params").values.flatMap(_.headOption).getOrElse(Json.Null)
+                          try {
+                            handler.handle(params) match {
+                              case Right(result) => JsonRpcCodec.successResponse(idJson, result)
+                              case Left(error)   =>
+                                JsonRpcCodec.errorResponse(
+                                  idJson,
+                                  -32603,
+                                  Option(error.getMessage).getOrElse("Internal error")
+                                )
+                            }
+                          } catch {
+                            case NonFatal(e) =>
+                              JsonRpcCodec.errorResponse(
+                                idJson,
+                                -32603,
+                                Option(e.getMessage).getOrElse("Internal error")
+                              )
+                          }
+                      }
+                    case _ =>
+                      JsonRpcCodec.errorResponse(idJson, -32600, "Invalid Request: 'method' must be a string")
+                  }
+              }
+              if (isNotification) None else Some(response)
+            }
+          case _ =>
+            Some(JsonRpcCodec.errorResponse(Json.Null, -32600, "Invalid Request: expected JSON object"))
+        }
+    }
+}
+
+object JsonRpcCodec {
+
+  /**
+   * Handles a single JSON-RPC operation by processing raw JSON parameters and
+   * returning a result.
+   *
+   * `params` is the raw JSON from the `"params"` field of the request, or
+   * `Json.Null` if the field is absent.
+   *
+   * Returns `Right(result)` on success (serialized as the `"result"` field) or
+   * `Left(error)` on failure (serialized as a `-32603` internal error).
+   * Non-fatal exceptions thrown during handling are caught and treated as
+   * `Left`.
+   */
+  trait OperationHandler {
+    def handle(params: Json): Either[Throwable, Json]
+  }
+
+  def successResponse(id: Json, result: Json): String =
+    Json
+      .Object(
+        Chunk(
+          ("jsonrpc", Json.String("2.0")),
+          ("result", result),
+          ("id", id)
+        )
+      )
+      .print
+
+  def errorResponse(id: Json, code: Int, message: String): String =
+    Json
+      .Object(
+        Chunk(
+          ("jsonrpc", Json.String("2.0")),
+          (
+            "error",
+            Json.Object(
+              Chunk(
+                ("code", Json.Number(code)),
+                ("message", Json.String(message))
+              )
+            )
+          ),
+          ("id", id)
+        )
+      )
+      .print
+}

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcCodec.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcCodec.scala
@@ -18,14 +18,16 @@ package zio.blocks.rpc.jsonrpc
 
 import scala.util.control.NonFatal
 import zio.blocks.chunk.Chunk
+import zio.blocks.schema.SchemaError
 import zio.blocks.schema.json.Json
 
 /**
- * A low-level JSON-RPC 2.0 dispatcher over raw operation handlers.
+ * A low-level JSON-RPC 2.0 dispatcher over internal JSON operation handlers.
  *
  * This type is transport-agnostic and executable, but intentionally unaware of
  * RPC descriptors or dependency injection. Higher-level runtimes can construct
- * it from a derived protocol contract plus concrete handlers.
+ * it from a derived protocol contract plus concrete typed bindings while raw
+ * JSON remains confined to the wire format boundary.
  */
 final class JsonRpcCodec(
   private val operationHandlers: Map[String, JsonRpcCodec.OperationHandler]
@@ -82,7 +84,7 @@ final class JsonRpcCodec(
                                 JsonRpcCodec.errorResponse(
                                   idJson,
                                   -32603,
-                                  Option(error.getMessage).getOrElse("Internal error")
+                                  JsonRpcCodec.message(error)
                                 )
                             }
                           } catch {
@@ -109,11 +111,10 @@ final class JsonRpcCodec(
 object JsonRpcCodec {
 
   /**
-   * Handles a single JSON-RPC operation by processing raw JSON parameters and
-   * returning a result.
+   * Handles a single JSON-RPC operation at the internal wire boundary.
    *
-   * `params` is the raw JSON from the `"params"` field of the request, or
-   * `Json.Null` if the field is absent.
+   * Public bindings should remain typed; this low-level trait exists only for
+   * the executable JSON-RPC dispatcher after typed protocol binding.
    *
    * Returns `Right(result)` on success (serialized as the `"result"` field) or
    * `Left(error)` on failure (serialized as a `-32603` internal error).
@@ -121,7 +122,12 @@ object JsonRpcCodec {
    * `Left`.
    */
   trait OperationHandler {
-    def handle(params: Json): Either[Throwable, Json]
+    def handle(params: Json): Either[SchemaError, Json]
+  }
+
+  private[jsonrpc] def message(error: SchemaError): String = {
+    val rendered = error.toString
+    if (rendered == null || rendered.isEmpty) "Internal error" else rendered
   }
 
   def successResponse(id: Json, result: Json): String =

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcCodec.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcCodec.scala
@@ -21,10 +21,13 @@ import zio.blocks.chunk.Chunk
 import zio.blocks.schema.json.Json
 
 /**
- * A JSON-RPC 2.0 handler derived from an RPC service descriptor.
- * Transport-agnostic: operates on `String => Option[String]`.
+ * A low-level JSON-RPC 2.0 dispatcher over raw operation handlers.
+ *
+ * This type is transport-agnostic and executable, but intentionally unaware of
+ * RPC descriptors or dependency injection. Higher-level runtimes can construct
+ * it from a derived protocol contract plus concrete handlers.
  */
-final class JsonRpcCodec[T](
+final class JsonRpcCodec(
   private val operationHandlers: Map[String, JsonRpcCodec.OperationHandler]
 ) {
 

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcCodecs.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcCodecs.scala
@@ -16,12 +16,10 @@
 
 package zio.blocks.rpc.jsonrpc
 
-import zio.blocks.rpc._
+import zio.blocks.schema.Schema
+import zio.blocks.schema.json.{JsonCodec, JsonFormat}
 
-/**
- * RpcFormat for JSON-RPC 2.0 protocol.
- */
-object JsonRpcFormat extends RpcFormat {
-  type Protocol[T] = JsonRpcProtocol[T]
-  def deriver: RpcDeriver[JsonRpcProtocol] = JsonRpcDeriver
+private[jsonrpc] object JsonRpcCodecs {
+  def derive(schema: Schema[?]): JsonCodec[?] =
+    schema.asInstanceOf[Schema[Any]].derive(JsonFormat).asInstanceOf[JsonCodec[?]]
 }

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcDeriver.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcDeriver.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc.jsonrpc
+
+import zio.blocks.rpc._
+import zio.blocks.schema.json.Json
+
+/**
+ * RpcDeriver that produces JsonRpcCodec instances from RPC descriptors.
+ */
+object JsonRpcDeriver extends RpcDeriver[JsonRpcCodec] {
+
+  override def deriveService[T](rpc: RPC[T]): JsonRpcCodec[T] = {
+    val handlers = rpc.operations.foldLeft(Map.empty[String, JsonRpcCodec.OperationHandler]) { (acc, op) =>
+      acc + (op.name -> createHandler(op))
+    }
+    new JsonRpcCodec[T](handlers)
+  }
+
+  private def createHandler(op: RPC.Operation[?, ?]): JsonRpcCodec.OperationHandler =
+    new JsonRpcCodec.OperationHandler {
+      def handle(params: Json): Either[Throwable, Json] =
+        Left(
+          new UnsupportedOperationException(
+            s"Operation '${op.name}' handler not bound to a service implementation"
+          )
+        )
+    }
+}

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcDeriver.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcDeriver.scala
@@ -17,27 +17,31 @@
 package zio.blocks.rpc.jsonrpc
 
 import zio.blocks.rpc._
-import zio.blocks.schema.json.Json
 
 /**
- * RpcDeriver that produces JsonRpcCodec instances from RPC descriptors.
+ * RpcDeriver that produces transport-neutral JSON-RPC contracts from RPC
+ * descriptors.
  */
-object JsonRpcDeriver extends RpcDeriver[JsonRpcCodec] {
+object JsonRpcDeriver extends RpcDeriver[JsonRpcProtocol] {
 
-  override def deriveService[T](rpc: RPC[T]): JsonRpcCodec[T] = {
-    val handlers = rpc.operations.foldLeft(Map.empty[String, JsonRpcCodec.OperationHandler]) { (acc, op) =>
-      acc + (op.name -> createHandler(op))
-    }
-    new JsonRpcCodec[T](handlers)
-  }
-
-  private def createHandler(op: RPC.Operation[?, ?]): JsonRpcCodec.OperationHandler =
-    new JsonRpcCodec.OperationHandler {
-      def handle(params: Json): Either[Throwable, Json] =
-        Left(
-          new UnsupportedOperationException(
-            s"Operation '${op.name}' handler not bound to a service implementation"
-          )
+  override def deriveService[T](rpc: RPC[T]): JsonRpcProtocol[T] =
+    JsonRpcProtocol[T](
+      serviceName = rpc.label,
+      serviceTypeId = rpc.typeId,
+      operations = rpc.operations.map { op =>
+        JsonRpcProtocol.Operation(
+          name = op.name,
+          inputSchema = op.inputSchema,
+          inputCodec = JsonRpcCodecs.derive(op.inputSchema),
+          outputSchema = op.outputSchema,
+          outputCodec = JsonRpcCodecs.derive(op.outputSchema),
+          errorSchema = op.errorSchema,
+          errorCodec = op.errorSchema.map(JsonRpcCodecs.derive),
+          parameterNames = op.parameterNames,
+          annotations = op.annotations,
+          parameterAnnotations = op.parameterAnnotations
         )
-    }
+      },
+      metadata = rpc.metadata
+    )
 }

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcFormat.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcFormat.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc.jsonrpc
+
+import zio.blocks.rpc._
+
+/**
+ * RpcFormat for JSON-RPC 2.0 protocol.
+ */
+object JsonRpcFormat extends RpcFormat {
+  type Protocol[T] = JsonRpcCodec[T]
+  def deriver: RpcDeriver[JsonRpcCodec] = JsonRpcDeriver
+}

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcProtocol.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcProtocol.scala
@@ -52,8 +52,10 @@ final case class JsonRpcProtocol[T](
     val extra   = boundNames.filterNot(bound => expectedNames.contains(bound))
 
     val errors = Chunk.empty[String] ++
-      (if (missing.nonEmpty) Chunk(s"Missing JSON-RPC handlers for operations: ${missing.mkString(", ")}") else Chunk.empty) ++
-      (if (extra.nonEmpty) Chunk(s"Unknown JSON-RPC handlers supplied for operations: ${extra.mkString(", ")}") else Chunk.empty)
+      (if (missing.nonEmpty) Chunk(s"Missing JSON-RPC handlers for operations: ${missing.mkString(", ")}")
+       else Chunk.empty) ++
+      (if (extra.nonEmpty) Chunk(s"Unknown JSON-RPC handlers supplied for operations: ${extra.mkString(", ")}")
+       else Chunk.empty)
 
     if (errors.nonEmpty) Left(errors.mkString("; "))
     else {

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcProtocol.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcProtocol.scala
@@ -66,8 +66,8 @@ final case class JsonRpcProtocol[T](
    * Binds a single typed operation handler and produces an executable codec.
    *
    * This reference binding keeps the public API in terms of typed values plus
-   * the derived operation schemas/codecs, while raw JSON remains internal to the
-   * wire format boundary.
+   * the derived operation schemas/codecs, while raw JSON remains internal to
+   * the wire format boundary.
    */
   def bind[Input, Output](
     name: String
@@ -78,7 +78,7 @@ final case class JsonRpcProtocol[T](
     val operationOpt = operations.find(_.name == name)
 
     operationOpt match {
-      case None => Left(s"Unknown JSON-RPC operation: $name")
+      case None            => Left(s"Unknown JSON-RPC operation: $name")
       case Some(operation) =>
         validateSchema(name, "input", operation.inputSchema, inputSchema)
           .flatMap(_ => validateSchema(name, "output", operation.outputSchema, outputSchema))
@@ -90,7 +90,8 @@ final case class JsonRpcProtocol[T](
                   handle = params => {
                     val typedInput = operation.inputCodec.asInstanceOf[JsonCodec[Input]].decodeValue(params)
                     try {
-                      handler(typedInput).map(output => operation.outputCodec.asInstanceOf[JsonCodec[Output]].encodeValue(output))
+                      handler(typedInput)
+                        .map(output => operation.outputCodec.asInstanceOf[JsonCodec[Output]].encodeValue(output))
                     } catch {
                       case NonFatal(error) => Left(SchemaError(error.getMessage))
                     }
@@ -117,7 +118,8 @@ final case class JsonRpcProtocol[T](
 
 object JsonRpcProtocol {
 
-  private[jsonrpc] /** Internal raw JSON handler after typed binding. */
+  private[jsonrpc]
+  /** Internal raw JSON handler after typed binding. */
   final case class BoundOperation(
     name: String,
     handle: Json => Either[SchemaError, Json]

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcProtocol.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcProtocol.scala
@@ -16,11 +16,11 @@
 
 package zio.blocks.rpc.jsonrpc
 
+import scala.util.control.NonFatal
 import zio.blocks.chunk.Chunk
 import zio.blocks.rpc.{MetaAnnotation, RPC}
-import zio.blocks.schema.Schema
-import zio.blocks.schema.json.Json
-import zio.blocks.schema.json.JsonCodec
+import zio.blocks.schema.{Schema, SchemaError}
+import zio.blocks.schema.json.{Json, JsonCodec}
 import zio.blocks.typeid.TypeId
 
 /**
@@ -37,14 +37,7 @@ final case class JsonRpcProtocol[T](
   metadata: RPC.ServiceMetadata
 ) {
 
-  /**
-   * Binds this protocol to concrete JSON-RPC handlers, producing an executable
-   * low-level dispatcher for testing or reference integrations.
-   *
-   * Every declared operation must have a corresponding handler and no unknown
-   * handlers may be supplied.
-   */
-  def bindHandlers(handlers: Chunk[JsonRpcProtocol.BoundOperation]): Either[String, JsonRpcCodec] = {
+  private[jsonrpc] def bindHandlers(handlers: Chunk[JsonRpcProtocol.BoundOperation]): Either[String, JsonRpcCodec] = {
     val expectedNames = operations.map(_.name)
     val boundNames    = handlers.map(_.name)
 
@@ -61,21 +54,73 @@ final case class JsonRpcProtocol[T](
     else {
       val handlerMap = handlers.foldLeft(Map.empty[String, JsonRpcCodec.OperationHandler]) { (acc, handler) =>
         acc + (handler.name -> new JsonRpcCodec.OperationHandler {
-          def handle(params: Json): Either[Throwable, Json] = handler.handle(params)
+          def handle(params: Json): Either[SchemaError, Json] = handler.handle(params)
         })
       }
 
       Right(new JsonRpcCodec(handlerMap))
     }
   }
+
+  /**
+   * Binds a single typed operation handler and produces an executable codec.
+   *
+   * This reference binding keeps the public API in terms of typed values plus
+   * the derived operation schemas/codecs, while raw JSON remains internal to the
+   * wire format boundary.
+   */
+  def bind[Input, Output](
+    name: String
+  )(handler: Input => Either[SchemaError, Output])(implicit
+    inputSchema: Schema[Input],
+    outputSchema: Schema[Output]
+  ): Either[String, JsonRpcCodec] = {
+    val operationOpt = operations.find(_.name == name)
+
+    operationOpt match {
+      case None => Left(s"Unknown JSON-RPC operation: $name")
+      case Some(operation) =>
+        validateSchema(name, "input", operation.inputSchema, inputSchema)
+          .flatMap(_ => validateSchema(name, "output", operation.outputSchema, outputSchema))
+          .flatMap(_ =>
+            bindHandlers(
+              Chunk(
+                JsonRpcProtocol.BoundOperation(
+                  name = name,
+                  handle = params => {
+                    val typedInput = operation.inputCodec.asInstanceOf[JsonCodec[Input]].decodeValue(params)
+                    try {
+                      handler(typedInput).map(output => operation.outputCodec.asInstanceOf[JsonCodec[Output]].encodeValue(output))
+                    } catch {
+                      case NonFatal(error) => Left(SchemaError(error.getMessage))
+                    }
+                  }
+                )
+              )
+            )
+          )
+    }
+  }
+
+  private def validateSchema[A](
+    operationName: String,
+    label: String,
+    actual: Schema[?],
+    expected: Schema[A]
+  ): Either[String, Unit] =
+    if (actual.reflect.typeId == expected.reflect.typeId) Right(())
+    else
+      Left(
+        s"JSON-RPC operation '$operationName' has $label schema ${actual.reflect.typeId}, but binding expects ${expected.reflect.typeId}"
+      )
 }
 
 object JsonRpcProtocol {
 
-  /** A concrete handler binding for a protocol operation. */
+  private[jsonrpc] /** Internal raw JSON handler after typed binding. */
   final case class BoundOperation(
     name: String,
-    handle: Json => Either[Throwable, Json]
+    handle: Json => Either[SchemaError, Json]
   )
 
   /**

--- a/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcProtocol.scala
+++ b/rpc/shared/src/main/scala/zio/blocks/rpc/jsonrpc/JsonRpcProtocol.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc.jsonrpc
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.rpc.{MetaAnnotation, RPC}
+import zio.blocks.schema.Schema
+import zio.blocks.schema.json.Json
+import zio.blocks.schema.json.JsonCodec
+import zio.blocks.typeid.TypeId
+
+/**
+ * A transport-neutral JSON-RPC 2.0 contract derived from an RPC descriptor.
+ *
+ * External runtimes can use this contract to build concrete Netty, Node, Wasm,
+ * browser, or other server/client implementations without storing executable
+ * logic in the descriptor itself.
+ */
+final case class JsonRpcProtocol[T](
+  serviceName: String,
+  serviceTypeId: TypeId[T],
+  operations: Chunk[JsonRpcProtocol.Operation],
+  metadata: RPC.ServiceMetadata
+) {
+
+  /**
+   * Binds this protocol to concrete JSON-RPC handlers, producing an executable
+   * low-level dispatcher for testing or reference integrations.
+   *
+   * Every declared operation must have a corresponding handler and no unknown
+   * handlers may be supplied.
+   */
+  def bindHandlers(handlers: Chunk[JsonRpcProtocol.BoundOperation]): Either[String, JsonRpcCodec] = {
+    val expectedNames = operations.map(_.name)
+    val boundNames    = handlers.map(_.name)
+
+    val missing = expectedNames.filterNot(expected => boundNames.contains(expected))
+    val extra   = boundNames.filterNot(bound => expectedNames.contains(bound))
+
+    val errors = Chunk.empty[String] ++
+      (if (missing.nonEmpty) Chunk(s"Missing JSON-RPC handlers for operations: ${missing.mkString(", ")}") else Chunk.empty) ++
+      (if (extra.nonEmpty) Chunk(s"Unknown JSON-RPC handlers supplied for operations: ${extra.mkString(", ")}") else Chunk.empty)
+
+    if (errors.nonEmpty) Left(errors.mkString("; "))
+    else {
+      val handlerMap = handlers.foldLeft(Map.empty[String, JsonRpcCodec.OperationHandler]) { (acc, handler) =>
+        acc + (handler.name -> new JsonRpcCodec.OperationHandler {
+          def handle(params: Json): Either[Throwable, Json] = handler.handle(params)
+        })
+      }
+
+      Right(new JsonRpcCodec(handlerMap))
+    }
+  }
+}
+
+object JsonRpcProtocol {
+
+  /** A concrete handler binding for a protocol operation. */
+  final case class BoundOperation(
+    name: String,
+    handle: Json => Either[Throwable, Json]
+  )
+
+  /**
+   * JSON-RPC-specific information for a single RPC operation.
+   *
+   * `inputCodec` encodes and decodes the combined input value described by
+   * `inputSchema`. Concrete runtimes are responsible for mapping this combined
+   * value to and from the JSON-RPC `params` representation they choose to
+   * support.
+   */
+  final case class Operation(
+    name: String,
+    inputSchema: Schema[?],
+    inputCodec: JsonCodec[?],
+    outputSchema: Schema[?],
+    outputCodec: JsonCodec[?],
+    errorSchema: Option[Schema[?]],
+    errorCodec: Option[JsonCodec[?]],
+    parameterNames: Chunk[String],
+    annotations: Chunk[MetaAnnotation],
+    parameterAnnotations: Chunk[Chunk[MetaAnnotation]]
+  )
+}

--- a/rpc/shared/src/test/scala-3/zio/blocks/rpc/RPCMacroSpec.scala
+++ b/rpc/shared/src/test/scala-3/zio/blocks/rpc/RPCMacroSpec.scala
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc
+
+import zio.test.*
+import zio.blocks.rpc.fixtures.*
+import zio.blocks.typeid.TypeId
+
+object RPCMacroSpec extends ZIOSpecDefault {
+  def spec = suite("RPCMacroSpec")(
+    suite("Macro derivation")(
+      test("GreeterService - single method") {
+        val rpc = RPC.derived[GreeterService]
+        assertTrue(
+          rpc.label == "GreeterService",
+          rpc.operations.length == 1,
+          rpc.operations(0).name == "greet",
+          rpc.operations(0).parameterNames.length == 1,
+          rpc.operations(0).parameterNames(0) == "name"
+        )
+      },
+      test("TodoService - multi-method") {
+        val rpc = RPC.derived[TodoService]
+        assertTrue(
+          rpc.operations.length == 3,
+          rpc.operations.map(_.name).toSet == Set("getTodo", "createTodo", "listTodos")
+        )
+      },
+      test("EmptyService - no methods") {
+        val rpc = RPC.derived[EmptyService]
+        assertTrue(rpc.operations.isEmpty)
+      },
+      test("HealthService - zero params") {
+        val rpc = RPC.derived[HealthService]
+        assertTrue(
+          rpc.operations.length == 1,
+          rpc.operations(0).parameterNames.isEmpty
+        )
+      },
+      test("SearchService - multi params") {
+        val rpc = RPC.derived[SearchService]
+        assertTrue(
+          rpc.operations(0).parameterNames.length == 3,
+          rpc.operations(0).parameterNames(0) == "query",
+          rpc.operations(0).parameterNames(1) == "limit",
+          rpc.operations(0).parameterNames(2) == "offset"
+        )
+      },
+      test("ErrorService - Either return type has error schema") {
+        val rpc = RPC.derived[ErrorService]
+        assertTrue(rpc.operations(0).errorSchema.isDefined)
+      },
+      test("AnnotatedService - method annotations") {
+        val rpc      = RPC.derived[AnnotatedService]
+        val lookupOp = rpc.operations.find(_.name == "lookup").get
+        assertTrue(lookupOp.annotations.exists(_.isInstanceOf[Idempotent]))
+      },
+      test("GreeterService - plain return type has no error schema") {
+        val rpc = RPC.derived[GreeterService]
+        assertTrue(rpc.operations(0).errorSchema.isEmpty)
+      },
+      test("TodoService - Either has error schema") {
+        val rpc = RPC.derived[TodoService]
+        assertTrue(rpc.operations(0).errorSchema.isDefined)
+      },
+      test("TodoService - createTodo has 2 params") {
+        val rpc      = RPC.derived[TodoService]
+        val createOp = rpc.operations.find(_.name == "createTodo").get
+        assertTrue(
+          createOp.parameterNames.length == 2,
+          createOp.parameterNames(0) == "title",
+          createOp.parameterNames(1) == "description"
+        )
+      },
+      test("AnnotatedService - subscribe has no extra annotations") {
+        val rpc         = RPC.derived[AnnotatedService]
+        val subscribeOp = rpc.operations.find(_.name == "subscribe").get
+        assertTrue(subscribeOp.annotations.isEmpty)
+      },
+      test("ErrorService - operation error schema from Either") {
+        val rpc = RPC.derived[ErrorService]
+        assertTrue(rpc.operations(0).errorSchema.isDefined)
+      },
+      test("AnnotatedService - Either methods have error schema") {
+        val rpc = RPC.derived[AnnotatedService]
+        assertTrue(rpc.operations.forall(_.errorSchema.isDefined))
+      },
+      test("InheritedService - includes parent methods") {
+        val rpc = RPC.derived[InheritedService]
+        assertTrue(
+          rpc.operations.map(_.name).toSet == Set("parentMethod", "childMethod")
+        )
+      },
+      test("MultiAnnotatedService - multiple annotations on same method") {
+        val rpc = RPC.derived[MultiAnnotatedService]
+        val op  = rpc.operations(0)
+        assertTrue(
+          op.annotations.length == 2,
+          op.annotations.exists(_.isInstanceOf[Idempotent]),
+          op.annotations.exists(_.isInstanceOf[RpcDeprecated])
+        )
+      }
+    ),
+    suite("Schema round-trip tests")(
+      test("GreeterService - outputSchema has correct TypeId for String") {
+        val rpc    = RPC.derived[GreeterService]
+        val actual = rpc.operations(0).outputSchema.reflect.typeId
+        assertTrue(actual == TypeId.of[String])
+      },
+      test("TodoService - inputSchema captures parameter type Int for getTodo") {
+        val rpc    = RPC.derived[TodoService]
+        val actual = rpc.operations.find(_.name == "getTodo").get.inputSchema.reflect.typeId
+        assertTrue(actual == TypeId.of[Int])
+      },
+      test("SearchService - inputSchema is tuple for multi-params") {
+        val rpc    = RPC.derived[SearchService]
+        val actual = rpc.operations(0).inputSchema.reflect.typeId
+        assertTrue(actual == TypeId.of[(String, Int, Int)])
+      },
+      test("HealthService - inputSchema is Unit for zero params") {
+        val rpc    = RPC.derived[HealthService]
+        val actual = rpc.operations(0).inputSchema.reflect.typeId
+        assertTrue(actual == TypeId.of[Unit])
+      },
+      test("TodoService - output schema for getTodo is Todo") {
+        val rpc    = RPC.derived[TodoService]
+        val actual = rpc.operations.find(_.name == "getTodo").get.outputSchema.reflect.typeId
+        assertTrue(actual == TypeId.of[Todo])
+      },
+      test("TodoService - listTodos output is List[Todo]") {
+        val rpc    = RPC.derived[TodoService]
+        val actual = rpc.operations.find(_.name == "listTodos").get.outputSchema.reflect.typeId
+        assertTrue(actual == TypeId.of[List[Todo]])
+      },
+      test("typeId captures service trait identity") {
+        val rpc = RPC.derived[GreeterService]
+        assertTrue(rpc.typeId == TypeId.of[GreeterService])
+      }
+    ),
+    suite("RPC.derive integration")(
+      test("RPC.derive convenience method compiles and works") {
+        val rpc         = RPC.derived[GreeterService]
+        val testDeriver = new RpcDeriver[List] {
+          def deriveService[T](rpc: RPC[T]): List[T] = Nil
+        }
+        val result = rpc.derive(testDeriver)
+        assertTrue(result == Nil)
+      },
+      test("RPC.derived label matches trait name") {
+        val rpc = RPC.derived[GreeterService]
+        assertTrue(rpc.label == "GreeterService")
+      }
+    )
+  )
+}

--- a/rpc/shared/src/test/scala-3/zio/blocks/rpc/fixtures/TestFixtures.scala
+++ b/rpc/shared/src/test/scala-3/zio/blocks/rpc/fixtures/TestFixtures.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc.fixtures
+
+import zio.blocks.schema.Schema
+import zio.blocks.rpc.MetaAnnotation
+
+// === Test Data Types (all with Schema derivation) ===
+
+case class Todo(id: Int, title: String) derives Schema
+
+case class SearchResult(items: List[String], total: Int) derives Schema
+
+case class ServiceError(code: Int, message: String) derives Schema
+
+case class BasicError(msg: String) derives Schema
+
+sealed trait Status derives Schema
+case object Healthy  extends Status
+case object Degraded extends Status
+
+// === Test Annotations ===
+
+class Idempotent extends MetaAnnotation
+
+class RpcDeprecated(reason: String) extends MetaAnnotation
+
+// === Service Trait Fixtures ===
+
+// Simple single-method service — plain return type (no error)
+trait GreeterService {
+  def greet(name: String): String
+}
+
+// Multi-method service — Either return types
+trait TodoService {
+  def getTodo(id: Int): Either[ServiceError, Todo]
+  def createTodo(title: String, description: String): Either[ServiceError, Todo]
+  def listTodos(): Either[ServiceError, List[Todo]]
+}
+
+// Empty service (edge case)
+trait EmptyService
+
+// Zero-param method — plain return type
+trait HealthService {
+  def health(): Status
+}
+
+// Multi-param method
+trait SearchService {
+  def search(query: String, limit: Int, offset: Int): Either[ServiceError, SearchResult]
+}
+
+// Service with error types from Either
+trait ErrorService {
+  def riskyOp(input: String): Either[ServiceError, String]
+}
+
+// Service with method-level annotations
+trait AnnotatedService {
+  @Idempotent
+  def lookup(id: Long): Either[BasicError, String]
+  def subscribe(topic: String): Either[BasicError, Unit]
+}
+
+// Parent service trait for inheritance tests
+trait ParentService {
+  def parentMethod(x: String): String
+}
+
+// Child inherits parent
+trait InheritedService extends ParentService {
+  def childMethod(y: Int): Either[BasicError, String]
+}
+
+// Multiple annotations on one method
+trait MultiAnnotatedService {
+  @Idempotent @RpcDeprecated("old")
+  def dualAnnotated(id: Long): String
+}

--- a/rpc/shared/src/test/scala-3/zio/blocks/rpc/jsonrpc/JsonRpcIntegrationSpec.scala
+++ b/rpc/shared/src/test/scala-3/zio/blocks/rpc/jsonrpc/JsonRpcIntegrationSpec.scala
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.rpc.jsonrpc
+
+import zio.test._
+import zio.blocks.rpc._
+import zio.blocks.rpc.fixtures._
+import zio.blocks.schema.json.Json
+
+object JsonRpcIntegrationSpec extends ZIOSpecDefault {
+
+  private def extractField(json: Json, key: String): Option[Json] =
+    json.get(key).values.flatMap(_.headOption)
+
+  private def extractString(json: Json, key: String): Option[String] =
+    extractField(json, key).collect { case s: Json.String => s.value }
+
+  private def extractNumber(json: Json, key: String): Option[BigDecimal] =
+    extractField(json, key).collect { case n: Json.Number => n.value }
+
+  private def parseResponse(raw: String): Json =
+    Json.parse(raw) match {
+      case Right(j) => j
+      case Left(e)  => throw e
+    }
+
+  private val greeterCodec = new JsonRpcCodec[GreeterService](
+    Map(
+      "greet" -> new JsonRpcCodec.OperationHandler {
+        def handle(params: Json): Either[Throwable, Json] = {
+          val name = extractString(params, "name").getOrElse("unknown")
+          Right(Json.String(s"Hello, $name!"))
+        }
+      }
+    )
+  )
+
+  private val failingCodec = new JsonRpcCodec[GreeterService](
+    Map(
+      "greet" -> new JsonRpcCodec.OperationHandler {
+        def handle(params: Json): Either[Throwable, Json] =
+          Left(new RuntimeException("Something went wrong"))
+      }
+    )
+  )
+
+  def spec = suite("JsonRpcIntegrationSpec")(
+    suite("successful request-response round-trip")(
+      test("returns correct result with string param") {
+        val request  = """{"jsonrpc":"2.0","method":"greet","params":{"name":"world"},"id":1}"""
+        val raw      = greeterCodec.handleRequest(request).get
+        val response = parseResponse(raw)
+        val result   = extractField(response, "result")
+        val jsonrpc  = extractString(response, "jsonrpc")
+        assertTrue(
+          jsonrpc.contains("2.0"),
+          result.exists {
+            case s: Json.String => s.value == "Hello, world!"
+            case _              => false
+          }
+        )
+      },
+      test("preserves request id in response") {
+        val request  = """{"jsonrpc":"2.0","method":"greet","params":{"name":"test"},"id":42}"""
+        val raw      = greeterCodec.handleRequest(request).get
+        val response = parseResponse(raw)
+        val id       = extractNumber(response, "id")
+        assertTrue(id.contains(BigDecimal(42)))
+      }
+    ),
+    suite("error handling")(
+      test("method not found returns -32601") {
+        val request  = """{"jsonrpc":"2.0","method":"nonexistent","params":{},"id":1}"""
+        val raw      = greeterCodec.handleRequest(request).get
+        val response = parseResponse(raw)
+        val error    = extractField(response, "error")
+        val code     = error.flatMap(e => extractNumber(e, "code"))
+        assertTrue(code.contains(BigDecimal(-32601)))
+      },
+      test("parse error returns -32700") {
+        val request  = "not valid json{{"
+        val raw      = greeterCodec.handleRequest(request).get
+        val response = parseResponse(raw)
+        val error    = extractField(response, "error")
+        val code     = error.flatMap(e => extractNumber(e, "code"))
+        assertTrue(code.contains(BigDecimal(-32700)))
+      },
+      test("missing method returns -32600") {
+        val request  = """{"jsonrpc":"2.0","params":{},"id":1}"""
+        val raw      = greeterCodec.handleRequest(request).get
+        val response = parseResponse(raw)
+        val error    = extractField(response, "error")
+        val code     = error.flatMap(e => extractNumber(e, "code"))
+        val message  = error.flatMap(e => extractString(e, "message"))
+        assertTrue(
+          code.contains(BigDecimal(-32600)),
+          message.exists(_.contains("missing 'method'"))
+        )
+      },
+      test("handler error returns -32603") {
+        val request  = """{"jsonrpc":"2.0","method":"greet","params":{"name":"test"},"id":1}"""
+        val raw      = failingCodec.handleRequest(request).get
+        val response = parseResponse(raw)
+        val error    = extractField(response, "error")
+        val code     = error.flatMap(e => extractNumber(e, "code"))
+        val message  = error.flatMap(e => extractString(e, "message"))
+        assertTrue(
+          code.contains(BigDecimal(-32603)),
+          message.contains("Something went wrong")
+        )
+      },
+      test("non-string method returns -32600") {
+        val request  = """{"jsonrpc":"2.0","method":123,"params":{},"id":1}"""
+        val raw      = greeterCodec.handleRequest(request).get
+        val response = parseResponse(raw)
+        val error    = extractField(response, "error")
+        val code     = error.flatMap(e => extractNumber(e, "code"))
+        assertTrue(code.contains(BigDecimal(-32600)))
+      },
+      test("missing jsonrpc field returns -32600") {
+        val request  = """{"method":"greet","params":{"name":"test"},"id":1}"""
+        val raw      = greeterCodec.handleRequest(request).get
+        val response = parseResponse(raw)
+        val error    = extractField(response, "error")
+        val code     = error.flatMap(e => extractNumber(e, "code"))
+        val message  = error.flatMap(e => extractString(e, "message"))
+        assertTrue(
+          code.contains(BigDecimal(-32600)),
+          message.exists(_.contains("jsonrpc"))
+        )
+      },
+      test("wrong jsonrpc version returns -32600") {
+        val request  = """{"jsonrpc":"1.0","method":"greet","params":{"name":"test"},"id":1}"""
+        val raw      = greeterCodec.handleRequest(request).get
+        val response = parseResponse(raw)
+        val error    = extractField(response, "error")
+        val code     = error.flatMap(e => extractNumber(e, "code"))
+        assertTrue(code.contains(BigDecimal(-32600)))
+      },
+      test("non-object request returns -32600") {
+        val request  = """[1, 2, 3]"""
+        val raw      = greeterCodec.handleRequest(request).get
+        val response = parseResponse(raw)
+        val error    = extractField(response, "error")
+        val code     = error.flatMap(e => extractNumber(e, "code"))
+        assertTrue(code.contains(BigDecimal(-32600)))
+      }
+    ),
+    suite("notification handling")(
+      test("notification without id returns None") {
+        val request = """{"jsonrpc":"2.0","method":"greet","params":{"name":"world"}}"""
+        val result  = greeterCodec.handleRequest(request)
+        assertTrue(result.isEmpty)
+      }
+    ),
+    suite("JsonRpcDeriver integration")(
+      test("deriveService creates codec from RPC descriptor") {
+        val rpc     = RPC.derived[GreeterService]
+        val codec   = JsonRpcDeriver.deriveService(rpc)
+        val request = """{"jsonrpc":"2.0","method":"unknown","params":{},"id":1}"""
+        val raw     = codec.handleRequest(request)
+        assertTrue(raw.exists(_.contains("-32601")))
+      },
+      test("derived codec returns internal error for unbound operations") {
+        val rpc      = RPC.derived[GreeterService]
+        val codec    = JsonRpcDeriver.deriveService(rpc)
+        val request  = """{"jsonrpc":"2.0","method":"greet","params":{"name":"test"},"id":1}"""
+        val raw      = codec.handleRequest(request).get
+        val response = parseResponse(raw)
+        val error    = extractField(response, "error")
+        val code     = error.flatMap(e => extractNumber(e, "code"))
+        assertTrue(code.contains(BigDecimal(-32603)))
+      }
+    ),
+    suite("JsonRpcFormat integration")(
+      test("deriver returns JsonRpcDeriver") {
+        assertTrue(JsonRpcFormat.deriver == JsonRpcDeriver)
+      },
+      test("RPC.derive with JsonRpcFormat produces codec") {
+        val rpc      = RPC.derived[GreeterService]
+        val codec    = rpc.derive(JsonRpcFormat.deriver)
+        val request  = """{"jsonrpc":"2.0","method":"greet","params":{"name":"test"},"id":1}"""
+        val raw      = codec.handleRequest(request).get
+        val response = parseResponse(raw)
+        val error    = extractField(response, "error")
+        assertTrue(error.isDefined)
+      }
+    )
+  )
+}

--- a/rpc/shared/src/test/scala-3/zio/blocks/rpc/jsonrpc/JsonRpcIntegrationSpec.scala
+++ b/rpc/shared/src/test/scala-3/zio/blocks/rpc/jsonrpc/JsonRpcIntegrationSpec.scala
@@ -20,6 +20,7 @@ import zio.test._
 import zio.blocks.rpc._
 import zio.blocks.rpc.fixtures._
 import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{Schema, SchemaError}
 import zio.blocks.schema.json.{Json, JsonCodec}
 
 object JsonRpcIntegrationSpec extends ZIOSpecDefault {
@@ -42,7 +43,7 @@ object JsonRpcIntegrationSpec extends ZIOSpecDefault {
   private val greeterCodec = new JsonRpcCodec(
     Map(
       "greet" -> new JsonRpcCodec.OperationHandler {
-        def handle(params: Json): Either[Throwable, Json] = {
+        def handle(params: Json): Either[SchemaError, Json] = {
           val name = extractString(params, "name").getOrElse("unknown")
           Right(Json.String(s"Hello, $name!"))
         }
@@ -53,8 +54,8 @@ object JsonRpcIntegrationSpec extends ZIOSpecDefault {
   private val failingCodec = new JsonRpcCodec(
     Map(
       "greet" -> new JsonRpcCodec.OperationHandler {
-        def handle(params: Json): Either[Throwable, Json] =
-          Left(new RuntimeException("Something went wrong"))
+        def handle(params: Json): Either[SchemaError, Json] =
+          Left(SchemaError("Something went wrong"))
       }
     )
   )
@@ -121,7 +122,7 @@ object JsonRpcIntegrationSpec extends ZIOSpecDefault {
         val message  = error.flatMap(e => extractString(e, "message"))
         assertTrue(
           code.contains(BigDecimal(-32603)),
-          message.contains("Something went wrong")
+          message.exists(_.contains("Something went wrong"))
         )
       },
       test("non-string method returns -32600") {
@@ -186,20 +187,10 @@ object JsonRpcIntegrationSpec extends ZIOSpecDefault {
       test("derived contract can be bound once into an executable codec") {
         val protocol = JsonRpcDeriver.deriveService(RPC.derived[GreeterService])
         val codec    = protocol
-          .bindHandlers(
-            Chunk(
-              JsonRpcProtocol.BoundOperation(
-                name = "greet",
-                handle = params => {
-                  val name = extractString(params, "name").getOrElse("unknown")
-                  Right(Json.String(s"Hello, $name!"))
-                }
-              )
-            )
-          )
+          .bind[String, String]("greet") { name => Right(s"Hello, $name!") }
           .fold(message => throw new RuntimeException(message), identity)
 
-        val request  = """{"jsonrpc":"2.0","method":"greet","params":{"name":"bound"},"id":1}"""
+        val request  = """{"jsonrpc":"2.0","method":"greet","params":"bound","id":1}"""
         val raw      = codec.handleRequest(request).get
         val response = parseResponse(raw)
         val result   = extractField(response, "result")
@@ -213,22 +204,21 @@ object JsonRpcIntegrationSpec extends ZIOSpecDefault {
       },
       test("binding rejects missing handlers") {
         val protocol = JsonRpcDeriver.deriveService(RPC.derived[GreeterService])
-        val result   = protocol.bindHandlers(Chunk.empty)
+        val result   = protocol.bind[Int, String]("missing")(_ => Right("ignored"))(Schema.int, Schema.string)
 
-        assertTrue(result.left.exists(_.contains("Missing JSON-RPC handlers")))
+        assertTrue(result.left.exists(_.contains("Unknown JSON-RPC operation")))
       },
-      test("binding rejects unknown handlers") {
+      test("binding rejects input schema mismatches") {
         val protocol = JsonRpcDeriver.deriveService(RPC.derived[GreeterService])
-        val result   = protocol.bindHandlers(
-          Chunk(
-            JsonRpcProtocol.BoundOperation(
-              name = "unknown",
-              handle = _ => Right(Json.String("ignored"))
-            )
-          )
-        )
+        val result   = protocol.bind[Int, String]("greet")(_ => Right("ignored"))(Schema.int, Schema.string)
 
-        assertTrue(result.left.exists(_.contains("Unknown JSON-RPC handlers")))
+        assertTrue(result.left.exists(_.contains("input schema")))
+      },
+      test("binding rejects output schema mismatches") {
+        val protocol = JsonRpcDeriver.deriveService(RPC.derived[GreeterService])
+        val result   = protocol.bind[String, Int]("greet")(_ => Right(1))(Schema.string, Schema.int)
+
+        assertTrue(result.left.exists(_.contains("output schema")))
       },
       test("derived contract includes JSON codecs for output and errors") {
         val protocol = JsonRpcDeriver.deriveService(RPC.derived[TodoService])

--- a/rpc/shared/src/test/scala-3/zio/blocks/rpc/jsonrpc/JsonRpcIntegrationSpec.scala
+++ b/rpc/shared/src/test/scala-3/zio/blocks/rpc/jsonrpc/JsonRpcIntegrationSpec.scala
@@ -19,7 +19,8 @@ package zio.blocks.rpc.jsonrpc
 import zio.test._
 import zio.blocks.rpc._
 import zio.blocks.rpc.fixtures._
-import zio.blocks.schema.json.Json
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.json.{Json, JsonCodec}
 
 object JsonRpcIntegrationSpec extends ZIOSpecDefault {
 
@@ -38,7 +39,7 @@ object JsonRpcIntegrationSpec extends ZIOSpecDefault {
       case Left(e)  => throw e
     }
 
-  private val greeterCodec = new JsonRpcCodec[GreeterService](
+  private val greeterCodec = new JsonRpcCodec(
     Map(
       "greet" -> new JsonRpcCodec.OperationHandler {
         def handle(params: Json): Either[Throwable, Json] = {
@@ -49,7 +50,7 @@ object JsonRpcIntegrationSpec extends ZIOSpecDefault {
     )
   )
 
-  private val failingCodec = new JsonRpcCodec[GreeterService](
+  private val failingCodec = new JsonRpcCodec(
     Map(
       "greet" -> new JsonRpcCodec.OperationHandler {
         def handle(params: Json): Either[Throwable, Json] =
@@ -168,36 +169,91 @@ object JsonRpcIntegrationSpec extends ZIOSpecDefault {
       }
     ),
     suite("JsonRpcDeriver integration")(
-      test("deriveService creates codec from RPC descriptor") {
-        val rpc     = RPC.derived[GreeterService]
-        val codec   = JsonRpcDeriver.deriveService(rpc)
-        val request = """{"jsonrpc":"2.0","method":"unknown","params":{},"id":1}"""
-        val raw     = codec.handleRequest(request)
-        assertTrue(raw.exists(_.contains("-32601")))
-      },
-      test("derived codec returns internal error for unbound operations") {
+      test("deriveService creates protocol contract from RPC descriptor") {
         val rpc      = RPC.derived[GreeterService]
-        val codec    = JsonRpcDeriver.deriveService(rpc)
-        val request  = """{"jsonrpc":"2.0","method":"greet","params":{"name":"test"},"id":1}"""
+        val protocol = JsonRpcDeriver.deriveService(rpc)
+        val op       = protocol.operations(0)
+
+        assertTrue(
+          protocol.serviceName == "GreeterService",
+          protocol.serviceTypeId == rpc.typeId,
+          protocol.metadata == rpc.metadata,
+          protocol.operations.length == 1,
+          op.name == "greet",
+          op.parameterNames == Chunk("name")
+        )
+      },
+      test("derived contract can be bound once into an executable codec") {
+        val protocol = JsonRpcDeriver.deriveService(RPC.derived[GreeterService])
+        val codec    = protocol
+          .bindHandlers(
+            Chunk(
+              JsonRpcProtocol.BoundOperation(
+                name = "greet",
+                handle = params => {
+                  val name = extractString(params, "name").getOrElse("unknown")
+                  Right(Json.String(s"Hello, $name!"))
+                }
+              )
+            )
+          )
+          .fold(message => throw new RuntimeException(message), identity)
+
+        val request  = """{"jsonrpc":"2.0","method":"greet","params":{"name":"bound"},"id":1}"""
         val raw      = codec.handleRequest(request).get
         val response = parseResponse(raw)
-        val error    = extractField(response, "error")
-        val code     = error.flatMap(e => extractNumber(e, "code"))
-        assertTrue(code.contains(BigDecimal(-32603)))
+        val result   = extractField(response, "result")
+
+        assertTrue(
+          result.exists {
+            case s: Json.String => s.value == "Hello, bound!"
+            case _              => false
+          }
+        )
+      },
+      test("binding rejects missing handlers") {
+        val protocol = JsonRpcDeriver.deriveService(RPC.derived[GreeterService])
+        val result   = protocol.bindHandlers(Chunk.empty)
+
+        assertTrue(result.left.exists(_.contains("Missing JSON-RPC handlers")))
+      },
+      test("binding rejects unknown handlers") {
+        val protocol = JsonRpcDeriver.deriveService(RPC.derived[GreeterService])
+        val result   = protocol.bindHandlers(
+          Chunk(
+            JsonRpcProtocol.BoundOperation(
+              name = "unknown",
+              handle = _ => Right(Json.String("ignored"))
+            )
+          )
+        )
+
+        assertTrue(result.left.exists(_.contains("Unknown JSON-RPC handlers")))
+      },
+      test("derived contract includes JSON codecs for output and errors") {
+        val protocol = JsonRpcDeriver.deriveService(RPC.derived[TodoService])
+        val getTodo  = protocol.operations.find(_.name == "getTodo").get
+        val output   = getTodo.outputCodec.asInstanceOf[JsonCodec[Todo]].encodeValue(Todo(1, "write tests"))
+        val error    = getTodo.errorCodec.get.asInstanceOf[JsonCodec[ServiceError]].encodeValue(ServiceError(500, "boom"))
+
+        assertTrue(
+          getTodo.errorCodec.isDefined,
+          output.isInstanceOf[Json.Object],
+          error.isInstanceOf[Json.Object]
+        )
       }
     ),
     suite("JsonRpcFormat integration")(
       test("deriver returns JsonRpcDeriver") {
         assertTrue(JsonRpcFormat.deriver == JsonRpcDeriver)
       },
-      test("RPC.derive with JsonRpcFormat produces codec") {
+      test("RPC.derive with JsonRpcFormat produces protocol contract") {
         val rpc      = RPC.derived[GreeterService]
-        val codec    = rpc.derive(JsonRpcFormat.deriver)
-        val request  = """{"jsonrpc":"2.0","method":"greet","params":{"name":"test"},"id":1}"""
-        val raw      = codec.handleRequest(request).get
-        val response = parseResponse(raw)
-        val error    = extractField(response, "error")
-        assertTrue(error.isDefined)
+        val protocol = rpc.derive(JsonRpcFormat.deriver)
+        assertTrue(
+          protocol.serviceName == "GreeterService",
+          protocol.operations.map(_.name) == Chunk("greet")
+        )
       }
     )
   )

--- a/rpc/shared/src/test/scala-3/zio/blocks/rpc/jsonrpc/JsonRpcIntegrationSpec.scala
+++ b/rpc/shared/src/test/scala-3/zio/blocks/rpc/jsonrpc/JsonRpcIntegrationSpec.scala
@@ -187,7 +187,7 @@ object JsonRpcIntegrationSpec extends ZIOSpecDefault {
       test("derived contract can be bound once into an executable codec") {
         val protocol = JsonRpcDeriver.deriveService(RPC.derived[GreeterService])
         val codec    = protocol
-          .bind[String, String]("greet") { name => Right(s"Hello, $name!") }
+          .bind[String, String]("greet")(name => Right(s"Hello, $name!"))
           .fold(message => throw new RuntimeException(message), identity)
 
         val request  = """{"jsonrpc":"2.0","method":"greet","params":"bound","id":1}"""


### PR DESCRIPTION
## Summary

Adds a new `zio-blocks-rpc` module providing a `derives RPC` type class that captures service trait structure as a pure descriptor, analogous to how `derives Schema` captures data types.

Closes #1143

### Design

```scala
trait UserService derives RPC:
  def getUser(id: Long): Either[UserError, User]

  @Idempotent
  def createUser(name: String, email: String): Either[UserError, User]

  def listUsers(): Either[UserError, List[User]]

  def health(): Status  // plain return, no error
```

`RPC[T]` captures method signatures, parameter schemas, success schemas, error schemas, and annotations at compile time. Protocol-specific artifacts derive from it via `RpcDeriver[Protocol[_]]`, just like codec formats derive from `Schema[A]`.

### Key Design Decisions

- **No ZIO dependency** — core rpc module depends only on schema
- **`ReturnTypeDecomposer` type class** — effect/error decomposition stays extensible. Built-in support covers `Either[E, A]` and plain return types.
- **Cross-version** — Scala 2.13 + 3.x shared API, with macro derivation on Scala 3 only
- **`MetaAnnotation`** — extensible annotation infrastructure for service/method metadata
- **Transport-neutral JSON-RPC support** — this PR derives a `JsonRpcProtocol[T]` contract plus a small reference binding to raw handlers for tests and lightweight integrations
- **Concrete runtimes stay out of blocks** — Netty / Node / Wasm / browser server-client implementations can build on the derived contracts in downstream modules

### What's Included

| Component | Description |
|-----------|-------------|
| `RPC[T]` | Type class capturing service operations, schemas, and annotations |
| `RPC.Operation[I, O]` | Per-operation metadata with Schema-backed I/O types |
| `ReturnTypeDecomposer[F]` | Compile-time type class for effect type decomposition |
| `MetaAnnotation` | Base class for service/method annotations |
| `RpcDeriver[Protocol[_]]` | Trait for protocol-specific artifact derivation |
| `RpcFormat` | Associates a protocol artifact with its deriver |
| `JsonRpcProtocol[T]` | Transport-neutral JSON-RPC contract derived from `RPC[T]` |
| `JsonRpcProtocol#bindHandlers` | Reference binding that validates one handler per operation and yields a low-level `JsonRpcCodec` |
| `JsonRpcCodec` | Low-level JSON-RPC request dispatcher over raw handlers |
| 42 tests | Macro derivation + JSON-RPC integration coverage |

### Module Structure

```text
rpc/shared/src/main/scala/        # Cross-version shared types
rpc/shared/src/main/scala-2/      # Scala 2 stubs (empty traits)
rpc/shared/src/main/scala-3/      # Macro derivation + version-specific
rpc/shared/src/test/scala-3/      # Tests (Scala 3 only)
```

### Scope Boundary

This PR intentionally stops at the descriptor / protocol-contract layer inside blocks.

What it includes:
- pure RPC descriptors
- protocol artifact derivation
- a reference JSON-RPC handler binding for tests and lightweight integrations

What it leaves for follow-up modules outside blocks:
- production server runtimes
- production client runtimes
- transport implementations (Netty, Node, Wasm, browser, etc.)
- DI-backed service execution wiring
