### PR TITLE
feat(schema): add Deriver.withInstance and Deriver.withModifier APIs

### DIFF
--- a/docs/reference/schema/type-class-derivation.md
+++ b/docs/reference/schema/type-class-derivation.md
@@ -167,6 +167,68 @@ import zio.blocks.schema.json._
 val jsonCodec = Person.schema.derive(JsonFormat)
 ```
 
+## Customizing Derivation with Instance and Modifier Overrides
+
+By default, `Deriver` automatically derives codecs for all types. But sometimes you need to customize how specific types are encoded or decoded—for example, encoding `LocalDate` as `"dd/MM/yyyy"` instead of ISO format.
+
+ZIO Blocks provides three levels of customization, in progressive order:
+
+1. **Type-level override** (`Deriver.withInstance`) — Override the codec for ALL occurrences of a type. Configure once, use everywhere:
+
+```scala
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+// Create a custom JsonCodec for LocalDate
+val customDateCodec: JsonCodec[LocalDate] = new JsonCodec[LocalDate] {
+  private val fmt = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+  def decodeValue(in: JsonReader): LocalDate = LocalDate.parse(in.readString(), fmt)
+  def encodeValue(x: LocalDate, out: JsonWriter): Unit = out.writeVal(fmt.format(x))
+  // ... AST overrides ...
+}
+
+// Configure the deriver once
+val myDeriver = JsonCodecDeriver.withInstance[LocalDate](customDateCodec)
+
+// Use everywhere — all LocalDate fields use the custom codec
+val codec1 = Schema[Event].deriving(myDeriver).derive
+val codec2 = Schema[Meeting].deriving(myDeriver).derive
+```
+
+2. **Field-level override** (`Deriver.withInstance` with typeId + termName) — Override a specific field only:
+
+```scala
+// Only Event.date uses custom format; other LocalDate fields are unchanged
+val deriver = JsonCodecDeriver.withInstance[Event, LocalDate](
+  TypeId.of[Event], "date", customDateCodec
+)
+```
+
+3. **Modifier override** (`Deriver.withModifier`) — Rename fields, add aliases:
+
+```scala
+val deriver = JsonCodecDeriver.withModifier(
+  TypeId.of[Person], "firstName", Modifier.rename("first_name")
+)
+```
+
+### Chaining Overrides
+
+Overrides compose, allowing you to build complex derivers incrementally:
+
+```scala
+val myDeriver = JsonCodecDeriver
+  .withInstance[LocalDate](customDateCodec)
+  .withModifier(TypeId.of[Event], "name", Modifier.rename("title"))
+```
+
+### Important Notes
+
+- `withInstance` and `withModifier` return a NEW deriver (they are immutable).
+- When combined with `DerivationBuilder`, deriver-level instance overrides take precedence over builder-level instance overrides. Modifier override precedence is order-sensitive and should not be assumed to follow the same rule.
+- Unknown `termName` values are silently ignored.
+- The `B` type parameter in field-level `withInstance` is not statically checked against the actual field type.
+
 ## Example 1: Deriving a `Show` Type Class Instance
 
 Let's say we want to derive a `Show` type class instance for any type of type `A`:

--- a/schema-csv/src/test/scala/zio/blocks/schema/csv/DeriverWithInstanceCsvSpec.scala
+++ b/schema-csv/src/test/scala/zio/blocks/schema/csv/DeriverWithInstanceCsvSpec.scala
@@ -22,8 +22,26 @@ import zio.test._
 
 import java.nio.CharBuffer
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import scala.util.control.NonFatal
 
 object DeriverWithInstanceCsvSpec extends SchemaBaseSpec {
+
+  private val basicIsoFmt = DateTimeFormatter.BASIC_ISO_DATE
+
+  private val yyyymmddLocalDateCodec: CsvCodec[LocalDate] = new CsvCodec[LocalDate] {
+    val headerNames: IndexedSeq[String] = IndexedSeq("value")
+
+    def encode(value: LocalDate, output: CharBuffer): Unit =
+      output.put(value.format(basicIsoFmt))
+
+    def decode(input: CharBuffer): Either[SchemaError, LocalDate] = {
+      val str = input.toString
+      input.position(input.limit())
+      try Right(LocalDate.parse(str, basicIsoFmt))
+      catch { case NonFatal(e) => Left(SchemaError(e.getMessage)) }
+    }
+  }
 
   case class Meeting(title: String, date: LocalDate)
   object Meeting {
@@ -37,8 +55,22 @@ object DeriverWithInstanceCsvSpec extends SchemaBaseSpec {
     codec.decode(CharBuffer.wrap(buf.toString))
   }
 
+  private def csvEncode(codec: CsvCodec[Meeting], value: Meeting): String = {
+    val buf = CharBuffer.allocate(4096)
+    codec.encode(value, buf)
+    buf.flip()
+    buf.toString
+  }
+
   def spec = suite("DeriverWithInstanceCsvSpec")(
-    test("withInstance wraps CsvCodecDeriver and still roundtrips") {
+    test("withInstance overrides LocalDate codec") {
+      val deriver = CsvCodecDeriver.withInstance[LocalDate](yyyymmddLocalDateCodec)
+      val codec   = Schema[Meeting].deriving(deriver).derive
+      val meeting = Meeting("retro", LocalDate.of(2025, 8, 1))
+      val csv     = csvEncode(codec, meeting)
+      assertTrue(csv.contains("20250801"))
+    },
+    test("withModifier wraps CsvCodecDeriver and still roundtrips") {
       val deriver = CsvCodecDeriver.withModifier(
         TypeId.of[Meeting],
         "title",

--- a/schema-csv/src/test/scala/zio/blocks/schema/csv/DeriverWithInstanceCsvSpec.scala
+++ b/schema-csv/src/test/scala/zio/blocks/schema/csv/DeriverWithInstanceCsvSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.csv
+
+import zio.blocks.schema._
+import zio.blocks.typeid.TypeId
+import zio.test._
+
+import java.nio.CharBuffer
+import java.time.LocalDate
+
+object DeriverWithInstanceCsvSpec extends SchemaBaseSpec {
+
+  case class Meeting(title: String, date: LocalDate)
+  object Meeting {
+    implicit val schema: Schema[Meeting] = Schema.derived
+  }
+
+  private def csvRoundTrip(codec: CsvCodec[Meeting], value: Meeting): Either[SchemaError, Meeting] = {
+    val buf = CharBuffer.allocate(4096)
+    codec.encode(value, buf)
+    buf.flip()
+    codec.decode(CharBuffer.wrap(buf.toString))
+  }
+
+  def spec = suite("DeriverWithInstanceCsvSpec")(
+    test("withInstance wraps CsvCodecDeriver and still roundtrips") {
+      val deriver = CsvCodecDeriver.withModifier(
+        TypeId.of[Meeting],
+        "title",
+        Modifier.alias("subject")
+      )
+      val codec   = Schema[Meeting].deriving(deriver).derive
+      val meeting = Meeting("retro", LocalDate.of(2025, 8, 1))
+      assertTrue(csvRoundTrip(codec, meeting) == Right(meeting))
+    },
+    test("chained overrides accumulate and still roundtrip") {
+      val deriver = CsvCodecDeriver
+        .withModifier(TypeId.of[Meeting], "title", Modifier.alias("subject"))
+        .withModifier(TypeId.of[Meeting], "date", Modifier.alias("when"))
+      val codec   = Schema[Meeting].deriving(deriver).derive
+      val meeting = Meeting("standup", LocalDate.of(2025, 7, 4))
+      assertTrue(csvRoundTrip(codec, meeting) == Right(meeting))
+    },
+    test("default CsvFormat derivation still works") {
+      val codec   = Schema[Meeting].derive(CsvFormat)
+      val meeting = Meeting("sync", LocalDate.of(2025, 5, 1))
+      assertTrue(
+        codec.headerNames == IndexedSeq("title", "date"),
+        csvRoundTrip(codec, meeting) == Right(meeting)
+      )
+    }
+  )
+}

--- a/schema-examples/src/main/scala/customcodec/CustomCodecOverrideExample.scala
+++ b/schema-examples/src/main/scala/customcodec/CustomCodecOverrideExample.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package customcodec
+
+import zio.blocks.schema._
+import zio.blocks.schema.json._
+import zio.blocks.typeid.TypeId
+
+import java.nio.ByteBuffer
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+/**
+ * Configure-once, use-everywhere codec overrides with `Deriver.withInstance`.
+ *
+ * Instead of repeating `.instance(...)` on every `DerivationBuilder`, create a
+ * pre-configured deriver once and derive codecs for any schema that contains
+ * the overridden type.
+ *
+ * Run with: sbt "schema-examples/runMain customcodec.CustomCodecOverrideExample"
+ */
+object CustomCodecOverrideExample extends App {
+
+  // Domain types
+  case class Event(name: String, date: LocalDate)
+  object Event {
+    implicit val schema: Schema[Event] = Schema.derived
+  }
+
+  case class Schedule(owner: String, events: List[Event])
+  object Schedule {
+    implicit val schema: Schema[Schedule] = Schema.derived
+  }
+
+  // Step 1: Define a custom codec for LocalDate using dd/MM/yyyy
+  private val dateFmt = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+
+  private val europeanDateCodec: JsonCodec[LocalDate] = new JsonCodec[LocalDate] {
+    def decodeValue(in: JsonReader): LocalDate =
+      LocalDate.parse(in.readString(), dateFmt)
+
+    def encodeValue(x: LocalDate, out: JsonWriter): Unit =
+      out.writeVal(dateFmt.format(x))
+
+    override def decodeValue(json: Json): LocalDate = json match {
+      case s: Json.String => LocalDate.parse(s.value, dateFmt)
+      case _              => error("expected Json.String")
+    }
+
+    override def encodeValue(x: LocalDate): Json =
+      new Json.String(dateFmt.format(x))
+  }
+
+  // Step 2: Create a pre-configured deriver — configure once
+  val myDeriver = JsonCodecDeriver
+    .withInstance[LocalDate](europeanDateCodec)
+    .withModifier(TypeId.of[Event], "name", Modifier.rename("title"))
+
+  // Step 3: Derive codecs for any schema — use everywhere
+  val eventCodec: JsonCodec[Event]       = Schema[Event].deriving(myDeriver).derive
+  val scheduleCodec: JsonCodec[Schedule] = Schema[Schedule].deriving(myDeriver).derive
+
+  // Demonstrate
+  val event    = Event("ZIO World", LocalDate.of(2025, 6, 15))
+  val schedule = Schedule("alice", List(event, Event("ScalaCon", LocalDate.of(2025, 9, 1))))
+
+  def encode[A](codec: JsonCodec[A], value: A): String = {
+    val buf = ByteBuffer.allocate(4096)
+    codec.encode(value, buf)
+    new String(java.util.Arrays.copyOf(buf.array, buf.position), "UTF-8")
+  }
+
+  println("=== Custom Codec Override Example ===")
+  println()
+  println("Event JSON:")
+  println(s"  ${encode(eventCodec, event)}")
+  println()
+  println("Schedule JSON (override applies to nested Events too):")
+  println(s"  ${encode(scheduleCodec, schedule)}")
+  println()
+
+  // Step 4: For comparison, default deriver uses ISO dates
+  val defaultCodec = Schema[Event].derive(JsonFormat)
+  println("Default Event JSON (ISO dates, original field names):")
+  println(s"  ${encode(defaultCodec, event)}")
+}

--- a/schema-examples/src/main/scala/customcodec/CustomCodecOverrideExample.scala
+++ b/schema-examples/src/main/scala/customcodec/CustomCodecOverrideExample.scala
@@ -31,7 +31,8 @@ import java.time.format.DateTimeFormatter
  * pre-configured deriver once and derive codecs for any schema that contains
  * the overridden type.
  *
- * Run with: sbt "schema-examples/runMain customcodec.CustomCodecOverrideExample"
+ * Run with: sbt "schema-examples/runMain
+ * customcodec.CustomCodecOverrideExample"
  */
 object CustomCodecOverrideExample extends App {
 

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/Deriver.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/Deriver.scala
@@ -101,4 +101,52 @@ trait Deriver[TC[_]] { self =>
   def instanceOverrides: IndexedSeq[InstanceOverride] = Chunk.empty
 
   def modifierOverrides: IndexedSeq[ModifierOverride] = Chunk.empty
+
+  /**
+   * Returns a new deriver that pre-registers a type-level instance override.
+   * During derivation, every occurrence of type `A` will use the supplied
+   * instance instead of deriving one.
+   */
+  final def withInstance[A](instance: => TC[A])(implicit typeId: TypeId[A]): Deriver[TC] =
+    new DeriverWithOverrides[TC](
+      self,
+      Chunk(new InstanceOverrideByType[TC, A](typeId, Lazy(instance))),
+      Chunk.empty
+    )
+
+  /**
+   * Returns a new deriver that pre-registers a field-level instance override.
+   * During derivation, the field named `termName` inside the parent type
+   * identified by `typeId` will use the supplied instance.
+   */
+  final def withInstance[A](typeId: TypeId[A], termName: String, instance: => TC[Any]): Deriver[TC] =
+    new DeriverWithOverrides[TC](
+      self,
+      Chunk(new InstanceOverrideByTypeAndTermName[TC, A, Any](typeId, termName, Lazy(instance))),
+      Chunk.empty
+    )
+
+  /**
+   * Returns a new deriver that pre-registers a reflect-level modifier override.
+   * During derivation, every occurrence of the type identified by `typeId` will
+   * have the modifier prepended to its modifiers.
+   */
+  final def withModifier[A](typeId: TypeId[A], modifier: Modifier.Reflect): Deriver[TC] =
+    new DeriverWithOverrides[TC](
+      self,
+      Chunk.empty,
+      Chunk(new ModifierReflectOverrideByType[A](typeId, modifier))
+    )
+
+  /**
+   * Returns a new deriver that pre-registers a term-level modifier override.
+   * During derivation, the field named `termName` inside the parent type
+   * identified by `typeId` will have the modifier applied.
+   */
+  final def withModifier[A](typeId: TypeId[A], termName: String, modifier: Modifier.Term): Deriver[TC] =
+    new DeriverWithOverrides[TC](
+      self,
+      Chunk.empty,
+      Chunk(new ModifierTermOverrideByType[A](typeId, termName, modifier))
+    )
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/Deriver.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/Deriver.scala
@@ -106,6 +106,21 @@ trait Deriver[TC[_]] { self =>
    * Returns a new deriver that pre-registers a type-level instance override.
    * During derivation, every occurrence of type `A` will use the supplied
    * instance instead of deriving one.
+   *
+   * When the returned deriver is passed to `DerivationBuilder`, deriver-level
+   * instance overrides take precedence over builder-level instance overrides
+   * for the same target because `DerivationBuilder.derive` merges them as
+   * `builderOverrides ++ deriver.instanceOverrides` and later entries win in
+   * the resulting `.toMap`.
+   *
+   * @tparam A
+   *   the type whose derived instance should be replaced
+   * @param instance
+   *   the custom type-class instance (evaluated lazily)
+   * @param typeId
+   *   implicit identifier for `A`, used to match occurrences during derivation
+   * @return
+   *   a new `Deriver` that wraps this deriver with the additional override
    */
   final def withInstance[A](instance: => TC[A])(implicit typeId: TypeId[A]): Deriver[TC] =
     new DeriverWithOverrides[TC](
@@ -116,13 +131,34 @@ trait Deriver[TC[_]] { self =>
 
   /**
    * Returns a new deriver that pre-registers a field-level instance override.
-   * During derivation, the field named `termName` inside the parent type
-   * identified by `typeId` will use the supplied instance.
+   * During derivation, the field named `termName` inside the parent
+   * record/variant identified by `typeId` will use the supplied instance
+   * instead of deriving one.
+   *
+   * This is a medium-precision override between optic-based (exact path) and
+   * type-based (all occurrences).
+   *
+   * @tparam A
+   *   the parent record or variant type that owns the field
+   * @tparam B
+   *   the type of the field being overridden. Note that `B` is not statically
+   *   checked against the actual field type; a mismatch will surface as a
+   *   runtime error during codec use, not at derivation time.
+   * @param typeId
+   *   identifier for the parent type `A`
+   * @param termName
+   *   the name of the field (or variant case) to override. If no field with
+   *   this name exists in the target type, the override is silently ignored
+   *   during derivation (matching `DerivationBuilder.instance` behaviour).
+   * @param instance
+   *   the custom type-class instance for the field (evaluated lazily)
+   * @return
+   *   a new `Deriver` that wraps this deriver with the additional override
    */
-  final def withInstance[A](typeId: TypeId[A], termName: String, instance: => TC[Any]): Deriver[TC] =
+  final def withInstance[A, B](typeId: TypeId[A], termName: String, instance: => TC[B]): Deriver[TC] =
     new DeriverWithOverrides[TC](
       self,
-      Chunk(new InstanceOverrideByTypeAndTermName[TC, A, Any](typeId, termName, Lazy(instance))),
+      Chunk(new InstanceOverrideByTypeAndTermName[TC, A, B](typeId, termName, Lazy(instance))),
       Chunk.empty
     )
 
@@ -130,6 +166,15 @@ trait Deriver[TC[_]] { self =>
    * Returns a new deriver that pre-registers a reflect-level modifier override.
    * During derivation, every occurrence of the type identified by `typeId` will
    * have the modifier prepended to its modifiers.
+   *
+   * @tparam A
+   *   the type to attach the modifier to
+   * @param typeId
+   *   identifier for `A`
+   * @param modifier
+   *   the reflect-level modifier to prepend
+   * @return
+   *   a new `Deriver` that wraps this deriver with the additional override
    */
   final def withModifier[A](typeId: TypeId[A], modifier: Modifier.Reflect): Deriver[TC] =
     new DeriverWithOverrides[TC](
@@ -142,6 +187,18 @@ trait Deriver[TC[_]] { self =>
    * Returns a new deriver that pre-registers a term-level modifier override.
    * During derivation, the field named `termName` inside the parent type
    * identified by `typeId` will have the modifier applied.
+   *
+   * @tparam A
+   *   the parent record or variant type that owns the field
+   * @param typeId
+   *   identifier for `A`
+   * @param termName
+   *   the name of the field (or variant case) to modify. If no field with this
+   *   name exists in the target type, the override is silently ignored.
+   * @param modifier
+   *   the term-level modifier to apply
+   * @return
+   *   a new `Deriver` that wraps this deriver with the additional override
    */
   final def withModifier[A](typeId: TypeId[A], termName: String, modifier: Modifier.Term): Deriver[TC] =
     new DeriverWithOverrides[TC](

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/DeriverWithOverrides.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/DeriverWithOverrides.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.derive
+
+import zio.blocks.schema._
+import zio.blocks.schema.binding._
+import zio.blocks.typeid.TypeId
+import zio.blocks.docs.Doc
+
+/**
+ * A deriver wrapper that accumulates instance and modifier overrides on top of
+ * a wrapped deriver. All abstract derivation methods delegate to the wrapped
+ * deriver; `instanceOverrides` and `modifierOverrides` return the union of the
+ * wrapped deriver's overrides and the additional ones registered via
+ * `withInstance` / `withModifier`.
+ *
+ * Chaining is naturally supported: each call to `withInstance` or
+ * `withModifier` wraps the current deriver in a new layer, and overrides
+ * accumulate.
+ */
+private[derive] final class DeriverWithOverrides[TC[_]](
+  wrapped: Deriver[TC],
+  additionalInstances: IndexedSeq[InstanceOverride],
+  additionalModifiers: IndexedSeq[ModifierOverride]
+) extends Deriver[TC] {
+
+  override def derivePrimitive[A](
+    primitiveType: PrimitiveType[A],
+    typeId: TypeId[A],
+    binding: Binding.Primitive[A],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[A],
+    examples: Seq[A]
+  ): Lazy[TC[A]] =
+    wrapped.derivePrimitive(primitiveType, typeId, binding, doc, modifiers, defaultValue, examples)
+
+  override def deriveRecord[F[_, _], A](
+    fields: IndexedSeq[Term[F, A, ?]],
+    typeId: TypeId[A],
+    binding: Binding.Record[A],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[A],
+    examples: Seq[A]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TC[A]] =
+    wrapped.deriveRecord(fields, typeId, binding, doc, modifiers, defaultValue, examples)
+
+  override def deriveVariant[F[_, _], A](
+    cases: IndexedSeq[Term[F, A, ?]],
+    typeId: TypeId[A],
+    binding: Binding.Variant[A],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[A],
+    examples: Seq[A]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TC[A]] =
+    wrapped.deriveVariant(cases, typeId, binding, doc, modifiers, defaultValue, examples)
+
+  override def deriveSequence[F[_, _], C[_], A](
+    element: Reflect[F, A],
+    typeId: TypeId[C[A]],
+    binding: Binding.Seq[C, A],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[C[A]],
+    examples: Seq[C[A]]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TC[C[A]]] =
+    wrapped.deriveSequence(element, typeId, binding, doc, modifiers, defaultValue, examples)
+
+  override def deriveMap[F[_, _], M[_, _], K, V](
+    key: Reflect[F, K],
+    value: Reflect[F, V],
+    typeId: TypeId[M[K, V]],
+    binding: Binding.Map[M, K, V],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[M[K, V]],
+    examples: Seq[M[K, V]]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TC[M[K, V]]] =
+    wrapped.deriveMap(key, value, typeId, binding, doc, modifiers, defaultValue, examples)
+
+  override def deriveDynamic[F[_, _]](
+    binding: Binding.Dynamic,
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[DynamicValue],
+    examples: Seq[DynamicValue]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TC[DynamicValue]] =
+    wrapped.deriveDynamic(binding, doc, modifiers, defaultValue, examples)
+
+  override def deriveWrapper[F[_, _], A, B](
+    wrapped0: Reflect[F, B],
+    typeId: TypeId[A],
+    binding: Binding.Wrapper[A, B],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[A],
+    examples: Seq[A]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[TC[A]] =
+    wrapped.deriveWrapper(wrapped0, typeId, binding, doc, modifiers, defaultValue, examples)
+
+  override def instanceOverrides: IndexedSeq[InstanceOverride] =
+    wrapped.instanceOverrides ++ additionalInstances
+
+  override def modifierOverrides: IndexedSeq[ModifierOverride] =
+    wrapped.modifierOverrides ++ additionalModifiers
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/derive/DeriverWithInstanceSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/derive/DeriverWithInstanceSpec.scala
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.derive
+
+import zio.blocks.schema._
+import zio.blocks.schema.json._
+import zio.blocks.typeid.TypeId
+import zio.test._
+
+import java.nio.ByteBuffer
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+/**
+ * Tests for `Deriver.withInstance` and `Deriver.withModifier`.
+ *
+ * Verifies that pre-registering overrides on a deriver produces correct
+ * results across JSON derivation, including type-level, field-level,
+ * modifier, chained, Option, and nested override scenarios. Also checks
+ * backward compatibility with existing `Schema.derive` and
+ * `DerivationBuilder` paths.
+ */
+object DeriverWithInstanceSpec extends SchemaBaseSpec {
+
+  // -- Custom JsonCodec: LocalDate as "dd/MM/yyyy" instead of ISO ---
+
+  private val customDateFmt = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+
+  private val customLocalDateCodec: JsonCodec[LocalDate] = new JsonCodec[LocalDate] {
+    def decodeValue(in: JsonReader): LocalDate = {
+      LocalDate.parse(in.readString(), customDateFmt)
+    }
+
+    def encodeValue(x: LocalDate, out: JsonWriter): Unit =
+      out.writeVal(customDateFmt.format(x))
+
+    override def decodeValue(json: Json): LocalDate = json match {
+      case s: Json.String => LocalDate.parse(s.value, customDateFmt)
+      case _              => error("expected Json.String")
+    }
+
+    override def encodeValue(x: LocalDate): Json =
+      new Json.String(customDateFmt.format(x))
+  }
+
+  // -- Domain types ---
+
+  case class Event(name: String, date: LocalDate)
+  object Event {
+    implicit val schema: Schema[Event] = Schema.derived
+  }
+
+  case class DateRange(label: String, start: LocalDate, end: LocalDate)
+  object DateRange extends CompanionOptics[DateRange] {
+    implicit val schema: Schema[DateRange] = Schema.derived
+    val start: Lens[DateRange, LocalDate]  = optic(_.start)
+    val end: Lens[DateRange, LocalDate]    = optic(_.end)
+  }
+
+  case class MaybeEvent(name: String, date: Option[LocalDate])
+  object MaybeEvent {
+    implicit val schema: Schema[MaybeEvent] = Schema.derived
+  }
+
+  case class Outer(tag: String, inner: Event)
+  object Outer {
+    implicit val schema: Schema[Outer] = Schema.derived
+  }
+
+  case class Named(firstName: String, lastName: String)
+  object Named {
+    implicit val schema: Schema[Named] = Schema.derived
+  }
+
+  // -- Helpers ---
+
+  private def jsonRoundTrip[A](codec: JsonCodec[A], value: A): (String, Either[SchemaError, A]) = {
+    val buf = ByteBuffer.allocate(4096)
+    codec.encode(value, buf)
+    val bytes   = java.util.Arrays.copyOf(buf.array, buf.position)
+    val encoded = new String(bytes, "UTF-8")
+    val decoded = codec.decode(bytes)
+    (encoded, decoded)
+  }
+
+  private def jsonEncode[A](codec: JsonCodec[A], value: A): String = {
+    val buf = ByteBuffer.allocate(4096)
+    codec.encode(value, buf)
+    new String(java.util.Arrays.copyOf(buf.array, buf.position), "UTF-8")
+  }
+
+  def spec: Spec[TestEnvironment, Any] = suite("DeriverWithInstanceSpec")(
+    suite("JSON withInstance")(
+      test("type-level override replaces all occurrences of a type") {
+        val deriver = JsonCodecDeriver.withInstance[LocalDate](customLocalDateCodec)
+        val codec   = Schema[Event].deriving(deriver).derive
+        val event   = Event("launch", LocalDate.of(2025, 6, 15))
+        val (json, decoded) = jsonRoundTrip(codec, event)
+        assertTrue(
+          json == """{"name":"launch","date":"15/06/2025"}""",
+          decoded == Right(event)
+        )
+      },
+      test("field-level override applies only to the specified field") {
+        val deriver = JsonCodecDeriver.withInstance[DateRange](
+          TypeId.of[DateRange],
+          "start",
+          customLocalDateCodec.asInstanceOf[JsonCodec[Any]]
+        )
+        val codec = Schema[DateRange].deriving(deriver).derive
+        val range = DateRange("q1", LocalDate.of(2025, 1, 1), LocalDate.of(2025, 3, 31))
+        val json  = jsonEncode(codec, range)
+        // start uses custom format, end uses default ISO format
+        assertTrue(
+          json == """{"label":"q1","start":"01/01/2025","end":"2025-03-31"}"""
+        )
+      },
+      test("Option[A] with type-level override") {
+        val deriver = JsonCodecDeriver.withInstance[LocalDate](customLocalDateCodec)
+        val codec   = Schema[MaybeEvent].deriving(deriver).derive
+
+        val withDate = MaybeEvent("party", Some(LocalDate.of(2025, 12, 25)))
+        val noDate   = MaybeEvent("tbd", None)
+
+        val (jsonWith, decodedWith) = jsonRoundTrip(codec, withDate)
+        val (jsonNone, decodedNone) = jsonRoundTrip(codec, noDate)
+
+        assertTrue(
+          jsonWith == """{"name":"party","date":"25/12/2025"}""",
+          decodedWith == Right(withDate),
+          jsonNone == """{"name":"tbd"}""",
+          decodedNone == Right(noDate)
+        )
+      },
+      test("nested record with type-level override") {
+        val deriver = JsonCodecDeriver.withInstance[LocalDate](customLocalDateCodec)
+        val codec   = Schema[Outer].deriving(deriver).derive
+        val outer   = Outer("wrapper", Event("inner-event", LocalDate.of(2024, 2, 29)))
+        val (json, decoded) = jsonRoundTrip(codec, outer)
+        assertTrue(
+          json == """{"tag":"wrapper","inner":{"name":"inner-event","date":"29/02/2024"}}""",
+          decoded == Right(outer)
+        )
+      }
+    ),
+    suite("JSON withModifier")(
+      test("field rename via withModifier") {
+        val deriver = JsonCodecDeriver.withModifier(
+          TypeId.of[Named],
+          "firstName",
+          Modifier.rename("first_name")
+        )
+        val codec = Schema[Named].deriving(deriver).derive
+        val named = Named("Alice", "Smith")
+        val (json, decoded) = jsonRoundTrip(codec, named)
+        assertTrue(
+          json == """{"first_name":"Alice","lastName":"Smith"}""",
+          decoded == Right(named)
+        )
+      }
+    ),
+    suite("chaining")(
+      test("withInstance + withModifier can be chained") {
+        val deriver = JsonCodecDeriver
+          .withInstance[LocalDate](customLocalDateCodec)
+          .withModifier(TypeId.of[Event], "name", Modifier.rename("title"))
+        val codec = Schema[Event].deriving(deriver).derive
+        val event = Event("conf", LocalDate.of(2025, 9, 1))
+        val (json, decoded) = jsonRoundTrip(codec, event)
+        assertTrue(
+          json == """{"title":"conf","date":"01/09/2025"}""",
+          decoded == Right(event)
+        )
+      },
+      test("multiple withInstance calls accumulate") {
+        val stringifyInt: JsonCodec[Int] = new JsonCodec[Int] {
+          def decodeValue(in: JsonReader): Int = in.readStringAsInt()
+
+          def encodeValue(x: Int, out: JsonWriter): Unit = out.writeValAsString(x)
+
+          override def decodeValue(json: Json): Int = json match {
+            case s: Json.String => s.value.toInt
+            case _              => error("expected Json.String")
+          }
+
+          override def encodeValue(x: Int): Json = new Json.String(x.toString)
+        }
+
+        val deriver = JsonCodecDeriver
+          .withInstance[LocalDate](customLocalDateCodec)
+          .withInstance[Int](stringifyInt)
+
+        val codec = Schema[Event].deriving(deriver).derive
+        val event = Event("test", LocalDate.of(2025, 1, 1))
+        val json  = jsonEncode(codec, event)
+        // LocalDate uses custom format, but Event has no Int field so just check date
+        assertTrue(json == """{"name":"test","date":"01/01/2025"}""")
+      }
+    ),
+    suite("backward compatibility")(
+      test("Schema.derive(Format) still works") {
+        val codec = Schema[Event].derive(JsonFormat)
+        val event = Event("compat", LocalDate.of(2025, 6, 1))
+        val (json, decoded) = jsonRoundTrip(codec, event)
+        assertTrue(
+          json == """{"name":"compat","date":"2025-06-01"}""",
+          decoded == Right(event)
+        )
+      },
+      test("DerivationBuilder path still works") {
+        val codec = Schema[Event]
+          .deriving(JsonCodecDeriver)
+          .instance(TypeId.of[LocalDate], customLocalDateCodec)
+          .derive
+        val event = Event("builder", LocalDate.of(2025, 3, 14))
+        val (json, decoded) = jsonRoundTrip(codec, event)
+        assertTrue(
+          json == """{"name":"builder","date":"14/03/2025"}""",
+          decoded == Right(event)
+        )
+      }
+    )
+  )
+}

--- a/schema/shared/src/test/scala/zio/blocks/schema/derive/DeriverWithInstanceSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/derive/DeriverWithInstanceSpec.scala
@@ -28,11 +28,10 @@ import java.time.format.DateTimeFormatter
 /**
  * Tests for `Deriver.withInstance` and `Deriver.withModifier`.
  *
- * Verifies that pre-registering overrides on a deriver produces correct
- * results across JSON derivation, including type-level, field-level,
- * modifier, chained, Option, and nested override scenarios. Also checks
- * backward compatibility with existing `Schema.derive` and
- * `DerivationBuilder` paths.
+ * Verifies that pre-registering overrides on a deriver produces correct results
+ * across JSON derivation, including type-level, field-level, modifier, chained,
+ * Option, and nested override scenarios. Also checks backward compatibility
+ * with existing `Schema.derive` and `DerivationBuilder` paths.
  */
 object DeriverWithInstanceSpec extends SchemaBaseSpec {
 
@@ -41,9 +40,8 @@ object DeriverWithInstanceSpec extends SchemaBaseSpec {
   private val customDateFmt = DateTimeFormatter.ofPattern("dd/MM/yyyy")
 
   private val customLocalDateCodec: JsonCodec[LocalDate] = new JsonCodec[LocalDate] {
-    def decodeValue(in: JsonReader): LocalDate = {
+    def decodeValue(in: JsonReader): LocalDate =
       LocalDate.parse(in.readString(), customDateFmt)
-    }
 
     def encodeValue(x: LocalDate, out: JsonWriter): Unit =
       out.writeVal(customDateFmt.format(x))
@@ -86,6 +84,11 @@ object DeriverWithInstanceSpec extends SchemaBaseSpec {
     implicit val schema: Schema[Named] = Schema.derived
   }
 
+  case class Scored(name: String, date: LocalDate, score: Int)
+  object Scored {
+    implicit val schema: Schema[Scored] = Schema.derived
+  }
+
   // -- Helpers ---
 
   private def jsonRoundTrip[A](codec: JsonCodec[A], value: A): (String, Either[SchemaError, A]) = {
@@ -106,9 +109,9 @@ object DeriverWithInstanceSpec extends SchemaBaseSpec {
   def spec: Spec[TestEnvironment, Any] = suite("DeriverWithInstanceSpec")(
     suite("JSON withInstance")(
       test("type-level override replaces all occurrences of a type") {
-        val deriver = JsonCodecDeriver.withInstance[LocalDate](customLocalDateCodec)
-        val codec   = Schema[Event].deriving(deriver).derive
-        val event   = Event("launch", LocalDate.of(2025, 6, 15))
+        val deriver         = JsonCodecDeriver.withInstance[LocalDate](customLocalDateCodec)
+        val codec           = Schema[Event].deriving(deriver).derive
+        val event           = Event("launch", LocalDate.of(2025, 6, 15))
         val (json, decoded) = jsonRoundTrip(codec, event)
         assertTrue(
           json == """{"name":"launch","date":"15/06/2025"}""",
@@ -116,10 +119,10 @@ object DeriverWithInstanceSpec extends SchemaBaseSpec {
         )
       },
       test("field-level override applies only to the specified field") {
-        val deriver = JsonCodecDeriver.withInstance[DateRange](
+        val deriver = JsonCodecDeriver.withInstance[DateRange, LocalDate](
           TypeId.of[DateRange],
           "start",
-          customLocalDateCodec.asInstanceOf[JsonCodec[Any]]
+          customLocalDateCodec
         )
         val codec = Schema[DateRange].deriving(deriver).derive
         val range = DateRange("q1", LocalDate.of(2025, 1, 1), LocalDate.of(2025, 3, 31))
@@ -147,9 +150,9 @@ object DeriverWithInstanceSpec extends SchemaBaseSpec {
         )
       },
       test("nested record with type-level override") {
-        val deriver = JsonCodecDeriver.withInstance[LocalDate](customLocalDateCodec)
-        val codec   = Schema[Outer].deriving(deriver).derive
-        val outer   = Outer("wrapper", Event("inner-event", LocalDate.of(2024, 2, 29)))
+        val deriver         = JsonCodecDeriver.withInstance[LocalDate](customLocalDateCodec)
+        val codec           = Schema[Outer].deriving(deriver).derive
+        val outer           = Outer("wrapper", Event("inner-event", LocalDate.of(2024, 2, 29)))
         val (json, decoded) = jsonRoundTrip(codec, outer)
         assertTrue(
           json == """{"tag":"wrapper","inner":{"name":"inner-event","date":"29/02/2024"}}""",
@@ -164,8 +167,8 @@ object DeriverWithInstanceSpec extends SchemaBaseSpec {
           "firstName",
           Modifier.rename("first_name")
         )
-        val codec = Schema[Named].deriving(deriver).derive
-        val named = Named("Alice", "Smith")
+        val codec           = Schema[Named].deriving(deriver).derive
+        val named           = Named("Alice", "Smith")
         val (json, decoded) = jsonRoundTrip(codec, named)
         assertTrue(
           json == """{"first_name":"Alice","lastName":"Smith"}""",
@@ -178,8 +181,8 @@ object DeriverWithInstanceSpec extends SchemaBaseSpec {
         val deriver = JsonCodecDeriver
           .withInstance[LocalDate](customLocalDateCodec)
           .withModifier(TypeId.of[Event], "name", Modifier.rename("title"))
-        val codec = Schema[Event].deriving(deriver).derive
-        val event = Event("conf", LocalDate.of(2025, 9, 1))
+        val codec           = Schema[Event].deriving(deriver).derive
+        val event           = Event("conf", LocalDate.of(2025, 9, 1))
         val (json, decoded) = jsonRoundTrip(codec, event)
         assertTrue(
           json == """{"title":"conf","date":"01/09/2025"}""",
@@ -204,17 +207,19 @@ object DeriverWithInstanceSpec extends SchemaBaseSpec {
           .withInstance[LocalDate](customLocalDateCodec)
           .withInstance[Int](stringifyInt)
 
-        val codec = Schema[Event].deriving(deriver).derive
-        val event = Event("test", LocalDate.of(2025, 1, 1))
-        val json  = jsonEncode(codec, event)
-        // LocalDate uses custom format, but Event has no Int field so just check date
-        assertTrue(json == """{"name":"test","date":"01/01/2025"}""")
+        val codec           = Schema[Scored].deriving(deriver).derive
+        val scored          = Scored("test", LocalDate.of(2025, 1, 1), 42)
+        val (json, decoded) = jsonRoundTrip(codec, scored)
+        assertTrue(
+          json == """{"name":"test","date":"01/01/2025","score":"42"}""",
+          decoded == Right(scored)
+        )
       }
     ),
     suite("backward compatibility")(
       test("Schema.derive(Format) still works") {
-        val codec = Schema[Event].derive(JsonFormat)
-        val event = Event("compat", LocalDate.of(2025, 6, 1))
+        val codec           = Schema[Event].derive(JsonFormat)
+        val event           = Event("compat", LocalDate.of(2025, 6, 1))
         val (json, decoded) = jsonRoundTrip(codec, event)
         assertTrue(
           json == """{"name":"compat","date":"2025-06-01"}""",
@@ -226,7 +231,7 @@ object DeriverWithInstanceSpec extends SchemaBaseSpec {
           .deriving(JsonCodecDeriver)
           .instance(TypeId.of[LocalDate], customLocalDateCodec)
           .derive
-        val event = Event("builder", LocalDate.of(2025, 3, 14))
+        val event           = Event("builder", LocalDate.of(2025, 3, 14))
         val (json, decoded) = jsonRoundTrip(codec, event)
         assertTrue(
           json == """{"name":"builder","date":"14/03/2025"}""",


### PR DESCRIPTION
## Summary

Adds `withInstance` and `withModifier` methods to the `Deriver[TC]` trait, enabling users to configure a deriver once and reuse it across all derivations — the configure-once-use-everywhere pattern.

Closes #1346

## Problem

Users cannot figure out how to customize codec behavior (e.g., custom date formats). The existing `DerivationBuilder` path requires repeating overrides on every `Schema[A].derive(...)` call, which doesn't scale.

## Solution

Four `final` methods on `Deriver[TC]`:

```scala
// Type-level: override codec for ALL occurrences of type A
val deriver = JsonCodecDeriver.withInstance[LocalDate](customDateCodec)

// Field-level: override codec for a specific field inside type A
val deriver = JsonCodecDeriver.withInstance[MyRecord](TypeId.of[MyRecord], "date", customCodec)

// Modifier: rename a field
val deriver = JsonCodecDeriver.withModifier(TypeId.of[Named], "firstName", Modifier.rename("first_name"))

// Chainable — configure once, use everywhere:
val myDeriver = JsonCodecDeriver
  .withInstance[LocalDate](customDateCodec)
  .withInstance[Instant](customInstantCodec)
  .withModifier(TypeId.of[Event], "name", Modifier.rename("title"))

val codec1 = Schema[Record1].deriving(myDeriver).derive
val codec2 = Schema[Record2].deriving(myDeriver).derive
val codec3 = Schema[Record3].deriving(myDeriver).derive
// All three get the overrides automatically
```

**Implementation**: A `private[derive] DeriverWithOverrides` class wraps any deriver, delegates all abstract methods, and returns accumulated overrides from `instanceOverrides`/`modifierOverrides`. Zero changes to any format-specific deriver — the existing `DerivationBuilder.derive` resolution machinery handles everything.

## Tests

- **JSON** (9 tests): type-level, field-level, Option[A], nested record, withModifier rename, chained, multiple withInstance, backward compat (Schema.derive + DerivationBuilder path)
- **CSV** (3 tests): wrapped deriver roundtrip, chained modifiers, default CsvFormat backward compat
- **Documentation example**: `CustomCodecOverrideExample.scala` showing configure-once-use-everywhere pattern