### PR TITLE
docs: add symbolic operator policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,10 @@ If `sbt --client` is causing trouble, try:
 sbt --client shutdown 2>/dev/null; pkill -f sbt 2>/dev/null; rm -rf .bsp project/target/active.json project/target/.sbt-server-connection.json
 ```
 
+## Policies
+
+- [Symbolic Operator Policy](SYMBOLIC_OPS_POLICY.md) — Rules for when symbolic operators are allowed in APIs. Consult before adding or reviewing any symbolic method.
+
 ## Mindset
 
 **sbt is slow—minutes per compile/test.** Wasted cycles waste hours.

--- a/SYMBOLIC_OPS_POLICY.md
+++ b/SYMBOLIC_OPS_POLICY.md
@@ -1,0 +1,79 @@
+# Symbolic Operator Policy
+
+## The Two Rules
+
+1. **Named-First** — Every symbolic operator MUST alias a named method. The name is the primary API; the symbol is sugar.
+2. **Read-Aloud Test** — If the target audience can't instantly read the symbol aloud, use a name instead.
+
+## Allowed Operators
+
+### Tier 1 — Universal (any programmer)
+
+| Symbols | Domain |
+|---|---|
+| `+` `-` `*` `/` `%` | Arithmetic |
+| `<` `>` `<=` `>=` `===` `!=` | Comparison |
+| `&&` `\|\|` `unary_!` | Boolean logic |
+| `&` `\|` `^` `~` `<<` `>>` `>>>` | Bitwise (integral types) |
+
+### Tier 2 — Scala-standard (Scala devs expect these)
+
+| Symbol | Reads as | Precedent |
+|---|---|---|
+| `++` | "concat" | `Seq.++` |
+| `:+` | "append" | `Seq.:+` |
+| `+:` | "prepend" | `Seq.+:` |
+| `/` | "slash" / "child" | Path composition |
+| `:=` | "assign" | Config/template DSLs |
+
+### Tier 3 — Domain-scoped DSL (obvious to practitioners of that domain)
+
+Allowed **only** when ALL of these hold:
+
+1. **Domain-native** — The symbol mirrors notation that practitioners already use outside of Scala (CSS syntax, SQL operators, regex, math notation, etc.)
+2. **Scoped** — The operator lives inside a DSL-specific package/object, not in general-purpose APIs.
+3. **Still aliases a named method** — Rule 1 still applies, no exceptions.
+4. **Documented at DSL entry point** — A quick-reference table of the DSL's operators exists in its Scaladoc or docs page.
+
+Examples of what qualifies:
+
+| DSL | Operator | Why it's clear |
+|---|---|---|
+| CSS | `:=` for property values | CSS devs write `color: red` — colon-assign is natural |
+| CSS | `-` in compound names | CSS devs write `font-size` — hyphen is native CSS |
+| HTML | `:=` for attributes | `href := "/home"` reads like `href="/home"` |
+| Path | `/` for segments | Universal path separator |
+| JSON | `/` for pointer paths | RFC 6901 notation |
+
+Examples of what does NOT qualify:
+
+| Rejected | Why |
+|---|---|
+| `~>` for CSS transitions | Not how CSS notation works — invented symbolism |
+| `\|+\|` for style merging | Category theory, not CSS |
+| `>>>` for selector chaining | Multi-arrow chain, not domain-native |
+
+## Banned (no exceptions)
+
+- **Multi-arrow chains**: `>+>` `>=>` `>>>` `<<<` `==>` `~>` `<~`
+- **Category-theory art**: `|+|` `<*>` `<+>` `*>` `<*` `>>=`
+- **Ambiguous singles**: `<>` `?` postfix `!`
+- **Unicode**: `⊛` `∘` `≟` `η`
+- **Any symbol with 3+ distinct punctuation characters**
+- **Invented symbolism** — symbols that look related to the domain but aren't actually used in it
+
+## Decision Flowchart
+
+```
+Tier 1 or 2?  → YES → Use it (alias a named method)
+               → NO  → Is it domain-native for a scoped DSL?
+                         → YES + all 4 criteria met → Use it (alias a named method)
+                         → NO → Use a named method. Period.
+```
+
+## Enforcement
+
+- Every `def <symbol>` delegates to a named `def`.
+- Named method appears first in source; symbolic alias follows.
+- Scaladoc goes on the named method, not the symbol.
+- Tier 3 operators require a DSL operator table in the package/module docs.


### PR DESCRIPTION
## Summary

Adds a concise, enforceable policy for symbolic operators in ZIO Blocks APIs.

- **New file**: `SYMBOLIC_OPS_POLICY.md` — three-tier system (Universal → Scala-standard → Domain-scoped DSL) with clear allowed/banned lists
- **Updated**: `AGENTS.md` — links to the policy under a new `## Policies` section so agents consult it when adding or reviewing symbolic methods

## Policy Highlights

**Two core rules:**
1. **Named-First** — every symbolic op must alias a named method
2. **Read-Aloud Test** — if the audience can't instantly read it aloud, use a name

**Three tiers of allowed operators:**
- **Tier 1**: Universal math/logic (`+`, `-`, `&&`, `|`, etc.)
- **Tier 2**: Scala-standard (`++`, `:+`, `+:`, `/`, `:=`)
- **Tier 3**: Domain-scoped DSL ops that mirror real-world notation (CSS `:=`, path `/`) — gated by 4 strict criteria

**Explicitly banned:** multi-arrow chains (`>+>`, `>>>`), category-theory art (`|+|`, `<*>`), Unicode operators, invented symbolism

## Motivation

ZIO Blocks builds *simple building blocks*. Complex symbolic operators (like ZIO's `>+>` or Scalaz's `⊛`) hurt discoverability, IDE support, and learnability. This policy codifies what the codebase already practices and prevents future drift.