### PR TITLE
build: update zio-golem-build-codegen to use Scala 2.12.21

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1030,11 +1030,10 @@ lazy val zioGolemIntegrationTests = project
 lazy val zioGolemBuildCodegen = project
   .in(file("golem/codegen"))
   .settings(
-    publish / skip     := true,
-    name               := "zio-golem-build-codegen",
-    organization       := "dev.zio",
-    crossScalaVersions := Seq("2.12.21", BuildHelper.Scala33),
-    scalaVersion       := BuildHelper.Scala33,
+    publish / skip          := true,
+    name                    := "zio-golem-build-codegen",
+    organization            := "dev.zio",
+    scalaVersion            := "2.12.21",
     libraryDependencies ++= Seq(
       "org.scalameta" %% "scalameta" % "4.16.0",
       "com.lihaoyi"   %% "ujson"     % "3.1.0",
@@ -1182,7 +1181,7 @@ lazy val docs = project
         "[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) " +
           "![CI Badge](https://github.com/zio/zio-blocks/workflows/CI/badge.svg) " +
           "[![ZIO Blocks](https://img.shields.io/github/stars/zio/zio-blocks?style=social)](https://github.com/zio/zio-blocks)"
-      )
+        )
     ),
     mdocOut := (ThisBuild / baseDirectory).value / "website" / "docs"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1030,10 +1030,10 @@ lazy val zioGolemIntegrationTests = project
 lazy val zioGolemBuildCodegen = project
   .in(file("golem/codegen"))
   .settings(
-    publish / skip          := true,
-    name                    := "zio-golem-build-codegen",
-    organization            := "dev.zio",
-    scalaVersion            := "2.12.21",
+    publish / skip := true,
+    name           := "zio-golem-build-codegen",
+    organization   := "dev.zio",
+    scalaVersion   := "2.12.21",
     libraryDependencies ++= Seq(
       "org.scalameta" %% "scalameta" % "4.16.0",
       "com.lihaoyi"   %% "ujson"     % "3.1.0",
@@ -1181,7 +1181,7 @@ lazy val docs = project
         "[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) " +
           "![CI Badge](https://github.com/zio/zio-blocks/workflows/CI/badge.svg) " +
           "[![ZIO Blocks](https://img.shields.io/github/stars/zio/zio-blocks?style=social)](https://github.com/zio/zio-blocks)"
-        )
+      )
     ),
     mdocOut := (ThisBuild / baseDirectory).value / "website" / "docs"
   )


### PR DESCRIPTION
## Summary

Fixes IntelliJ IDEA SBT import issues by updating the `zioGolemBuildCodegen` project configuration:

- Removed `crossScalaVersions` setting
- Set `scalaVersion` to "2.12.21" instead of Scala 3.3
- Fixed indentation formatting in docs configuration

## Why

IntelliJ IDEA's SBT importer has compatibility issues with mixed Scala version settings. By pinning to a single stable version (2.12.21) for the build code generator, we resolve the import conflict while maintaining full functionality.

## Testing

- [x] Build compiles without errors
- [x] SBT configuration is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)