### PR TITLE
feat(schedule): add Schedule GADT — pure declarative recurring policy data type

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,21 +98,21 @@ addCommandAlias(
 )
 lazy val testJVMScala2Command =
   "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
-    "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; muxJVM/test; mediatypeJVM/test; " +
-    "endpointJVM/test; openapiJVM/test; smithy/test; codegen/test; htmlJVM/test"
+    "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; muxJVM/test; configJVM/test; config-yamlJVM/test; config-jsonJVM/test; config-hoconJVM/test; mediatypeJVM/test; " +
+    "endpointJVM/test; openapiJVM/test; scheduleJVM/test; smithy/test; codegen/test; htmlJVM/test"
 
 lazy val testJVMScala3Command =
   "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
-    "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; muxJVM/test; mediatypeJVM/test; http-modelJVM/test; " +
-    "http-model-schemaJVM/test; endpointJVM/test; openapiJVM/test; smithy/test; codegen/test; htmlJVM/test; datastarJVM/test; htmxJVM/test"
+    "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; muxJVM/test; configJVM/test; config-yamlJVM/test; config-jsonJVM/test; config-hoconJVM/test; mediatypeJVM/test; http-modelJVM/test; " +
+    "http-model-schemaJVM/test; endpointJVM/test; openapiJVM/test; scheduleJVM/test; smithy/test; codegen/test; htmlJVM/test; datastarJVM/test; htmxJVM/test"
 
 lazy val testJSScala2Command =
   "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
-    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; muxJS/test; mediatypeJS/test; endpointJS/test; htmlJS/test"
+    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; muxJS/test; configJS/test; config-yamlJS/test; config-jsonJS/test; config-hoconJS/test; mediatypeJS/test; endpointJS/test; scheduleJS/test; htmlJS/test"
 
 lazy val testJSScala3Command =
   "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
-    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; muxJS/test; mediatypeJS/test; http-modelJS/test; http-model-schemaJS/test; endpointJS/test; htmlJS/test; datastarJS/test; htmxJS/test"
+    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; muxJS/test; configJS/test; config-yamlJS/test; config-jsonJS/test; config-hoconJS/test; mediatypeJS/test; http-modelJS/test; http-model-schemaJS/test; endpointJS/test; scheduleJS/test; htmlJS/test; datastarJS/test; htmxJS/test"
 
 lazy val testJS1Scala2Command =
   "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test"
@@ -121,40 +121,40 @@ lazy val testJS1Scala3Command =
   "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test"
 
 lazy val testJS2Scala2Command =
-  "openapiJS/test; schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; htmlJS/test"
+  "openapiJS/test; schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; scheduleJS/test; htmlJS/test"
 
 lazy val testJS2Scala3Command =
-  "openapiJS/test; schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; http-modelJS/test; http-model-schemaJS/test; endpointJS/test; htmlJS/test; datastarJS/test; htmxJS/test"
+  "openapiJS/test; schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; http-modelJS/test; http-model-schemaJS/test; endpointJS/test; scheduleJS/test; htmlJS/test; datastarJS/test; htmxJS/test"
 
 lazy val docJVMScala2Command =
   "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
     "schema-thrift/doc; schema-bson/doc; schema-xmlJVM/doc; schema-yamlJVM/doc; schema-csvJVM/doc; contextJVM/doc; scopeJVM/doc; muxJVM/doc; mediatypeJVM/doc; " +
-    "endpointJVM/doc; openapiJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc"
+    "endpointJVM/doc; openapiJVM/doc; scheduleJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc"
 
 lazy val docJVMScala3Command =
   "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
     "schema-thrift/doc; schema-bson/doc; schema-xmlJVM/doc; schema-yamlJVM/doc; schema-csvJVM/doc; contextJVM/doc; scopeJVM/doc; muxJVM/doc; mediatypeJVM/doc; http-modelJVM/doc; " +
-    "http-model-schemaJVM/doc; openapiJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc; datastarJVM/doc; htmxJVM/doc"
+    "http-model-schemaJVM/doc; openapiJVM/doc; scheduleJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc; datastarJVM/doc; htmxJVM/doc"
 
 lazy val docJSScala2Command =
   "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
-    "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; muxJS/doc; mediatypeJS/doc; endpointJS/doc; htmlJS/doc"
+    "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; muxJS/doc; mediatypeJS/doc; endpointJS/doc; scheduleJS/doc; htmlJS/doc"
 
 lazy val docJSScala2Batch1Command =
   "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc"
 
 lazy val docJSScala2Batch2Command =
-  "openapiJS/doc; schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; htmlJS/doc"
+  "openapiJS/doc; schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; scheduleJS/doc; htmlJS/doc"
 
 lazy val docJSScala3Command =
   "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
-    "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; muxJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; htmlJS/doc; datastarJS/doc; htmxJS/doc"
+    "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; muxJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; scheduleJS/doc; htmlJS/doc; datastarJS/doc; htmxJS/doc"
 
 lazy val docJSScala3Batch1Command =
   "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc"
 
 lazy val docJSScala3Batch2Command =
-  "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; htmlJS/doc; datastarJS/doc"
+  "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; scheduleJS/doc; htmlJS/doc; datastarJS/doc"
 
 def commandForScalaVersion(name: String, scala2Command: String, scala3Command: String): Command =
   Command.command(name) { state =>
@@ -254,6 +254,8 @@ lazy val root = project
     ringbuffer.jvm,
     ringbuffer.js,
     ringbufferBenchmarks,
+    schedule.jvm,
+    schedule.js,
     smithy,
     `smithy-examples`
   )
@@ -573,6 +575,23 @@ lazy val chunk = crossProject(JSPlatform, JVMPlatform)
     ),
     coverageMinimumStmtTotal   := 91,
     coverageMinimumBranchTotal := 86
+  )
+
+lazy val schedule = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Full)
+  .settings(stdSettings("zio-blocks-schedule"))
+  .settings(crossProjectSettings)
+  .settings(buildInfoSettings("zio.blocks.schedule"))
+  .enablePlugins(BuildInfoPlugin)
+  .jvmSettings(mimaSettings(failOnProblem = false))
+  .jsSettings(jsSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "dev.zio" %%% "zio-test"     % "2.1.25" % Test,
+      "dev.zio" %%% "zio-test-sbt" % "2.1.25" % Test
+    ),
+    coverageMinimumStmtTotal   := 80,
+    coverageMinimumBranchTotal := 75
   )
 
 lazy val mediatype = crossProject(JSPlatform, JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -99,38 +99,38 @@ addCommandAlias(
 lazy val testJVMScala2Command =
   "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
     "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; mediatypeJVM/test; " +
-    "openapiJVM/test; smithy/test; codegen/test; htmlJVM/test"
+    "openapiJVM/test; scheduleJVM/test; smithy/test; codegen/test; htmlJVM/test"
 
 lazy val testJVMScala3Command =
   "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
     "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; mediatypeJVM/test; http-modelJVM/test; " +
-    "http-model-schemaJVM/test; endpointJVM/test; openapiJVM/test; smithy/test; codegen/test; htmlJVM/test; datastarJVM/test"
+    "http-model-schemaJVM/test; endpointJVM/test; openapiJVM/test; scheduleJVM/test; smithy/test; codegen/test; htmlJVM/test; datastarJVM/test"
 
 lazy val testJSScala2Command =
   "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
-    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; htmlJS/test"
+    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; scheduleJS/test; htmlJS/test"
 
 lazy val testJSScala3Command =
   "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
-    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; http-modelJS/test; http-model-schemaJS/test; endpointJS/test; htmlJS/test; datastarJS/test"
+    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; http-modelJS/test; http-model-schemaJS/test; endpointJS/test; scheduleJS/test; htmlJS/test; datastarJS/test"
 
 lazy val docJVMScala2Command =
   "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
     "schema-thrift/doc; schema-bson/doc; schema-xmlJVM/doc; schema-yamlJVM/doc; schema-csvJVM/doc; contextJVM/doc; scopeJVM/doc; mediatypeJVM/doc; " +
-    "openapiJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc"
+    "openapiJVM/doc; scheduleJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc"
 
 lazy val docJVMScala3Command =
   "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
     "schema-thrift/doc; schema-bson/doc; schema-xmlJVM/doc; schema-yamlJVM/doc; schema-csvJVM/doc; contextJVM/doc; scopeJVM/doc; mediatypeJVM/doc; http-modelJVM/doc; " +
-    "http-model-schemaJVM/doc; openapiJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc; datastarJVM/doc"
+    "http-model-schemaJVM/doc; openapiJVM/doc; scheduleJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc; datastarJVM/doc"
 
 lazy val docJSScala2Command =
   "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
-    "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; htmlJS/doc"
+    "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; scheduleJS/doc; htmlJS/doc"
 
 lazy val docJSScala3Command =
   "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
-    "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; htmlJS/doc; datastarJS/doc"
+    "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; scheduleJS/doc; htmlJS/doc; datastarJS/doc"
 
 def commandForScalaVersion(name: String, scala2Command: String, scala3Command: String): Command =
   Command.command(name) { state =>
@@ -222,6 +222,8 @@ lazy val root = project
     ringbuffer.jvm,
     ringbuffer.js,
     ringbufferBenchmarks,
+    schedule.jvm,
+    schedule.js,
     smithy
   )
 
@@ -516,6 +518,23 @@ lazy val chunk = crossProject(JSPlatform, JVMPlatform)
     ),
     coverageMinimumStmtTotal   := 91,
     coverageMinimumBranchTotal := 86
+  )
+
+lazy val schedule = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Full)
+  .settings(stdSettings("zio-blocks-schedule"))
+  .settings(crossProjectSettings)
+  .settings(buildInfoSettings("zio.blocks.schedule"))
+  .enablePlugins(BuildInfoPlugin)
+  .jvmSettings(mimaSettings(failOnProblem = false))
+  .jsSettings(jsSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "dev.zio" %%% "zio-test"     % "2.1.25" % Test,
+      "dev.zio" %%% "zio-test-sbt" % "2.1.25" % Test
+    ),
+    coverageMinimumStmtTotal   := 80,
+    coverageMinimumBranchTotal := 75
   )
 
 lazy val mediatype = crossProject(JSPlatform, JVMPlatform)

--- a/schedule/shared/src/main/scala/zio/blocks/schedule/Schedule.scala
+++ b/schedule/shared/src/main/scala/zio/blocks/schedule/Schedule.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schedule
+
+import scala.concurrent.duration.Duration
+
+/**
+ * A scheduling decision indicating whether evaluation should continue or
+ * terminate.
+ */
+sealed trait Decision
+object Decision {
+
+  /**
+   * Continue the schedule after waiting for `delay`.
+   *
+   * @param delay
+   *   the amount of time an interpreter should wait before the next step
+   */
+  final case class Continue(delay: Duration) extends Decision
+
+  /** The schedule has completed — interpreters should stop evaluating. */
+  case object Done extends Decision
+}
+
+/**
+ * A pure, declarative description of a recurring policy.
+ *
+ * `Schedule` is an AST only — values describe scheduling behavior but do not
+ * execute it. An interpreter walks the nodes and, for each step, produces an
+ * output together with a [[Decision]] indicating whether to continue.
+ *
+ * @tparam In
+ *   Input consumed at each step (e.g. errors for retry, successes for repeat).
+ * @tparam Out
+ *   Output produced at each step (e.g. retry count, computed delay).
+ */
+sealed trait Schedule[-In, +Out] { self =>
+
+  /** Transforms the output of this schedule. */
+  def map[Out2](f: Out => Out2): Schedule[In, Out2] = Schedule.Map(self, f)
+
+  /** Transforms the input of this schedule. */
+  def contramap[In2](f: In2 => In): Schedule[In2, Out] = Schedule.Contramap(self, f)
+
+  /** Replaces the output with a constant value. */
+  def as[Out2](out2: Out2): Schedule[In, Out2] = map(_ => out2)
+
+  /** Discards the output, producing `Unit`. */
+  def unit: Schedule[In, Unit] = as(())
+
+  /** Combines with `that` — both must continue; outputs are paired. */
+  def both[In1 <: In, Out2](that: Schedule[In1, Out2]): Schedule[In1, (Out, Out2)] = Schedule.Both(self, that)
+
+  /** Alias for [[both]]. */
+  def &&[In1 <: In, Out2](that: Schedule[In1, Out2]): Schedule[In1, (Out, Out2)] = both(that)
+
+  /** Combines with `that` — either may continue; outputs are paired. */
+  def either[In1 <: In, Out2](that: Schedule[In1, Out2]): Schedule[In1, (Out, Out2)] = Schedule.Either(self, that)
+
+  /** Alias for [[either]]. */
+  def ||[In1 <: In, Out2](that: Schedule[In1, Out2]): Schedule[In1, (Out, Out2)] = either(that)
+
+  /** Feeds the output of `that` into the input of this schedule. */
+  def compose[In2](that: Schedule[In2, In]): Schedule[In2, Out] = Schedule.Compose(self, that)
+
+  /** Runs this schedule until done, then switches to `that`. */
+  def andThen[In1 <: In, Out2](that: Schedule[In1, Out2]): Schedule[In1, Out2] = Schedule.AndThen(self, that)
+
+  /** Alias for [[both]]. */
+  def zip[In1 <: In, Out2](that: Schedule[In1, Out2]): Schedule[In1, (Out, Out2)] = both(that)
+
+  /** Adds a delay derived from the schedule output. */
+  def addDelay(f: Out => Duration): Schedule[In, Out] = Schedule.Delayed(self, f)
+
+  /** Applies full-range jitter (0.0 to 1.0) to delays. */
+  def jittered: Schedule[In, Out] = jittered(0.0, 1.0)
+
+  /** Applies jitter with custom bounds to delays. */
+  def jittered(min: Double, max: Double): Schedule[In, Out] = Schedule.Jittered(self, min, max)
+
+  /** Continues only while the input satisfies `f`. */
+  def whileInput[In1 <: In](f: In1 => Boolean): Schedule[In1, Out] = Schedule.WhileInput(self, f)
+
+  /** Continues only while the output satisfies `f`. */
+  def whileOutput(f: Out => Boolean): Schedule[In, Out] = Schedule.WhileOutput(self, f)
+
+  /** Revises both the output and the continuation decision after each step. */
+  def reconsider[In1 <: In, Out2](f: (In1, Out, Decision) => (Out2, Decision)): Schedule[In1, Out2] =
+    Schedule.Reconsider(self, f)
+}
+
+object Schedule {
+
+  // --- Primitive case classes (all private[schedule]) ---
+
+  private[schedule] final case class Identity[A]()                    extends Schedule[A, A]
+  private[schedule] final case class Succeed[Out](value: Out)         extends Schedule[Any, Out]
+  private[schedule] final case class Unfold[S](initial: S, f: S => S) extends Schedule[Any, S]
+  private[schedule] final case class Map[In, Out, Out2](schedule: Schedule[In, Out], f: Out => Out2)
+      extends Schedule[In, Out2]
+  private[schedule] final case class Contramap[In, In2, Out](schedule: Schedule[In, Out], f: In2 => In)
+      extends Schedule[In2, Out]
+  private[schedule] final case class Both[In, Out1, Out2](left: Schedule[In, Out1], right: Schedule[In, Out2])
+      extends Schedule[In, (Out1, Out2)]
+  private[schedule] final case class Either[In, Out1, Out2](left: Schedule[In, Out1], right: Schedule[In, Out2])
+      extends Schedule[In, (Out1, Out2)]
+  private[schedule] final case class Compose[In, Mid, Out](outer: Schedule[Mid, Out], inner: Schedule[In, Mid])
+      extends Schedule[In, Out]
+  private[schedule] final case class AndThen[In, Out1, Out2](first: Schedule[In, Out1], second: Schedule[In, Out2])
+      extends Schedule[In, Out2]
+  private[schedule] final case class Delayed[In, Out](schedule: Schedule[In, Out], f: Out => Duration)
+      extends Schedule[In, Out]
+  private[schedule] final case class Jittered[In, Out](schedule: Schedule[In, Out], min: Double, max: Double)
+      extends Schedule[In, Out]
+  private[schedule] final case class WhileInput[In, Out](schedule: Schedule[In, Out], f: In => Boolean)
+      extends Schedule[In, Out]
+  private[schedule] final case class WhileOutput[In, Out](schedule: Schedule[In, Out], f: Out => Boolean)
+      extends Schedule[In, Out]
+  private[schedule] final case class Reconsider[In, Out, Out2](
+    schedule: Schedule[In, Out],
+    f: (In, Out, Decision) => (Out2, Decision)
+  ) extends Schedule[In, Out2]
+
+  // --- Factory methods ---
+
+  /**
+   * Passes input through as output. Identity element for
+   * [[Schedule.compose compose]].
+   */
+  def identity[A]: Schedule[A, A] = Identity()
+
+  /** Always continues, emitting a constant value. */
+  def succeed[A](value: A): Schedule[Any, A] = Succeed(value)
+
+  /**
+   * Iterates a state function forever: `initial`, `f(initial)`,
+   * `f(f(initial))`, etc.
+   */
+  def unfold[S](initial: S)(f: S => S): Schedule[Any, S] = Unfold(initial, f)
+
+  /** Counts from 0 forever. */
+  def forever: Schedule[Any, Long] = unfold(0L)(_ + 1L)
+
+  /** Continues for `n` steps, emitting the step count. */
+  def recurs(n: Long): Schedule[Any, Long] = forever.whileOutput(_ < n)
+
+  /** Continues forever with a fixed delay between steps. */
+  def spaced(duration: Duration): Schedule[Any, Long] = forever.addDelay(_ => duration)
+
+  /** Exponential backoff: `base * factor^step`. */
+  def exponential(base: Duration, factor: Double = 2.0): Schedule[Any, Duration] =
+    forever.map(step => base * math.pow(factor, step.toDouble)).addDelay(d => d)
+
+  /** Fibonacci backoff: `one`, `one`, `2*one`, `3*one`, `5*one`, etc. */
+  def fibonacci(one: Duration): Schedule[Any, Duration] =
+    unfold[(Duration, Duration)]((one, one)) { case (a, b) => (b, a + b) }.map(_._1).addDelay(d => d)
+}

--- a/schedule/shared/src/test/scala/zio/blocks/schedule/ScheduleSpec.scala
+++ b/schedule/shared/src/test/scala/zio/blocks/schedule/ScheduleSpec.scala
@@ -1,0 +1,431 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schedule
+
+import zio.test._
+
+import scala.concurrent.duration._
+
+object ScheduleSpec extends ZIOSpecDefault {
+
+  val spec: Spec[Any, Nothing] = suite("Schedule")(
+    factoryMethodSuite,
+    combinatorSuite,
+    symbolicAliasSuite,
+    varianceSuite,
+    edgeCaseSuite,
+    decisionSuite
+  )
+
+  private def factoryMethodSuite = suite("factory methods")(
+    test("identity creates Identity node") {
+      val s = Schedule.identity[Int]
+      assertTrue(s.isInstanceOf[Schedule.Identity[_]])
+    },
+    test("succeed creates Succeed node with correct value") {
+      Schedule.succeed(42) match {
+        case Schedule.Succeed(value) => assertTrue(value == 42)
+        case _                       => assertTrue(false)
+      }
+    },
+    test("succeed preserves reference types") {
+      val list = List(1, 2, 3)
+      Schedule.succeed(list) match {
+        case Schedule.Succeed(value) => assertTrue(value eq list)
+        case _                       => assertTrue(false)
+      }
+    },
+    test("unfold creates Unfold node with correct initial value") {
+      Schedule.unfold(0)(_ + 1) match {
+        case Schedule.Unfold(initial, _) => assertTrue(initial == 0)
+        case _                           => assertTrue(false)
+      }
+    },
+    test("unfold captures the step function") {
+      Schedule.unfold(0)(_ + 1) match {
+        case Schedule.Unfold(_, f) => assertTrue(f(5) == 6)
+        case _                     => assertTrue(false)
+      }
+    },
+    test("forever creates Unfold starting at 0L") {
+      Schedule.forever match {
+        case Schedule.Unfold(initial, f) =>
+          assertTrue(initial == 0L, f(0L) == 1L, f(99L) == 100L)
+        case _ => assertTrue(false)
+      }
+    },
+    test("recurs creates WhileOutput wrapping Unfold") {
+      Schedule.recurs(5) match {
+        case Schedule.WhileOutput(Schedule.Unfold(initial, _), _) =>
+          assertTrue(initial == 0L)
+        case _ => assertTrue(false)
+      }
+    },
+    test("recurs predicate filters correctly") {
+      Schedule.recurs(5) match {
+        case Schedule.WhileOutput(_, pred) =>
+          assertTrue(pred(0L), pred(4L), !pred(5L), !pred(100L))
+        case _ => assertTrue(false)
+      }
+    },
+    test("spaced creates Delayed wrapping Unfold") {
+      Schedule.spaced(1.second) match {
+        case Schedule.Delayed(Schedule.Unfold(initial, _), f) =>
+          assertTrue(initial == 0L, f(0L) == 1.second, f(999L) == 1.second)
+        case _ => assertTrue(false)
+      }
+    },
+    test("exponential creates Delayed(Map(Unfold))") {
+      Schedule.exponential(1.second) match {
+        case Schedule.Delayed(Schedule.Map(Schedule.Unfold(initial, _), _), _) =>
+          assertTrue(initial == 0L)
+        case _ => assertTrue(false)
+      }
+    },
+    test("exponential with custom factor") {
+      Schedule.exponential(100.millis, 3.0) match {
+        case Schedule.Delayed(Schedule.Map(Schedule.Unfold(_, _), _), _) =>
+          assertCompletes
+        case _ => assertTrue(false)
+      }
+    },
+    test("fibonacci creates Delayed(Map(Unfold))") {
+      Schedule.fibonacci(1.second) match {
+        case Schedule.Delayed(Schedule.Map(Schedule.Unfold(initial, _), _), _) =>
+          assertTrue(initial == (1.second, 1.second))
+        case _ => assertTrue(false)
+      }
+    },
+    test("fibonacci unfold step produces Fibonacci sequence") {
+      Schedule.fibonacci(1.second) match {
+        case Schedule.Delayed(Schedule.Map(Schedule.Unfold(initial, f), _), _) =>
+          val step1 = f(initial)
+          val step2 = f(step1)
+          assertTrue(
+            initial == (1.second, 1.second),
+            step1 == (1.second, 2.seconds),
+            step2 == (2.seconds, 3.seconds)
+          )
+        case _ => assertTrue(false)
+      }
+    }
+  )
+
+  private def combinatorSuite = suite("combinators")(
+    test("map wraps in Map") {
+      val s = Schedule.succeed(42).map(_.toString)
+      s match {
+        case Schedule.Map(Schedule.Succeed(42), _) => assertCompletes
+        case _                                     => assertTrue(false)
+      }
+    },
+    test("map function is applied correctly") {
+      val s = Schedule.succeed(42).map(_.toString)
+      s match {
+        case Schedule.Map(_, f) =>
+          assertTrue(f.asInstanceOf[Int => String](42) == "42")
+        case _ => assertTrue(false)
+      }
+    },
+    test("contramap wraps in Contramap") {
+      val s = Schedule.identity[Int].contramap[String](_.length)
+      s match {
+        case cm: Schedule.Contramap[_, _, _] =>
+          assertTrue(cm.schedule.isInstanceOf[Schedule.Identity[_]])
+        case _ => assertTrue(false)
+      }
+    },
+    test("contramap function is applied correctly") {
+      val s = Schedule.identity[Int].contramap[String](_.length)
+      s match {
+        case cm: Schedule.Contramap[_, _, _] =>
+          assertTrue(cm.f.asInstanceOf[String => Int]("hello") == 5)
+        case _ => assertTrue(false)
+      }
+    },
+    test("as wraps in Map that ignores input") {
+      val s = Schedule.succeed(42).as("constant")
+      s match {
+        case Schedule.Map(Schedule.Succeed(42), f) =>
+          assertTrue(f.asInstanceOf[Int => String](42) == "constant")
+        case _ => assertTrue(false)
+      }
+    },
+    test("unit wraps in Map producing ()") {
+      val s = Schedule.succeed(42).unit
+      s match {
+        case Schedule.Map(_, f) =>
+          assertTrue(f.asInstanceOf[Int => Unit](42) == (()))
+        case _ => assertTrue(false)
+      }
+    },
+    test("both wraps in Both") {
+      val s1 = Schedule.succeed(1)
+      val s2 = Schedule.succeed("a")
+      s1.both(s2) match {
+        case Schedule.Both(Schedule.Succeed(1), Schedule.Succeed("a")) => assertCompletes
+        case _                                                         => assertTrue(false)
+      }
+    },
+    test("either wraps in Either") {
+      val s1 = Schedule.succeed(1)
+      val s2 = Schedule.succeed("a")
+      s1.either(s2) match {
+        case Schedule.Either(Schedule.Succeed(1), Schedule.Succeed("a")) => assertCompletes
+        case _                                                           => assertTrue(false)
+      }
+    },
+    test("compose wraps in Compose") {
+      val outer: Schedule[Int, String] = Schedule.identity[Int].map(_.toString)
+      val inner: Schedule[String, Int] = Schedule.identity[String].map(_.length)
+      outer.compose(inner) match {
+        case Schedule.Compose(_, _) => assertCompletes
+        case _                      => assertTrue(false)
+      }
+    },
+    test("andThen wraps in AndThen") {
+      val s1 = Schedule.succeed(1)
+      val s2 = Schedule.succeed("done")
+      s1.andThen(s2) match {
+        case Schedule.AndThen(Schedule.Succeed(1), Schedule.Succeed("done")) => assertCompletes
+        case _                                                               => assertTrue(false)
+      }
+    },
+    test("addDelay wraps in Delayed") {
+      val s = Schedule.succeed(42).addDelay(_ => 1.second)
+      s match {
+        case Schedule.Delayed(Schedule.Succeed(42), f) => assertTrue(f(42) == 1.second)
+        case _                                         => assertTrue(false)
+      }
+    },
+    test("jittered wraps in Jittered with defaults 0.0 and 1.0") {
+      val s = Schedule.succeed(42).jittered
+      s match {
+        case Schedule.Jittered(Schedule.Succeed(42), min, max) =>
+          assertTrue(min == 0.0, max == 1.0)
+        case _ => assertTrue(false)
+      }
+    },
+    test("jittered with custom bounds") {
+      val s = Schedule.succeed(42).jittered(0.5, 2.0)
+      s match {
+        case Schedule.Jittered(Schedule.Succeed(42), min, max) =>
+          assertTrue(min == 0.5, max == 2.0)
+        case _ => assertTrue(false)
+      }
+    },
+    test("whileInput wraps in WhileInput") {
+      val s = Schedule.identity[Int].whileInput[Int](_ > 0)
+      s match {
+        case Schedule.WhileInput(Schedule.Identity(), pred) =>
+          assertTrue(pred(1), !pred(0), !pred(-1))
+        case _ => assertTrue(false)
+      }
+    },
+    test("whileOutput wraps in WhileOutput") {
+      val s = Schedule.succeed(42).whileOutput(_ < 100)
+      s match {
+        case Schedule.WhileOutput(Schedule.Succeed(42), pred) =>
+          assertTrue(pred(42), pred(99), !pred(100))
+        case _ => assertTrue(false)
+      }
+    },
+    test("reconsider wraps in Reconsider") {
+      val f: (Any, Int, Decision) => (String, Decision) = (_, out, dec) => (out.toString, dec)
+      val s                                             = Schedule.succeed(42).reconsider(f)
+      s match {
+        case Schedule.Reconsider(Schedule.Succeed(42), _) => assertCompletes
+        case _                                            => assertTrue(false)
+      }
+    },
+    test("reconsider function is applied correctly") {
+      val f: (Any, Int, Decision) => (String, Decision) =
+        (_, out, _) => (out.toString, Decision.Done)
+      val s = Schedule.succeed(42).reconsider(f)
+      s match {
+        case Schedule.Reconsider(_, g) =>
+          val fn            = g.asInstanceOf[(Any, Int, Decision) => (String, Decision)]
+          val (outStr, dec) = fn((), 42, Decision.Continue(1.second))
+          assertTrue(outStr == "42", dec == Decision.Done)
+        case _ => assertTrue(false)
+      }
+    }
+  )
+
+  private def symbolicAliasSuite = suite("symbolic aliases")(
+    test("&& is alias for both and produces Both") {
+      val s1 = Schedule.succeed(1)
+      val s2 = Schedule.succeed("a")
+      (s1 && s2) match {
+        case Schedule.Both(Schedule.Succeed(1), Schedule.Succeed("a")) => assertCompletes
+        case _                                                         => assertTrue(false)
+      }
+    },
+    test("|| is alias for either and produces Either") {
+      val s1 = Schedule.succeed(1)
+      val s2 = Schedule.succeed("a")
+      (s1 || s2) match {
+        case Schedule.Either(Schedule.Succeed(1), Schedule.Succeed("a")) => assertCompletes
+        case _                                                           => assertTrue(false)
+      }
+    },
+    test("zip is alias for both and produces Both") {
+      val s1 = Schedule.succeed(1)
+      val s2 = Schedule.succeed("a")
+      s1.zip(s2) match {
+        case Schedule.Both(Schedule.Succeed(1), Schedule.Succeed("a")) => assertCompletes
+        case _                                                         => assertTrue(false)
+      }
+    }
+  )
+
+  private def varianceSuite = suite("variance")(
+    test("contravariant In: Schedule[Any, Int] assignable to Schedule[String, Int]") {
+      val s: Schedule[Any, Int]    = Schedule.succeed(42)
+      val _: Schedule[String, Int] = s
+      assertCompletes
+    },
+    test("covariant Out: Schedule[Any, Int] assignable to Schedule[Any, AnyVal]") {
+      val s: Schedule[Any, Int]    = Schedule.succeed(42)
+      val _: Schedule[Any, AnyVal] = s
+      assertCompletes
+    },
+    test("both with different In types narrows to most specific") {
+      val s1: Schedule[String, Int]                 = Schedule.succeed(42)
+      val s2: Schedule[Any, String]                 = Schedule.succeed("hello")
+      val combined: Schedule[String, (Int, String)] = s1.both(s2)
+      assertTrue(combined.isInstanceOf[Schedule.Both[_, _, _]])
+    },
+    test("either with different In types narrows to most specific") {
+      val s1: Schedule[String, Int]                 = Schedule.succeed(42)
+      val s2: Schedule[Any, String]                 = Schedule.succeed("hello")
+      val combined: Schedule[String, (Int, String)] = s1.either(s2)
+      assertTrue(combined.isInstanceOf[Schedule.Either[_, _, _]])
+    },
+    test("succeed has type Schedule[Any, A]") {
+      val s: Schedule[Any, Int] = Schedule.succeed(42)
+      assertCompletes
+    },
+    test("identity preserves type parameter") {
+      val s: Schedule[Int, Int] = Schedule.identity[Int]
+      assertCompletes
+    },
+    test("contramap widens input type") {
+      val s: Schedule[Int, Int]     = Schedule.identity[Int]
+      val s2: Schedule[String, Int] = s.contramap[String](_.length)
+      assertCompletes
+    }
+  )
+
+  private def edgeCaseSuite = suite("edge cases")(
+    test("recurs(0) compiles and creates WhileOutput") {
+      val s = Schedule.recurs(0)
+      s match {
+        case Schedule.WhileOutput(_, pred) => assertTrue(!pred(0L))
+        case _                             => assertTrue(false)
+      }
+    },
+    test("recurs(1) creates WhileOutput that allows exactly one step") {
+      val s = Schedule.recurs(1)
+      s match {
+        case Schedule.WhileOutput(_, pred) => assertTrue(pred(0L), !pred(1L))
+        case _                             => assertTrue(false)
+      }
+    },
+    test("recurs with Long.MaxValue compiles") {
+      val s = Schedule.recurs(Long.MaxValue)
+      assertTrue(s.isInstanceOf[Schedule.WhileOutput[_, _]])
+    },
+    test("deeply nested composition builds correct AST") {
+      val s = Schedule.forever
+        .map(_.toString)
+        .addDelay(_ => 1.second)
+        .whileOutput(_.length < 5)
+        .jittered
+      s match {
+        case Schedule.Jittered(
+              Schedule.WhileOutput(
+                Schedule.Delayed(
+                  Schedule.Map(Schedule.Unfold(_, _), _),
+                  _
+                ),
+                _
+              ),
+              _,
+              _
+            ) =>
+          assertCompletes
+        case _ => assertTrue(false)
+      }
+    },
+    test("chained map operations nest correctly") {
+      val s = Schedule.succeed(1).map(_ + 1).map(_.toString).map(_.length)
+      s match {
+        case Schedule.Map(Schedule.Map(Schedule.Map(Schedule.Succeed(1), _), _), _) =>
+          assertCompletes
+        case _ => assertTrue(false)
+      }
+    },
+    test("spaced with Duration.Zero compiles") {
+      val s = Schedule.spaced(Duration.Zero)
+      s match {
+        case Schedule.Delayed(Schedule.Unfold(_, _), f) =>
+          assertTrue(f(0L) == Duration.Zero)
+        case _ => assertTrue(false)
+      }
+    },
+    test("fibonacci initial state is (one, one)") {
+      Schedule.fibonacci(500.millis) match {
+        case Schedule.Delayed(Schedule.Map(Schedule.Unfold(initial, _), _), _) =>
+          assertTrue(initial == (500.millis, 500.millis))
+        case _ => assertTrue(false)
+      }
+    },
+    test("exponential with default factor 2.0") {
+      Schedule.exponential(1.second) match {
+        case Schedule.Delayed(Schedule.Map(Schedule.Unfold(0L, _), mapFn0), delayFn0) =>
+          val mapFn   = mapFn0.asInstanceOf[Long => Duration]
+          val delayFn = delayFn0.asInstanceOf[Duration => Duration]
+          val dur0    = mapFn(0L)
+          val dur1    = mapFn(1L)
+          val dur2    = mapFn(2L)
+          assertTrue(
+            dur0 == 1.second,
+            dur1 == 2.seconds,
+            dur2 == 4.seconds,
+            delayFn(dur0) == dur0
+          )
+        case _ => assertTrue(false)
+      }
+    }
+  )
+
+  private def decisionSuite = suite("Decision ADT")(
+    test("Continue holds delay duration") {
+      val d = Decision.Continue(1.second)
+      assertTrue(d.delay == 1.second)
+    },
+    test("Done is a singleton") {
+      assertTrue(Decision.Done eq Decision.Done)
+    },
+    test("Continue and Done are distinct") {
+      val continue: Decision = Decision.Continue(Duration.Zero)
+      val done: Decision     = Decision.Done
+      assertTrue(continue != done)
+    }
+  )
+}


### PR DESCRIPTION
## Summary

Adds a new `schedule/` module containing a pure, declarative `Schedule[-In, +Out]` GADT — a composable description of recurring policies (retry, repeat, backoff) with no execution logic.

This is the **data type only** — no interpreter, no Driver, no integration with scope or streams. Future work will add execution support.

## What's included

- **`Schedule[-In, +Out]`** sealed trait with 14 `private[schedule]` GADT case classes
- **`Decision`** ADT: `Continue(delay: Duration) | Done`
- **8 factory methods**: `identity`, `succeed`, `unfold`, `forever`, `recurs`, `spaced`, `exponential`, `fibonacci`
- **~20 combinator methods** (named-first per symbolic ops policy): `map`, `contramap`, `both` (`&&`), `either` (`||`), `compose`, `andThen`, `addDelay`, `jittered`, `whileInput`, `whileOutput`, `reconsider`, `as`, `unit`, `zip`
- **51 tests** covering AST construction, combinator composition, symbolic aliases, variance soundness, and edge cases
- Cross-platform (JVM + JS), zero runtime dependencies

## Design decisions

- **GADT over final-tagless**: Inspectable, pattern-matchable, matches zio-blocks' Stream pattern. ZIO's final-tagless extensibility was never exercised.
- **`-In` kept, `-Env` dropped**: No effects, but `-In` enables error-aware retry semantics at the type level.
- **`Duration` over `Intervals`**: Simpler timing model, sufficient for the data type, upgradeable pre-1.0.
- **`Jittered` stores bounds only**: Interpreter provides RNG — data type just declares intent.
- **Named-first**: `both`/`either` are primary, `&&`/`||` are Tier 1 aliases. No `>>>` or other banned operators.

## Derivation chain

All derived schedules compose primitives:
```
forever    = unfold(0L)(_ + 1L)
recurs(n)  = forever.whileOutput(_ < n)
spaced(d)  = forever.addDelay(_ => d)
exponential(base, f) = forever.map(i => base * f^i).addDelay(d => d)
fibonacci(one) = unfold((one, one)){fib}.map(_._1).addDelay(d => d)
```

## Verification

- ✅ `scheduleJVM/test` — 51 tests pass (Scala 3.8.3)
- ✅ `scheduleJVM/test` — 51 tests pass (Scala 2.13.18)
- ✅ `scheduleJS/test` — 51 tests pass (Scala 3.8.3)
- ✅ Formatting clean (`fmtDirty` produces no diff)
- ✅ No banned operators (`grep -r ">>>"` — clean)
- ✅ Existing modules unaffected (`chunkJVM/compile` passes)