### PR TITLE
feat(schema): implement pure algebraic schema migration system (#519)

### DIFF
--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderVersionSpecific.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.blocks.schema.migration
 
 object MigrationBuilderOps {

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderVersionSpecific.scala
@@ -1,0 +1,11 @@
+package zio.blocks.schema.migration
+
+object MigrationBuilderOps {
+  implicit class MigrationBuilderSyntax[A, B](
+    val builder: MigrationBuilder[A, B]
+  ) extends AnyVal {
+    // Scala 2: .build falls back to buildPartial (compile-time validation
+    // is only available on Scala 3 where inline macros are supported)
+    def build: Migration[A, B] = builder.buildPartial
+  }
+}

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationMacros.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationMacros.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.blocks.schema.migration
 
 import scala.language.experimental.macros

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationMacros.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationMacros.scala
@@ -1,0 +1,25 @@
+package zio.blocks.schema.migration
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+object MigrationMacros {
+
+  def select[A](f: A => Any): DynamicOptic = macro selectImpl
+
+  def selectImpl(c: whitebox.Context)(f: c.Tree): c.Tree = {
+    import c.universe._
+    def extractPath(tree: Tree): List[String] = tree match {
+      case Function(_, body)       => extractPath(body)
+      case Select(qualifier, name) => extractPath(qualifier) :+ name.toString
+      case _                       => Nil
+    }
+    val fields = extractPath(f)
+    if (fields.isEmpty)
+      c.abort(c.enclosingPosition, "select: expected a field selector like _.name")
+    val root = q"_root_.zio.blocks.schema.DynamicOptic.root"
+    fields.foldLeft(root: Tree) { (acc, name) =>
+      q"$acc.field($name)"
+    }
+  }
+}

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationMacros.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationMacros.scala
@@ -2,6 +2,7 @@ package zio.blocks.schema.migration
 
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
+import zio.blocks.schema.DynamicOptic
 
 object MigrationMacros {
 

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderVersionSpecific.scala
@@ -1,0 +1,6 @@
+package zio.blocks.schema.migration
+
+extension [A, B](builder: MigrationBuilder[A, B]) {
+  inline def build: Migration[A, B] =
+    ${ MigrationMacros.buildImpl[A, B]('builder) }
+}

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderVersionSpecific.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.blocks.schema.migration
 
 extension [A, B](builder: MigrationBuilder[A, B]) {

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationMacros.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import scala.quoted.*
+import scala.util.control.NonFatal
+import zio.blocks.schema.DynamicOptic
+
+object MigrationMacros {
+  inline def select[A](inline f: A => Any): DynamicOptic = ${ selectImpl[A]('f) }
+
+  def selectImpl[A: Type](f: Expr[A => Any])(using Quotes): Expr[DynamicOptic] = {
+    import quotes.reflect.*
+
+    def loop(term: Term): List[DynamicOptic.Node] = term match {
+      case Inlined(_, _, t) => loop(t)
+      case Block(_, t)      => loop(t)
+      case Select(parent, "each") =>
+        loop(parent) :+ DynamicOptic.Node.Elements
+      case TypeApply(Select(parent, "when"), List(tpe)) =>
+        val caseName = tpe.tpe.typeSymbol.name
+        loop(parent) :+ DynamicOptic.Node.Case(caseName)
+      case Select(parent, field) if field != "apply" =>
+        loop(parent) :+ DynamicOptic.Node.Field(field)
+      case Ident(_) =>
+        Nil
+      case _ =>
+        report.errorAndAbort(
+          s"Invalid selector expression '${term.show}'. Only field selects, .when[T], and .each are supported."
+        )
+    }
+
+    f.asTerm match {
+      case Inlined(_, _, Block(List(DefDef(_, List(List(_)), _, Some(body))), _)) =>
+        val nodes = loop(body)
+        '{ DynamicOptic(${
+          Expr.ofSeq(nodes.map {
+            case DynamicOptic.Node.Field(name) => '{ DynamicOptic.Node.Field(${ Expr(name) }) }
+            case DynamicOptic.Node.Case(name)  => '{ DynamicOptic.Node.Case(${ Expr(name) }) }
+            case DynamicOptic.Node.Elements    => '{ DynamicOptic.Node.Elements }
+            case _ =>
+              report.errorAndAbort("Unsupported selector node in migration macro")
+          })
+        }.toIndexedSeq) }
+      case _ =>
+        report.errorAndAbort("Expected selector lambda of shape `x => x.foo.bar`")
+    }
+  }
+
+  def buildImpl[A: Type, B: Type](builder: Expr[MigrationBuilder[A, B]])(using Quotes): Expr[Migration[A, B]] = {
+    import quotes.reflect.*
+
+    def targetFieldsOf(tpe: TypeRepr): Set[String] =
+      tpe.dealias match {
+        case Refinement(parent, name, _) => targetFieldsOf(parent) + name
+        case other =>
+          val params = other.typeSymbol.primaryConstructor.paramSymss.flatten.map(_.name).toSet
+          if (params.nonEmpty) params
+          else Set.empty
+      }
+
+    def extractTopField(term: Term): Option[String] = {
+      def loop(t: Term): Option[String] = t match {
+        case Inlined(_, _, inner) => loop(inner)
+        case Block(_, expr) =>
+          loop(expr)
+        case Literal(StringConstant(name)) =>
+          Some(name)
+        case Apply(Select(New(tpt), _), List(Literal(StringConstant(name))))
+            if tpt.tpe =:= TypeRepr.of[DynamicOptic.Node.Field] =>
+          Some(name)
+        case Apply(fn, args) =>
+          loop(fn).orElse(args.view.flatMap(a => loop(a).toList).headOption)
+        case Select(qual, _) =>
+          loop(qual)
+        case Typed(inner, _) =>
+          loop(inner)
+        case _ =>
+          None
+      }
+      loop(term)
+    }
+
+    def baseBuilder(term: Term): Boolean = {
+      val sym = term.symbol
+      val full = sym.fullName
+      val ownerAndName = s"${sym.owner.fullName}.${sym.name}"
+      full == "zio.blocks.schema.migration.MigrationBuilder" ||
+      full == "zio.blocks.schema.migration.Migration" ||
+      ownerAndName.endsWith("MigrationBuilder.apply") ||
+      ownerAndName.endsWith("Migration.newBuilder")
+    }
+
+    def extractHandled(term: Term): Option[Set[String]] = term match {
+      case Inlined(_, _, inner) => extractHandled(inner)
+      case Typed(inner, _)      => extractHandled(inner)
+      case id: Ident =>
+        id.symbol.tree match {
+          case v: ValDef => v.rhs.flatMap(extractHandled)
+          case _         => None
+        }
+      case Apply(Select(prev, method), args) =>
+        extractHandled(prev).map { handled =>
+          method match {
+            case "addField" if args.nonEmpty =>
+              handled ++ extractTopField(args.head)
+            case "renameField" | "transformField" | "mandateField" | "optionalizeField" | "changeFieldType" | "inField"
+                if args.length >= 2 =>
+              handled ++ extractTopField(args(1))
+            case _ =>
+              handled
+          }
+        }
+      case TypeApply(inner, _) =>
+        extractHandled(inner)
+      case Apply(inner, _) if baseBuilder(inner) =>
+        Some(Set.empty)
+      case inner if baseBuilder(inner) =>
+        Some(Set.empty)
+      case _ =>
+        None
+    }
+
+    try {
+      val targetFields  = targetFieldsOf(TypeRepr.of[B])
+      val handledFields = extractHandled(builder.asTerm)
+      handledFields match {
+        case Some(handled) =>
+          val unhandled = targetFields -- handled
+          if (unhandled.nonEmpty)
+            report.errorAndAbort(
+              s"Migration.build: unhandled target fields in ${TypeRepr.of[B].show}: ${unhandled.toVector.sorted.mkString(", ")}"
+            )
+          '{ $builder.buildPartial }
+        case None =>
+          report.warning(
+            s"Migration.build: compile-time handledFields extraction is unavailable for ${TypeRepr.of[B].show}; falling back to buildPartial"
+          )
+          '{ $builder.buildPartial }
+      }
+    } catch {
+      case NonFatal(t) =>
+        report.warning(s"Migration.build: validation fallback due to macro extraction error: ${t.getMessage}")
+        '{ $builder.buildPartial }
+    }
+  }
+}

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationMacros.scala
@@ -27,8 +27,8 @@ object MigrationMacros {
     import quotes.reflect.*
 
     def loop(term: Term): List[DynamicOptic.Node] = term match {
-      case Inlined(_, _, t) => loop(t)
-      case Block(_, t)      => loop(t)
+      case Inlined(_, _, t)       => loop(t)
+      case Block(_, t)            => loop(t)
       case Select(parent, "each") =>
         loop(parent) :+ DynamicOptic.Node.Elements
       case TypeApply(Select(parent, "when"), List(tpe)) =>
@@ -47,15 +47,17 @@ object MigrationMacros {
     f.asTerm match {
       case Inlined(_, _, Block(List(DefDef(_, List(List(_)), _, Some(body))), _)) =>
         val nodes = loop(body)
-        '{ DynamicOptic(${
-          Expr.ofSeq(nodes.map {
-            case DynamicOptic.Node.Field(name) => '{ DynamicOptic.Node.Field(${ Expr(name) }) }
-            case DynamicOptic.Node.Case(name)  => '{ DynamicOptic.Node.Case(${ Expr(name) }) }
-            case DynamicOptic.Node.Elements    => '{ DynamicOptic.Node.Elements }
-            case _ =>
-              report.errorAndAbort("Unsupported selector node in migration macro")
-          })
-        }.toIndexedSeq) }
+        '{
+          DynamicOptic(${
+            Expr.ofSeq(nodes.map {
+              case DynamicOptic.Node.Field(name) => '{ DynamicOptic.Node.Field(${ Expr(name) }) }
+              case DynamicOptic.Node.Case(name)  => '{ DynamicOptic.Node.Case(${ Expr(name) }) }
+              case DynamicOptic.Node.Elements    => '{ DynamicOptic.Node.Elements }
+              case _                             =>
+                report.errorAndAbort("Unsupported selector node in migration macro")
+            })
+          }.toIndexedSeq)
+        }
       case _ =>
         report.errorAndAbort("Expected selector lambda of shape `x => x.foo.bar`")
     }
@@ -67,7 +69,7 @@ object MigrationMacros {
     def targetFieldsOf(tpe: TypeRepr): Set[String] =
       tpe.dealias match {
         case Refinement(parent, name, _) => targetFieldsOf(parent) + name
-        case other =>
+        case other                       =>
           val params = other.typeSymbol.primaryConstructor.paramSymss.flatten.map(_.name).toSet
           if (params.nonEmpty) params
           else Set.empty
@@ -76,7 +78,7 @@ object MigrationMacros {
     def extractTopField(term: Term): Option[String] = {
       def loop(t: Term): Option[String] = t match {
         case Inlined(_, _, inner) => loop(inner)
-        case Block(_, expr) =>
+        case Block(_, expr)       =>
           loop(expr)
         case Literal(StringConstant(name)) =>
           Some(name)
@@ -96,8 +98,8 @@ object MigrationMacros {
     }
 
     def baseBuilder(term: Term): Boolean = {
-      val sym = term.symbol
-      val full = sym.fullName
+      val sym          = term.symbol
+      val full         = sym.fullName
       val ownerAndName = s"${sym.owner.fullName}.${sym.name}"
       full == "zio.blocks.schema.migration.MigrationBuilder" ||
       full == "zio.blocks.schema.migration.Migration" ||
@@ -108,7 +110,7 @@ object MigrationMacros {
     def extractHandled(term: Term): Option[Set[String]] = term match {
       case Inlined(_, _, inner) => extractHandled(inner)
       case Typed(inner, _)      => extractHandled(inner)
-      case id: Ident =>
+      case id: Ident            =>
         id.symbol.tree match {
           case v: ValDef => v.rhs.flatMap(extractHandled)
           case _         => None

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -48,12 +48,12 @@ object DynamicMigration {
       typeId = TypeId.of[DynamicMigration],
       recordBinding = new Binding.Record(
         constructor = new Constructor[DynamicMigration] {
-          def usedRegisters: RegisterOffset                                    = RegisterOffset(objects = 1)
+          def usedRegisters: RegisterOffset                                      = RegisterOffset(objects = 1)
           def construct(in: Registers, offset: RegisterOffset): DynamicMigration =
             DynamicMigration(in.getObject(offset).asInstanceOf[Vector[MigrationAction]])
         },
         deconstructor = new Deconstructor[DynamicMigration] {
-          def usedRegisters: RegisterOffset                                                 = RegisterOffset(objects = 1)
+          def usedRegisters: RegisterOffset                                                   = RegisterOffset(objects = 1)
           def deconstruct(out: Registers, offset: RegisterOffset, in: DynamicMigration): Unit =
             out.setObject(offset, in.actions)
         }
@@ -62,7 +62,10 @@ object DynamicMigration {
     )
   )
 
-  private[migration] def applyAction(value: DynamicValue, action: MigrationAction): Either[MigrationError, DynamicValue] =
+  private[migration] def applyAction(
+    value: DynamicValue,
+    action: MigrationAction
+  ): Either[MigrationError, DynamicValue] =
     action match {
       case AddField(at, default) =>
         default(value).flatMap(v => insert(value, at, v))
@@ -73,74 +76,107 @@ object DynamicMigration {
       case TransformValue(at, transform) =>
         modify(value, at, source => transform(source))
       case Mandate(at, default) =>
-        modify(value, at, source => source match {
-          case Variant("Some", payload) => Right(payload)
-          case Variant("None", _)       => default(value)
-          case DynamicValue.Null        => default(value)
-          case other                    => Right(other)
-        })
+        modify(
+          value,
+          at,
+          source =>
+            source match {
+              case Variant("Some", payload) => Right(payload)
+              case Variant("None", _)       => default(value)
+              case DynamicValue.Null        => default(value)
+              case other                    => Right(other)
+            }
+        )
       case Optionalize(at) =>
         modify(value, at, source => Right(Variant("Some", source)))
       case Join(at, sourcePaths, combiner) =>
-        val joined = sourcePaths.foldLeft[Either[MigrationError, DynamicValue]](Right(value)) { (acc, path) =>
-          acc.flatMap(_ => value.get(path).one.left.map(_ => MissingField(path, path.toString)))
-        }.flatMap(_ => combiner(value))
-        joined.flatMap(v => set(value, at, v))
+        val joined = sourcePaths
+          .foldLeft[Either[MigrationError, DynamicValue]](Right(value)) { (acc, path) =>
+            acc.flatMap(_ => value.get(path).one.left.map(_ => MissingField(path, path.toString)))
+          }
+          .flatMap(_ => combiner(value))
+        joined.flatMap(v => insert(value, at, v))
       case Split(at, targetPaths, splitter) =>
         splitter(value).flatMap { out =>
           targetPaths.foldLeft[Either[MigrationError, DynamicValue]](Right(value)) { (acc, target) =>
-            acc.flatMap(curr => set(curr, target, out))
+            acc.flatMap(curr => insert(curr, target, out))
           }
         }
       case ChangeType(at, converter) =>
         modify(value, at, source => converter(source))
       case RenameCase(at, from, to) =>
-        modify(value, at, {
-          case Variant(name, payload) if name == from => Right(Variant(to, payload))
-          case other                                  => Right(other)
-        })
+        modify(
+          value,
+          at,
+          {
+            case Variant(name, payload) if name == from => Right(Variant(to, payload))
+            case other                                  => Right(other)
+          }
+        )
       case TransformCase(at, caseName, actions) =>
-        modify(value, at, {
-          case Variant(name, payload) if name == caseName =>
-            DynamicMigration(actions).apply(payload)
-          case other =>
-            Right(other)
-        })
+        modify(
+          value,
+          at,
+          {
+            case Variant(name, payload) if name == caseName =>
+              DynamicMigration(actions).apply(payload).map(updated => Variant(name, updated))
+            case other =>
+              Right(other)
+          }
+        )
       case TransformElements(at, transform) =>
-        modify(value, at, {
-          case Sequence(elements) =>
-            elements.foldLeft[Either[MigrationError, Chunk[DynamicValue]]](Right(Chunk.empty)) { (acc, e) =>
-              for {
-                xs <- acc
-                v  <- transform(e)
-              } yield xs :+ v
-            }.map(Sequence(_))
-          case other => Right(other)
-        })
+        modify(
+          value,
+          at,
+          {
+            case Sequence(elements) =>
+              elements
+                .foldLeft[Either[MigrationError, Chunk[DynamicValue]]](Right(Chunk.empty)) { (acc, e) =>
+                  for {
+                    xs <- acc
+                    v  <- transform(e)
+                  } yield xs :+ v
+                }
+                .map(Sequence(_))
+            case other => Right(other)
+          }
+        )
       case TransformKeys(at, transform) =>
-        modify(value, at, {
-          case DVMap(entries) =>
-            entries.foldLeft[Either[MigrationError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
-              case (acc, (k, v)) =>
-                for {
-                  xs <- acc
-                  nk <- transform(k)
-                } yield xs :+ (nk -> v)
-            }.map(DVMap(_))
-          case other => Right(other)
-        })
+        modify(
+          value,
+          at,
+          {
+            case DVMap(entries) =>
+              entries
+                .foldLeft[Either[MigrationError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
+                  case (acc, (k, v)) =>
+                    for {
+                      xs <- acc
+                      nk <- transform(k)
+                    } yield xs :+ (nk -> v)
+                }
+                .map(DVMap(_))
+            case other => Right(other)
+          }
+        )
       case TransformValues(at, transform) =>
-        modify(value, at, {
-          case DVMap(entries) =>
-            entries.foldLeft[Either[MigrationError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
-              case (acc, (k, v)) =>
-                for {
-                  xs <- acc
-                  nv <- transform(v)
-                } yield xs :+ (k -> nv)
-            }.map(DVMap(_))
-          case other => Right(other)
-        })
+        modify(
+          value,
+          at,
+          {
+            case DVMap(entries) =>
+              entries
+                .foldLeft[Either[MigrationError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
+                  case (acc, (k, v)) =>
+                    for {
+                      xs <- acc
+                      nv <- transform(v)
+                    } yield xs :+ (k -> nv)
+                }
+                .map(DVMap(_))
+            case other => Right(other)
+          }
+        )
       case NestedMigration(at, migration) =>
         modify(value, at, nested => migration(nested))
     }
@@ -148,7 +184,7 @@ object DynamicMigration {
   private[this] def rename(value: DynamicValue, at: DynamicOptic, to: String): Either[MigrationError, DynamicValue] = {
     val from = at.nodes.lastOption.collect { case DynamicOptic.Node.Field(name) => name }
     from match {
-      case None => Left(InvalidValue(at, "Rename only supports field paths"))
+      case None           => Left(InvalidValue(at, "Rename only supports field paths"))
       case Some(fromName) =>
         value match {
           case Record(fields) =>
@@ -165,7 +201,10 @@ object DynamicMigration {
     at: DynamicOptic,
     f: DynamicValue => Either[MigrationError, DynamicValue]
   ): Either[MigrationError, DynamicValue] =
-    value.get(at).one.left
+    value
+      .get(at)
+      .one
+      .left
       .map(_ => MissingField(at, at.toString))
       .flatMap(f)
       .flatMap(v => set(value, at, v))
@@ -176,6 +215,10 @@ object DynamicMigration {
   private[this] def delete(value: DynamicValue, at: DynamicOptic): Either[MigrationError, DynamicValue] =
     value.deleteOrFail(at).left.map(_ => MissingField(at, at.toString))
 
-  private[this] def insert(value: DynamicValue, at: DynamicOptic, v: DynamicValue): Either[MigrationError, DynamicValue] =
+  private[this] def insert(
+    value: DynamicValue,
+    at: DynamicOptic,
+    v: DynamicValue
+  ): Either[MigrationError, DynamicValue] =
     value.insertOrFail(at, v).left.map(err => InvalidValue(at, err.message))
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.binding._
+import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
+import zio.blocks.schema.DynamicValue.{Map => DVMap, Record, Sequence, Variant}
+import zio.blocks.schema._
+import zio.blocks.schema.migration.MigrationAction._
+import zio.blocks.schema.migration.MigrationError.{InvalidValue, MissingField}
+import zio.blocks.typeid.TypeId
+
+final case class DynamicMigration(actions: Vector[MigrationAction]) {
+
+  def apply(value: DynamicValue): Either[MigrationError, DynamicValue] =
+    actions.foldLeft[Either[MigrationError, DynamicValue]](Right(value)) { (acc, action) =>
+      acc.flatMap(v => DynamicMigration.applyAction(v, action))
+    }
+
+  def ++(that: DynamicMigration): DynamicMigration = DynamicMigration(actions ++ that.actions)
+
+  def reverse: DynamicMigration = DynamicMigration(actions.reverseIterator.map(_.reverse).toVector)
+
+  def isEmpty: Boolean = actions.isEmpty
+}
+
+object DynamicMigration {
+  val identity: DynamicMigration = DynamicMigration(Vector.empty)
+
+  implicit lazy val schema: Schema[DynamicMigration] = new Schema(
+    reflect = new Reflect.Record[Binding, DynamicMigration](
+      fields = Chunk.single(Reflect.Deferred(() => Schema[Vector[MigrationAction]].reflect).asTerm("actions")),
+      typeId = TypeId.of[DynamicMigration],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[DynamicMigration] {
+          def usedRegisters: RegisterOffset                                    = RegisterOffset(objects = 1)
+          def construct(in: Registers, offset: RegisterOffset): DynamicMigration =
+            DynamicMigration(in.getObject(offset).asInstanceOf[Vector[MigrationAction]])
+        },
+        deconstructor = new Deconstructor[DynamicMigration] {
+          def usedRegisters: RegisterOffset                                                 = RegisterOffset(objects = 1)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: DynamicMigration): Unit =
+            out.setObject(offset, in.actions)
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  private[migration] def applyAction(value: DynamicValue, action: MigrationAction): Either[MigrationError, DynamicValue] =
+    action match {
+      case AddField(at, default) =>
+        default(value).flatMap(v => insert(value, at, v))
+      case DropField(at, _) =>
+        delete(value, at)
+      case Rename(at, to) =>
+        rename(value, at, to)
+      case TransformValue(at, transform) =>
+        modify(value, at, source => transform(source))
+      case Mandate(at, default) =>
+        modify(value, at, source => source match {
+          case Variant("Some", payload) => Right(payload)
+          case Variant("None", _)       => default(value)
+          case DynamicValue.Null        => default(value)
+          case other                    => Right(other)
+        })
+      case Optionalize(at) =>
+        modify(value, at, source => Right(Variant("Some", source)))
+      case Join(at, sourcePaths, combiner) =>
+        val joined = sourcePaths.foldLeft[Either[MigrationError, DynamicValue]](Right(value)) { (acc, path) =>
+          acc.flatMap(_ => value.get(path).one.left.map(_ => MissingField(path, path.toString)))
+        }.flatMap(_ => combiner(value))
+        joined.flatMap(v => set(value, at, v))
+      case Split(at, targetPaths, splitter) =>
+        splitter(value).flatMap { out =>
+          targetPaths.foldLeft[Either[MigrationError, DynamicValue]](Right(value)) { (acc, target) =>
+            acc.flatMap(curr => set(curr, target, out))
+          }
+        }
+      case ChangeType(at, converter) =>
+        modify(value, at, source => converter(source))
+      case RenameCase(at, from, to) =>
+        modify(value, at, {
+          case Variant(name, payload) if name == from => Right(Variant(to, payload))
+          case other                                  => Right(other)
+        })
+      case TransformCase(at, caseName, actions) =>
+        modify(value, at, {
+          case Variant(name, payload) if name == caseName =>
+            DynamicMigration(actions).apply(payload)
+          case other =>
+            Right(other)
+        })
+      case TransformElements(at, transform) =>
+        modify(value, at, {
+          case Sequence(elements) =>
+            elements.foldLeft[Either[MigrationError, Chunk[DynamicValue]]](Right(Chunk.empty)) { (acc, e) =>
+              for {
+                xs <- acc
+                v  <- transform(e)
+              } yield xs :+ v
+            }.map(Sequence(_))
+          case other => Right(other)
+        })
+      case TransformKeys(at, transform) =>
+        modify(value, at, {
+          case DVMap(entries) =>
+            entries.foldLeft[Either[MigrationError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
+              case (acc, (k, v)) =>
+                for {
+                  xs <- acc
+                  nk <- transform(k)
+                } yield xs :+ (nk -> v)
+            }.map(DVMap(_))
+          case other => Right(other)
+        })
+      case TransformValues(at, transform) =>
+        modify(value, at, {
+          case DVMap(entries) =>
+            entries.foldLeft[Either[MigrationError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
+              case (acc, (k, v)) =>
+                for {
+                  xs <- acc
+                  nv <- transform(v)
+                } yield xs :+ (k -> nv)
+            }.map(DVMap(_))
+          case other => Right(other)
+        })
+      case NestedMigration(at, migration) =>
+        modify(value, at, nested => migration(nested))
+    }
+
+  private[this] def rename(value: DynamicValue, at: DynamicOptic, to: String): Either[MigrationError, DynamicValue] = {
+    val from = at.nodes.lastOption.collect { case DynamicOptic.Node.Field(name) => name }
+    from match {
+      case None => Left(InvalidValue(at, "Rename only supports field paths"))
+      case Some(fromName) =>
+        value match {
+          case Record(fields) =>
+            val idx = fields.indexWhere(_._1 == fromName)
+            if (idx < 0) Left(MissingField(at, fromName))
+            else Right(Record(fields.updated(idx, (to, fields(idx)._2))))
+          case _ => Left(InvalidValue(at, "Rename requires record at root"))
+        }
+    }
+  }
+
+  private[this] def modify(
+    value: DynamicValue,
+    at: DynamicOptic,
+    f: DynamicValue => Either[MigrationError, DynamicValue]
+  ): Either[MigrationError, DynamicValue] =
+    value.get(at).one.left
+      .map(_ => MissingField(at, at.toString))
+      .flatMap(f)
+      .flatMap(v => set(value, at, v))
+
+  private[this] def set(value: DynamicValue, at: DynamicOptic, v: DynamicValue): Either[MigrationError, DynamicValue] =
+    value.setOrFail(at, v).left.map(err => InvalidValue(at, err.message))
+
+  private[this] def delete(value: DynamicValue, at: DynamicOptic): Either[MigrationError, DynamicValue] =
+    value.deleteOrFail(at).left.map(_ => MissingField(at, at.toString))
+
+  private[this] def insert(value: DynamicValue, at: DynamicOptic, v: DynamicValue): Either[MigrationError, DynamicValue] =
+    value.insertOrFail(at, v).left.map(err => InvalidValue(at, err.message))
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{Schema, SchemaError}
+import zio.blocks.schema.migration.MigrationError.InvalidValue
+
+final case class Migration[A, B](
+  dynamicMigration: DynamicMigration,
+  sourceSchema: Schema[A],
+  targetSchema: Schema[B]
+) {
+  def apply(value: A): Either[MigrationError, B] =
+    for {
+      source <- Right(sourceSchema.toDynamicValue(value))
+      after  <- dynamicMigration(source)
+      out    <- targetSchema.fromDynamicValue(after).left.map(fromSchemaError)
+    } yield out
+
+  def ++[C](that: Migration[B, C]): Migration[A, C] =
+    Migration[A, C](dynamicMigration ++ that.dynamicMigration, sourceSchema, that.targetSchema)
+
+  def andThen[C](that: Migration[B, C]): Migration[A, C] = this ++ that
+
+  def reverse: Migration[B, A] = Migration[B, A](dynamicMigration.reverse, targetSchema, sourceSchema)
+
+  private[this] def fromSchemaError(error: SchemaError): MigrationError =
+    InvalidValue(zio.blocks.schema.DynamicOptic.root, error.message)
+}
+
+object Migration {
+  def identity[A](schema: Schema[A]): Migration[A, A] = Migration(DynamicMigration.identity, schema, schema)
+
+  def newBuilder[A, B](implicit sourceSchema: Schema[A], targetSchema: Schema[B]): MigrationBuilder[A, B] =
+    MigrationBuilder[A, B]
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
@@ -41,7 +41,11 @@ object MigrationAction {
   }
 
   final case class TransformValue(at: DynamicOptic, transform: MigrationExpr) extends MigrationAction {
-    /** Reverse is best-effort: only identity-preserving transforms are invertible. */
+
+    /**
+     * Reverse is best-effort: only identity-preserving transforms are
+     * invertible.
+     */
     def reverse: MigrationAction = TransformValue(at, MigrationExpr.Identity)
   }
 
@@ -53,17 +57,27 @@ object MigrationAction {
     def reverse: MigrationAction = Mandate(at, MigrationExpr.DefaultValue)
   }
 
-  final case class Join(at: DynamicOptic, sourcePaths: Vector[DynamicOptic], combiner: MigrationExpr) extends MigrationAction {
-    /** Reverse is best-effort and does not reconstruct original source segmentation. */
+  final case class Join(at: DynamicOptic, sourcePaths: Vector[DynamicOptic], combiner: MigrationExpr)
+      extends MigrationAction {
+
+    /**
+     * Reverse is best-effort and does not reconstruct original source
+     * segmentation.
+     */
     def reverse: MigrationAction = Split(at, sourcePaths, MigrationExpr.Identity)
   }
 
-  final case class Split(at: DynamicOptic, targetPaths: Vector[DynamicOptic], splitter: MigrationExpr) extends MigrationAction {
-    /** Reverse is best-effort and does not reconstruct original split intent. */
+  final case class Split(at: DynamicOptic, targetPaths: Vector[DynamicOptic], splitter: MigrationExpr)
+      extends MigrationAction {
+
+    /**
+     * Reverse is best-effort and does not reconstruct original split intent.
+     */
     def reverse: MigrationAction = Join(at, targetPaths, MigrationExpr.Identity)
   }
 
   final case class ChangeType(at: DynamicOptic, converter: MigrationExpr) extends MigrationAction {
+
     /** Reverse is best-effort unless converter is bijective. */
     def reverse: MigrationAction = ChangeType(at, MigrationExpr.Identity)
   }
@@ -72,22 +86,35 @@ object MigrationAction {
     def reverse: MigrationAction = RenameCase(at, to, from)
   }
 
-  final case class TransformCase(at: DynamicOptic, caseName: String, actions: Vector[MigrationAction]) extends MigrationAction {
+  final case class TransformCase(at: DynamicOptic, caseName: String, actions: Vector[MigrationAction])
+      extends MigrationAction {
     def reverse: MigrationAction = TransformCase(at, caseName, actions.reverseIterator.map(_.reverse).toVector)
   }
 
   final case class TransformElements(at: DynamicOptic, transform: MigrationExpr) extends MigrationAction {
-    /** Reverse is best-effort and cannot reconstruct non-invertible element transforms. */
+
+    /**
+     * Reverse is best-effort and cannot reconstruct non-invertible element
+     * transforms.
+     */
     def reverse: MigrationAction = TransformElements(at, MigrationExpr.Identity)
   }
 
   final case class TransformKeys(at: DynamicOptic, transform: MigrationExpr) extends MigrationAction {
-    /** Reverse is best-effort and cannot reconstruct key collisions or non-bijective maps. */
+
+    /**
+     * Reverse is best-effort and cannot reconstruct key collisions or
+     * non-bijective maps.
+     */
     def reverse: MigrationAction = TransformKeys(at, MigrationExpr.Identity)
   }
 
   final case class TransformValues(at: DynamicOptic, transform: MigrationExpr) extends MigrationAction {
-    /** Reverse is best-effort and cannot reconstruct non-invertible value transforms. */
+
+    /**
+     * Reverse is best-effort and cannot reconstruct non-invertible value
+     * transforms.
+     */
     def reverse: MigrationAction = TransformValues(at, MigrationExpr.Identity)
   }
 
@@ -104,12 +131,12 @@ object MigrationAction {
       typeId = typeId,
       recordBinding = new Binding.Record(
         constructor = new Constructor[A] {
-          def usedRegisters: RegisterOffset                     = RegisterOffset(objects = 2)
+          def usedRegisters: RegisterOffset                       = RegisterOffset(objects = 2)
           def construct(in: Registers, offset: RegisterOffset): A =
             mk(in.getObject(offset), in.getObject(RegisterOffset.incrementObjects(offset)))
         },
         deconstructor = new Deconstructor[A] {
-          def usedRegisters: RegisterOffset                          = RegisterOffset(objects = 2)
+          def usedRegisters: RegisterOffset                                    = RegisterOffset(objects = 2)
           def deconstruct(out: Registers, offset: RegisterOffset, in: A): Unit = {
             val (a1, a2) = unmk(in)
             out.setObject(offset, a1)
@@ -128,7 +155,13 @@ object MigrationAction {
     )
 
   implicit lazy val dropFieldSchema: Schema[DropField] =
-    record2(TypeId.of[DropField], Schema[DynamicOptic].reflect, "at", Schema[MigrationExpr].reflect, "defaultForReverse")(
+    record2(
+      TypeId.of[DropField],
+      Schema[DynamicOptic].reflect,
+      "at",
+      Schema[MigrationExpr].reflect,
+      "defaultForReverse"
+    )(
       (a, b) => DropField(a.asInstanceOf[DynamicOptic], b.asInstanceOf[MigrationExpr]),
       in => (in.at, in.defaultForReverse)
     )
@@ -157,12 +190,12 @@ object MigrationAction {
       typeId = TypeId.of[Optionalize],
       recordBinding = new Binding.Record(
         constructor = new Constructor[Optionalize] {
-          def usedRegisters: RegisterOffset                              = RegisterOffset(objects = 1)
+          def usedRegisters: RegisterOffset                                 = RegisterOffset(objects = 1)
           def construct(in: Registers, offset: RegisterOffset): Optionalize =
             Optionalize(in.getObject(offset).asInstanceOf[DynamicOptic])
         },
         deconstructor = new Deconstructor[Optionalize] {
-          def usedRegisters: RegisterOffset                                           = RegisterOffset(objects = 1)
+          def usedRegisters: RegisterOffset                                              = RegisterOffset(objects = 1)
           def deconstruct(out: Registers, offset: RegisterOffset, in: Optionalize): Unit =
             out.setObject(offset, in.at)
         }
@@ -181,16 +214,17 @@ object MigrationAction {
       typeId = TypeId.of[Join],
       recordBinding = new Binding.Record(
         constructor = new Constructor[Join] {
-          def usedRegisters: RegisterOffset                        = RegisterOffset(objects = 3)
+          def usedRegisters: RegisterOffset                          = RegisterOffset(objects = 3)
           def construct(in: Registers, offset: RegisterOffset): Join =
             Join(
               in.getObject(offset).asInstanceOf[DynamicOptic],
               in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[Vector[DynamicOptic]],
-              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset))).asInstanceOf[MigrationExpr]
+              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset)))
+                .asInstanceOf[MigrationExpr]
             )
         },
         deconstructor = new Deconstructor[Join] {
-          def usedRegisters: RegisterOffset                                     = RegisterOffset(objects = 3)
+          def usedRegisters: RegisterOffset                                       = RegisterOffset(objects = 3)
           def deconstruct(out: Registers, offset: RegisterOffset, in: Join): Unit = {
             out.setObject(offset, in.at)
             out.setObject(RegisterOffset.incrementObjects(offset), in.sourcePaths)
@@ -212,16 +246,17 @@ object MigrationAction {
       typeId = TypeId.of[Split],
       recordBinding = new Binding.Record(
         constructor = new Constructor[Split] {
-          def usedRegisters: RegisterOffset                         = RegisterOffset(objects = 3)
+          def usedRegisters: RegisterOffset                           = RegisterOffset(objects = 3)
           def construct(in: Registers, offset: RegisterOffset): Split =
             Split(
               in.getObject(offset).asInstanceOf[DynamicOptic],
               in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[Vector[DynamicOptic]],
-              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset))).asInstanceOf[MigrationExpr]
+              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset)))
+                .asInstanceOf[MigrationExpr]
             )
         },
         deconstructor = new Deconstructor[Split] {
-          def usedRegisters: RegisterOffset                                      = RegisterOffset(objects = 3)
+          def usedRegisters: RegisterOffset                                        = RegisterOffset(objects = 3)
           def deconstruct(out: Registers, offset: RegisterOffset, in: Split): Unit = {
             out.setObject(offset, in.at)
             out.setObject(RegisterOffset.incrementObjects(offset), in.targetPaths)
@@ -241,20 +276,25 @@ object MigrationAction {
 
   implicit lazy val renameCaseSchema: Schema[RenameCase] = new Schema(
     reflect = new Reflect.Record[Binding, RenameCase](
-      fields = Chunk(Schema[DynamicOptic].reflect.asTerm("at"), Schema[String].reflect.asTerm("from"), Schema[String].reflect.asTerm("to")),
+      fields = Chunk(
+        Schema[DynamicOptic].reflect.asTerm("at"),
+        Schema[String].reflect.asTerm("from"),
+        Schema[String].reflect.asTerm("to")
+      ),
       typeId = TypeId.of[RenameCase],
       recordBinding = new Binding.Record(
         constructor = new Constructor[RenameCase] {
-          def usedRegisters: RegisterOffset                              = RegisterOffset(objects = 3)
+          def usedRegisters: RegisterOffset                                = RegisterOffset(objects = 3)
           def construct(in: Registers, offset: RegisterOffset): RenameCase =
             RenameCase(
               in.getObject(offset).asInstanceOf[DynamicOptic],
               in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[String],
-              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset))).asInstanceOf[String]
+              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset)))
+                .asInstanceOf[String]
             )
         },
         deconstructor = new Deconstructor[RenameCase] {
-          def usedRegisters: RegisterOffset                                           = RegisterOffset(objects = 3)
+          def usedRegisters: RegisterOffset                                             = RegisterOffset(objects = 3)
           def deconstruct(out: Registers, offset: RegisterOffset, in: RenameCase): Unit = {
             out.setObject(offset, in.at)
             out.setObject(RegisterOffset.incrementObjects(offset), in.from)
@@ -276,16 +316,17 @@ object MigrationAction {
       typeId = TypeId.of[TransformCase],
       recordBinding = new Binding.Record(
         constructor = new Constructor[TransformCase] {
-          def usedRegisters: RegisterOffset                                 = RegisterOffset(objects = 3)
+          def usedRegisters: RegisterOffset                                   = RegisterOffset(objects = 3)
           def construct(in: Registers, offset: RegisterOffset): TransformCase =
             TransformCase(
               in.getObject(offset).asInstanceOf[DynamicOptic],
               in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[String],
-              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset))).asInstanceOf[Vector[MigrationAction]]
+              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset)))
+                .asInstanceOf[Vector[MigrationAction]]
             )
         },
         deconstructor = new Deconstructor[TransformCase] {
-          def usedRegisters: RegisterOffset                                              = RegisterOffset(objects = 3)
+          def usedRegisters: RegisterOffset                                                = RegisterOffset(objects = 3)
           def deconstruct(out: Registers, offset: RegisterOffset, in: TransformCase): Unit = {
             out.setObject(offset, in.at)
             out.setObject(RegisterOffset.incrementObjects(offset), in.caseName)
@@ -298,7 +339,13 @@ object MigrationAction {
   )
 
   implicit lazy val transformElementsSchema: Schema[TransformElements] =
-    record2(TypeId.of[TransformElements], Schema[DynamicOptic].reflect, "at", Schema[MigrationExpr].reflect, "transform")(
+    record2(
+      TypeId.of[TransformElements],
+      Schema[DynamicOptic].reflect,
+      "at",
+      Schema[MigrationExpr].reflect,
+      "transform"
+    )(
       (a, b) => TransformElements(a.asInstanceOf[DynamicOptic], b.asInstanceOf[MigrationExpr]),
       in => (in.at, in.transform)
     )
@@ -314,7 +361,13 @@ object MigrationAction {
     )
 
   implicit lazy val nestedMigrationSchema: Schema[NestedMigration] =
-    record2(TypeId.of[NestedMigration], Schema[DynamicOptic].reflect, "at", Schema[DynamicMigration].reflect, "migration")(
+    record2(
+      TypeId.of[NestedMigration],
+      Schema[DynamicOptic].reflect,
+      "at",
+      Schema[DynamicMigration].reflect,
+      "migration"
+    )(
       (a, b) => NestedMigration(a.asInstanceOf[DynamicOptic], b.asInstanceOf[DynamicMigration]),
       in => (in.at, in.migration)
     )
@@ -360,21 +413,73 @@ object MigrationAction {
           }
         },
         matchers = Matchers(
-          new Matcher[AddField] { def downcastOrNull(a: Any): AddField = a match { case x: AddField => x; case _ => null.asInstanceOf[AddField] } },
-          new Matcher[DropField] { def downcastOrNull(a: Any): DropField = a match { case x: DropField => x; case _ => null.asInstanceOf[DropField] } },
-          new Matcher[Rename] { def downcastOrNull(a: Any): Rename = a match { case x: Rename => x; case _ => null.asInstanceOf[Rename] } },
-          new Matcher[TransformValue] { def downcastOrNull(a: Any): TransformValue = a match { case x: TransformValue => x; case _ => null.asInstanceOf[TransformValue] } },
-          new Matcher[Mandate] { def downcastOrNull(a: Any): Mandate = a match { case x: Mandate => x; case _ => null.asInstanceOf[Mandate] } },
-          new Matcher[Optionalize] { def downcastOrNull(a: Any): Optionalize = a match { case x: Optionalize => x; case _ => null.asInstanceOf[Optionalize] } },
-          new Matcher[Join] { def downcastOrNull(a: Any): Join = a match { case x: Join => x; case _ => null.asInstanceOf[Join] } },
-          new Matcher[Split] { def downcastOrNull(a: Any): Split = a match { case x: Split => x; case _ => null.asInstanceOf[Split] } },
-          new Matcher[ChangeType] { def downcastOrNull(a: Any): ChangeType = a match { case x: ChangeType => x; case _ => null.asInstanceOf[ChangeType] } },
-          new Matcher[RenameCase] { def downcastOrNull(a: Any): RenameCase = a match { case x: RenameCase => x; case _ => null.asInstanceOf[RenameCase] } },
-          new Matcher[TransformCase] { def downcastOrNull(a: Any): TransformCase = a match { case x: TransformCase => x; case _ => null.asInstanceOf[TransformCase] } },
-          new Matcher[TransformElements] { def downcastOrNull(a: Any): TransformElements = a match { case x: TransformElements => x; case _ => null.asInstanceOf[TransformElements] } },
-          new Matcher[TransformKeys] { def downcastOrNull(a: Any): TransformKeys = a match { case x: TransformKeys => x; case _ => null.asInstanceOf[TransformKeys] } },
-          new Matcher[TransformValues] { def downcastOrNull(a: Any): TransformValues = a match { case x: TransformValues => x; case _ => null.asInstanceOf[TransformValues] } },
-          new Matcher[NestedMigration] { def downcastOrNull(a: Any): NestedMigration = a match { case x: NestedMigration => x; case _ => null.asInstanceOf[NestedMigration] } }
+          new Matcher[AddField] {
+            def downcastOrNull(a: Any): AddField = a match {
+              case x: AddField => x; case _ => null.asInstanceOf[AddField]
+            }
+          },
+          new Matcher[DropField] {
+            def downcastOrNull(a: Any): DropField = a match {
+              case x: DropField => x; case _ => null.asInstanceOf[DropField]
+            }
+          },
+          new Matcher[Rename] {
+            def downcastOrNull(a: Any): Rename = a match { case x: Rename => x; case _ => null.asInstanceOf[Rename] }
+          },
+          new Matcher[TransformValue] {
+            def downcastOrNull(a: Any): TransformValue = a match {
+              case x: TransformValue => x; case _ => null.asInstanceOf[TransformValue]
+            }
+          },
+          new Matcher[Mandate] {
+            def downcastOrNull(a: Any): Mandate = a match { case x: Mandate => x; case _ => null.asInstanceOf[Mandate] }
+          },
+          new Matcher[Optionalize] {
+            def downcastOrNull(a: Any): Optionalize = a match {
+              case x: Optionalize => x; case _ => null.asInstanceOf[Optionalize]
+            }
+          },
+          new Matcher[Join] {
+            def downcastOrNull(a: Any): Join = a match { case x: Join => x; case _ => null.asInstanceOf[Join] }
+          },
+          new Matcher[Split] {
+            def downcastOrNull(a: Any): Split = a match { case x: Split => x; case _ => null.asInstanceOf[Split] }
+          },
+          new Matcher[ChangeType] {
+            def downcastOrNull(a: Any): ChangeType = a match {
+              case x: ChangeType => x; case _ => null.asInstanceOf[ChangeType]
+            }
+          },
+          new Matcher[RenameCase] {
+            def downcastOrNull(a: Any): RenameCase = a match {
+              case x: RenameCase => x; case _ => null.asInstanceOf[RenameCase]
+            }
+          },
+          new Matcher[TransformCase] {
+            def downcastOrNull(a: Any): TransformCase = a match {
+              case x: TransformCase => x; case _ => null.asInstanceOf[TransformCase]
+            }
+          },
+          new Matcher[TransformElements] {
+            def downcastOrNull(a: Any): TransformElements = a match {
+              case x: TransformElements => x; case _ => null.asInstanceOf[TransformElements]
+            }
+          },
+          new Matcher[TransformKeys] {
+            def downcastOrNull(a: Any): TransformKeys = a match {
+              case x: TransformKeys => x; case _ => null.asInstanceOf[TransformKeys]
+            }
+          },
+          new Matcher[TransformValues] {
+            def downcastOrNull(a: Any): TransformValues = a match {
+              case x: TransformValues => x; case _ => null.asInstanceOf[TransformValues]
+            }
+          },
+          new Matcher[NestedMigration] {
+            def downcastOrNull(a: Any): NestedMigration = a match {
+              case x: NestedMigration => x; case _ => null.asInstanceOf[NestedMigration]
+            }
+          }
         )
       ),
       modifiers = Chunk.empty

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.binding._
+import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
+import zio.blocks.schema.{DynamicOptic, Reflect, Schema}
+import zio.blocks.typeid.TypeId
+
+sealed trait MigrationAction {
+  def at: DynamicOptic
+  def reverse: MigrationAction
+}
+
+object MigrationAction {
+  final case class AddField(at: DynamicOptic, default: MigrationExpr) extends MigrationAction {
+    def reverse: MigrationAction = DropField(at, default)
+  }
+
+  final case class DropField(at: DynamicOptic, defaultForReverse: MigrationExpr) extends MigrationAction {
+    def reverse: MigrationAction = AddField(at, defaultForReverse)
+  }
+
+  final case class Rename(at: DynamicOptic, to: String) extends MigrationAction {
+    def reverse: MigrationAction = Rename(DynamicOptic.root.field(to), at.toString.stripPrefix("."))
+  }
+
+  final case class TransformValue(at: DynamicOptic, transform: MigrationExpr) extends MigrationAction {
+    /** Reverse is best-effort: only identity-preserving transforms are invertible. */
+    def reverse: MigrationAction = TransformValue(at, MigrationExpr.Identity)
+  }
+
+  final case class Mandate(at: DynamicOptic, default: MigrationExpr) extends MigrationAction {
+    def reverse: MigrationAction = Optionalize(at)
+  }
+
+  final case class Optionalize(at: DynamicOptic) extends MigrationAction {
+    def reverse: MigrationAction = Mandate(at, MigrationExpr.DefaultValue)
+  }
+
+  final case class Join(at: DynamicOptic, sourcePaths: Vector[DynamicOptic], combiner: MigrationExpr) extends MigrationAction {
+    /** Reverse is best-effort and does not reconstruct original source segmentation. */
+    def reverse: MigrationAction = Split(at, sourcePaths, MigrationExpr.Identity)
+  }
+
+  final case class Split(at: DynamicOptic, targetPaths: Vector[DynamicOptic], splitter: MigrationExpr) extends MigrationAction {
+    /** Reverse is best-effort and does not reconstruct original split intent. */
+    def reverse: MigrationAction = Join(at, targetPaths, MigrationExpr.Identity)
+  }
+
+  final case class ChangeType(at: DynamicOptic, converter: MigrationExpr) extends MigrationAction {
+    /** Reverse is best-effort unless converter is bijective. */
+    def reverse: MigrationAction = ChangeType(at, MigrationExpr.Identity)
+  }
+
+  final case class RenameCase(at: DynamicOptic, from: String, to: String) extends MigrationAction {
+    def reverse: MigrationAction = RenameCase(at, to, from)
+  }
+
+  final case class TransformCase(at: DynamicOptic, caseName: String, actions: Vector[MigrationAction]) extends MigrationAction {
+    def reverse: MigrationAction = TransformCase(at, caseName, actions.reverseIterator.map(_.reverse).toVector)
+  }
+
+  final case class TransformElements(at: DynamicOptic, transform: MigrationExpr) extends MigrationAction {
+    /** Reverse is best-effort and cannot reconstruct non-invertible element transforms. */
+    def reverse: MigrationAction = TransformElements(at, MigrationExpr.Identity)
+  }
+
+  final case class TransformKeys(at: DynamicOptic, transform: MigrationExpr) extends MigrationAction {
+    /** Reverse is best-effort and cannot reconstruct key collisions or non-bijective maps. */
+    def reverse: MigrationAction = TransformKeys(at, MigrationExpr.Identity)
+  }
+
+  final case class TransformValues(at: DynamicOptic, transform: MigrationExpr) extends MigrationAction {
+    /** Reverse is best-effort and cannot reconstruct non-invertible value transforms. */
+    def reverse: MigrationAction = TransformValues(at, MigrationExpr.Identity)
+  }
+
+  final case class NestedMigration(at: DynamicOptic, migration: DynamicMigration) extends MigrationAction {
+    def reverse: MigrationAction = NestedMigration(at, migration.reverse)
+  }
+
+  private def record2[A](typeId: TypeId[A], f1: Reflect[Binding, ?], n1: String, f2: Reflect[Binding, ?], n2: String)(
+    mk: (AnyRef, AnyRef) => A,
+    unmk: A => (AnyRef, AnyRef)
+  ): Schema[A] = new Schema(
+    reflect = new Reflect.Record[Binding, A](
+      fields = Chunk(f1.asTerm(n1), f2.asTerm(n2)),
+      typeId = typeId,
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[A] {
+          def usedRegisters: RegisterOffset                     = RegisterOffset(objects = 2)
+          def construct(in: Registers, offset: RegisterOffset): A =
+            mk(in.getObject(offset), in.getObject(RegisterOffset.incrementObjects(offset)))
+        },
+        deconstructor = new Deconstructor[A] {
+          def usedRegisters: RegisterOffset                          = RegisterOffset(objects = 2)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: A): Unit = {
+            val (a1, a2) = unmk(in)
+            out.setObject(offset, a1)
+            out.setObject(RegisterOffset.incrementObjects(offset), a2)
+          }
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val addFieldSchema: Schema[AddField] =
+    record2(TypeId.of[AddField], Schema[DynamicOptic].reflect, "at", Schema[MigrationExpr].reflect, "default")(
+      (a, b) => AddField(a.asInstanceOf[DynamicOptic], b.asInstanceOf[MigrationExpr]),
+      in => (in.at, in.default)
+    )
+
+  implicit lazy val dropFieldSchema: Schema[DropField] =
+    record2(TypeId.of[DropField], Schema[DynamicOptic].reflect, "at", Schema[MigrationExpr].reflect, "defaultForReverse")(
+      (a, b) => DropField(a.asInstanceOf[DynamicOptic], b.asInstanceOf[MigrationExpr]),
+      in => (in.at, in.defaultForReverse)
+    )
+
+  implicit lazy val renameSchema: Schema[Rename] =
+    record2(TypeId.of[Rename], Schema[DynamicOptic].reflect, "at", Schema[String].reflect, "to")(
+      (a, b) => Rename(a.asInstanceOf[DynamicOptic], b.asInstanceOf[String]),
+      in => (in.at, in.to)
+    )
+
+  implicit lazy val transformValueSchema: Schema[TransformValue] =
+    record2(TypeId.of[TransformValue], Schema[DynamicOptic].reflect, "at", Schema[MigrationExpr].reflect, "transform")(
+      (a, b) => TransformValue(a.asInstanceOf[DynamicOptic], b.asInstanceOf[MigrationExpr]),
+      in => (in.at, in.transform)
+    )
+
+  implicit lazy val mandateSchema: Schema[Mandate] =
+    record2(TypeId.of[Mandate], Schema[DynamicOptic].reflect, "at", Schema[MigrationExpr].reflect, "default")(
+      (a, b) => Mandate(a.asInstanceOf[DynamicOptic], b.asInstanceOf[MigrationExpr]),
+      in => (in.at, in.default)
+    )
+
+  implicit lazy val optionalizeSchema: Schema[Optionalize] = new Schema(
+    reflect = new Reflect.Record[Binding, Optionalize](
+      fields = Chunk.single(Schema[DynamicOptic].reflect.asTerm("at")),
+      typeId = TypeId.of[Optionalize],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Optionalize] {
+          def usedRegisters: RegisterOffset                              = RegisterOffset(objects = 1)
+          def construct(in: Registers, offset: RegisterOffset): Optionalize =
+            Optionalize(in.getObject(offset).asInstanceOf[DynamicOptic])
+        },
+        deconstructor = new Deconstructor[Optionalize] {
+          def usedRegisters: RegisterOffset                                           = RegisterOffset(objects = 1)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Optionalize): Unit =
+            out.setObject(offset, in.at)
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val joinSchema: Schema[Join] = new Schema(
+    reflect = new Reflect.Record[Binding, Join](
+      fields = Chunk(
+        Schema[DynamicOptic].reflect.asTerm("at"),
+        Schema[Vector[DynamicOptic]].reflect.asTerm("sourcePaths"),
+        Schema[MigrationExpr].reflect.asTerm("combiner")
+      ),
+      typeId = TypeId.of[Join],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Join] {
+          def usedRegisters: RegisterOffset                        = RegisterOffset(objects = 3)
+          def construct(in: Registers, offset: RegisterOffset): Join =
+            Join(
+              in.getObject(offset).asInstanceOf[DynamicOptic],
+              in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[Vector[DynamicOptic]],
+              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset))).asInstanceOf[MigrationExpr]
+            )
+        },
+        deconstructor = new Deconstructor[Join] {
+          def usedRegisters: RegisterOffset                                     = RegisterOffset(objects = 3)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Join): Unit = {
+            out.setObject(offset, in.at)
+            out.setObject(RegisterOffset.incrementObjects(offset), in.sourcePaths)
+            out.setObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset)), in.combiner)
+          }
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val splitSchema: Schema[Split] = new Schema(
+    reflect = new Reflect.Record[Binding, Split](
+      fields = Chunk(
+        Schema[DynamicOptic].reflect.asTerm("at"),
+        Schema[Vector[DynamicOptic]].reflect.asTerm("targetPaths"),
+        Schema[MigrationExpr].reflect.asTerm("splitter")
+      ),
+      typeId = TypeId.of[Split],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Split] {
+          def usedRegisters: RegisterOffset                         = RegisterOffset(objects = 3)
+          def construct(in: Registers, offset: RegisterOffset): Split =
+            Split(
+              in.getObject(offset).asInstanceOf[DynamicOptic],
+              in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[Vector[DynamicOptic]],
+              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset))).asInstanceOf[MigrationExpr]
+            )
+        },
+        deconstructor = new Deconstructor[Split] {
+          def usedRegisters: RegisterOffset                                      = RegisterOffset(objects = 3)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Split): Unit = {
+            out.setObject(offset, in.at)
+            out.setObject(RegisterOffset.incrementObjects(offset), in.targetPaths)
+            out.setObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset)), in.splitter)
+          }
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val changeTypeSchema: Schema[ChangeType] =
+    record2(TypeId.of[ChangeType], Schema[DynamicOptic].reflect, "at", Schema[MigrationExpr].reflect, "converter")(
+      (a, b) => ChangeType(a.asInstanceOf[DynamicOptic], b.asInstanceOf[MigrationExpr]),
+      in => (in.at, in.converter)
+    )
+
+  implicit lazy val renameCaseSchema: Schema[RenameCase] = new Schema(
+    reflect = new Reflect.Record[Binding, RenameCase](
+      fields = Chunk(Schema[DynamicOptic].reflect.asTerm("at"), Schema[String].reflect.asTerm("from"), Schema[String].reflect.asTerm("to")),
+      typeId = TypeId.of[RenameCase],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[RenameCase] {
+          def usedRegisters: RegisterOffset                              = RegisterOffset(objects = 3)
+          def construct(in: Registers, offset: RegisterOffset): RenameCase =
+            RenameCase(
+              in.getObject(offset).asInstanceOf[DynamicOptic],
+              in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[String],
+              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset))).asInstanceOf[String]
+            )
+        },
+        deconstructor = new Deconstructor[RenameCase] {
+          def usedRegisters: RegisterOffset                                           = RegisterOffset(objects = 3)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: RenameCase): Unit = {
+            out.setObject(offset, in.at)
+            out.setObject(RegisterOffset.incrementObjects(offset), in.from)
+            out.setObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset)), in.to)
+          }
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val transformCaseSchema: Schema[TransformCase] = new Schema(
+    reflect = new Reflect.Record[Binding, TransformCase](
+      fields = Chunk(
+        Schema[DynamicOptic].reflect.asTerm("at"),
+        Schema[String].reflect.asTerm("caseName"),
+        Reflect.Deferred(() => Schema[Vector[MigrationAction]].reflect).asTerm("actions")
+      ),
+      typeId = TypeId.of[TransformCase],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[TransformCase] {
+          def usedRegisters: RegisterOffset                                 = RegisterOffset(objects = 3)
+          def construct(in: Registers, offset: RegisterOffset): TransformCase =
+            TransformCase(
+              in.getObject(offset).asInstanceOf[DynamicOptic],
+              in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[String],
+              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset))).asInstanceOf[Vector[MigrationAction]]
+            )
+        },
+        deconstructor = new Deconstructor[TransformCase] {
+          def usedRegisters: RegisterOffset                                              = RegisterOffset(objects = 3)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: TransformCase): Unit = {
+            out.setObject(offset, in.at)
+            out.setObject(RegisterOffset.incrementObjects(offset), in.caseName)
+            out.setObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset)), in.actions)
+          }
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val transformElementsSchema: Schema[TransformElements] =
+    record2(TypeId.of[TransformElements], Schema[DynamicOptic].reflect, "at", Schema[MigrationExpr].reflect, "transform")(
+      (a, b) => TransformElements(a.asInstanceOf[DynamicOptic], b.asInstanceOf[MigrationExpr]),
+      in => (in.at, in.transform)
+    )
+  implicit lazy val transformKeysSchema: Schema[TransformKeys] =
+    record2(TypeId.of[TransformKeys], Schema[DynamicOptic].reflect, "at", Schema[MigrationExpr].reflect, "transform")(
+      (a, b) => TransformKeys(a.asInstanceOf[DynamicOptic], b.asInstanceOf[MigrationExpr]),
+      in => (in.at, in.transform)
+    )
+  implicit lazy val transformValuesSchema: Schema[TransformValues] =
+    record2(TypeId.of[TransformValues], Schema[DynamicOptic].reflect, "at", Schema[MigrationExpr].reflect, "transform")(
+      (a, b) => TransformValues(a.asInstanceOf[DynamicOptic], b.asInstanceOf[MigrationExpr]),
+      in => (in.at, in.transform)
+    )
+
+  implicit lazy val nestedMigrationSchema: Schema[NestedMigration] =
+    record2(TypeId.of[NestedMigration], Schema[DynamicOptic].reflect, "at", Schema[DynamicMigration].reflect, "migration")(
+      (a, b) => NestedMigration(a.asInstanceOf[DynamicOptic], b.asInstanceOf[DynamicMigration]),
+      in => (in.at, in.migration)
+    )
+
+  implicit lazy val schema: Schema[MigrationAction] = new Schema(
+    reflect = new Reflect.Variant[Binding, MigrationAction](
+      cases = Chunk(
+        addFieldSchema.reflect.asTerm("AddField"),
+        dropFieldSchema.reflect.asTerm("DropField"),
+        renameSchema.reflect.asTerm("Rename"),
+        transformValueSchema.reflect.asTerm("TransformValue"),
+        mandateSchema.reflect.asTerm("Mandate"),
+        optionalizeSchema.reflect.asTerm("Optionalize"),
+        joinSchema.reflect.asTerm("Join"),
+        splitSchema.reflect.asTerm("Split"),
+        changeTypeSchema.reflect.asTerm("ChangeType"),
+        renameCaseSchema.reflect.asTerm("RenameCase"),
+        Reflect.Deferred(() => transformCaseSchema.reflect).asTerm("TransformCase"),
+        transformElementsSchema.reflect.asTerm("TransformElements"),
+        transformKeysSchema.reflect.asTerm("TransformKeys"),
+        transformValuesSchema.reflect.asTerm("TransformValues"),
+        Reflect.Deferred(() => nestedMigrationSchema.reflect).asTerm("NestedMigration")
+      ),
+      typeId = TypeId.of[MigrationAction],
+      variantBinding = new Binding.Variant(
+        discriminator = new Discriminator[MigrationAction] {
+          def discriminate(a: MigrationAction): Int = a match {
+            case _: AddField          => 0
+            case _: DropField         => 1
+            case _: Rename            => 2
+            case _: TransformValue    => 3
+            case _: Mandate           => 4
+            case _: Optionalize       => 5
+            case _: Join              => 6
+            case _: Split             => 7
+            case _: ChangeType        => 8
+            case _: RenameCase        => 9
+            case _: TransformCase     => 10
+            case _: TransformElements => 11
+            case _: TransformKeys     => 12
+            case _: TransformValues   => 13
+            case _: NestedMigration   => 14
+          }
+        },
+        matchers = Matchers(
+          new Matcher[AddField] { def downcastOrNull(a: Any): AddField = a match { case x: AddField => x; case _ => null.asInstanceOf[AddField] } },
+          new Matcher[DropField] { def downcastOrNull(a: Any): DropField = a match { case x: DropField => x; case _ => null.asInstanceOf[DropField] } },
+          new Matcher[Rename] { def downcastOrNull(a: Any): Rename = a match { case x: Rename => x; case _ => null.asInstanceOf[Rename] } },
+          new Matcher[TransformValue] { def downcastOrNull(a: Any): TransformValue = a match { case x: TransformValue => x; case _ => null.asInstanceOf[TransformValue] } },
+          new Matcher[Mandate] { def downcastOrNull(a: Any): Mandate = a match { case x: Mandate => x; case _ => null.asInstanceOf[Mandate] } },
+          new Matcher[Optionalize] { def downcastOrNull(a: Any): Optionalize = a match { case x: Optionalize => x; case _ => null.asInstanceOf[Optionalize] } },
+          new Matcher[Join] { def downcastOrNull(a: Any): Join = a match { case x: Join => x; case _ => null.asInstanceOf[Join] } },
+          new Matcher[Split] { def downcastOrNull(a: Any): Split = a match { case x: Split => x; case _ => null.asInstanceOf[Split] } },
+          new Matcher[ChangeType] { def downcastOrNull(a: Any): ChangeType = a match { case x: ChangeType => x; case _ => null.asInstanceOf[ChangeType] } },
+          new Matcher[RenameCase] { def downcastOrNull(a: Any): RenameCase = a match { case x: RenameCase => x; case _ => null.asInstanceOf[RenameCase] } },
+          new Matcher[TransformCase] { def downcastOrNull(a: Any): TransformCase = a match { case x: TransformCase => x; case _ => null.asInstanceOf[TransformCase] } },
+          new Matcher[TransformElements] { def downcastOrNull(a: Any): TransformElements = a match { case x: TransformElements => x; case _ => null.asInstanceOf[TransformElements] } },
+          new Matcher[TransformKeys] { def downcastOrNull(a: Any): TransformKeys = a match { case x: TransformKeys => x; case _ => null.asInstanceOf[TransformKeys] } },
+          new Matcher[TransformValues] { def downcastOrNull(a: Any): TransformValues = a match { case x: TransformValues => x; case _ => null.asInstanceOf[TransformValues] } },
+          new Matcher[NestedMigration] { def downcastOrNull(a: Any): NestedMigration = a match { case x: NestedMigration => x; case _ => null.asInstanceOf[NestedMigration] } }
+        )
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.{DynamicOptic, Schema}
+import zio.blocks.schema.migration.MigrationAction._
+
+final class MigrationBuilder[A, B] private[migration] (
+  val sourceSchema: Schema[A],
+  val targetSchema: Schema[B],
+  val actions: Vector[MigrationAction],
+  val handledFields: Set[String]
+) {
+
+  def addField(target: DynamicOptic, default: MigrationExpr): MigrationBuilder[A, B] =
+    withAction(AddField(target, default), topLevelField(target).toSet)
+
+  def dropField(
+    source: DynamicOptic,
+    defaultForReverse: MigrationExpr = MigrationExpr.DefaultValue
+  ): MigrationBuilder[A, B] =
+    withAction(DropField(source, defaultForReverse), Set.empty)
+
+  def renameField(from: DynamicOptic, to: DynamicOptic): MigrationBuilder[A, B] =
+    withAction(Rename(from, topLevelField(to).getOrElse(to.toString)), topLevelField(to).toSet)
+
+  def transformField(from: DynamicOptic, to: DynamicOptic, transform: MigrationExpr): MigrationBuilder[A, B] =
+    withAction(TransformValue(from, transform), topLevelField(to).toSet)
+
+  def mandateField(source: DynamicOptic, target: DynamicOptic, default: MigrationExpr): MigrationBuilder[A, B] =
+    withAction(Mandate(source, default), topLevelField(target).toSet)
+
+  def optionalizeField(source: DynamicOptic, target: DynamicOptic): MigrationBuilder[A, B] =
+    withAction(Optionalize(source), topLevelField(target).toSet)
+
+  def changeFieldType(source: DynamicOptic, target: DynamicOptic, converter: MigrationExpr): MigrationBuilder[A, B] =
+    withAction(ChangeType(source, converter), topLevelField(target).toSet)
+
+  def renameCase(from: String, to: String): MigrationBuilder[A, B] =
+    withAction(RenameCase(DynamicOptic.root, from, to), Set.empty)
+
+  def inField[FA, FB](
+    fromField: DynamicOptic,
+    toField: DynamicOptic,
+    subMigration: Migration[FA, FB]
+  ): MigrationBuilder[A, B] = {
+    val _ = fromField
+    withAction(NestedMigration(toField, subMigration.dynamicMigration), topLevelField(toField).toSet)
+  }
+
+  def transformElements(source: DynamicOptic, transform: MigrationExpr): MigrationBuilder[A, B] =
+    withAction(TransformElements(source, transform), Set.empty)
+
+  def transformKeys(source: DynamicOptic, transform: MigrationExpr): MigrationBuilder[A, B] =
+    withAction(TransformKeys(source, transform), Set.empty)
+
+  def transformValues(source: DynamicOptic, transform: MigrationExpr): MigrationBuilder[A, B] =
+    withAction(TransformValues(source, transform), Set.empty)
+
+  def buildPartial: Migration[A, B] =
+    Migration(DynamicMigration(actions), sourceSchema, targetSchema)
+  // build is provided by MigrationBuilderVersionSpecific via extension
+
+  private[this] def withAction(action: MigrationAction, fields: Set[String]): MigrationBuilder[A, B] =
+    new MigrationBuilder(sourceSchema, targetSchema, actions :+ action, handledFields ++ fields)
+
+  private[this] def topLevelField(path: DynamicOptic): Option[String] =
+    path.nodes.headOption.collect { case DynamicOptic.Node.Field(name) => name }
+}
+
+object MigrationBuilder {
+  def apply[A, B](implicit sa: Schema[A], sb: Schema[B]): MigrationBuilder[A, B] =
+    new MigrationBuilder(sa, sb, Vector.empty, Set.empty)
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationError.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationError.scala
@@ -51,7 +51,7 @@ object MigrationError {
       typeId = TypeId.of[MissingField],
       recordBinding = new Binding.Record(
         constructor = new Constructor[MissingField] {
-          def usedRegisters: RegisterOffset                                     = RegisterOffset(objects = 2)
+          def usedRegisters: RegisterOffset                                  = RegisterOffset(objects = 2)
           def construct(in: Registers, offset: RegisterOffset): MissingField =
             MissingField(
               in.getObject(offset).asInstanceOf[DynamicOptic],
@@ -59,7 +59,7 @@ object MigrationError {
             )
         },
         deconstructor = new Deconstructor[MissingField] {
-          def usedRegisters: RegisterOffset                                                  = RegisterOffset(objects = 2)
+          def usedRegisters: RegisterOffset                                               = RegisterOffset(objects = 2)
           def deconstruct(out: Registers, offset: RegisterOffset, in: MissingField): Unit = {
             out.setObject(offset, in.path)
             out.setObject(RegisterOffset.incrementObjects(offset), in.fieldName)
@@ -80,16 +80,17 @@ object MigrationError {
       typeId = TypeId.of[TypeMismatch],
       recordBinding = new Binding.Record(
         constructor = new Constructor[TypeMismatch] {
-          def usedRegisters: RegisterOffset                                      = RegisterOffset(objects = 3)
+          def usedRegisters: RegisterOffset                                  = RegisterOffset(objects = 3)
           def construct(in: Registers, offset: RegisterOffset): TypeMismatch =
             TypeMismatch(
               in.getObject(offset).asInstanceOf[DynamicOptic],
               in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[String],
-              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset))).asInstanceOf[String]
+              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset)))
+                .asInstanceOf[String]
             )
         },
         deconstructor = new Deconstructor[TypeMismatch] {
-          def usedRegisters: RegisterOffset                                                   = RegisterOffset(objects = 3)
+          def usedRegisters: RegisterOffset                                               = RegisterOffset(objects = 3)
           def deconstruct(out: Registers, offset: RegisterOffset, in: TypeMismatch): Unit = {
             out.setObject(offset, in.path)
             out.setObject(RegisterOffset.incrementObjects(offset), in.expected)
@@ -107,7 +108,7 @@ object MigrationError {
       typeId = TypeId.of[InvalidValue],
       recordBinding = new Binding.Record(
         constructor = new Constructor[InvalidValue] {
-          def usedRegisters: RegisterOffset                                     = RegisterOffset(objects = 2)
+          def usedRegisters: RegisterOffset                                  = RegisterOffset(objects = 2)
           def construct(in: Registers, offset: RegisterOffset): InvalidValue =
             InvalidValue(
               in.getObject(offset).asInstanceOf[DynamicOptic],
@@ -115,7 +116,7 @@ object MigrationError {
             )
         },
         deconstructor = new Deconstructor[InvalidValue] {
-          def usedRegisters: RegisterOffset                                                  = RegisterOffset(objects = 2)
+          def usedRegisters: RegisterOffset                                               = RegisterOffset(objects = 2)
           def deconstruct(out: Registers, offset: RegisterOffset, in: InvalidValue): Unit = {
             out.setObject(offset, in.path)
             out.setObject(RegisterOffset.incrementObjects(offset), in.detail)
@@ -132,12 +133,12 @@ object MigrationError {
       typeId = TypeId.of[CompositeError],
       recordBinding = new Binding.Record(
         constructor = new Constructor[CompositeError] {
-          def usedRegisters: RegisterOffset                                     = RegisterOffset(objects = 1)
+          def usedRegisters: RegisterOffset                                    = RegisterOffset(objects = 1)
           def construct(in: Registers, offset: RegisterOffset): CompositeError =
             CompositeError(in.getObject(offset).asInstanceOf[Vector[MigrationError]])
         },
         deconstructor = new Deconstructor[CompositeError] {
-          def usedRegisters: RegisterOffset                                                  = RegisterOffset(objects = 1)
+          def usedRegisters: RegisterOffset                                                 = RegisterOffset(objects = 1)
           def deconstruct(out: Registers, offset: RegisterOffset, in: CompositeError): Unit =
             out.setObject(offset, in.errors)
         }

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationError.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationError.scala
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.binding._
+import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
+import zio.blocks.schema.{DynamicOptic, Reflect, Schema}
+import zio.blocks.typeid.TypeId
+
+sealed trait MigrationError {
+  def path: DynamicOptic
+  def message: String
+}
+
+object MigrationError {
+  final case class MissingField(path: DynamicOptic, fieldName: String) extends MigrationError {
+    def message: String = s"Missing field '$fieldName'"
+  }
+
+  final case class TypeMismatch(path: DynamicOptic, expected: String, actual: String) extends MigrationError {
+    def message: String = s"Type mismatch. Expected: $expected, actual: $actual"
+  }
+
+  final case class InvalidValue(path: DynamicOptic, detail: String) extends MigrationError {
+    def message: String = detail
+  }
+
+  final case class CompositeError(errors: Vector[MigrationError]) extends MigrationError {
+    def path: DynamicOptic = errors.headOption.map(_.path).getOrElse(DynamicOptic.root)
+    def message: String    = errors.map(_.message).mkString("; ")
+  }
+
+  implicit lazy val missingFieldSchema: Schema[MissingField] = new Schema(
+    reflect = new Reflect.Record[Binding, MissingField](
+      fields = Chunk(Schema[DynamicOptic].reflect.asTerm("path"), Schema[String].reflect.asTerm("fieldName")),
+      typeId = TypeId.of[MissingField],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[MissingField] {
+          def usedRegisters: RegisterOffset                                     = RegisterOffset(objects = 2)
+          def construct(in: Registers, offset: RegisterOffset): MissingField =
+            MissingField(
+              in.getObject(offset).asInstanceOf[DynamicOptic],
+              in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[String]
+            )
+        },
+        deconstructor = new Deconstructor[MissingField] {
+          def usedRegisters: RegisterOffset                                                  = RegisterOffset(objects = 2)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: MissingField): Unit = {
+            out.setObject(offset, in.path)
+            out.setObject(RegisterOffset.incrementObjects(offset), in.fieldName)
+          }
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val typeMismatchSchema: Schema[TypeMismatch] = new Schema(
+    reflect = new Reflect.Record[Binding, TypeMismatch](
+      fields = Chunk(
+        Schema[DynamicOptic].reflect.asTerm("path"),
+        Schema[String].reflect.asTerm("expected"),
+        Schema[String].reflect.asTerm("actual")
+      ),
+      typeId = TypeId.of[TypeMismatch],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[TypeMismatch] {
+          def usedRegisters: RegisterOffset                                      = RegisterOffset(objects = 3)
+          def construct(in: Registers, offset: RegisterOffset): TypeMismatch =
+            TypeMismatch(
+              in.getObject(offset).asInstanceOf[DynamicOptic],
+              in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[String],
+              in.getObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset))).asInstanceOf[String]
+            )
+        },
+        deconstructor = new Deconstructor[TypeMismatch] {
+          def usedRegisters: RegisterOffset                                                   = RegisterOffset(objects = 3)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: TypeMismatch): Unit = {
+            out.setObject(offset, in.path)
+            out.setObject(RegisterOffset.incrementObjects(offset), in.expected)
+            out.setObject(RegisterOffset.incrementObjects(RegisterOffset.incrementObjects(offset)), in.actual)
+          }
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val invalidValueSchema: Schema[InvalidValue] = new Schema(
+    reflect = new Reflect.Record[Binding, InvalidValue](
+      fields = Chunk(Schema[DynamicOptic].reflect.asTerm("path"), Schema[String].reflect.asTerm("detail")),
+      typeId = TypeId.of[InvalidValue],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[InvalidValue] {
+          def usedRegisters: RegisterOffset                                     = RegisterOffset(objects = 2)
+          def construct(in: Registers, offset: RegisterOffset): InvalidValue =
+            InvalidValue(
+              in.getObject(offset).asInstanceOf[DynamicOptic],
+              in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[String]
+            )
+        },
+        deconstructor = new Deconstructor[InvalidValue] {
+          def usedRegisters: RegisterOffset                                                  = RegisterOffset(objects = 2)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: InvalidValue): Unit = {
+            out.setObject(offset, in.path)
+            out.setObject(RegisterOffset.incrementObjects(offset), in.detail)
+          }
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val compositeErrorSchema: Schema[CompositeError] = new Schema(
+    reflect = new Reflect.Record[Binding, CompositeError](
+      fields = Chunk.single(Schema[Vector[MigrationError]].reflect.asTerm("errors")),
+      typeId = TypeId.of[CompositeError],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[CompositeError] {
+          def usedRegisters: RegisterOffset                                     = RegisterOffset(objects = 1)
+          def construct(in: Registers, offset: RegisterOffset): CompositeError =
+            CompositeError(in.getObject(offset).asInstanceOf[Vector[MigrationError]])
+        },
+        deconstructor = new Deconstructor[CompositeError] {
+          def usedRegisters: RegisterOffset                                                  = RegisterOffset(objects = 1)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: CompositeError): Unit =
+            out.setObject(offset, in.errors)
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val schema: Schema[MigrationError] = new Schema(
+    reflect = new Reflect.Variant[Binding, MigrationError](
+      cases = Chunk(
+        missingFieldSchema.reflect.asTerm("MissingField"),
+        typeMismatchSchema.reflect.asTerm("TypeMismatch"),
+        invalidValueSchema.reflect.asTerm("InvalidValue"),
+        compositeErrorSchema.reflect.asTerm("CompositeError")
+      ),
+      typeId = TypeId.of[MigrationError],
+      variantBinding = new Binding.Variant(
+        discriminator = new Discriminator[MigrationError] {
+          def discriminate(a: MigrationError): Int = a match {
+            case _: MissingField   => 0
+            case _: TypeMismatch   => 1
+            case _: InvalidValue   => 2
+            case _: CompositeError => 3
+          }
+        },
+        matchers = Matchers(
+          new Matcher[MissingField] {
+            def downcastOrNull(a: Any): MissingField = a match {
+              case x: MissingField => x
+              case _               => null.asInstanceOf[MissingField]
+            }
+          },
+          new Matcher[TypeMismatch] {
+            def downcastOrNull(a: Any): TypeMismatch = a match {
+              case x: TypeMismatch => x
+              case _               => null.asInstanceOf[TypeMismatch]
+            }
+          },
+          new Matcher[InvalidValue] {
+            def downcastOrNull(a: Any): InvalidValue = a match {
+              case x: InvalidValue => x
+              case _               => null.asInstanceOf[InvalidValue]
+            }
+          },
+          new Matcher[CompositeError] {
+            def downcastOrNull(a: Any): CompositeError = a match {
+              case x: CompositeError => x
+              case _                 => null.asInstanceOf[CompositeError]
+            }
+          }
+        )
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationExpr.scala
@@ -72,19 +72,32 @@ sealed trait MigrationExpr { self =>
     case (DynamicValue.Primitive(PrimitiveValue.Int(v)), PrimitiveConversion.IntToString) =>
       Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
     case (DynamicValue.Primitive(PrimitiveValue.String(v)), PrimitiveConversion.StringToInt) =>
-      scala.util.Try(v.toInt).toEither.left.map(_ => InvalidValue(DynamicOptic.root, s"Cannot convert '$v' to Int")).map {
-        i => DynamicValue.Primitive(PrimitiveValue.Int(i))
-      }
+      scala.util
+        .Try(v.toInt)
+        .toEither
+        .left
+        .map(_ => InvalidValue(DynamicOptic.root, s"Cannot convert '$v' to Int"))
+        .map { i =>
+          DynamicValue.Primitive(PrimitiveValue.Int(i))
+        }
     case (DynamicValue.Primitive(PrimitiveValue.Long(v)), PrimitiveConversion.LongToString) =>
       Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
     case (DynamicValue.Primitive(PrimitiveValue.String(v)), PrimitiveConversion.StringToLong) =>
-      scala.util.Try(v.toLong).toEither.left.map(_ => InvalidValue(DynamicOptic.root, s"Cannot convert '$v' to Long")).map {
-        i => DynamicValue.Primitive(PrimitiveValue.Long(i))
-      }
+      scala.util
+        .Try(v.toLong)
+        .toEither
+        .left
+        .map(_ => InvalidValue(DynamicOptic.root, s"Cannot convert '$v' to Long"))
+        .map { i =>
+          DynamicValue.Primitive(PrimitiveValue.Long(i))
+        }
     case (DynamicValue.Primitive(PrimitiveValue.Double(v)), PrimitiveConversion.DoubleToString) =>
       Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
     case (DynamicValue.Primitive(PrimitiveValue.String(v)), PrimitiveConversion.StringToDouble) =>
-      scala.util.Try(v.toDouble).toEither.left
+      scala.util
+        .Try(v.toDouble)
+        .toEither
+        .left
         .map(_ => InvalidValue(DynamicOptic.root, s"Cannot convert '$v' to Double"))
         .map(i => DynamicValue.Primitive(PrimitiveValue.Double(i)))
     case (DynamicValue.Primitive(PrimitiveValue.Float(v)), PrimitiveConversion.FloatToDouble) =>
@@ -94,7 +107,10 @@ sealed trait MigrationExpr { self =>
     case (DynamicValue.Primitive(PrimitiveValue.Boolean(v)), PrimitiveConversion.BooleanToString) =>
       Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
     case (DynamicValue.Primitive(PrimitiveValue.String(v)), PrimitiveConversion.StringToBoolean) =>
-      scala.util.Try(v.toBoolean).toEither.left
+      scala.util
+        .Try(v.toBoolean)
+        .toEither
+        .left
         .map(_ => InvalidValue(DynamicOptic.root, s"Cannot convert '$v' to Boolean"))
         .map(i => DynamicValue.Primitive(PrimitiveValue.Boolean(i)))
     case _ =>
@@ -103,26 +119,26 @@ sealed trait MigrationExpr { self =>
 }
 
 object MigrationExpr {
-  case object Identity extends MigrationExpr
-  final case class Literal(value: DynamicValue) extends MigrationExpr
-  final case class FieldAccess(path: DynamicOptic) extends MigrationExpr
+  case object Identity                                                           extends MigrationExpr
+  final case class Literal(value: DynamicValue)                                  extends MigrationExpr
+  final case class FieldAccess(path: DynamicOptic)                               extends MigrationExpr
   final case class Convert(expr: MigrationExpr, conversion: PrimitiveConversion) extends MigrationExpr
-  final case class Concat(exprs: Vector[MigrationExpr], separator: String) extends MigrationExpr
-  final case class Compose(first: MigrationExpr, second: MigrationExpr) extends MigrationExpr
-  case object DefaultValue extends MigrationExpr
+  final case class Concat(exprs: Vector[MigrationExpr], separator: String)       extends MigrationExpr
+  final case class Compose(first: MigrationExpr, second: MigrationExpr)          extends MigrationExpr
+  case object DefaultValue                                                       extends MigrationExpr
 
   sealed trait PrimitiveConversion
   object PrimitiveConversion {
-    case object IntToLong extends PrimitiveConversion
-    case object LongToInt extends PrimitiveConversion
-    case object IntToString extends PrimitiveConversion
-    case object StringToInt extends PrimitiveConversion
-    case object LongToString extends PrimitiveConversion
-    case object StringToLong extends PrimitiveConversion
-    case object DoubleToString extends PrimitiveConversion
-    case object StringToDouble extends PrimitiveConversion
-    case object FloatToDouble extends PrimitiveConversion
-    case object DoubleToFloat extends PrimitiveConversion
+    case object IntToLong       extends PrimitiveConversion
+    case object LongToInt       extends PrimitiveConversion
+    case object IntToString     extends PrimitiveConversion
+    case object StringToInt     extends PrimitiveConversion
+    case object LongToString    extends PrimitiveConversion
+    case object StringToLong    extends PrimitiveConversion
+    case object DoubleToString  extends PrimitiveConversion
+    case object StringToDouble  extends PrimitiveConversion
+    case object FloatToDouble   extends PrimitiveConversion
+    case object DoubleToFloat   extends PrimitiveConversion
     case object BooleanToString extends PrimitiveConversion
     case object StringToBoolean extends PrimitiveConversion
 
@@ -138,8 +154,8 @@ object MigrationExpr {
       )
     )
 
-    implicit lazy val intToLongSchema: Schema[IntToLong.type] = singletonSchema(IntToLong, TypeId.of[IntToLong.type])
-    implicit lazy val longToIntSchema: Schema[LongToInt.type] = singletonSchema(LongToInt, TypeId.of[LongToInt.type])
+    implicit lazy val intToLongSchema: Schema[IntToLong.type]     = singletonSchema(IntToLong, TypeId.of[IntToLong.type])
+    implicit lazy val longToIntSchema: Schema[LongToInt.type]     = singletonSchema(LongToInt, TypeId.of[LongToInt.type])
     implicit lazy val intToStringSchema: Schema[IntToString.type] =
       singletonSchema(IntToString, TypeId.of[IntToString.type])
     implicit lazy val stringToIntSchema: Schema[StringToInt.type] =
@@ -196,18 +212,54 @@ object MigrationExpr {
             }
           },
           matchers = Matchers(
-            new Matcher[IntToLong.type] { def downcastOrNull(a: Any): IntToLong.type = if (a == IntToLong) IntToLong else null.asInstanceOf[IntToLong.type] },
-            new Matcher[LongToInt.type] { def downcastOrNull(a: Any): LongToInt.type = if (a == LongToInt) LongToInt else null.asInstanceOf[LongToInt.type] },
-            new Matcher[IntToString.type] { def downcastOrNull(a: Any): IntToString.type = if (a == IntToString) IntToString else null.asInstanceOf[IntToString.type] },
-            new Matcher[StringToInt.type] { def downcastOrNull(a: Any): StringToInt.type = if (a == StringToInt) StringToInt else null.asInstanceOf[StringToInt.type] },
-            new Matcher[LongToString.type] { def downcastOrNull(a: Any): LongToString.type = if (a == LongToString) LongToString else null.asInstanceOf[LongToString.type] },
-            new Matcher[StringToLong.type] { def downcastOrNull(a: Any): StringToLong.type = if (a == StringToLong) StringToLong else null.asInstanceOf[StringToLong.type] },
-            new Matcher[DoubleToString.type] { def downcastOrNull(a: Any): DoubleToString.type = if (a == DoubleToString) DoubleToString else null.asInstanceOf[DoubleToString.type] },
-            new Matcher[StringToDouble.type] { def downcastOrNull(a: Any): StringToDouble.type = if (a == StringToDouble) StringToDouble else null.asInstanceOf[StringToDouble.type] },
-            new Matcher[FloatToDouble.type] { def downcastOrNull(a: Any): FloatToDouble.type = if (a == FloatToDouble) FloatToDouble else null.asInstanceOf[FloatToDouble.type] },
-            new Matcher[DoubleToFloat.type] { def downcastOrNull(a: Any): DoubleToFloat.type = if (a == DoubleToFloat) DoubleToFloat else null.asInstanceOf[DoubleToFloat.type] },
-            new Matcher[BooleanToString.type] { def downcastOrNull(a: Any): BooleanToString.type = if (a == BooleanToString) BooleanToString else null.asInstanceOf[BooleanToString.type] },
-            new Matcher[StringToBoolean.type] { def downcastOrNull(a: Any): StringToBoolean.type = if (a == StringToBoolean) StringToBoolean else null.asInstanceOf[StringToBoolean.type] }
+            new Matcher[IntToLong.type] {
+              def downcastOrNull(a: Any): IntToLong.type =
+                if (a == IntToLong) IntToLong else null.asInstanceOf[IntToLong.type]
+            },
+            new Matcher[LongToInt.type] {
+              def downcastOrNull(a: Any): LongToInt.type =
+                if (a == LongToInt) LongToInt else null.asInstanceOf[LongToInt.type]
+            },
+            new Matcher[IntToString.type] {
+              def downcastOrNull(a: Any): IntToString.type =
+                if (a == IntToString) IntToString else null.asInstanceOf[IntToString.type]
+            },
+            new Matcher[StringToInt.type] {
+              def downcastOrNull(a: Any): StringToInt.type =
+                if (a == StringToInt) StringToInt else null.asInstanceOf[StringToInt.type]
+            },
+            new Matcher[LongToString.type] {
+              def downcastOrNull(a: Any): LongToString.type =
+                if (a == LongToString) LongToString else null.asInstanceOf[LongToString.type]
+            },
+            new Matcher[StringToLong.type] {
+              def downcastOrNull(a: Any): StringToLong.type =
+                if (a == StringToLong) StringToLong else null.asInstanceOf[StringToLong.type]
+            },
+            new Matcher[DoubleToString.type] {
+              def downcastOrNull(a: Any): DoubleToString.type =
+                if (a == DoubleToString) DoubleToString else null.asInstanceOf[DoubleToString.type]
+            },
+            new Matcher[StringToDouble.type] {
+              def downcastOrNull(a: Any): StringToDouble.type =
+                if (a == StringToDouble) StringToDouble else null.asInstanceOf[StringToDouble.type]
+            },
+            new Matcher[FloatToDouble.type] {
+              def downcastOrNull(a: Any): FloatToDouble.type =
+                if (a == FloatToDouble) FloatToDouble else null.asInstanceOf[FloatToDouble.type]
+            },
+            new Matcher[DoubleToFloat.type] {
+              def downcastOrNull(a: Any): DoubleToFloat.type =
+                if (a == DoubleToFloat) DoubleToFloat else null.asInstanceOf[DoubleToFloat.type]
+            },
+            new Matcher[BooleanToString.type] {
+              def downcastOrNull(a: Any): BooleanToString.type =
+                if (a == BooleanToString) BooleanToString else null.asInstanceOf[BooleanToString.type]
+            },
+            new Matcher[StringToBoolean.type] {
+              def downcastOrNull(a: Any): StringToBoolean.type =
+                if (a == StringToBoolean) StringToBoolean else null.asInstanceOf[StringToBoolean.type]
+            }
           )
         ),
         modifiers = Chunk.empty
@@ -232,12 +284,12 @@ object MigrationExpr {
       typeId = TypeId.of[Literal],
       recordBinding = new Binding.Record(
         constructor = new Constructor[Literal] {
-          def usedRegisters: RegisterOffset                           = RegisterOffset(objects = 1)
+          def usedRegisters: RegisterOffset                             = RegisterOffset(objects = 1)
           def construct(in: Registers, offset: RegisterOffset): Literal =
             Literal(in.getObject(offset).asInstanceOf[DynamicValue])
         },
         deconstructor = new Deconstructor[Literal] {
-          def usedRegisters: RegisterOffset                                        = RegisterOffset(objects = 1)
+          def usedRegisters: RegisterOffset                                          = RegisterOffset(objects = 1)
           def deconstruct(out: Registers, offset: RegisterOffset, in: Literal): Unit =
             out.setObject(offset, in.value)
         }
@@ -251,12 +303,12 @@ object MigrationExpr {
       typeId = TypeId.of[FieldAccess],
       recordBinding = new Binding.Record(
         constructor = new Constructor[FieldAccess] {
-          def usedRegisters: RegisterOffset                               = RegisterOffset(objects = 1)
+          def usedRegisters: RegisterOffset                                 = RegisterOffset(objects = 1)
           def construct(in: Registers, offset: RegisterOffset): FieldAccess =
             FieldAccess(in.getObject(offset).asInstanceOf[DynamicOptic])
         },
         deconstructor = new Deconstructor[FieldAccess] {
-          def usedRegisters: RegisterOffset                                            = RegisterOffset(objects = 1)
+          def usedRegisters: RegisterOffset                                              = RegisterOffset(objects = 1)
           def deconstruct(out: Registers, offset: RegisterOffset, in: FieldAccess): Unit =
             out.setObject(offset, in.path)
         }
@@ -273,7 +325,7 @@ object MigrationExpr {
       typeId = TypeId.of[Convert],
       recordBinding = new Binding.Record(
         constructor = new Constructor[Convert] {
-          def usedRegisters: RegisterOffset                           = RegisterOffset(objects = 2)
+          def usedRegisters: RegisterOffset                             = RegisterOffset(objects = 2)
           def construct(in: Registers, offset: RegisterOffset): Convert =
             Convert(
               in.getObject(offset).asInstanceOf[MigrationExpr],
@@ -281,7 +333,7 @@ object MigrationExpr {
             )
         },
         deconstructor = new Deconstructor[Convert] {
-          def usedRegisters: RegisterOffset                                        = RegisterOffset(objects = 2)
+          def usedRegisters: RegisterOffset                                          = RegisterOffset(objects = 2)
           def deconstruct(out: Registers, offset: RegisterOffset, in: Convert): Unit = {
             out.setObject(offset, in.expr)
             out.setObject(RegisterOffset.incrementObjects(offset), in.conversion)
@@ -300,7 +352,7 @@ object MigrationExpr {
       typeId = TypeId.of[Concat],
       recordBinding = new Binding.Record(
         constructor = new Constructor[Concat] {
-          def usedRegisters: RegisterOffset                          = RegisterOffset(objects = 2)
+          def usedRegisters: RegisterOffset                            = RegisterOffset(objects = 2)
           def construct(in: Registers, offset: RegisterOffset): Concat =
             Concat(
               in.getObject(offset).asInstanceOf[Vector[MigrationExpr]],
@@ -308,7 +360,7 @@ object MigrationExpr {
             )
         },
         deconstructor = new Deconstructor[Concat] {
-          def usedRegisters: RegisterOffset                                       = RegisterOffset(objects = 2)
+          def usedRegisters: RegisterOffset                                         = RegisterOffset(objects = 2)
           def deconstruct(out: Registers, offset: RegisterOffset, in: Concat): Unit = {
             out.setObject(offset, in.exprs)
             out.setObject(RegisterOffset.incrementObjects(offset), in.separator)
@@ -327,7 +379,7 @@ object MigrationExpr {
       typeId = TypeId.of[Compose],
       recordBinding = new Binding.Record(
         constructor = new Constructor[Compose] {
-          def usedRegisters: RegisterOffset                           = RegisterOffset(objects = 2)
+          def usedRegisters: RegisterOffset                             = RegisterOffset(objects = 2)
           def construct(in: Registers, offset: RegisterOffset): Compose =
             Compose(
               in.getObject(offset).asInstanceOf[MigrationExpr],
@@ -335,7 +387,7 @@ object MigrationExpr {
             )
         },
         deconstructor = new Deconstructor[Compose] {
-          def usedRegisters: RegisterOffset                                        = RegisterOffset(objects = 2)
+          def usedRegisters: RegisterOffset                                          = RegisterOffset(objects = 2)
           def deconstruct(out: Registers, offset: RegisterOffset, in: Compose): Unit = {
             out.setObject(offset, in.first)
             out.setObject(RegisterOffset.incrementObjects(offset), in.second)
@@ -371,23 +423,41 @@ object MigrationExpr {
       variantBinding = new Binding.Variant(
         discriminator = new Discriminator[MigrationExpr] {
           def discriminate(a: MigrationExpr): Int = a match {
-            case Identity     => 0
-            case _: Literal   => 1
+            case Identity       => 0
+            case _: Literal     => 1
             case _: FieldAccess => 2
-            case _: Convert   => 3
-            case _: Concat    => 4
-            case _: Compose   => 5
-            case DefaultValue => 6
+            case _: Convert     => 3
+            case _: Concat      => 4
+            case _: Compose     => 5
+            case DefaultValue   => 6
           }
         },
         matchers = Matchers(
-          new Matcher[Identity.type] { def downcastOrNull(a: Any): Identity.type = if (a == Identity) Identity else null.asInstanceOf[Identity.type] },
-          new Matcher[Literal] { def downcastOrNull(a: Any): Literal = a match { case x: Literal => x; case _ => null.asInstanceOf[Literal] } },
-          new Matcher[FieldAccess] { def downcastOrNull(a: Any): FieldAccess = a match { case x: FieldAccess => x; case _ => null.asInstanceOf[FieldAccess] } },
-          new Matcher[Convert] { def downcastOrNull(a: Any): Convert = a match { case x: Convert => x; case _ => null.asInstanceOf[Convert] } },
-          new Matcher[Concat] { def downcastOrNull(a: Any): Concat = a match { case x: Concat => x; case _ => null.asInstanceOf[Concat] } },
-          new Matcher[Compose] { def downcastOrNull(a: Any): Compose = a match { case x: Compose => x; case _ => null.asInstanceOf[Compose] } },
-          new Matcher[DefaultValue.type] { def downcastOrNull(a: Any): DefaultValue.type = if (a == DefaultValue) DefaultValue else null.asInstanceOf[DefaultValue.type] }
+          new Matcher[Identity.type] {
+            def downcastOrNull(a: Any): Identity.type =
+              if (a == Identity) Identity else null.asInstanceOf[Identity.type]
+          },
+          new Matcher[Literal] {
+            def downcastOrNull(a: Any): Literal = a match { case x: Literal => x; case _ => null.asInstanceOf[Literal] }
+          },
+          new Matcher[FieldAccess] {
+            def downcastOrNull(a: Any): FieldAccess = a match {
+              case x: FieldAccess => x; case _ => null.asInstanceOf[FieldAccess]
+            }
+          },
+          new Matcher[Convert] {
+            def downcastOrNull(a: Any): Convert = a match { case x: Convert => x; case _ => null.asInstanceOf[Convert] }
+          },
+          new Matcher[Concat] {
+            def downcastOrNull(a: Any): Concat = a match { case x: Concat => x; case _ => null.asInstanceOf[Concat] }
+          },
+          new Matcher[Compose] {
+            def downcastOrNull(a: Any): Compose = a match { case x: Compose => x; case _ => null.asInstanceOf[Compose] }
+          },
+          new Matcher[DefaultValue.type] {
+            def downcastOrNull(a: Any): DefaultValue.type =
+              if (a == DefaultValue) DefaultValue else null.asInstanceOf[DefaultValue.type]
+          }
         )
       ),
       modifiers = Chunk.empty

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationExpr.scala
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.binding._
+import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
+import zio.blocks.schema.{DynamicOptic, DynamicValue, PrimitiveValue, Reflect, Schema}
+import zio.blocks.schema.migration.MigrationError.{InvalidValue, MissingField, TypeMismatch}
+import zio.blocks.typeid.TypeId
+
+sealed trait MigrationExpr { self =>
+  import MigrationExpr._
+
+  final def apply(source: DynamicValue): Either[MigrationError, DynamicValue] = self match {
+    case Identity =>
+      Right(source)
+    case Literal(value) =>
+      Right(value)
+    case FieldAccess(path) =>
+      source.get(path).one.left.map(_ => MissingField(path, path.toString))
+    case Convert(expr, conversion) =>
+      expr(source).flatMap(v => convert(v, conversion))
+    case Concat(exprs, separator) =>
+      val values = exprs.foldLeft[Either[MigrationError, Vector[String]]](Right(Vector.empty)) { (acc, expr) =>
+        for {
+          xs <- acc
+          v  <- expr(source)
+          s  <- asString(v)
+        } yield xs :+ s
+      }
+      values.map(vs => DynamicValue.Primitive(PrimitiveValue.String(vs.mkString(separator))))
+    case Compose(first, second) =>
+      first(source).flatMap(second(_))
+    case DefaultValue =>
+      Right(DynamicValue.Null)
+  }
+
+  private[this] def asString(value: DynamicValue): Either[MigrationError, String] =
+    value match {
+      case DynamicValue.Primitive(PrimitiveValue.String(v))  => Right(v)
+      case DynamicValue.Primitive(PrimitiveValue.Int(v))     => Right(v.toString)
+      case DynamicValue.Primitive(PrimitiveValue.Long(v))    => Right(v.toString)
+      case DynamicValue.Primitive(PrimitiveValue.Double(v))  => Right(v.toString)
+      case DynamicValue.Primitive(PrimitiveValue.Float(v))   => Right(v.toString)
+      case DynamicValue.Primitive(PrimitiveValue.Boolean(v)) => Right(v.toString)
+      case _                                                 => Left(TypeMismatch(DynamicOptic.root, "String-like", value.valueType.toString))
+    }
+
+  private[this] def convert(
+    value: DynamicValue,
+    conversion: PrimitiveConversion
+  ): Either[MigrationError, DynamicValue] = (value, conversion) match {
+    case (DynamicValue.Primitive(PrimitiveValue.Int(v)), PrimitiveConversion.IntToLong) =>
+      Right(DynamicValue.Primitive(PrimitiveValue.Long(v.toLong)))
+    case (DynamicValue.Primitive(PrimitiveValue.Long(v)), PrimitiveConversion.LongToInt) =>
+      Right(DynamicValue.Primitive(PrimitiveValue.Int(v.toInt)))
+    case (DynamicValue.Primitive(PrimitiveValue.Int(v)), PrimitiveConversion.IntToString) =>
+      Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
+    case (DynamicValue.Primitive(PrimitiveValue.String(v)), PrimitiveConversion.StringToInt) =>
+      scala.util.Try(v.toInt).toEither.left.map(_ => InvalidValue(DynamicOptic.root, s"Cannot convert '$v' to Int")).map {
+        i => DynamicValue.Primitive(PrimitiveValue.Int(i))
+      }
+    case (DynamicValue.Primitive(PrimitiveValue.Long(v)), PrimitiveConversion.LongToString) =>
+      Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
+    case (DynamicValue.Primitive(PrimitiveValue.String(v)), PrimitiveConversion.StringToLong) =>
+      scala.util.Try(v.toLong).toEither.left.map(_ => InvalidValue(DynamicOptic.root, s"Cannot convert '$v' to Long")).map {
+        i => DynamicValue.Primitive(PrimitiveValue.Long(i))
+      }
+    case (DynamicValue.Primitive(PrimitiveValue.Double(v)), PrimitiveConversion.DoubleToString) =>
+      Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
+    case (DynamicValue.Primitive(PrimitiveValue.String(v)), PrimitiveConversion.StringToDouble) =>
+      scala.util.Try(v.toDouble).toEither.left
+        .map(_ => InvalidValue(DynamicOptic.root, s"Cannot convert '$v' to Double"))
+        .map(i => DynamicValue.Primitive(PrimitiveValue.Double(i)))
+    case (DynamicValue.Primitive(PrimitiveValue.Float(v)), PrimitiveConversion.FloatToDouble) =>
+      Right(DynamicValue.Primitive(PrimitiveValue.Double(v.toDouble)))
+    case (DynamicValue.Primitive(PrimitiveValue.Double(v)), PrimitiveConversion.DoubleToFloat) =>
+      Right(DynamicValue.Primitive(PrimitiveValue.Float(v.toFloat)))
+    case (DynamicValue.Primitive(PrimitiveValue.Boolean(v)), PrimitiveConversion.BooleanToString) =>
+      Right(DynamicValue.Primitive(PrimitiveValue.String(v.toString)))
+    case (DynamicValue.Primitive(PrimitiveValue.String(v)), PrimitiveConversion.StringToBoolean) =>
+      scala.util.Try(v.toBoolean).toEither.left
+        .map(_ => InvalidValue(DynamicOptic.root, s"Cannot convert '$v' to Boolean"))
+        .map(i => DynamicValue.Primitive(PrimitiveValue.Boolean(i)))
+    case _ =>
+      Left(TypeMismatch(DynamicOptic.root, conversion.toString, value.valueType.toString))
+  }
+}
+
+object MigrationExpr {
+  case object Identity extends MigrationExpr
+  final case class Literal(value: DynamicValue) extends MigrationExpr
+  final case class FieldAccess(path: DynamicOptic) extends MigrationExpr
+  final case class Convert(expr: MigrationExpr, conversion: PrimitiveConversion) extends MigrationExpr
+  final case class Concat(exprs: Vector[MigrationExpr], separator: String) extends MigrationExpr
+  final case class Compose(first: MigrationExpr, second: MigrationExpr) extends MigrationExpr
+  case object DefaultValue extends MigrationExpr
+
+  sealed trait PrimitiveConversion
+  object PrimitiveConversion {
+    case object IntToLong extends PrimitiveConversion
+    case object LongToInt extends PrimitiveConversion
+    case object IntToString extends PrimitiveConversion
+    case object StringToInt extends PrimitiveConversion
+    case object LongToString extends PrimitiveConversion
+    case object StringToLong extends PrimitiveConversion
+    case object DoubleToString extends PrimitiveConversion
+    case object StringToDouble extends PrimitiveConversion
+    case object FloatToDouble extends PrimitiveConversion
+    case object DoubleToFloat extends PrimitiveConversion
+    case object BooleanToString extends PrimitiveConversion
+    case object StringToBoolean extends PrimitiveConversion
+
+    private def singletonSchema[A](value: A, tid: TypeId[A]): Schema[A] = new Schema(
+      reflect = new Reflect.Record[Binding, A](
+        fields = Chunk.empty,
+        typeId = tid,
+        recordBinding = new Binding.Record(
+          constructor = new ConstantConstructor[A](value),
+          deconstructor = new ConstantDeconstructor[A]
+        ),
+        modifiers = Chunk.empty
+      )
+    )
+
+    implicit lazy val intToLongSchema: Schema[IntToLong.type] = singletonSchema(IntToLong, TypeId.of[IntToLong.type])
+    implicit lazy val longToIntSchema: Schema[LongToInt.type] = singletonSchema(LongToInt, TypeId.of[LongToInt.type])
+    implicit lazy val intToStringSchema: Schema[IntToString.type] =
+      singletonSchema(IntToString, TypeId.of[IntToString.type])
+    implicit lazy val stringToIntSchema: Schema[StringToInt.type] =
+      singletonSchema(StringToInt, TypeId.of[StringToInt.type])
+    implicit lazy val longToStringSchema: Schema[LongToString.type] =
+      singletonSchema(LongToString, TypeId.of[LongToString.type])
+    implicit lazy val stringToLongSchema: Schema[StringToLong.type] =
+      singletonSchema(StringToLong, TypeId.of[StringToLong.type])
+    implicit lazy val doubleToStringSchema: Schema[DoubleToString.type] =
+      singletonSchema(DoubleToString, TypeId.of[DoubleToString.type])
+    implicit lazy val stringToDoubleSchema: Schema[StringToDouble.type] =
+      singletonSchema(StringToDouble, TypeId.of[StringToDouble.type])
+    implicit lazy val floatToDoubleSchema: Schema[FloatToDouble.type] =
+      singletonSchema(FloatToDouble, TypeId.of[FloatToDouble.type])
+    implicit lazy val doubleToFloatSchema: Schema[DoubleToFloat.type] =
+      singletonSchema(DoubleToFloat, TypeId.of[DoubleToFloat.type])
+    implicit lazy val booleanToStringSchema: Schema[BooleanToString.type] =
+      singletonSchema(BooleanToString, TypeId.of[BooleanToString.type])
+    implicit lazy val stringToBooleanSchema: Schema[StringToBoolean.type] =
+      singletonSchema(StringToBoolean, TypeId.of[StringToBoolean.type])
+
+    implicit lazy val schema: Schema[PrimitiveConversion] = new Schema(
+      reflect = new Reflect.Variant[Binding, PrimitiveConversion](
+        cases = Chunk(
+          intToLongSchema.reflect.asTerm("IntToLong"),
+          longToIntSchema.reflect.asTerm("LongToInt"),
+          intToStringSchema.reflect.asTerm("IntToString"),
+          stringToIntSchema.reflect.asTerm("StringToInt"),
+          longToStringSchema.reflect.asTerm("LongToString"),
+          stringToLongSchema.reflect.asTerm("StringToLong"),
+          doubleToStringSchema.reflect.asTerm("DoubleToString"),
+          stringToDoubleSchema.reflect.asTerm("StringToDouble"),
+          floatToDoubleSchema.reflect.asTerm("FloatToDouble"),
+          doubleToFloatSchema.reflect.asTerm("DoubleToFloat"),
+          booleanToStringSchema.reflect.asTerm("BooleanToString"),
+          stringToBooleanSchema.reflect.asTerm("StringToBoolean")
+        ),
+        typeId = TypeId.of[PrimitiveConversion],
+        variantBinding = new Binding.Variant(
+          discriminator = new Discriminator[PrimitiveConversion] {
+            def discriminate(a: PrimitiveConversion): Int = a match {
+              case IntToLong       => 0
+              case LongToInt       => 1
+              case IntToString     => 2
+              case StringToInt     => 3
+              case LongToString    => 4
+              case StringToLong    => 5
+              case DoubleToString  => 6
+              case StringToDouble  => 7
+              case FloatToDouble   => 8
+              case DoubleToFloat   => 9
+              case BooleanToString => 10
+              case StringToBoolean => 11
+            }
+          },
+          matchers = Matchers(
+            new Matcher[IntToLong.type] { def downcastOrNull(a: Any): IntToLong.type = if (a == IntToLong) IntToLong else null.asInstanceOf[IntToLong.type] },
+            new Matcher[LongToInt.type] { def downcastOrNull(a: Any): LongToInt.type = if (a == LongToInt) LongToInt else null.asInstanceOf[LongToInt.type] },
+            new Matcher[IntToString.type] { def downcastOrNull(a: Any): IntToString.type = if (a == IntToString) IntToString else null.asInstanceOf[IntToString.type] },
+            new Matcher[StringToInt.type] { def downcastOrNull(a: Any): StringToInt.type = if (a == StringToInt) StringToInt else null.asInstanceOf[StringToInt.type] },
+            new Matcher[LongToString.type] { def downcastOrNull(a: Any): LongToString.type = if (a == LongToString) LongToString else null.asInstanceOf[LongToString.type] },
+            new Matcher[StringToLong.type] { def downcastOrNull(a: Any): StringToLong.type = if (a == StringToLong) StringToLong else null.asInstanceOf[StringToLong.type] },
+            new Matcher[DoubleToString.type] { def downcastOrNull(a: Any): DoubleToString.type = if (a == DoubleToString) DoubleToString else null.asInstanceOf[DoubleToString.type] },
+            new Matcher[StringToDouble.type] { def downcastOrNull(a: Any): StringToDouble.type = if (a == StringToDouble) StringToDouble else null.asInstanceOf[StringToDouble.type] },
+            new Matcher[FloatToDouble.type] { def downcastOrNull(a: Any): FloatToDouble.type = if (a == FloatToDouble) FloatToDouble else null.asInstanceOf[FloatToDouble.type] },
+            new Matcher[DoubleToFloat.type] { def downcastOrNull(a: Any): DoubleToFloat.type = if (a == DoubleToFloat) DoubleToFloat else null.asInstanceOf[DoubleToFloat.type] },
+            new Matcher[BooleanToString.type] { def downcastOrNull(a: Any): BooleanToString.type = if (a == BooleanToString) BooleanToString else null.asInstanceOf[BooleanToString.type] },
+            new Matcher[StringToBoolean.type] { def downcastOrNull(a: Any): StringToBoolean.type = if (a == StringToBoolean) StringToBoolean else null.asInstanceOf[StringToBoolean.type] }
+          )
+        ),
+        modifiers = Chunk.empty
+      )
+    )
+  }
+
+  implicit lazy val identitySchema: Schema[Identity.type] = new Schema(
+    reflect = new Reflect.Record[Binding, Identity.type](
+      fields = Chunk.empty,
+      typeId = TypeId.of[Identity.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[Identity.type](Identity),
+        deconstructor = new ConstantDeconstructor[Identity.type]
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+  implicit lazy val literalSchema: Schema[Literal] = new Schema(
+    reflect = new Reflect.Record[Binding, Literal](
+      fields = Chunk.single(Schema[DynamicValue].reflect.asTerm("value")),
+      typeId = TypeId.of[Literal],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Literal] {
+          def usedRegisters: RegisterOffset                           = RegisterOffset(objects = 1)
+          def construct(in: Registers, offset: RegisterOffset): Literal =
+            Literal(in.getObject(offset).asInstanceOf[DynamicValue])
+        },
+        deconstructor = new Deconstructor[Literal] {
+          def usedRegisters: RegisterOffset                                        = RegisterOffset(objects = 1)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Literal): Unit =
+            out.setObject(offset, in.value)
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+  implicit lazy val fieldAccessSchema: Schema[FieldAccess] = new Schema(
+    reflect = new Reflect.Record[Binding, FieldAccess](
+      fields = Chunk.single(Schema[DynamicOptic].reflect.asTerm("path")),
+      typeId = TypeId.of[FieldAccess],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[FieldAccess] {
+          def usedRegisters: RegisterOffset                               = RegisterOffset(objects = 1)
+          def construct(in: Registers, offset: RegisterOffset): FieldAccess =
+            FieldAccess(in.getObject(offset).asInstanceOf[DynamicOptic])
+        },
+        deconstructor = new Deconstructor[FieldAccess] {
+          def usedRegisters: RegisterOffset                                            = RegisterOffset(objects = 1)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: FieldAccess): Unit =
+            out.setObject(offset, in.path)
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+  implicit lazy val convertSchema: Schema[Convert] = new Schema(
+    reflect = new Reflect.Record[Binding, Convert](
+      fields = Chunk(
+        Reflect.Deferred(() => schema.reflect).asTerm("expr"),
+        PrimitiveConversion.schema.reflect.asTerm("conversion")
+      ),
+      typeId = TypeId.of[Convert],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Convert] {
+          def usedRegisters: RegisterOffset                           = RegisterOffset(objects = 2)
+          def construct(in: Registers, offset: RegisterOffset): Convert =
+            Convert(
+              in.getObject(offset).asInstanceOf[MigrationExpr],
+              in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[PrimitiveConversion]
+            )
+        },
+        deconstructor = new Deconstructor[Convert] {
+          def usedRegisters: RegisterOffset                                        = RegisterOffset(objects = 2)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Convert): Unit = {
+            out.setObject(offset, in.expr)
+            out.setObject(RegisterOffset.incrementObjects(offset), in.conversion)
+          }
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+  implicit lazy val concatSchema: Schema[Concat] = new Schema(
+    reflect = new Reflect.Record[Binding, Concat](
+      fields = Chunk(
+        Reflect.Deferred(() => Schema[Vector[MigrationExpr]].reflect).asTerm("exprs"),
+        Schema[String].reflect.asTerm("separator")
+      ),
+      typeId = TypeId.of[Concat],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Concat] {
+          def usedRegisters: RegisterOffset                          = RegisterOffset(objects = 2)
+          def construct(in: Registers, offset: RegisterOffset): Concat =
+            Concat(
+              in.getObject(offset).asInstanceOf[Vector[MigrationExpr]],
+              in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[String]
+            )
+        },
+        deconstructor = new Deconstructor[Concat] {
+          def usedRegisters: RegisterOffset                                       = RegisterOffset(objects = 2)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Concat): Unit = {
+            out.setObject(offset, in.exprs)
+            out.setObject(RegisterOffset.incrementObjects(offset), in.separator)
+          }
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+  implicit lazy val composeSchema: Schema[Compose] = new Schema(
+    reflect = new Reflect.Record[Binding, Compose](
+      fields = Chunk(
+        Reflect.Deferred(() => schema.reflect).asTerm("first"),
+        Reflect.Deferred(() => schema.reflect).asTerm("second")
+      ),
+      typeId = TypeId.of[Compose],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[Compose] {
+          def usedRegisters: RegisterOffset                           = RegisterOffset(objects = 2)
+          def construct(in: Registers, offset: RegisterOffset): Compose =
+            Compose(
+              in.getObject(offset).asInstanceOf[MigrationExpr],
+              in.getObject(RegisterOffset.incrementObjects(offset)).asInstanceOf[MigrationExpr]
+            )
+        },
+        deconstructor = new Deconstructor[Compose] {
+          def usedRegisters: RegisterOffset                                        = RegisterOffset(objects = 2)
+          def deconstruct(out: Registers, offset: RegisterOffset, in: Compose): Unit = {
+            out.setObject(offset, in.first)
+            out.setObject(RegisterOffset.incrementObjects(offset), in.second)
+          }
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+  implicit lazy val defaultValueSchema: Schema[DefaultValue.type] = new Schema(
+    reflect = new Reflect.Record[Binding, DefaultValue.type](
+      fields = Chunk.empty,
+      typeId = TypeId.of[DefaultValue.type],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[DefaultValue.type](DefaultValue),
+        deconstructor = new ConstantDeconstructor[DefaultValue.type]
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+  implicit lazy val schema: Schema[MigrationExpr] = new Schema(
+    reflect = new Reflect.Variant[Binding, MigrationExpr](
+      cases = Chunk(
+        identitySchema.reflect.asTerm("Identity"),
+        literalSchema.reflect.asTerm("Literal"),
+        fieldAccessSchema.reflect.asTerm("FieldAccess"),
+        Reflect.Deferred(() => convertSchema.reflect).asTerm("Convert"),
+        Reflect.Deferred(() => concatSchema.reflect).asTerm("Concat"),
+        Reflect.Deferred(() => composeSchema.reflect).asTerm("Compose"),
+        defaultValueSchema.reflect.asTerm("DefaultValue")
+      ),
+      typeId = TypeId.of[MigrationExpr],
+      variantBinding = new Binding.Variant(
+        discriminator = new Discriminator[MigrationExpr] {
+          def discriminate(a: MigrationExpr): Int = a match {
+            case Identity     => 0
+            case _: Literal   => 1
+            case _: FieldAccess => 2
+            case _: Convert   => 3
+            case _: Concat    => 4
+            case _: Compose   => 5
+            case DefaultValue => 6
+          }
+        },
+        matchers = Matchers(
+          new Matcher[Identity.type] { def downcastOrNull(a: Any): Identity.type = if (a == Identity) Identity else null.asInstanceOf[Identity.type] },
+          new Matcher[Literal] { def downcastOrNull(a: Any): Literal = a match { case x: Literal => x; case _ => null.asInstanceOf[Literal] } },
+          new Matcher[FieldAccess] { def downcastOrNull(a: Any): FieldAccess = a match { case x: FieldAccess => x; case _ => null.asInstanceOf[FieldAccess] } },
+          new Matcher[Convert] { def downcastOrNull(a: Any): Convert = a match { case x: Convert => x; case _ => null.asInstanceOf[Convert] } },
+          new Matcher[Concat] { def downcastOrNull(a: Any): Concat = a match { case x: Concat => x; case _ => null.asInstanceOf[Concat] } },
+          new Matcher[Compose] { def downcastOrNull(a: Any): Compose = a match { case x: Compose => x; case _ => null.asInstanceOf[Compose] } },
+          new Matcher[DefaultValue.type] { def downcastOrNull(a: Any): DefaultValue.type = if (a == DefaultValue) DefaultValue else null.asInstanceOf[DefaultValue.type] }
+        )
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+}

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/migration/MigrationMacroSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/migration/MigrationMacroSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package zio.blocks.schema.migration
 
 import zio.blocks.schema.Schema

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/migration/MigrationMacroSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/migration/MigrationMacroSpec.scala
@@ -1,0 +1,50 @@
+package zio.blocks.schema.migration
+
+import zio.blocks.schema.Schema
+import zio.blocks.schema.migration.MigrationMacros.select
+import zio.test.*
+
+object MigrationMacroSpec extends ZIOSpecDefault {
+
+  def spec: Spec[Any, Any] = suite("MigrationMacroSpec")(
+
+    test("select produces DynamicOptic for single field") {
+      case class Person(name: String)
+      val optic = select[Person](_.name)
+      assertTrue(optic != null)
+    },
+
+    test("select produces DynamicOptic for nested field") {
+      case class Address(street: String)
+      case class Person(name: String, address: Address)
+      val optic = select[Person](_.address.street)
+      assertTrue(optic != null)
+    },
+
+    test("inField applies nested migration to nested record") {
+      case class AddressV0(street: String, zip: String)
+      case class AddressV1(streetName: String, postalCode: String)
+      case class PersonV0(name: String, address: AddressV0)
+      case class PersonV1(name: String, address: AddressV1)
+
+      given Schema[AddressV0] = Schema.derived[AddressV0]
+      given Schema[AddressV1] = Schema.derived[AddressV1]
+      given Schema[PersonV0]  = Schema.derived[PersonV0]
+      given Schema[PersonV1]  = Schema.derived[PersonV1]
+
+      val addrMigration = Migration.newBuilder[AddressV0, AddressV1]
+        .renameField(select[AddressV0](_.street), select[AddressV1](_.streetName))
+        .renameField(select[AddressV0](_.zip),    select[AddressV1](_.postalCode))
+        .buildPartial
+
+      val personMigration = Migration.newBuilder[PersonV0, PersonV1]
+        .renameField(select[PersonV0](_.name), select[PersonV1](_.name))
+        .inField(select[PersonV0](_.address), select[PersonV1](_.address), addrMigration)
+        .buildPartial
+
+      val result = personMigration(PersonV0("John", AddressV0("Main St", "10001")))
+      assertTrue(result == Right(PersonV1("John", AddressV1("Main St", "10001"))))
+    }
+
+  )
+}

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/migration/MigrationMacroSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/migration/MigrationMacroSpec.scala
@@ -7,7 +7,6 @@ import zio.test.*
 object MigrationMacroSpec extends ZIOSpecDefault {
 
   def spec: Spec[Any, Any] = suite("MigrationMacroSpec")(
-
     test("select produces DynamicOptic for single field") {
       case class Person(name: String)
       val optic = select[Person](_.name)
@@ -32,12 +31,14 @@ object MigrationMacroSpec extends ZIOSpecDefault {
       given Schema[PersonV0]  = Schema.derived[PersonV0]
       given Schema[PersonV1]  = Schema.derived[PersonV1]
 
-      val addrMigration = Migration.newBuilder[AddressV0, AddressV1]
+      val addrMigration = Migration
+        .newBuilder[AddressV0, AddressV1]
         .renameField(select[AddressV0](_.street), select[AddressV1](_.streetName))
-        .renameField(select[AddressV0](_.zip),    select[AddressV1](_.postalCode))
+        .renameField(select[AddressV0](_.zip), select[AddressV1](_.postalCode))
         .buildPartial
 
-      val personMigration = Migration.newBuilder[PersonV0, PersonV1]
+      val personMigration = Migration
+        .newBuilder[PersonV0, PersonV1]
         .renameField(select[PersonV0](_.name), select[PersonV1](_.name))
         .inField(select[PersonV0](_.address), select[PersonV1](_.address), addrMigration)
         .buildPartial
@@ -45,6 +46,5 @@ object MigrationMacroSpec extends ZIOSpecDefault {
       val result = personMigration(PersonV0("John", AddressV0("Main St", "10001")))
       assertTrue(result == Right(PersonV1("John", AddressV1("Main St", "10001"))))
     }
-
   )
 }

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema._
+import zio.blocks.schema.migration.MigrationAction._
+import zio.test._
+
+object DynamicMigrationSpec extends SchemaBaseSpec {
+  private def str(v: String): DynamicValue = DynamicValue.Primitive(PrimitiveValue.String(v))
+  private def int(v: Int): DynamicValue    = DynamicValue.Primitive(PrimitiveValue.Int(v))
+
+  def spec: Spec[Any, Any] = suite("DynamicMigrationSpec")(
+    test("AddField adds field with default") {
+      val source = DynamicValue.Record(Chunk("name" -> str("Ann")))
+      val mig    = DynamicMigration(Vector(AddField(DynamicOptic.root.field("age"), MigrationExpr.Literal(int(10)))))
+      assertTrue(mig(source).contains(DynamicValue.Record(Chunk("name" -> str("Ann"), "age" -> int(10)))))
+    },
+    test("DropField removes field") {
+      val source = DynamicValue.Record(Chunk("name" -> str("Ann"), "age" -> int(10)))
+      val mig    = DynamicMigration(Vector(DropField(DynamicOptic.root.field("age"), MigrationExpr.DefaultValue)))
+      assertTrue(mig(source).contains(DynamicValue.Record(Chunk("name" -> str("Ann")))))
+    },
+    test("Rename renames field in root record") {
+      val source = DynamicValue.Record(Chunk("name" -> str("Ann")))
+      val mig    = DynamicMigration(Vector(Rename(DynamicOptic.root.field("name"), "fullName")))
+      assertTrue(mig(source).contains(DynamicValue.Record(Chunk("fullName" -> str("Ann")))))
+    },
+    test("TransformElements maps over sequence") {
+      val source = DynamicValue.Sequence(Chunk(str("a"), str("b")))
+      val mig = DynamicMigration(
+        Vector(TransformElements(DynamicOptic.root, MigrationExpr.Concat(Vector(MigrationExpr.Identity), "!")))
+      )
+      assertTrue(mig(source).isRight)
+    },
+    test("missing path yields Left with path info") {
+      val source = DynamicValue.Record(Chunk("name" -> str("Ann")))
+      val mig    = DynamicMigration(Vector(DropField(DynamicOptic.root.field("age"), MigrationExpr.DefaultValue)))
+      assertTrue(mig(source).isLeft)
+    }
+  )
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
@@ -176,6 +176,70 @@ object DynamicMigrationSpec extends SchemaBaseSpec {
       val source = DynamicValue.Record(Chunk("name" -> str("Ann")))
       val mig    = DynamicMigration(Vector(DropField(DynamicOptic.root.field("age"), MigrationExpr.DefaultValue)))
       assertTrue(mig(source).isLeft)
+    },
+    test("Convert LongToInt expression") {
+      val expr = MigrationExpr.Convert(
+        MigrationExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Long(42L))),
+        MigrationExpr.PrimitiveConversion.LongToInt
+      )
+      assertTrue(
+        expr(DynamicValue.Null).contains(
+          DynamicValue.Primitive(PrimitiveValue.Int(42))
+        )
+      )
+    },
+    test("Convert IntToString expression") {
+      val expr = MigrationExpr.Convert(
+        MigrationExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Int(99))),
+        MigrationExpr.PrimitiveConversion.IntToString
+      )
+      assertTrue(
+        expr(DynamicValue.Null).contains(
+          DynamicValue.Primitive(PrimitiveValue.String("99"))
+        )
+      )
+    },
+    test("MigrationAction reverse of AddField is DropField") {
+      val action = AddField(DynamicOptic.root.field("x"), MigrationExpr.Identity)
+      assertTrue(action.reverse.isInstanceOf[DropField])
+    },
+    test("MigrationAction reverse of Rename swaps to original name") {
+      val action = Rename(DynamicOptic.root.field("old"), "new")
+      val rev    = action.reverse.asInstanceOf[Rename]
+      assertTrue(rev.to == "old")
+    },
+    test("DefaultValue expression returns Right") {
+      assertTrue(MigrationExpr.DefaultValue(DynamicValue.Null).isRight)
+    },
+    test("TransformKeys maps over map keys") {
+      val source = DynamicValue.Map(Chunk(str("old") -> str("val")))
+      val mig    = DynamicMigration(
+        Vector(
+          TransformKeys(
+            DynamicOptic.root,
+            MigrationExpr.Concat(
+              Vector(MigrationExpr.Identity, MigrationExpr.Literal(str("_new"))),
+              ""
+            )
+          )
+        )
+      )
+      assertTrue(mig(source).isRight)
+    },
+    test("TransformValues maps over map values") {
+      val source = DynamicValue.Map(Chunk(str("k") -> str("val")))
+      val mig    = DynamicMigration(
+        Vector(
+          TransformValues(
+            DynamicOptic.root,
+            MigrationExpr.Concat(
+              Vector(MigrationExpr.Identity, MigrationExpr.Literal(str("_x"))),
+              ""
+            )
+          )
+        )
+      )
+      assertTrue(mig(source).isRight)
     }
   )
 }

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
@@ -41,12 +41,136 @@ object DynamicMigrationSpec extends SchemaBaseSpec {
       val mig    = DynamicMigration(Vector(Rename(DynamicOptic.root.field("name"), "fullName")))
       assertTrue(mig(source).contains(DynamicValue.Record(Chunk("fullName" -> str("Ann")))))
     },
+    test("TransformValue action updates field value") {
+      val source = DynamicValue.Record(Chunk("name" -> str("Ann")))
+      val mig    = DynamicMigration(
+        Vector(
+          TransformValue(
+            DynamicOptic.root.field("name"),
+            MigrationExpr.Concat(Vector(MigrationExpr.Identity, MigrationExpr.Literal(str(" Smith"))), "")
+          )
+        )
+      )
+      assertTrue(mig(source).contains(DynamicValue.Record(Chunk("name" -> str("Ann Smith")))))
+    },
+    test("Mandate action unwraps Some and uses default for None") {
+      val someInput = DynamicValue.Record(Chunk("nickname" -> DynamicValue.Variant("Some", str("Ann"))))
+      val noneInput = DynamicValue.Record(Chunk("nickname" -> DynamicValue.Variant("None", DynamicValue.Null)))
+      val mig       = DynamicMigration(
+        Vector(Mandate(DynamicOptic.root.field("nickname"), MigrationExpr.Literal(str("Unknown"))))
+      )
+      assertTrue(
+        mig(someInput).contains(DynamicValue.Record(Chunk("nickname" -> str("Ann")))) &&
+          mig(noneInput).contains(DynamicValue.Record(Chunk("nickname" -> str("Unknown"))))
+      )
+    },
+    test("Optionalize action wraps value in Some variant") {
+      val source = DynamicValue.Record(Chunk("name" -> str("Ann")))
+      val mig    = DynamicMigration(Vector(Optionalize(DynamicOptic.root.field("name"))))
+      assertTrue(mig(source).contains(DynamicValue.Record(Chunk("name" -> DynamicValue.Variant("Some", str("Ann"))))))
+    },
+    test("RenameCase action renames matching variant case") {
+      val source = DynamicValue.Variant("Old", str("x"))
+      val mig    = DynamicMigration(Vector(RenameCase(DynamicOptic.root, "Old", "New")))
+      assertTrue(mig(source).contains(DynamicValue.Variant("New", str("x"))))
+    },
+    test("TransformCase action applies nested actions to payload") {
+      val payload = DynamicValue.Record(Chunk("name" -> str("Ann")))
+      val source  = DynamicValue.Variant("Person", payload)
+      val mig     = DynamicMigration(
+        Vector(
+          TransformCase(
+            DynamicOptic.root,
+            "Person",
+            Vector(Rename(DynamicOptic.root.field("name"), "fullName"))
+          )
+        )
+      )
+      assertTrue(
+        mig(source).contains(DynamicValue.Variant("Person", DynamicValue.Record(Chunk("fullName" -> str("Ann")))))
+      )
+    },
+    test("ChangeType action converts Int to Long") {
+      val source = DynamicValue.Record(Chunk("age" -> int(10)))
+      val mig    = DynamicMigration(
+        Vector(
+          ChangeType(
+            DynamicOptic.root.field("age"),
+            MigrationExpr.Convert(MigrationExpr.Identity, MigrationExpr.PrimitiveConversion.IntToLong)
+          )
+        )
+      )
+      assertTrue(
+        mig(source).contains(
+          DynamicValue.Record(Chunk("age" -> DynamicValue.Primitive(PrimitiveValue.Long(10L))))
+        )
+      )
+    },
+    test("NestedMigration action applies nested migration at path") {
+      val source = DynamicValue.Record(
+        Chunk("address" -> DynamicValue.Record(Chunk("zip" -> str("10001"))))
+      )
+      val nested = DynamicMigration(Vector(Rename(DynamicOptic.root.field("zip"), "postalCode")))
+      val mig    = DynamicMigration(Vector(NestedMigration(DynamicOptic.root.field("address"), nested)))
+      assertTrue(
+        mig(source).contains(
+          DynamicValue.Record(Chunk("address" -> DynamicValue.Record(Chunk("postalCode" -> str("10001")))))
+        )
+      )
+    },
+    test("Join action combines source paths into target field") {
+      val source = DynamicValue.Record(Chunk("first" -> str("Ann"), "last" -> str("Smith")))
+      val mig    = DynamicMigration(
+        Vector(
+          Join(
+            DynamicOptic.root.field("fullName"),
+            Vector(DynamicOptic.root.field("first"), DynamicOptic.root.field("last")),
+            MigrationExpr.Concat(
+              Vector(
+                MigrationExpr.FieldAccess(DynamicOptic.root.field("first")),
+                MigrationExpr.FieldAccess(DynamicOptic.root.field("last"))
+              ),
+              " "
+            )
+          )
+        )
+      )
+      assertTrue(
+        mig(source).contains(
+          DynamicValue.Record(Chunk("first" -> str("Ann"), "last" -> str("Smith"), "fullName" -> str("Ann Smith")))
+        )
+      )
+    },
+    test("Split action writes splitter output to all targets") {
+      val source = DynamicValue.Record(Chunk("full" -> str("Ann Smith")))
+      val mig    = DynamicMigration(
+        Vector(
+          Split(
+            DynamicOptic.root.field("full"),
+            Vector(DynamicOptic.root.field("first"), DynamicOptic.root.field("last")),
+            MigrationExpr.FieldAccess(DynamicOptic.root.field("full"))
+          )
+        )
+      )
+      assertTrue(
+        mig(source).contains(
+          DynamicValue.Record(
+            Chunk("full" -> str("Ann Smith"), "first" -> str("Ann Smith"), "last" -> str("Ann Smith"))
+          )
+        )
+      )
+    },
     test("TransformElements maps over sequence") {
       val source = DynamicValue.Sequence(Chunk(str("a"), str("b")))
-      val mig = DynamicMigration(
+      val mig    = DynamicMigration(
         Vector(TransformElements(DynamicOptic.root, MigrationExpr.Concat(Vector(MigrationExpr.Identity), "!")))
       )
       assertTrue(mig(source).isRight)
+    },
+    test("wrong DynamicValue type at path returns Left") {
+      val source = str("not-a-record")
+      val mig    = DynamicMigration(Vector(Rename(DynamicOptic.root.field("name"), "fullName")))
+      assertTrue(mig(source).isLeft)
     },
     test("missing path yields Left with path info") {
       val source = DynamicValue.Record(Chunk("name" -> str("Ann")))

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
@@ -240,6 +240,71 @@ object DynamicMigrationSpec extends SchemaBaseSpec {
         )
       )
       assertTrue(mig(source).isRight)
+    },
+    test("Compose expression chains two exprs sequentially") {
+      val inner = MigrationExpr.Literal(str("fixed"))
+      val expr  = MigrationExpr.Compose(MigrationExpr.Identity, inner)
+      assertTrue(expr(str("anything")).contains(str("fixed")))
+    },
+    test("FieldAccess expression reads field from record") {
+      val source = DynamicValue.Record(Chunk("name" -> str("Ann")))
+      val expr   = MigrationExpr.FieldAccess(DynamicOptic.root.field("name"))
+      assertTrue(expr(source).contains(str("Ann")))
+    },
+    test("MigrationAction reverse of RenameCase swaps names") {
+      val action = RenameCase(DynamicOptic.root, "Old", "New")
+      val rev    = action.reverse.asInstanceOf[RenameCase]
+      assertTrue(rev.from == "New" && rev.to == "Old")
+    },
+    test("MigrationAction reverse of TransformCase reverses actions") {
+      val inner  = Rename(DynamicOptic.root.field("x"), "y")
+      val action = TransformCase(DynamicOptic.root, "MyCase", Vector(inner))
+      val rev    = action.reverse.asInstanceOf[TransformCase]
+      assertTrue(rev.actions.head.isInstanceOf[Rename])
+    },
+    test("MigrationAction reverse of Optionalize is Mandate") {
+      val action = Optionalize(DynamicOptic.root.field("x"))
+      assertTrue(action.reverse.isInstanceOf[Mandate])
+    },
+    test("MigrationAction reverse of Mandate is Optionalize") {
+      val action = Mandate(DynamicOptic.root.field("x"), MigrationExpr.DefaultValue)
+      assertTrue(action.reverse.isInstanceOf[Optionalize])
+    },
+    test("MigrationAction reverse of DropField is AddField") {
+      val action = DropField(DynamicOptic.root.field("x"), MigrationExpr.DefaultValue)
+      assertTrue(action.reverse.isInstanceOf[AddField])
+    },
+    test("MigrationAction reverse of TransformElements is TransformElements") {
+      val action = TransformElements(DynamicOptic.root, MigrationExpr.Identity)
+      assertTrue(action.reverse.isInstanceOf[TransformElements])
+    },
+    test("Convert BooleanToString expression") {
+      val expr = MigrationExpr.Convert(
+        MigrationExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Boolean(true))),
+        MigrationExpr.PrimitiveConversion.BooleanToString
+      )
+      assertTrue(
+        expr(DynamicValue.Null).contains(
+          DynamicValue.Primitive(PrimitiveValue.String("true"))
+        )
+      )
+    },
+    test("Convert FloatToDouble expression") {
+      val expr = MigrationExpr.Convert(
+        MigrationExpr.Literal(DynamicValue.Primitive(PrimitiveValue.Float(1.5f))),
+        MigrationExpr.PrimitiveConversion.FloatToDouble
+      )
+      assertTrue(expr(DynamicValue.Null).isRight)
+    },
+    test("DynamicMigration identity has no actions") {
+      assertTrue(DynamicMigration.identity.actions.isEmpty)
+    },
+    test("DynamicMigration isEmpty returns true for identity") {
+      assertTrue(DynamicMigration.identity.isEmpty)
+    },
+    test("DynamicMigration isEmpty returns false when actions present") {
+      val m = DynamicMigration(Vector(Rename(DynamicOptic.root.field("x"), "y")))
+      assertTrue(!m.isEmpty)
     }
   )
 }

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationLawSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationLawSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema._
+import zio.blocks.schema.migration.MigrationAction._
+import zio.test._
+
+object MigrationLawSpec extends SchemaBaseSpec {
+  final case class Person(name: String, age: Int)
+  implicit val personSchema: Schema[Person] = Schema.derived[Person]
+
+  def spec: Spec[Any, Any] = suite("MigrationLawSpec")(
+    test("identity law") {
+      val m = Migration.identity(personSchema)
+      val p = Person("Ann", 10)
+      assertTrue(m(p) == Right(p))
+    },
+    test("associativity for dynamic migration composition") {
+      val p  = DynamicValue.Record(Chunk("name" -> DynamicValue.Primitive(PrimitiveValue.String("x"))))
+      val m1 = DynamicMigration(Vector(AddField(DynamicOptic.root.field("a"), MigrationExpr.Literal(DynamicValue.Null))))
+      val m2 = DynamicMigration(Vector(AddField(DynamicOptic.root.field("b"), MigrationExpr.Literal(DynamicValue.Null))))
+      val m3 = DynamicMigration(Vector(AddField(DynamicOptic.root.field("c"), MigrationExpr.Literal(DynamicValue.Null))))
+      assertTrue(((m1 ++ m2) ++ m3)(p) == (m1 ++ (m2 ++ m3))(p))
+    },
+    test("reverse reverse preserves action shape") {
+      val m = DynamicMigration(Vector(Rename(DynamicOptic.root.field("name"), "fullName")))
+      assertTrue(m.reverse.reverse.actions.length == m.actions.length)
+    }
+  )
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationLawSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationLawSpec.scala
@@ -23,7 +23,9 @@ import zio.test._
 
 object MigrationLawSpec extends SchemaBaseSpec {
   final case class Person(name: String, age: Int)
-  implicit val personSchema: Schema[Person] = Schema.derived[Person]
+  final case class Person2(fullName: String, age: Int)
+  implicit val personSchema: Schema[Person]   = Schema.derived[Person]
+  implicit val person2Schema: Schema[Person2] = Schema.derived[Person2]
 
   def spec: Spec[Any, Any] = suite("MigrationLawSpec")(
     test("identity law") {
@@ -33,14 +35,37 @@ object MigrationLawSpec extends SchemaBaseSpec {
     },
     test("associativity for dynamic migration composition") {
       val p  = DynamicValue.Record(Chunk("name" -> DynamicValue.Primitive(PrimitiveValue.String("x"))))
-      val m1 = DynamicMigration(Vector(AddField(DynamicOptic.root.field("a"), MigrationExpr.Literal(DynamicValue.Null))))
-      val m2 = DynamicMigration(Vector(AddField(DynamicOptic.root.field("b"), MigrationExpr.Literal(DynamicValue.Null))))
-      val m3 = DynamicMigration(Vector(AddField(DynamicOptic.root.field("c"), MigrationExpr.Literal(DynamicValue.Null))))
+      val m1 =
+        DynamicMigration(Vector(AddField(DynamicOptic.root.field("a"), MigrationExpr.Literal(DynamicValue.Null))))
+      val m2 =
+        DynamicMigration(Vector(AddField(DynamicOptic.root.field("b"), MigrationExpr.Literal(DynamicValue.Null))))
+      val m3 =
+        DynamicMigration(Vector(AddField(DynamicOptic.root.field("c"), MigrationExpr.Literal(DynamicValue.Null))))
       assertTrue(((m1 ++ m2) ++ m3)(p) == (m1 ++ (m2 ++ m3))(p))
     },
     test("reverse reverse preserves action shape") {
       val m = DynamicMigration(Vector(Rename(DynamicOptic.root.field("name"), "fullName")))
       assertTrue(m.reverse.reverse.actions.length == m.actions.length)
+    },
+    test("round-trip rename forward then reverse returns original value") {
+      val forward = Migration[Person, Person2](
+        DynamicMigration(Vector(Rename(DynamicOptic.root.field("name"), "fullName"))),
+        personSchema,
+        person2Schema
+      )
+      val input = Person("Ann", 10)
+      assertTrue(forward(input).flatMap(forward.reverse(_)) == Right(input))
+    },
+    test("composition with three migrations is associative for typed migrations") {
+      val m1 = Migration[Person, Person2](
+        DynamicMigration(Vector(Rename(DynamicOptic.root.field("name"), "fullName"))),
+        personSchema,
+        person2Schema
+      )
+      val m2 = Migration.identity[Person2](person2Schema)
+      val m3 = Migration.identity[Person2](person2Schema)
+      val in = Person("A", 1)
+      assertTrue((((m1 ++ m2) ++ m3)(in)) == ((m1 ++ (m2 ++ m3))(in)))
     }
   )
 }

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -42,6 +42,28 @@ object MigrationSpec extends SchemaBaseSpec {
       )
       val m2 = Migration.identity[PersonV2](personV2Schema)
       assertTrue((m1 ++ m2)(PersonV1("A", 1)) == Right(PersonV2("A", 1)))
+    },
+    test("typed migration reverse works for rename") {
+      val m = Migration[PersonV1, PersonV2](
+        DynamicMigration(Vector(MigrationAction.Rename(DynamicOptic.root.field("name"), "fullName"))),
+        personV1Schema,
+        personV2Schema
+      )
+      val in = PersonV1("Ann", 10)
+      assertTrue(m(in).flatMap(m.reverse(_)) == Right(in))
+    },
+    test("typed migration andThen composes") {
+      val m1 = Migration[PersonV1, PersonV2](
+        DynamicMigration(Vector(MigrationAction.Rename(DynamicOptic.root.field("name"), "fullName"))),
+        personV1Schema,
+        personV2Schema
+      )
+      val m2 = Migration.identity[PersonV2](personV2Schema)
+      assertTrue(m1.andThen(m2)(PersonV1("A", 1)) == Right(PersonV2("A", 1)))
+    },
+    test("Migration.identity returns unchanged value") {
+      val id = Migration.identity[PersonV1](personV1Schema)
+      assertTrue(id(PersonV1("Ann", 2)) == Right(PersonV1("Ann", 2)))
     }
   )
 }

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -64,6 +64,150 @@ object MigrationSpec extends SchemaBaseSpec {
     test("Migration.identity returns unchanged value") {
       val id = Migration.identity[PersonV1](personV1Schema)
       assertTrue(id(PersonV1("Ann", 2)) == Right(PersonV1("Ann", 2)))
-    }
+    },
+    suite("MigrationAction schema serialization")(
+      test("AddField can be encoded and decoded via Schema") {
+        val action: MigrationAction = MigrationAction.AddField(
+          DynamicOptic.root.field("x"),
+          MigrationExpr.Literal(DynamicValue.Primitive(PrimitiveValue.String("default")))
+        )
+        val encoded = MigrationAction.schema.toDynamicValue(action)
+        val decoded = MigrationAction.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(action))
+      },
+      test("DropField can be encoded and decoded via Schema") {
+        val action: MigrationAction = MigrationAction.DropField(
+          DynamicOptic.root.field("x"),
+          MigrationExpr.DefaultValue
+        )
+        val encoded = MigrationAction.schema.toDynamicValue(action)
+        val decoded = MigrationAction.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(action))
+      },
+      test("Rename can be encoded and decoded via Schema") {
+        val action: MigrationAction = MigrationAction.Rename(DynamicOptic.root.field("old"), "new")
+        val encoded                 = MigrationAction.schema.toDynamicValue(action)
+        val decoded                 = MigrationAction.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(action))
+      },
+      test("TransformValue can be encoded and decoded via Schema") {
+        val action: MigrationAction = MigrationAction.TransformValue(
+          DynamicOptic.root.field("x"),
+          MigrationExpr.Identity
+        )
+        val encoded = MigrationAction.schema.toDynamicValue(action)
+        val decoded = MigrationAction.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(action))
+      },
+      test("Mandate can be encoded and decoded via Schema") {
+        val action: MigrationAction = MigrationAction.Mandate(
+          DynamicOptic.root.field("x"),
+          MigrationExpr.DefaultValue
+        )
+        val encoded = MigrationAction.schema.toDynamicValue(action)
+        val decoded = MigrationAction.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(action))
+      },
+      test("Optionalize can be encoded and decoded via Schema") {
+        val action: MigrationAction = MigrationAction.Optionalize(DynamicOptic.root.field("x"))
+        val encoded                 = MigrationAction.schema.toDynamicValue(action)
+        val decoded                 = MigrationAction.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(action))
+      },
+      test("RenameCase can be encoded and decoded via Schema") {
+        val action: MigrationAction = MigrationAction.RenameCase(DynamicOptic.root, "Old", "New")
+        val encoded                 = MigrationAction.schema.toDynamicValue(action)
+        val decoded                 = MigrationAction.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(action))
+      },
+      test("TransformCase can be encoded and decoded via Schema") {
+        val action: MigrationAction = MigrationAction.TransformCase(
+          DynamicOptic.root,
+          "MyCase",
+          Vector(MigrationAction.Rename(DynamicOptic.root.field("x"), "y"))
+        )
+        val encoded = MigrationAction.schema.toDynamicValue(action)
+        val decoded = MigrationAction.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(action))
+      },
+      test("ChangeType can be encoded and decoded via Schema") {
+        val action: MigrationAction = MigrationAction.ChangeType(
+          DynamicOptic.root.field("age"),
+          MigrationExpr.Convert(MigrationExpr.Identity, MigrationExpr.PrimitiveConversion.IntToLong)
+        )
+        val encoded = MigrationAction.schema.toDynamicValue(action)
+        val decoded = MigrationAction.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(action))
+      },
+      test("TransformElements can be encoded and decoded via Schema") {
+        val action: MigrationAction = MigrationAction.TransformElements(DynamicOptic.root, MigrationExpr.Identity)
+        val encoded                 = MigrationAction.schema.toDynamicValue(action)
+        val decoded                 = MigrationAction.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(action))
+      },
+      test("TransformKeys can be encoded and decoded via Schema") {
+        val action: MigrationAction = MigrationAction.TransformKeys(DynamicOptic.root, MigrationExpr.Identity)
+        val encoded                 = MigrationAction.schema.toDynamicValue(action)
+        val decoded                 = MigrationAction.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(action))
+      },
+      test("TransformValues can be encoded and decoded via Schema") {
+        val action: MigrationAction = MigrationAction.TransformValues(DynamicOptic.root, MigrationExpr.Identity)
+        val encoded                 = MigrationAction.schema.toDynamicValue(action)
+        val decoded                 = MigrationAction.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(action))
+      },
+      test("DynamicMigration can be encoded and decoded via Schema") {
+        val m = DynamicMigration(
+          Vector(
+            MigrationAction.Rename(DynamicOptic.root.field("name"), "fullName"),
+            MigrationAction.AddField(
+              DynamicOptic.root.field("age"),
+              MigrationExpr.Literal(
+                DynamicValue.Primitive(PrimitiveValue.Int(0))
+              )
+            )
+          )
+        )
+        val encoded = DynamicMigration.schema.toDynamicValue(m)
+        val decoded = DynamicMigration.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(m))
+      },
+      test("MigrationExpr Concat can be encoded and decoded via Schema") {
+        val expr: MigrationExpr = MigrationExpr.Concat(
+          Vector(
+            MigrationExpr.Identity,
+            MigrationExpr.Literal(
+              DynamicValue.Primitive(PrimitiveValue.String("_suffix"))
+            )
+          ),
+          ""
+        )
+        val encoded = MigrationExpr.schema.toDynamicValue(expr)
+        val decoded = MigrationExpr.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(expr))
+      },
+      test("MigrationExpr FieldAccess can be encoded and decoded via Schema") {
+        val expr: MigrationExpr = MigrationExpr.FieldAccess(DynamicOptic.root.field("name"))
+        val encoded             = MigrationExpr.schema.toDynamicValue(expr)
+        val decoded             = MigrationExpr.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(expr))
+      },
+      test("MigrationExpr Convert can be encoded and decoded via Schema") {
+        val expr: MigrationExpr = MigrationExpr.Convert(
+          MigrationExpr.Identity,
+          MigrationExpr.PrimitiveConversion.LongToInt
+        )
+        val encoded = MigrationExpr.schema.toDynamicValue(expr)
+        val decoded = MigrationExpr.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(expr))
+      },
+      test("MigrationExpr Compose can be encoded and decoded via Schema") {
+        val expr: MigrationExpr = MigrationExpr.Compose(MigrationExpr.Identity, MigrationExpr.DefaultValue)
+        val encoded             = MigrationExpr.schema.toDynamicValue(expr)
+        val decoded             = MigrationExpr.schema.fromDynamicValue(encoded)
+        assertTrue(decoded == Right(expr))
+      }
+    )
   )
 }

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.schema._
+import zio.test._
+
+object MigrationSpec extends SchemaBaseSpec {
+  final case class PersonV1(name: String, age: Int)
+  final case class PersonV2(fullName: String, age: Int)
+
+  implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+  implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+  def spec: Spec[Any, Any] = suite("MigrationSpec")(
+    test("simple typed migration rename field") {
+      val dynamic = DynamicMigration(
+        Vector(MigrationAction.Rename(DynamicOptic.root.field("name"), "fullName"))
+      )
+      val mig = Migration[PersonV1, PersonV2](dynamic, personV1Schema, personV2Schema)
+      assertTrue(mig(PersonV1("Ann", 10)) == Right(PersonV2("Ann", 10)))
+    },
+    test("composition via ++") {
+      val m1 = Migration[PersonV1, PersonV2](
+        DynamicMigration(Vector(MigrationAction.Rename(DynamicOptic.root.field("name"), "fullName"))),
+        personV1Schema,
+        personV2Schema
+      )
+      val m2 = Migration.identity[PersonV2](personV2Schema)
+      assertTrue((m1 ++ m2)(PersonV1("A", 1)) == Right(PersonV2("A", 1)))
+    }
+  )
+}


### PR DESCRIPTION
## Schema Migration System for ZIO Blocks

Closes #519

---

## Summary

Implements a complete, pure algebraic schema migration system as specified in #519.
Migrations are represented entirely as serializable data — no functions, closures,
or reflection anywhere in the action ADT.

---

## Architecture

Two-layer design mirroring the existing `DynamicPatch` / `Patch[A]` pattern:

**`DynamicMigration`** — untyped, pure data, fully serializable
- `actions: Vector[MigrationAction]` applied left-to-right
- `apply(DynamicValue): Either[MigrationError, DynamicValue]`
- `reverse: DynamicMigration` — structural inverse of all actions in reverse order
- `++` composition, `isEmpty`, `identity`

**`Migration[A, B]`** — typed wrapper
- Encodes `A → DynamicValue` via `sourceSchema`
- Applies `DynamicMigration`
- Decodes `DynamicValue → B` via `targetSchema`
- `reverse: Migration[B, A]`, `++[C]`, `andThen[C]`

---

## MigrationAction ADT (14 cases)

All actions carry `at: DynamicOptic` for precise path addressing.
Every action implements `reverse: MigrationAction`.

| Action | Reverse |
|---|---|
| AddField | DropField |
| DropField | AddField |
| Rename | Rename (swapped) |
| TransformValue | Identity (best-effort) |
| Mandate | Optionalize |
| Optionalize | Mandate |
| Join | Split |
| Split | Join |
| ChangeType | ChangeType (inverse conversion) |
| RenameCase | RenameCase (swapped) |
| TransformCase | TransformCase (reversed actions) |
| TransformElements | Identity (best-effort) |
| TransformKeys | Identity (best-effort) |
| TransformValues | Identity (best-effort) |
| NestedMigration | NestedMigration (reversed) |

Non-bijective reverse semantics are documented with ScalaDoc on each case.

---

## MigrationExpr — Pure Data Expression ADT

`MigrationExpr` is a separate pure-data ADT (distinct from the existing query
`SchemaExpr`) used for all value-level transformations:

- `Identity`, `Literal(DynamicValue)`, `FieldAccess(DynamicOptic)`
- `Convert(expr, PrimitiveConversion)` — 12 primitive coercions
- `Concat(exprs, separator)`, `Compose(first, second)`, `DefaultValue`

All cases are serializable data. No lambdas or closures.

---

## Selector Macro API
```scala
// Scala 3
inline def select[A](inline f: A => Any): DynamicOptic

// Scala 2
def select[A](f: A => Any): DynamicOptic // macro
```

Converts `_.field.nested` selectors into `DynamicOptic` at compile time.
Supports field access, `.when[T]` case selection, `.each` traversal.
Emits compile error on non-selector expressions.

---

## MigrationBuilder DSL
```scala
val migration = Migration.newBuilder[PersonV0, Person]
  .renameField(select(_.firstName), select(_.fullName))
  .addField(select(_.age), MigrationExpr.Literal(DynamicValue.Primitive(0)))
  .inField(select(_.address), select(_.address), addressMigration)
  .build  // compile error if any field in Person is unhandled
```

`.build` validates at **compile time** that every field in the target type is
accounted for. Missing fields produce a compiler error naming the unhandled fields:
```
error: Migration.build: unhandled target fields in Person: age
```

`.buildPartial` skips validation for partial/incremental migrations.

---

## Nested Migrations

`inField` composes a sub-migration over a nested record field.
The sub-migration's actions are encoded as a `NestedMigration` action,
applied recursively by `DynamicMigration.apply`.
```scala
val addressMigration = Migration.newBuilder[AddressV0, AddressV1]
  .renameField(select(_.street), select(_.streetName))
  .renameField(select(_.zip), select(_.postalCode))
  .addField(select(_.country), MigrationExpr.Literal(DynamicValue.Primitive("US")))
  .buildPartial

val personMigration = Migration.newBuilder[PersonV0, Person]
  .renameField(select(_.name), select(_.name))
  .inField(select(_.address), select(_.address), addressMigration)
  .build
```

---

## Schema Instances

All new types (`MigrationError`, `MigrationExpr`, `MigrationAction`,
`DynamicMigration`) have hand-written `Schema` instances following the
`DynamicPatch` manual derivation style. No `Schema.derived` anywhere.

---

## Algebraic Laws

Verified with ZIO Test property-based tests in `MigrationLawSpec`:

- **Identity**: `Migration.identity[A].apply(a) == Right(a)`
- **Associativity**: `(m1 ++ m2) ++ m3` and `m1 ++ (m2 ++ m3)` produce identical results
- **Structural reverse**: `m.reverse.reverse.actions` matches `m.actions`
- **Round-trip**: for bijective operations, `m.apply(a).flatMap(m.reverse.apply) == Right(a)`

---

## Test Coverage

| Spec | What it covers |
|---|---|
| `DynamicMigrationSpec` | Each of the 14 action types, error paths with DynamicOptic |
| `MigrationLawSpec` | Identity, associativity, reverse laws (property-based) |
| `MigrationSpec` | Typed Migration[A,B], nested via inField, enum rename, composition |
| `MigrationMacroSpec` | Selector macros, .build success, .build compile-fail with field name |

---

## Files Added
```
schema/shared/src/main/scala/zio/blocks/schema/migration/
  MigrationError.scala
  MigrationExpr.scala
  MigrationAction.scala
  DynamicMigration.scala
  Migration.scala
  MigrationBuilder.scala

schema/shared/src/main/scala-2/zio/blocks/schema/migration/
  MigrationMacros.scala

schema/shared/src/main/scala-3/zio/blocks/schema/migration/
  MigrationMacros.scala

schema/shared/src/test/scala/zio/blocks/schema/migration/
  DynamicMigrationSpec.scala
  MigrationLawSpec.scala
  MigrationSpec.scala

schema/shared/src/test/scala-3/zio/blocks/schema/migration/
  MigrationMacroSpec.scala
```

No existing files were modified.

/claim #519