### PR TITLE
docs(openapi): add mdoc modifiers to all runnable code blocks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1249,7 +1249,8 @@ lazy val docs = project
     `schema-xml`.jvm,
     mediatype.jvm,
     `http-model`.jvm,
-    `http-model-schema`.jvm
+    `http-model-schema`.jvm,
+    openapi.jvm
   )
   .enablePlugins(WebsitePlugin)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -627,7 +627,7 @@ ZIO Blocks supports **Scala 2.13** and **Scala 3.x** with full source compatibil
 - [Context](./reference/context.md) - Type-indexed heterogeneous collections
 - [Docs (Markdown)](./reference/docs.md) - Markdown parsing and rendering
 - [MediaType](./reference/media-type.md) - Type-safe IANA media types
-- [HTTP Model](./reference/http-model.md) - Pure HTTP data model with URL parsing, headers, cookies, and forms
+- [HTTP Model](./reference/http-model) - Pure HTTP data model with URL parsing, headers, cookies, and forms
 - [OpenAPI](./reference/openapi.md) - Type-safe OpenAPI 3.1 specification generation and rendering
 - [Ring Buffer](./reference/ringbuffer.mdx) - High-performance bounded ring buffers
 - [Stream](./reference/streams/stream.md) - Lazy, pull-based, type-safe streaming with resource safety

--- a/docs/index.md
+++ b/docs/index.md
@@ -627,7 +627,7 @@ ZIO Blocks supports **Scala 2.13** and **Scala 3.x** with full source compatibil
 - [Context](./reference/context.md) - Type-indexed heterogeneous collections
 - [Docs (Markdown)](./reference/docs.md) - Markdown parsing and rendering
 - [MediaType](./reference/media-type.md) - Type-safe IANA media types
-- [HTTP Model](./reference/http-model) - Pure HTTP data model with URL parsing, headers, cookies, and forms
+- [HTTP Model](./reference/http-model.md) - Pure HTTP data model with URL parsing, headers, cookies, and forms
 - [OpenAPI](./reference/openapi.md) - Type-safe OpenAPI 3.1 specification generation and rendering
 - [Ring Buffer](./reference/ringbuffer.mdx) - High-performance bounded ring buffers
 - [Stream](./reference/streams/stream.md) - Lazy, pull-based, type-safe streaming with resource safety

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ The philosophy is simple: **use what you need, nothing more**. Each block is ind
 | **TypeId** | Compile-time type identity with rich metadata | ✅ Available |
 | **Context** | Type-indexed heterogeneous collections | ✅ Available |
 | **MediaType** | Type-safe IANA media types with 2,600+ predefined types | ✅ Available |
+| **OpenAPI** | Type-safe OpenAPI 3.1 specification generation | ✅ Available |
 | **Ring Buffer** | High-performance bounded ring buffers (SPSC, MPSC, SPMC, MPMC) | ✅ Available |
 | **Streams** | Pull-based streaming primitives | ✅ Available |
 
@@ -627,6 +628,7 @@ ZIO Blocks supports **Scala 2.13** and **Scala 3.x** with full source compatibil
 - [Docs (Markdown)](./reference/docs.md) - Markdown parsing and rendering
 - [MediaType](./reference/media-type.md) - Type-safe IANA media types
 - [HTTP Model](./reference/http-model) - Pure HTTP data model with URL parsing, headers, cookies, and forms
+- [OpenAPI](./reference/openapi.md) - Type-safe OpenAPI 3.1 specification generation and rendering
 - [Ring Buffer](./reference/ringbuffer.mdx) - High-performance bounded ring buffers
 - [Stream](./reference/streams/stream.md) - Lazy, pull-based, type-safe streaming with resource safety
 - [Pipeline](./reference/streams/pipeline.md) - Reusable, composable stream transformations

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -632,7 +632,7 @@ Key fields:
 
 ### Creating a RequestBody
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -662,7 +662,7 @@ Key fields:
 
 ### Creating a Response
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -690,7 +690,7 @@ val errorResponse = Response(
 
 `Responses` is a map of HTTP status codes to `ReferenceOr[Response]`:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -727,7 +727,7 @@ Key fields:
 
 With schema and example:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -744,7 +744,7 @@ val jsonMedia = MediaType(
 
 For form data:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -777,7 +777,7 @@ Key fields:
 
 ### Creating Components
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -840,7 +840,7 @@ val components = Components(
 
 Directly from a `Schema[A]`:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -851,7 +851,7 @@ val userSchema = Schema[User].toOpenAPISchema
 
 Or with additional OpenAPI metadata:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -882,7 +882,7 @@ val enrichedSchema = SchemaObject(
 
 Use the `SchemaOps` extension methods on any `Schema[A]`:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -909,7 +909,7 @@ Two cases:
 
 Prefer `Ref` for reusable components:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -923,7 +923,7 @@ val responseRef = ReferenceOr.Ref(Reference(
 
 Use `Value` for inline, one-off definitions:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -938,7 +938,7 @@ val inlineError = ReferenceOr.Value(Response(
 
 ### Pattern Matching on ReferenceOr
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -968,7 +968,7 @@ Sealed trait variants:
 
 API Key authentication:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -982,7 +982,7 @@ val apiKeySecurity = SecurityScheme.APIKey(
 
 HTTP Bearer token:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -996,7 +996,7 @@ val bearerSecurity = SecurityScheme.HTTP(
 
 OAuth 2.0:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1022,7 +1022,7 @@ The `OAuthFlows` type supports multiple flow types: `implicit`, `password`, `cli
 
 OpenID Connect:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1049,7 +1049,7 @@ Key fields:
 
 Simple discriminator by property name:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1062,7 +1062,7 @@ val discriminator = Discriminator(
 
 With explicit value-to-schema mapping:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1099,7 +1099,7 @@ val mappedDiscriminator = Discriminator(
 
 Single static server:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1113,7 +1113,7 @@ val server = Server(
 
 Server with variables (showing structure without reserved keywords):
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1160,7 +1160,7 @@ Key fields:
 
 ### Creating Tags
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1187,7 +1187,7 @@ val productsTag = Tag(
 
 All types support custom `x-*` extension fields for vendor-specific metadata. These extensions are preserved during encoding/decoding:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1214,7 +1214,7 @@ val operationWithExtensions = Operation(
 
 All OpenAPI types have `Schema.derived` instances, enabling serialization through `DynamicValue`:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -47,7 +47,7 @@ The OpenAPI module follows a clear workflow:
 
 **1. Define your data types** using ZIO Blocks `Schema`:
 
-```scala
+```scala mdoc:silent
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -67,7 +67,7 @@ object ErrorResponse {
 
 **2. Create an OpenAPI document** by composing types:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -150,7 +150,7 @@ val api = OpenAPI(
 
 **3. Serialize to JSON** for tools to consume:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -162,7 +162,7 @@ val json = openAPICodec.encodeValue(api)
 
 **4. Render or serve** the JSON (e.g., to Swagger UI):
 
-```scala
+```scala mdoc:compile-only
 // Pseudo-code: render json to string and serve at GET /openapi.json
 val jsonString = json.render // Produces JSON string
 ```

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -47,9 +47,9 @@ The OpenAPI module follows a clear workflow:
 
 **1. Define your data types** using ZIO Blocks `Schema`:
 
-```scala
+```scala mdoc:silent
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 import zio.blocks.schema._
@@ -69,11 +69,9 @@ object ErrorResponse {
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
-
-import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.schema._
 
 val api = OpenAPI(
   openapi = "3.1.0",
@@ -152,7 +150,7 @@ val api = OpenAPI(
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 import zio.blocks.openapi.OpenAPICodec._
@@ -201,10 +199,16 @@ OpenAPI (root document)
 
 Avoid duplicating schema definitions by moving them to `components.schemas`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
+
+case class User(id: Int, name: String, email: String)
+object User {
+  implicit val schema: Schema[User] = Schema.derived
+}
 
 val userSchemaComponent = Schema[User].toRefSchema
 // Returns: (ReferenceOr.Ref(...), ("User", SchemaObject(...)))
@@ -220,13 +224,14 @@ val userSchemaComponent = Schema[User].toRefSchema
 
 Prefer `Ref` for reusable schemas; use `Value` for simple, one-off schemas:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 // Reusable: use Ref
-val userRef = ReferenceOr.Ref(Reference("$ref" -> "#/components/schemas/User"))
+val userRef = ReferenceOr.Ref(Reference(`$ref` = "#/components/schemas/User"))
 
 // One-off: use Value
 val simpleString = ReferenceOr.Value(Schema[String].toOpenAPISchema)
@@ -238,7 +243,7 @@ Define authentication methods in `components.securitySchemes`:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val apiKeyScheme = SecurityScheme.APIKey(
@@ -272,7 +277,7 @@ Distinguish parameter locations using `ParameterLocation`:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val pathParam = Parameter(
@@ -327,7 +332,7 @@ To construct an `OpenAPI` document:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val minimalApi = OpenAPI(
@@ -345,7 +350,7 @@ Encode an `OpenAPI` document to `Json` AST:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 import zio.blocks.openapi.OpenAPICodec._
@@ -357,7 +362,7 @@ Decode from `Json` AST back to an `OpenAPI` instance:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val decoded: OpenAPI = openAPICodec.decodeValue(encoded)
@@ -385,7 +390,7 @@ Optional fields:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val info = Info(
@@ -425,7 +430,7 @@ To define a path with multiple operations:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val userPaths = Paths(ChunkMap(
@@ -514,7 +519,7 @@ With summary, description, and parameters:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val getUser = Operation(
@@ -573,7 +578,7 @@ Path parameter (required):
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val idPathParam = Parameter(
@@ -589,7 +594,7 @@ Query parameter (optional with default):
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val limitQueryParam = Parameter(
@@ -605,7 +610,7 @@ Header parameter:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val authHeaderParam = Parameter(
@@ -634,7 +639,7 @@ Key fields:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val createUserBody = RequestBody(
@@ -664,7 +669,7 @@ Key fields:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val successResponse = Response(
@@ -692,7 +697,7 @@ val errorResponse = Response(
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val responses = Responses(ChunkMap(
@@ -729,7 +734,7 @@ With schema and example:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val jsonMedia = MediaType(
@@ -746,7 +751,7 @@ For form data:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val formMedia = MediaType(
@@ -779,7 +784,7 @@ Key fields:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val components = Components(
@@ -842,7 +847,7 @@ Directly from a `Schema[A]`:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val userSchema = Schema[User].toOpenAPISchema
@@ -853,7 +858,7 @@ Or with additional OpenAPI metadata:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val enrichedSchema = SchemaObject(
@@ -884,7 +889,7 @@ Use the `SchemaOps` extension methods on any `Schema[A]`:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val schemaObj: SchemaObject = Schema[User].toOpenAPISchema
@@ -911,7 +916,7 @@ Prefer `Ref` for reusable components:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val userRef = ReferenceOr.Ref(Reference("$ref" -> "#/components/schemas/User"))
@@ -925,7 +930,7 @@ Use `Value` for inline, one-off definitions:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val inlineUser = ReferenceOr.Value(Schema[User].toOpenAPISchema)
@@ -940,7 +945,7 @@ val inlineError = ReferenceOr.Value(Response(
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 def describeRef[A](ref: ReferenceOr[A]): String = ref match {
@@ -970,7 +975,7 @@ API Key authentication:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val apiKeySecurity = SecurityScheme.APIKey(
@@ -984,7 +989,7 @@ HTTP Bearer token:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val bearerSecurity = SecurityScheme.HTTP(
@@ -998,7 +1003,7 @@ OAuth 2.0:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val oauthSecurity = SecurityScheme.OAuth2(
@@ -1024,7 +1029,7 @@ OpenID Connect:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val oidcSecurity = SecurityScheme.OpenIdConnect(
@@ -1051,7 +1056,7 @@ Simple discriminator by property name:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val discriminator = Discriminator(
@@ -1064,7 +1069,7 @@ With explicit value-to-schema mapping:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val mappedDiscriminator = Discriminator(
@@ -1101,7 +1106,7 @@ Single static server:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val server = Server(
@@ -1115,7 +1120,7 @@ Server with variables (showing structure without reserved keywords):
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val variableServer = Server(
@@ -1162,7 +1167,7 @@ Key fields:
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val userTag = Tag(
@@ -1189,7 +1194,7 @@ All types support custom `x-*` extension fields for vendor-specific metadata. Th
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val operationWithExtensions = Operation(
@@ -1216,7 +1221,7 @@ All OpenAPI types have `Schema.derived` instances, enabling serialization throug
 
 ```scala
 import zio.blocks.openapi._
-import zio.blocks.markdown._
+import zio.blocks.docs._
 import zio.blocks.chunk._
 
 val openAPISchema = Schema[OpenAPI]

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -201,7 +201,7 @@ OpenAPI (root document)
 
 Avoid duplicating schema definitions by moving them to `components.schemas`:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -220,7 +220,7 @@ val userSchemaComponent = Schema[User].toRefSchema
 
 Prefer `Ref` for reusable schemas; use `Value` for simple, one-off schemas:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -236,7 +236,7 @@ val simpleString = ReferenceOr.Value(Schema[String].toOpenAPISchema)
 
 Define authentication methods in `components.securitySchemes`:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -270,7 +270,7 @@ val components = Components(
 
 Distinguish parameter locations using `ParameterLocation`:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -1,0 +1,1230 @@
+---
+id: openapi
+title: "OpenAPI"
+---
+
+`zio-blocks-openapi` is a **complete, type-safe OpenAPI 3.1 data model** for building API documentation programmatically. It provides immutable case classes and sealed traits representing every OpenAPI concept—operations, parameters, security schemes, and components—enabling you to construct OpenAPI documents in compile-time-safe Scala and export them as JSON for consumption by tools like Swagger UI, Redoc, and API validators.
+
+Core types: `OpenAPI`, `Info`, `Paths`, `PathItem`, `Operation`, `Parameter`, `RequestBody`, `Response`, `Components`, `SchemaObject`, `SecurityScheme`, `ReferenceOr`.
+
+```scala
+final case class OpenAPI(
+  openapi: String,
+  info: Info,
+  servers: Option[Chunk[Server]] = None,
+  paths: Option[Paths] = None,
+  components: Option[Components] = None,
+  security: Option[Chunk[SecurityRequirement]] = None
+)
+```
+
+## Introduction
+
+OpenAPI documents are the **lingua franca for API specifications**. They define request/response contracts, authentication methods, and data schemas in a standardized JSON or YAML format that external tools consume. Building these documents manually in JSON is error-prone; maintaining them as your API evolves is tedious.
+
+The OpenAPI module bridges the gap by letting you author API specs as Scala code—leveraging the type system for compile-time correctness—then export to standard JSON that any OpenAPI tool understands. You get type safety during authoring plus interoperability with the entire OpenAPI ecosystem.
+
+## Installation
+
+```scala
+libraryDependencies += "dev.zio" %% "zio-blocks-openapi" % "@VERSION@"
+
+// You'll also need the schema module for Schema[A] integration:
+libraryDependencies += "dev.zio" %% "zio-blocks-schema" % "@VERSION@"
+```
+
+For Scala.js:
+
+```scala
+libraryDependencies += "dev.zio" %%% "zio-blocks-openapi" % "@VERSION@"
+```
+
+Supported Scala versions: 2.13.x and 3.x.
+
+## How They Work Together
+
+The OpenAPI module follows a clear workflow:
+
+**1. Define your data types** using ZIO Blocks `Schema`:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+import zio.blocks.schema._
+
+case class User(id: Int, name: String, email: String)
+object User {
+  implicit val schema: Schema[User] = Schema.derived
+}
+
+case class ErrorResponse(code: Int, message: String)
+object ErrorResponse {
+  implicit val schema: Schema[ErrorResponse] = Schema.derived
+}
+```
+
+**2. Create an OpenAPI document** by composing types:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+
+val api = OpenAPI(
+  openapi = "3.1.0",
+  info = Info(
+    title = "User API",
+    version = "1.0.0",
+    description = Some(Doc("API for managing users"))
+  ),
+  paths = Some(Paths(ChunkMap(
+    "/users" -> PathItem(
+      get = Some(Operation(
+        summary = Some("List all users"),
+        description = Some(Doc("Returns a paginated list of users")),
+        responses = Responses(ChunkMap(
+          "200" -> ReferenceOr.Value(Response(
+            description = Doc("Successful response"),
+            content = ChunkMap(
+              "application/json" -> MediaType(
+                schema = Some(ReferenceOr.Value(
+                  Schema[List[User]].toOpenAPISchema
+                ))
+              )
+            )
+          ))
+        ))
+      ))
+    ),
+    "/users/{id}" -> PathItem(
+      get = Some(Operation(
+        summary = Some("Get a user by ID"),
+        parameters = Some(Chunk(
+          ReferenceOr.Value(Parameter(
+            name = "id",
+            in = ParameterLocation.Path,
+            required = true,
+            schema = Some(ReferenceOr.Value(
+              Schema[Int].toOpenAPISchema
+            ))
+          ))
+        )),
+        responses = Responses(ChunkMap(
+          "200" -> ReferenceOr.Value(Response(
+            description = Doc("User found"),
+            content = ChunkMap(
+              "application/json" -> MediaType(
+                schema = Some(ReferenceOr.Value(
+                  Schema[User].toOpenAPISchema
+                ))
+              )
+            )
+          )),
+          "404" -> ReferenceOr.Value(Response(
+            description = Doc("User not found"),
+            content = ChunkMap(
+              "application/json" -> MediaType(
+                schema = Some(ReferenceOr.Value(
+                  Schema[ErrorResponse].toOpenAPISchema
+                ))
+              )
+            )
+          ))
+        ))
+      ))
+    )
+  ))),
+  components = Some(Components(
+    schemas = Some(ChunkMap(
+      Schema[User].toRefSchema._2,
+      Schema[ErrorResponse].toRefSchema._2
+    ))
+  ))
+)
+```
+
+**3. Serialize to JSON** for tools to consume:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+import zio.blocks.openapi.OpenAPICodec._
+
+val json = openAPICodec.encodeValue(api)
+```
+
+**4. Render or serve** the JSON (e.g., to Swagger UI):
+
+```scala
+// Pseudo-code: render json to string and serve at GET /openapi.json
+val jsonString = json.render // Produces JSON string
+```
+
+### Type Relationships Diagram
+
+```
+OpenAPI (root document)
+├─ info: Info (metadata)
+├─ servers: Chunk[Server]
+├─ paths: Paths (map of path strings to PathItem)
+│  └─ PathItem
+│     ├─ get: Operation
+│     ├─ post: Operation
+│     ├─ put: Operation
+│     └─ ... (other HTTP methods)
+│        ├─ parameters: Chunk[ReferenceOr[Parameter]]
+│        ├─ requestBody: ReferenceOr[RequestBody]
+│        │  └─ content: Map[String, MediaType]
+│        │     └─ schema: ReferenceOr[SchemaObject]
+│        └─ responses: Responses
+│           └─ Map[statusCode, ReferenceOr[Response]]
+│              └─ content: Map[String, MediaType]
+│                 └─ schema: ReferenceOr[SchemaObject]
+├─ components: Components
+│  ├─ schemas: Map[String, SchemaObject]
+│  ├─ responses: Map[String, ReferenceOr[Response]]
+│  ├─ parameters: Map[String, ReferenceOr[Parameter]]
+│  └─ securitySchemes: Map[String, ReferenceOr[SecurityScheme]]
+└─ security: Chunk[SecurityRequirement]
+```
+
+## Common Patterns
+
+### Building Reusable Schema Components
+
+Avoid duplicating schema definitions by moving them to `components.schemas`:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val userSchemaComponent = Schema[User].toRefSchema
+// Returns: (ReferenceOr.Ref(...), ("User", SchemaObject(...)))
+// Use the ref in operations, store the component in components.schemas
+```
+
+### Using `ReferenceOr` for Inline vs. Referenced Schemas
+
+`ReferenceOr[A]` is a sealed trait with two cases:
+
+- **`ReferenceOr.Ref`**: Points to a schema in `#/components/schemas/<name>`
+- **`ReferenceOr.Value`**: Inline schema definition
+
+Prefer `Ref` for reusable schemas; use `Value` for simple, one-off schemas:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+// Reusable: use Ref
+val userRef = ReferenceOr.Ref(Reference("$ref" -> "#/components/schemas/User"))
+
+// One-off: use Value
+val simpleString = ReferenceOr.Value(Schema[String].toOpenAPISchema)
+```
+
+### Security Schemes
+
+Define authentication methods in `components.securitySchemes`:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val apiKeyScheme = SecurityScheme.APIKey(
+  name = "X-API-Key",
+  in = "header",
+  description = Some(Doc("API key for authentication"))
+)
+
+val oauthScheme = SecurityScheme.OAuth2(
+  flows = OAuthFlows(
+    authorizationCode = Some(OAuthFlow(
+      authorizationUrl = "https://example.com/oauth/authorize",
+      tokenUrl = "https://example.com/oauth/token",
+      scopes = ChunkMap("read" -> Doc("Read access"), "write" -> Doc("Write access"))
+    ))
+  ),
+  description = Some(Doc("OAuth 2.0 authorization"))
+)
+
+val components = Components(
+  securitySchemes = Some(ChunkMap(
+    "api_key" -> ReferenceOr.Value(apiKeyScheme),
+    "oauth2" -> ReferenceOr.Value(oauthScheme)
+  ))
+)
+```
+
+### Path Parameters vs. Query Parameters
+
+Distinguish parameter locations using `ParameterLocation`:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val pathParam = Parameter(
+  name = "id",
+  in = ParameterLocation.Path,
+  required = true,
+  schema = Some(ReferenceOr.Value(Schema[Int].toOpenAPISchema))
+)
+
+val queryParam = Parameter(
+  name = "limit",
+  in = ParameterLocation.Query,
+  required = false,
+  schema = Some(ReferenceOr.Value(Schema[Int].toOpenAPISchema))
+)
+
+val headerParam = Parameter(
+  name = "X-Custom-Header",
+  in = ParameterLocation.Header,
+  required = false,
+  schema = Some(ReferenceOr.Value(Schema[String].toOpenAPISchema))
+)
+```
+
+## Integration Points
+
+The OpenAPI module integrates tightly with other ZIO Blocks components:
+
+- **Schema Integration**: All OpenAPI types have `Schema.derived` instances, enabling round-trip serialization via `DynamicValue`. Use `Schema[A].toOpenAPISchema` to convert any schema to an OpenAPI component.
+- **Markdown Support**: Description fields use the in-house `Doc` type, which supports CommonMark rendering. This ensures markdown descriptions round-trip correctly.
+- **JSON AST**: All codecs operate on the `Json` AST from `zio-blocks-schema`, not external JSON libraries. To render as YAML, pipe the `Json` through `zio-blocks-schema-yaml` separately.
+
+---
+
+## OpenAPI
+
+`OpenAPI` is the root document object representing a complete OpenAPI 3.1 specification.
+
+### Definition
+
+Every OpenAPI document requires:
+- **`openapi`**: Version string (typically `"3.1.0"`)
+- **`info`**: Metadata about the API (`Info`)
+- **`paths`**: Map of endpoint paths to operations (`Paths`)
+- **`responses`**: HTTP response definitions (`Responses`)
+
+Optional fields include servers, components, security requirements, tags, and external documentation.
+
+### Creating an OpenAPI Document
+
+To construct an `OpenAPI` document:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val minimalApi = OpenAPI(
+  openapi = "3.1.0",
+  info = Info(title = "My API", version = "1.0.0"),
+  paths = Some(Paths(ChunkMap()))  // Empty paths initially
+)
+```
+
+Add paths, operations, and components as shown in the "How They Work Together" section above.
+
+### Serialization
+
+Encode an `OpenAPI` document to `Json` AST:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+import zio.blocks.openapi.OpenAPICodec._
+
+val encoded: Json = openAPICodec.encodeValue(api)
+```
+
+Decode from `Json` AST back to an `OpenAPI` instance:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val decoded: OpenAPI = openAPICodec.decodeValue(encoded)
+```
+
+---
+
+## Info
+
+`Info` contains metadata about the API: title, version, contact, and license.
+
+### Definition
+
+Required fields:
+- **`title`**: API name (e.g., `"User API"`)
+- **`version`**: API version (e.g., `"1.0.0"`)
+
+Optional fields:
+- **`description`**: Markdown-formatted description (`Doc`)
+- **`termsOfService`**: Terms of service URL
+- **`contact`**: Contact information (`Contact`)
+- **`license`**: License information (`License`)
+
+### Creating Info
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val info = Info(
+  title = "Pet Store API",
+  version = "3.0.0",
+  description = Some(Doc("API for managing a pet store")),
+  contact = Some(Contact(
+    name = Some("API Support"),
+    url = Some("https://example.com/support"),
+    email = Some("support@example.com")
+  )),
+  license = Some(License(
+    name = "Apache 2.0",
+    identifier = Some("Apache-2.0")
+  ))
+)
+```
+
+---
+
+## Paths & PathItem
+
+`Paths` is a map of URL paths to their operations. `PathItem` groups HTTP methods (GET, POST, PUT, etc.) on a single path.
+
+### Definition
+
+`Paths` is a type alias for `ChunkMap[String, PathItem]`, where keys are path strings (e.g., `"/users/{id}"`).
+
+`PathItem` contains optional fields for each HTTP method:
+- **`get`, `post`, `put`, `delete`, `patch`, `head`, `options`, `trace`**: `Operation` instances
+- **`parameters`**: Path-level parameters shared by all methods on this path
+- **`servers`**: Optional server overrides for this path
+
+### Creating Path Items
+
+To define a path with multiple operations:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val userPaths = Paths(ChunkMap(
+  "/users" -> PathItem(
+    get = Some(Operation(
+      summary = Some("List users"),
+      responses = Responses(ChunkMap(
+        "200" -> ReferenceOr.Value(Response(
+          description = Doc("User list"),
+          content = ChunkMap(
+            "application/json" -> MediaType(schema = None)
+          )
+        ))
+      ))
+    )),
+    post = Some(Operation(
+      summary = Some("Create user"),
+      requestBody = Some(ReferenceOr.Value(RequestBody(
+        description = Some(Doc("User data")),
+        content = ChunkMap(
+          "application/json" -> MediaType(schema = None)
+        ),
+        required = true
+      ))),
+      responses = Responses(ChunkMap(
+        "201" -> ReferenceOr.Value(Response(
+          description = Doc("User created"),
+          content = ChunkMap(
+            "application/json" -> MediaType(schema = None)
+          )
+        ))
+      ))
+    ))
+  ),
+  "/users/{id}" -> PathItem(
+    parameters = Some(Chunk(
+      ReferenceOr.Value(Parameter(
+        name = "id",
+        in = ParameterLocation.Path,
+        required = true,
+        schema = Some(ReferenceOr.Value(Schema[String].toOpenAPISchema))
+      ))
+    )),
+    get = Some(Operation(
+      summary = Some("Get user by ID"),
+      responses = Responses(ChunkMap(
+        "200" -> ReferenceOr.Value(Response(
+          description = Doc("User found"),
+          content = ChunkMap(
+            "application/json" -> MediaType(schema = None)
+          )
+        )),
+        "404" -> ReferenceOr.Value(Response(
+          description = Doc("User not found"),
+          content = ChunkMap(
+            "application/json" -> MediaType(schema = None)
+          )
+        ))
+      ))
+    ))
+  )
+))
+```
+
+---
+
+## Operation
+
+`Operation` represents a single HTTP operation (GET, POST, etc.) on a path.
+
+### Definition
+
+Key fields:
+- **`responses`**: Required. Map of status codes to response definitions
+- **`operationId`**: Unique operation identifier
+- **`summary`**: Short description
+- **`description`**: Detailed markdown description
+- **`parameters`**: Path, query, header, and cookie parameters
+- **`requestBody`**: Request payload definition
+- **`deprecated`**: Whether the operation is deprecated
+- **`tags`**: Group operations in documentation (e.g., `"users"`, `"products"`)
+
+### Defining an Operation
+
+With summary, description, and parameters:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val getUser = Operation(
+  tags = Some(Chunk("users")),
+  summary = Some("Retrieve user"),
+  description = Some(Doc("Fetches a single user by ID")),
+  operationId = Some("getUserById"),
+  parameters = Some(Chunk(
+    ReferenceOr.Value(Parameter(
+      name = "id",
+      in = ParameterLocation.Path,
+      required = true,
+      schema = Some(ReferenceOr.Value(Schema[String].toOpenAPISchema)),
+      description = Some(Doc("User ID"))
+    ))
+  )),
+  responses = Responses(ChunkMap(
+    "200" -> ReferenceOr.Value(Response(
+      description = Doc("User found"),
+      content = ChunkMap(
+        "application/json" -> MediaType(schema = None)
+      )
+    )),
+    "404" -> ReferenceOr.Value(Response(
+      description = Doc("User not found"),
+      content = ChunkMap(
+        "application/json" -> MediaType(schema = None)
+      )
+    ))
+  ))
+)
+```
+
+---
+
+## Parameter
+
+`Parameter` represents query, path, header, or cookie parameters in a request.
+
+### Definition
+
+Required fields:
+- **`name`**: Parameter name (e.g., `"id"`, `"limit"`)
+- **`in`**: Location—`Path`, `Query`, `Header`, or `Cookie` (`ParameterLocation`)
+- **`schema`**: Data type of the parameter (`ReferenceOr[SchemaObject]`)
+
+Optional fields:
+- **`description`**: Markdown description
+- **`required`**: Whether the parameter is mandatory (default: `false`)
+- **`deprecated`**: Whether the parameter is deprecated
+- **`allowEmptyValue`**: Whether empty string values are allowed
+
+### Creating Parameters
+
+Path parameter (required):
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val idPathParam = Parameter(
+  name = "id",
+  in = ParameterLocation.Path,
+  required = true,
+  schema = Some(ReferenceOr.Value(Schema[String].toOpenAPISchema)),
+  description = Some(Doc("User identifier"))
+)
+```
+
+Query parameter (optional with default):
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val limitQueryParam = Parameter(
+  name = "limit",
+  in = ParameterLocation.Query,
+  required = false,
+  schema = Some(ReferenceOr.Value(Schema[Int].toOpenAPISchema)),
+  description = Some(Doc("Maximum number of results (default: 20)"))
+)
+```
+
+Header parameter:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val authHeaderParam = Parameter(
+  name = "X-API-Key",
+  in = ParameterLocation.Header,
+  required = true,
+  schema = Some(ReferenceOr.Value(Schema[String].toOpenAPISchema)),
+  description = Some(Doc("API key for authentication"))
+)
+```
+
+---
+
+## RequestBody & Response
+
+`RequestBody` defines the structure of a request payload. `Response` defines the structure and status of a response.
+
+### RequestBody Definition
+
+Key fields:
+- **`content`**: Map of MIME types to `MediaType` definitions
+- **`description`**: Optional markdown description
+- **`required`**: Whether the request body is mandatory (default: `false`)
+
+### Creating a RequestBody
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val createUserBody = RequestBody(
+  description = Some(Doc("User data to create")),
+  content = ChunkMap(
+    "application/json" -> MediaType(
+      schema = Some(ReferenceOr.Value(Schema[User].toOpenAPISchema)),
+      example = Some(Json.Object(Map(
+        "name" -> Json.String("John Doe"),
+        "email" -> Json.String("john@example.com")
+      )))
+    )
+  ),
+  required = true
+)
+```
+
+### Response Definition
+
+Key fields:
+- **`description`**: Required. Markdown description of the response
+- **`content`**: Map of MIME types to `MediaType` definitions
+- **`headers`**: Optional response headers
+- **`links`**: Optional links to related operations
+
+### Creating a Response
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val successResponse = Response(
+  description = Doc("User successfully created"),
+  content = ChunkMap(
+    "application/json" -> MediaType(
+      schema = Some(ReferenceOr.Value(Schema[User].toOpenAPISchema))
+    )
+  )
+)
+
+val errorResponse = Response(
+  description = Doc("Request validation failed"),
+  content = ChunkMap(
+    "application/json" -> MediaType(
+      schema = Some(ReferenceOr.Value(Schema[ErrorResponse].toOpenAPISchema))
+    )
+  )
+)
+```
+
+### Responses
+
+`Responses` is a map of HTTP status codes to `ReferenceOr[Response]`:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val responses = Responses(ChunkMap(
+  "201" -> ReferenceOr.Value(successResponse),
+  "400" -> ReferenceOr.Value(errorResponse),
+  "401" -> ReferenceOr.Value(Response(
+    description = Doc("Unauthorized"),
+    content = ChunkMap()
+  )),
+  "500" -> ReferenceOr.Value(Response(
+    description = Doc("Internal server error"),
+    content = ChunkMap()
+  ))
+))
+```
+
+---
+
+## MediaType
+
+`MediaType` specifies the schema and encoding for a particular MIME type in a request or response.
+
+### Definition
+
+Key fields:
+- **`schema`**: Data type for this MIME type (`ReferenceOr[SchemaObject]`)
+- **`example`**: Example value as `Json`
+- **`encoding`**: Encoding rules for multipart form data
+- **`extensions`**: Custom vendor extensions (`x-*` fields)
+
+### Creating MediaType
+
+With schema and example:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val jsonMedia = MediaType(
+  schema = Some(ReferenceOr.Value(Schema[User].toOpenAPISchema)),
+  example = Some(Json.Object(Map(
+    "id" -> Json.Number(1),
+    "name" -> Json.String("Alice"),
+    "email" -> Json.String("alice@example.com")
+  )))
+)
+```
+
+For form data:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val formMedia = MediaType(
+  schema = Some(ReferenceOr.Value(Schema[Map[String, String]].toOpenAPISchema)),
+  encoding = Some(ChunkMap(
+    "file" -> Encoding(
+      contentType = Some("application/octet-stream"),
+      style = Some("form")
+    )
+  ))
+)
+```
+
+---
+
+## Components
+
+`Components` stores reusable schema and security definitions referenced throughout the document.
+
+### Definition
+
+Key fields:
+- **`schemas`**: Reusable schema objects (`ChunkMap[String, SchemaObject]`)
+- **`responses`**: Reusable response definitions
+- **`parameters`**: Reusable parameter definitions
+- **`securitySchemes`**: Authentication method definitions
+- **`examples`**, **`requestBodies`**, **`headers`**, **`links`**, **`callbacks`**: Additional reusable components
+
+### Creating Components
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val components = Components(
+  schemas = Some(ChunkMap(
+    Schema[User].toRefSchema._2,
+    Schema[ErrorResponse].toRefSchema._2
+  )),
+  parameters = Some(ChunkMap(
+    "id" -> ReferenceOr.Value(Parameter(
+      name = "id",
+      in = ParameterLocation.Path,
+      required = true,
+      schema = Some(ReferenceOr.Value(Schema[String].toOpenAPISchema))
+    ))
+  )),
+  responses = Some(ChunkMap(
+    "NotFound" -> ReferenceOr.Value(Response(
+      description = Doc("Resource not found"),
+      content = ChunkMap(
+        "application/json" -> MediaType(
+          schema = Some(ReferenceOr.Value(
+            Schema[ErrorResponse].toOpenAPISchema
+          ))
+        )
+      )
+    )),
+    "Unauthorized" -> ReferenceOr.Value(Response(
+      description = Doc("Unauthorized access"),
+      content = ChunkMap()
+    ))
+  )),
+  securitySchemes = Some(ChunkMap(
+    "api_key" -> ReferenceOr.Value(SecurityScheme.APIKey(
+      name = "X-API-Key",
+      in = "header",
+      description = Some(Doc("API key header"))
+    ))
+  ))
+)
+```
+
+---
+
+## SchemaObject
+
+`SchemaObject` wraps a JSON Schema 2020-12 definition with OpenAPI-specific extensions like discriminator, XML metadata, and examples.
+
+### Definition
+
+`SchemaObject` contains:
+- **`jsonSchema`**: Raw JSON Schema 2020-12 as `Json` AST
+- **`discriminator`**: Polymorphism discriminator for oneOf/anyOf
+- **`xml`**: XML serialization metadata
+- **`example`**: Example value for documentation
+- **`extensions`**: Custom `x-*` fields
+
+### Creating SchemaObject
+
+Directly from a `Schema[A]`:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val userSchema = Schema[User].toOpenAPISchema
+// Returns a SchemaObject with the User type's JSON Schema
+```
+
+Or with additional OpenAPI metadata:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val enrichedSchema = SchemaObject(
+  jsonSchema = Schema[User].toJsonSchema.toJson,
+  discriminator = None,
+  xml = Some(XML(
+    name = Some("user"),
+    prefix = None,
+    namespace = None,
+    attribute = false,
+    wrapped = false,
+    extensions = None
+  )),
+  example = Some(Json.Object(Map(
+    "id" -> Json.Number(1),
+    "name" -> Json.String("John")
+  ))),
+  extensions = Some(ChunkMap(
+    "x-generated" -> Json.String("true"),
+    "x-version" -> Json.String("1.0.0")
+  ))
+)
+```
+
+### Converting Schemas to SchemaObject
+
+Use the `SchemaOps` extension methods on any `Schema[A]`:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val schemaObj: SchemaObject = Schema[User].toOpenAPISchema
+val (ref, component) = Schema[User].toRefSchema
+// ref = ReferenceOr.Ref pointing to #/components/schemas/User
+// component = ("User", SchemaObject(...))
+```
+
+---
+
+## ReferenceOr
+
+`ReferenceOr[A]` is a sealed trait representing the OpenAPI pattern of choosing between a `$ref` and an inline value.
+
+### Definition
+
+Two cases:
+- **`ReferenceOr.Ref`**: Points to a definition at `#/components/<type>/<name>`
+- **`ReferenceOr.Value`**: Inline definition without reference
+
+### Using ReferenceOr
+
+Prefer `Ref` for reusable components:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val userRef = ReferenceOr.Ref(Reference("$ref" -> "#/components/schemas/User"))
+
+val responseRef = ReferenceOr.Ref(Reference(
+  "$ref" -> "#/components/responses/NotFound"
+))
+```
+
+Use `Value` for inline, one-off definitions:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val inlineUser = ReferenceOr.Value(Schema[User].toOpenAPISchema)
+
+val inlineError = ReferenceOr.Value(Response(
+  description = Doc("Quick error"),
+  content = ChunkMap()
+))
+```
+
+### Pattern Matching on ReferenceOr
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+def describeRef[A](ref: ReferenceOr[A]): String = ref match {
+  case ReferenceOr.Ref(r) => s"Reference to ${r.ref}"
+  case ReferenceOr.Value(v) => "Inline value"
+}
+```
+
+---
+
+## SecurityScheme
+
+`SecurityScheme` is a sealed trait representing different authentication methods. Variants include API Key, HTTP Basic/Bearer, OAuth 2.0, OpenID Connect, and Mutual TLS.
+
+### Definition
+
+Sealed trait variants:
+- **`APIKey`**: API key in header, query, or cookie
+- **`HTTP`**: HTTP authentication (Basic, Bearer, etc.)
+- **`OAuth2`**: OAuth 2.0 authorization flows
+- **`OpenIdConnect`**: OpenID Connect discovery
+- **`MutualTLS`**: Mutual TLS certificate-based
+
+### Creating Security Schemes
+
+API Key authentication:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val apiKeySecurity = SecurityScheme.APIKey(
+  name = "X-API-Key",
+  in = "header",
+  description = Some(Doc("API key required in header"))
+)
+```
+
+HTTP Bearer token:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val bearerSecurity = SecurityScheme.HTTP(
+  scheme = "bearer",
+  bearerFormat = Some("JWT"),
+  description = Some(Doc("JWT bearer token"))
+)
+```
+
+OAuth 2.0:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val oauthSecurity = SecurityScheme.OAuth2(
+  flows = OAuthFlows(
+    authorizationCode = Some(OAuthFlow(
+      authorizationUrl = "https://example.com/oauth/authorize",
+      tokenUrl = "https://example.com/oauth/token",
+      scopes = ChunkMap(
+        "read:users" -> Doc("Read user data"),
+        "write:users" -> Doc("Modify user data")
+      )
+    ))
+  ),
+  description = Some(Doc("OAuth 2.0 authorization"))
+)
+```
+
+:::note
+The `OAuthFlows` type supports multiple flow types: `implicit`, `password`, `clientCredentials`, and `authorizationCode`. Choose the flow that matches your OAuth 2.0 configuration.
+:::
+
+OpenID Connect:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val oidcSecurity = SecurityScheme.OpenIdConnect(
+  openIdConnectUrl = "https://example.com/.well-known/openid-configuration",
+  description = Some(Doc("OpenID Connect discovery"))
+)
+```
+
+---
+
+## Discriminator
+
+`Discriminator` specifies how to distinguish between different variants in a polymorphic schema (using `oneOf` or `anyOf`).
+
+### Definition
+
+Key fields:
+- **`propertyName`**: Field name used to discriminate (e.g., `"type"`, `"kind"`)
+- **`mapping`**: Optional explicit mapping of discriminator values to schema references
+
+### Creating a Discriminator
+
+Simple discriminator by property name:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val discriminator = Discriminator(
+  propertyName = "type",
+  mapping = None
+)
+```
+
+With explicit value-to-schema mapping:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val mappedDiscriminator = Discriminator(
+  propertyName = "kind",
+  mapping = Some(ChunkMap(
+    "user" -> "#/components/schemas/User",
+    "admin" -> "#/components/schemas/Admin",
+    "guest" -> "#/components/schemas/Guest"
+  ))
+)
+```
+
+---
+
+## Server & ServerVariable
+
+`Server` specifies base URLs and server-specific variables. `ServerVariable` allows parameterization of server URLs.
+
+### Definition
+
+`Server` contains:
+- **`url`**: Server URL (may contain variable placeholders like `{base_path}`)
+- **`description`**: Optional description
+- **`variables`**: Map of variable names to `ServerVariable`
+
+`ServerVariable` contains:
+- **`enum`**: List of allowed values
+- **`default`**: Default value
+- **`description`**: Description of the variable
+
+### Creating Servers
+
+Single static server:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val server = Server(
+  url = "https://api.example.com",
+  description = Some(Doc("Production API")),
+  variables = None
+)
+```
+
+Server with variables (showing structure without reserved keywords):
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val variableServer = Server(
+  url = "https://{host}:{port}/{basePath}",
+  description = Some(Doc("Development API with variables")),
+  variables = Some(ChunkMap(
+    "host" -> ServerVariable(
+      default = "localhost",
+      enumValues = Some(Chunk("localhost", "staging.example.com", "api.example.com")),
+      description = Some(Doc("API host"))
+    ),
+    "port" -> ServerVariable(
+      default = "8080",
+      enumValues = Some(Chunk("8080", "443")),
+      description = Some(Doc("Port number"))
+    ),
+    "basePath" -> ServerVariable(
+      default = "v1",
+      enumValues = Some(Chunk("v1", "v2")),
+      description = Some(Doc("API version path"))
+    )
+  ))
+)
+```
+
+:::note
+`ServerVariable` contains enumerable values for each variable. The field is named to avoid the reserved `enum` keyword in Scala.
+:::
+
+---
+
+## Tag
+
+`Tag` groups related operations under a heading in generated documentation.
+
+### Definition
+
+Key fields:
+- **`name`**: Tag identifier (e.g., `"users"`, `"products"`)
+- **`description`**: Markdown description of the tag
+- **`externalDocs`**: Link to external documentation
+
+### Creating Tags
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val userTag = Tag(
+  name = "users",
+  description = Some(Doc("User management operations")),
+  externalDocs = None
+)
+
+val productsTag = Tag(
+  name = "products",
+  description = Some(Doc("Product catalog operations")),
+  externalDocs = Some(ExternalDocumentation(
+    url = "https://docs.example.com/products",
+    description = Some(Doc("Full product API documentation"))
+  ))
+)
+```
+
+---
+
+## Common Extension Fields
+
+All types support custom `x-*` extension fields for vendor-specific metadata. These extensions are preserved during encoding/decoding:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val operationWithExtensions = Operation(
+  summary = Some("Get user"),
+  responses = Responses(ChunkMap(
+    "200" -> ReferenceOr.Value(Response(
+      description = Doc("User found"),
+      content = ChunkMap()
+    ))
+  )),
+  extensions = Some(ChunkMap(
+    "x-internal" -> Json.Bool(true),
+    "x-rate-limit" -> Json.Number(100),
+    "x-deprecated-at" -> Json.String("2024-01-01")
+  ))
+)
+```
+
+---
+
+## Round-Tripping with Schema
+
+All OpenAPI types have `Schema.derived` instances, enabling serialization through `DynamicValue`:
+
+```scala
+import zio.blocks.openapi._
+import zio.blocks.markdown._
+import zio.blocks.chunk._
+
+val openAPISchema = Schema[OpenAPI]
+
+val apiDynamic = openAPISchema.toDynamicValue(api)
+
+val apiRestored = openAPISchema.fromDynamicValue(apiDynamic)
+// apiRestored == api
+```
+
+This enables integration with other ZIO Blocks modules that work with `DynamicValue`.

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -325,7 +325,7 @@ Optional fields include servers, components, security requirements, tags, and ex
 
 To construct an `OpenAPI` document:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -343,7 +343,7 @@ Add paths, operations, and components as shown in the "How They Work Together" s
 
 Encode an `OpenAPI` document to `Json` AST:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -355,7 +355,7 @@ val encoded: Json = openAPICodec.encodeValue(api)
 
 Decode from `Json` AST back to an `OpenAPI` instance:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -383,7 +383,7 @@ Optional fields:
 
 ### Creating Info
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -423,7 +423,7 @@ val info = Info(
 
 To define a path with multiple operations:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -512,7 +512,7 @@ Key fields:
 
 With summary, description, and parameters:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -571,7 +571,7 @@ Optional fields:
 
 Path parameter (required):
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -587,7 +587,7 @@ val idPathParam = Parameter(
 
 Query parameter (optional with default):
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -603,7 +603,7 @@ val limitQueryParam = Parameter(
 
 Header parameter:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -67,27 +67,22 @@ object ErrorResponse {
 
 **2. Create an OpenAPI document** by composing types:
 
-```scala
-import zio.blocks.openapi._
-import zio.blocks.docs._
-import zio.blocks.chunk._
-import zio.blocks.schema._
-
+```scala mdoc:silent
 val api = OpenAPI(
   openapi = "3.1.0",
   info = Info(
     title = "User API",
     version = "1.0.0",
-    description = Some(Doc("API for managing users"))
+    description = Some(md"API for managing users")
   ),
   paths = Some(Paths(ChunkMap(
     "/users" -> PathItem(
       get = Some(Operation(
-        summary = Some("List all users"),
-        description = Some(Doc("Returns a paginated list of users")),
+        summary = Some(md"List all users"),
+        description = Some(md"Returns a paginated list of users"),
         responses = Responses(ChunkMap(
           "200" -> ReferenceOr.Value(Response(
-            description = Doc("Successful response"),
+            description = md"Successful response",
             content = ChunkMap(
               "application/json" -> MediaType(
                 schema = Some(ReferenceOr.Value(
@@ -101,8 +96,8 @@ val api = OpenAPI(
     ),
     "/users/{id}" -> PathItem(
       get = Some(Operation(
-        summary = Some("Get a user by ID"),
-        parameters = Some(Chunk(
+        summary = Some(md"Get a user by ID"),
+        parameters = Chunk(
           ReferenceOr.Value(Parameter(
             name = "id",
             in = ParameterLocation.Path,
@@ -111,10 +106,10 @@ val api = OpenAPI(
               Schema[Int].toOpenAPISchema
             ))
           ))
-        )),
+        ),
         responses = Responses(ChunkMap(
           "200" -> ReferenceOr.Value(Response(
-            description = Doc("User found"),
+            description = md"User found",
             content = ChunkMap(
               "application/json" -> MediaType(
                 schema = Some(ReferenceOr.Value(
@@ -124,7 +119,7 @@ val api = OpenAPI(
             )
           )),
           "404" -> ReferenceOr.Value(Response(
-            description = Doc("User not found"),
+            description = md"User not found",
             content = ChunkMap(
               "application/json" -> MediaType(
                 schema = Some(ReferenceOr.Value(
@@ -138,21 +133,17 @@ val api = OpenAPI(
     )
   ))),
   components = Some(Components(
-    schemas = Some(ChunkMap(
-      Schema[User].toRefSchema._2,
-      Schema[ErrorResponse].toRefSchema._2
-    ))
+    schemas = ChunkMap(
+      Schema[User].toRefSchema._2._1 -> ReferenceOr.Value(Schema[User].toRefSchema._2._2),
+      Schema[ErrorResponse].toRefSchema._2._1 -> ReferenceOr.Value(Schema[ErrorResponse].toRefSchema._2._2)
+    )
   ))
 )
 ```
 
 **3. Serialize to JSON** for tools to consume:
 
-```scala
-import zio.blocks.openapi._
-import zio.blocks.docs._
-import zio.blocks.chunk._
-
+```scala mdoc:silent
 import zio.blocks.openapi.OpenAPICodec._
 
 val json = openAPICodec.encodeValue(api)
@@ -241,33 +232,34 @@ val simpleString = ReferenceOr.Value(Schema[String].toOpenAPISchema)
 
 Define authentication methods in `components.securitySchemes`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val apiKeyScheme = SecurityScheme.APIKey(
   name = "X-API-Key",
-  in = "header",
-  description = Some(Doc("API key for authentication"))
+  in = APIKeyLocation.Header,
+  description = Some(md"API key for authentication")
 )
 
 val oauthScheme = SecurityScheme.OAuth2(
   flows = OAuthFlows(
     authorizationCode = Some(OAuthFlow(
-      authorizationUrl = "https://example.com/oauth/authorize",
-      tokenUrl = "https://example.com/oauth/token",
-      scopes = ChunkMap("read" -> Doc("Read access"), "write" -> Doc("Write access"))
+      authorizationUrl = Some("https://example.com/oauth/authorize"),
+      tokenUrl = Some("https://example.com/oauth/token"),
+      scopes = ChunkMap("read" -> "Read access", "write" -> "Write access")
     ))
   ),
-  description = Some(Doc("OAuth 2.0 authorization"))
+  description = Some(md"OAuth 2.0 authorization")
 )
 
 val components = Components(
-  securitySchemes = Some(ChunkMap(
+  securitySchemes = ChunkMap(
     "api_key" -> ReferenceOr.Value(apiKeyScheme),
     "oauth2" -> ReferenceOr.Value(oauthScheme)
-  ))
+  )
 )
 ```
 
@@ -275,10 +267,11 @@ val components = Components(
 
 Distinguish parameter locations using `ParameterLocation`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val pathParam = Parameter(
   name = "id",
@@ -330,15 +323,15 @@ Optional fields include servers, components, security requirements, tags, and ex
 
 To construct an `OpenAPI` document:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val minimalApi = OpenAPI(
   openapi = "3.1.0",
-  info = Info(title = "My API", version = "1.0.0"),
-  paths = Some(Paths(ChunkMap()))  // Empty paths initially
+  info = Info(title = "My API", version = "1.0.0")
 )
 ```
 
@@ -348,23 +341,32 @@ Add paths, operations, and components as shown in the "How They Work Together" s
 
 Encode an `OpenAPI` document to `Json` AST:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
+import zio.blocks.openapi.OpenAPICodec._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
-import zio.blocks.openapi.OpenAPICodec._
+import zio.blocks.schema.json._
 
-val encoded: Json = openAPICodec.encodeValue(api)
+val myApi = OpenAPI(openapi = "3.1.0", info = Info(title = "My API", version = "1.0.0"))
+val encoded: Json = openAPICodec.encodeValue(myApi)
 ```
 
 Decode from `Json` AST back to an `OpenAPI` instance:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
+import zio.blocks.openapi.OpenAPICodec._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
+import zio.blocks.schema.json._
+
+val myApi = OpenAPI(openapi = "3.1.0", info = Info(title = "My API", version = "1.0.0"))
+val encoded: Json = openAPICodec.encodeValue(myApi)
 val decoded: OpenAPI = openAPICodec.decodeValue(encoded)
 ```
 
@@ -388,15 +390,16 @@ Optional fields:
 
 ### Creating Info
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val info = Info(
   title = "Pet Store API",
   version = "3.0.0",
-  description = Some(Doc("API for managing a pet store")),
+  description = Some(md"API for managing a pet store"),
   contact = Some(Contact(
     name = Some("API Support"),
     url = Some("https://example.com/support"),
@@ -428,18 +431,19 @@ val info = Info(
 
 To define a path with multiple operations:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val userPaths = Paths(ChunkMap(
   "/users" -> PathItem(
     get = Some(Operation(
-      summary = Some("List users"),
+      summary = Some(md"List users"),
       responses = Responses(ChunkMap(
         "200" -> ReferenceOr.Value(Response(
-          description = Doc("User list"),
+          description = md"User list",
           content = ChunkMap(
             "application/json" -> MediaType(schema = None)
           )
@@ -447,9 +451,9 @@ val userPaths = Paths(ChunkMap(
       ))
     )),
     post = Some(Operation(
-      summary = Some("Create user"),
+      summary = Some(md"Create user"),
       requestBody = Some(ReferenceOr.Value(RequestBody(
-        description = Some(Doc("User data")),
+        description = Some(md"User data"),
         content = ChunkMap(
           "application/json" -> MediaType(schema = None)
         ),
@@ -457,7 +461,7 @@ val userPaths = Paths(ChunkMap(
       ))),
       responses = Responses(ChunkMap(
         "201" -> ReferenceOr.Value(Response(
-          description = Doc("User created"),
+          description = md"User created",
           content = ChunkMap(
             "application/json" -> MediaType(schema = None)
           )
@@ -466,25 +470,25 @@ val userPaths = Paths(ChunkMap(
     ))
   ),
   "/users/{id}" -> PathItem(
-    parameters = Some(Chunk(
+    parameters = Chunk(
       ReferenceOr.Value(Parameter(
         name = "id",
         in = ParameterLocation.Path,
         required = true,
         schema = Some(ReferenceOr.Value(Schema[String].toOpenAPISchema))
       ))
-    )),
+    ),
     get = Some(Operation(
-      summary = Some("Get user by ID"),
+      summary = Some(md"Get user by ID"),
       responses = Responses(ChunkMap(
         "200" -> ReferenceOr.Value(Response(
-          description = Doc("User found"),
+          description = md"User found",
           content = ChunkMap(
             "application/json" -> MediaType(schema = None)
           )
         )),
         "404" -> ReferenceOr.Value(Response(
-          description = Doc("User not found"),
+          description = md"User not found",
           content = ChunkMap(
             "application/json" -> MediaType(schema = None)
           )
@@ -517,34 +521,35 @@ Key fields:
 
 With summary, description, and parameters:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val getUser = Operation(
-  tags = Some(Chunk("users")),
-  summary = Some("Retrieve user"),
-  description = Some(Doc("Fetches a single user by ID")),
+  tags = Chunk("users"),
+  summary = Some(md"Retrieve user"),
+  description = Some(md"Fetches a single user by ID"),
   operationId = Some("getUserById"),
-  parameters = Some(Chunk(
+  parameters = Chunk(
     ReferenceOr.Value(Parameter(
       name = "id",
       in = ParameterLocation.Path,
       required = true,
       schema = Some(ReferenceOr.Value(Schema[String].toOpenAPISchema)),
-      description = Some(Doc("User ID"))
+      description = Some(md"User ID")
     ))
-  )),
+  ),
   responses = Responses(ChunkMap(
     "200" -> ReferenceOr.Value(Response(
-      description = Doc("User found"),
+      description = md"User found",
       content = ChunkMap(
         "application/json" -> MediaType(schema = None)
       )
     )),
     "404" -> ReferenceOr.Value(Response(
-      description = Doc("User not found"),
+      description = md"User not found",
       content = ChunkMap(
         "application/json" -> MediaType(schema = None)
       )
@@ -576,49 +581,52 @@ Optional fields:
 
 Path parameter (required):
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val idPathParam = Parameter(
   name = "id",
   in = ParameterLocation.Path,
   required = true,
   schema = Some(ReferenceOr.Value(Schema[String].toOpenAPISchema)),
-  description = Some(Doc("User identifier"))
+  description = Some(md"User identifier")
 )
 ```
 
 Query parameter (optional with default):
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val limitQueryParam = Parameter(
   name = "limit",
   in = ParameterLocation.Query,
   required = false,
   schema = Some(ReferenceOr.Value(Schema[Int].toOpenAPISchema)),
-  description = Some(Doc("Maximum number of results (default: 20)"))
+  description = Some(md"Maximum number of results (default: 20)")
 )
 ```
 
 Header parameter:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val authHeaderParam = Parameter(
   name = "X-API-Key",
   in = ParameterLocation.Header,
   required = true,
   schema = Some(ReferenceOr.Value(Schema[String].toOpenAPISchema)),
-  description = Some(Doc("API key for authentication"))
+  description = Some(md"API key for authentication")
 )
 ```
 
@@ -637,17 +645,22 @@ Key fields:
 
 ### Creating a RequestBody
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
+import zio.blocks.schema.json._
+
+case class User(name: String, email: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
 
 val createUserBody = RequestBody(
-  description = Some(Doc("User data to create")),
+  description = Some(md"User data to create"),
   content = ChunkMap(
     "application/json" -> MediaType(
       schema = Some(ReferenceOr.Value(Schema[User].toOpenAPISchema)),
-      example = Some(Json.Object(Map(
+      example = Some(Json.Object(Chunk(
         "name" -> Json.String("John Doe"),
         "email" -> Json.String("john@example.com")
       )))
@@ -667,25 +680,31 @@ Key fields:
 
 ### Creating a Response
 
-```scala
+```scala mdoc:silent
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
+
+case class User2(id: Int, name: String, email: String)
+object User2 { implicit val schema: Schema[User2] = Schema.derived }
+case class ErrorResponse2(code: Int, message: String)
+object ErrorResponse2 { implicit val schema: Schema[ErrorResponse2] = Schema.derived }
 
 val successResponse = Response(
-  description = Doc("User successfully created"),
+  description = md"User successfully created",
   content = ChunkMap(
     "application/json" -> MediaType(
-      schema = Some(ReferenceOr.Value(Schema[User].toOpenAPISchema))
+      schema = Some(ReferenceOr.Value(Schema[User2].toOpenAPISchema))
     )
   )
 )
 
 val errorResponse = Response(
-  description = Doc("Request validation failed"),
+  description = md"Request validation failed",
   content = ChunkMap(
     "application/json" -> MediaType(
-      schema = Some(ReferenceOr.Value(Schema[ErrorResponse].toOpenAPISchema))
+      schema = Some(ReferenceOr.Value(Schema[ErrorResponse2].toOpenAPISchema))
     )
   )
 )
@@ -695,20 +714,24 @@ val errorResponse = Response(
 
 `Responses` is a map of HTTP status codes to `ReferenceOr[Response]`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
+
+val ok = Response(description = md"Created", content = ChunkMap())
+val err = Response(description = md"Bad request", content = ChunkMap())
 
 val responses = Responses(ChunkMap(
-  "201" -> ReferenceOr.Value(successResponse),
-  "400" -> ReferenceOr.Value(errorResponse),
+  "201" -> ReferenceOr.Value(ok),
+  "400" -> ReferenceOr.Value(err),
   "401" -> ReferenceOr.Value(Response(
-    description = Doc("Unauthorized"),
+    description = md"Unauthorized",
     content = ChunkMap()
   )),
   "500" -> ReferenceOr.Value(Response(
-    description = Doc("Internal server error"),
+    description = md"Internal server error",
     content = ChunkMap()
   ))
 ))
@@ -732,36 +755,41 @@ Key fields:
 
 With schema and example:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
+import zio.blocks.schema.json._
+
+case class User(id: Int, name: String, email: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
 
 val jsonMedia = MediaType(
   schema = Some(ReferenceOr.Value(Schema[User].toOpenAPISchema)),
-  example = Some(Json.Object(Map(
+  example = Some(Json.Object(
     "id" -> Json.Number(1),
     "name" -> Json.String("Alice"),
     "email" -> Json.String("alice@example.com")
-  )))
+  ))
 )
 ```
 
 For form data:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val formMedia = MediaType(
   schema = Some(ReferenceOr.Value(Schema[Map[String, String]].toOpenAPISchema)),
-  encoding = Some(ChunkMap(
+  encoding = ChunkMap(
     "file" -> Encoding(
-      contentType = Some("application/octet-stream"),
-      style = Some("form")
+      contentType = Some("application/octet-stream")
     )
-  ))
+  )
 )
 ```
 
@@ -782,27 +810,33 @@ Key fields:
 
 ### Creating Components
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
+
+case class User(id: Int, name: String, email: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
+case class ErrorResponse(code: Int, message: String)
+object ErrorResponse { implicit val schema: Schema[ErrorResponse] = Schema.derived }
 
 val components = Components(
-  schemas = Some(ChunkMap(
-    Schema[User].toRefSchema._2,
-    Schema[ErrorResponse].toRefSchema._2
-  )),
-  parameters = Some(ChunkMap(
+  schemas = ChunkMap(
+    Schema[User].toRefSchema._2._1 -> ReferenceOr.Value(Schema[User].toRefSchema._2._2),
+    Schema[ErrorResponse].toRefSchema._2._1 -> ReferenceOr.Value(Schema[ErrorResponse].toRefSchema._2._2)
+  ),
+  parameters = ChunkMap(
     "id" -> ReferenceOr.Value(Parameter(
       name = "id",
       in = ParameterLocation.Path,
       required = true,
       schema = Some(ReferenceOr.Value(Schema[String].toOpenAPISchema))
     ))
-  )),
-  responses = Some(ChunkMap(
+  ),
+  responses = ChunkMap(
     "NotFound" -> ReferenceOr.Value(Response(
-      description = Doc("Resource not found"),
+      description = md"Resource not found",
       content = ChunkMap(
         "application/json" -> MediaType(
           schema = Some(ReferenceOr.Value(
@@ -812,17 +846,17 @@ val components = Components(
       )
     )),
     "Unauthorized" -> ReferenceOr.Value(Response(
-      description = Doc("Unauthorized access"),
+      description = md"Unauthorized access",
       content = ChunkMap()
     ))
-  )),
-  securitySchemes = Some(ChunkMap(
+  ),
+  securitySchemes = ChunkMap(
     "api_key" -> ReferenceOr.Value(SecurityScheme.APIKey(
       name = "X-API-Key",
-      in = "header",
-      description = Some(Doc("API key header"))
+      in = APIKeyLocation.Header,
+      description = Some(md"API key header")
     ))
-  ))
+  )
 )
 ```
 
@@ -845,10 +879,14 @@ val components = Components(
 
 Directly from a `Schema[A]`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
+
+case class User(id: Int, name: String, email: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
 
 val userSchema = Schema[User].toOpenAPISchema
 // Returns a SchemaObject with the User type's JSON Schema
@@ -856,30 +894,34 @@ val userSchema = Schema[User].toOpenAPISchema
 
 Or with additional OpenAPI metadata:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
+import zio.blocks.schema.json._
+
+case class User(id: Int, name: String, email: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
 
 val enrichedSchema = SchemaObject(
   jsonSchema = Schema[User].toJsonSchema.toJson,
   discriminator = None,
   xml = Some(XML(
     name = Some("user"),
-    prefix = None,
     namespace = None,
+    prefix = None,
     attribute = false,
-    wrapped = false,
-    extensions = None
+    wrapped = false
   )),
-  example = Some(Json.Object(Map(
+  example = Some(Json.Object(
     "id" -> Json.Number(1),
     "name" -> Json.String("John")
-  ))),
-  extensions = Some(ChunkMap(
+  )),
+  extensions = ChunkMap(
     "x-generated" -> Json.String("true"),
     "x-version" -> Json.String("1.0.0")
-  ))
+  )
 )
 ```
 
@@ -887,10 +929,14 @@ val enrichedSchema = SchemaObject(
 
 Use the `SchemaOps` extension methods on any `Schema[A]`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
+
+case class User(id: Int, name: String, email: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
 
 val schemaObj: SchemaObject = Schema[User].toOpenAPISchema
 val (ref, component) = Schema[User].toRefSchema
@@ -914,43 +960,49 @@ Two cases:
 
 Prefer `Ref` for reusable components:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
-val userRef = ReferenceOr.Ref(Reference("$ref" -> "#/components/schemas/User"))
+val userRef = ReferenceOr.Ref(Reference(`$ref` = "#/components/schemas/User"))
 
 val responseRef = ReferenceOr.Ref(Reference(
-  "$ref" -> "#/components/responses/NotFound"
+  `$ref` = "#/components/responses/NotFound"
 ))
 ```
 
 Use `Value` for inline, one-off definitions:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
+
+case class User(id: Int, name: String, email: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
 
 val inlineUser = ReferenceOr.Value(Schema[User].toOpenAPISchema)
 
 val inlineError = ReferenceOr.Value(Response(
-  description = Doc("Quick error"),
+  description = md"Quick error",
   content = ChunkMap()
 ))
 ```
 
 ### Pattern Matching on ReferenceOr
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 def describeRef[A](ref: ReferenceOr[A]): String = ref match {
-  case ReferenceOr.Ref(r) => s"Reference to ${r.ref}"
-  case ReferenceOr.Value(v) => "Inline value"
+  case ReferenceOr.Ref(r)   => s"Reference to ${r.`$ref`}"
+  case ReferenceOr.Value(_) => "Inline value"
 }
 ```
 
@@ -973,51 +1025,54 @@ Sealed trait variants:
 
 API Key authentication:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val apiKeySecurity = SecurityScheme.APIKey(
   name = "X-API-Key",
-  in = "header",
-  description = Some(Doc("API key required in header"))
+  in = APIKeyLocation.Header,
+  description = Some(md"API key required in header")
 )
 ```
 
 HTTP Bearer token:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val bearerSecurity = SecurityScheme.HTTP(
   scheme = "bearer",
   bearerFormat = Some("JWT"),
-  description = Some(Doc("JWT bearer token"))
+  description = Some(md"JWT bearer token")
 )
 ```
 
 OAuth 2.0:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val oauthSecurity = SecurityScheme.OAuth2(
   flows = OAuthFlows(
     authorizationCode = Some(OAuthFlow(
-      authorizationUrl = "https://example.com/oauth/authorize",
-      tokenUrl = "https://example.com/oauth/token",
+      authorizationUrl = Some("https://example.com/oauth/authorize"),
+      tokenUrl = Some("https://example.com/oauth/token"),
       scopes = ChunkMap(
-        "read:users" -> Doc("Read user data"),
-        "write:users" -> Doc("Modify user data")
+        "read:users" -> "Read user data",
+        "write:users" -> "Modify user data"
       )
     ))
   ),
-  description = Some(Doc("OAuth 2.0 authorization"))
+  description = Some(md"OAuth 2.0 authorization")
 )
 ```
 
@@ -1027,14 +1082,15 @@ The `OAuthFlows` type supports multiple flow types: `implicit`, `password`, `cli
 
 OpenID Connect:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val oidcSecurity = SecurityScheme.OpenIdConnect(
   openIdConnectUrl = "https://example.com/.well-known/openid-configuration",
-  description = Some(Doc("OpenID Connect discovery"))
+  description = Some(md"OpenID Connect discovery")
 )
 ```
 
@@ -1054,31 +1110,30 @@ Key fields:
 
 Simple discriminator by property name:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
-val discriminator = Discriminator(
-  propertyName = "type",
-  mapping = None
-)
+val discriminator = Discriminator(propertyName = "type")
 ```
 
 With explicit value-to-schema mapping:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val mappedDiscriminator = Discriminator(
   propertyName = "kind",
-  mapping = Some(ChunkMap(
+  mapping = ChunkMap(
     "user" -> "#/components/schemas/User",
     "admin" -> "#/components/schemas/Admin",
     "guest" -> "#/components/schemas/Guest"
-  ))
+  )
 )
 ```
 
@@ -1104,45 +1159,46 @@ val mappedDiscriminator = Discriminator(
 
 Single static server:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val server = Server(
   url = "https://api.example.com",
-  description = Some(Doc("Production API")),
-  variables = None
+  description = Some(md"Production API")
 )
 ```
 
-Server with variables (showing structure without reserved keywords):
+Server with variables:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val variableServer = Server(
   url = "https://{host}:{port}/{basePath}",
-  description = Some(Doc("Development API with variables")),
-  variables = Some(ChunkMap(
+  description = Some(md"Development API with variables"),
+  variables = ChunkMap(
     "host" -> ServerVariable(
       default = "localhost",
-      enumValues = Some(Chunk("localhost", "staging.example.com", "api.example.com")),
-      description = Some(Doc("API host"))
+      `enum` = Chunk("localhost", "staging.example.com", "api.example.com"),
+      description = Some(md"API host")
     ),
     "port" -> ServerVariable(
       default = "8080",
-      enumValues = Some(Chunk("8080", "443")),
-      description = Some(Doc("Port number"))
+      `enum` = Chunk("8080", "443"),
+      description = Some(md"Port number")
     ),
     "basePath" -> ServerVariable(
       default = "v1",
-      enumValues = Some(Chunk("v1", "v2")),
-      description = Some(Doc("API version path"))
+      `enum` = Chunk("v1", "v2"),
+      description = Some(md"API version path")
     )
-  ))
+  )
 )
 ```
 
@@ -1165,23 +1221,23 @@ Key fields:
 
 ### Creating Tags
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
 val userTag = Tag(
   name = "users",
-  description = Some(Doc("User management operations")),
-  externalDocs = None
+  description = Some(md"User management operations")
 )
 
 val productsTag = Tag(
   name = "products",
-  description = Some(Doc("Product catalog operations")),
+  description = Some(md"Product catalog operations"),
   externalDocs = Some(ExternalDocumentation(
     url = "https://docs.example.com/products",
-    description = Some(Doc("Full product API documentation"))
+    description = Some(md"Full product API documentation")
   ))
 )
 ```
@@ -1192,24 +1248,26 @@ val productsTag = Tag(
 
 All types support custom `x-*` extension fields for vendor-specific metadata. These extensions are preserved during encoding/decoding:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
+import zio.blocks.schema.json._
 
 val operationWithExtensions = Operation(
-  summary = Some("Get user"),
+  summary = Some(md"Get user"),
   responses = Responses(ChunkMap(
     "200" -> ReferenceOr.Value(Response(
-      description = Doc("User found"),
+      description = md"User found",
       content = ChunkMap()
     ))
   )),
-  extensions = Some(ChunkMap(
-    "x-internal" -> Json.Bool(true),
+  extensions = ChunkMap(
+    "x-internal" -> Json.Boolean(true),
     "x-rate-limit" -> Json.Number(100),
     "x-deprecated-at" -> Json.String("2024-01-01")
-  ))
+  )
 )
 ```
 
@@ -1219,17 +1277,18 @@ val operationWithExtensions = Operation(
 
 All OpenAPI types have `Schema.derived` instances, enabling serialization through `DynamicValue`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.docs._
 import zio.blocks.chunk._
+import zio.blocks.schema._
 
+val myApi = OpenAPI(openapi = "3.1.0", info = Info(title = "My API", version = "1.0.0"))
 val openAPISchema = Schema[OpenAPI]
 
-val apiDynamic = openAPISchema.toDynamicValue(api)
+val apiDynamic = openAPISchema.toDynamicValue(myApi)
 
 val apiRestored = openAPISchema.fromDynamicValue(apiDynamic)
-// apiRestored == api
 ```
 
 This enables integration with other ZIO Blocks modules that work with `DynamicValue`.

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -325,7 +325,7 @@ Optional fields include servers, components, security requirements, tags, and ex
 
 To construct an `OpenAPI` document:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -343,7 +343,7 @@ Add paths, operations, and components as shown in the "How They Work Together" s
 
 Encode an `OpenAPI` document to `Json` AST:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -355,7 +355,7 @@ val encoded: Json = openAPICodec.encodeValue(api)
 
 Decode from `Json` AST back to an `OpenAPI` instance:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -383,7 +383,7 @@ Optional fields:
 
 ### Creating Info
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -423,7 +423,7 @@ val info = Info(
 
 To define a path with multiple operations:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -512,7 +512,7 @@ Key fields:
 
 With summary, description, and parameters:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -571,7 +571,7 @@ Optional fields:
 
 Path parameter (required):
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -587,7 +587,7 @@ val idPathParam = Parameter(
 
 Query parameter (optional with default):
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -603,7 +603,7 @@ val limitQueryParam = Parameter(
 
 Header parameter:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -162,8 +162,8 @@ val jsonString = Json.jsonCodec.encodeToString(json, WriterConfig.withIndentionS
 ```
 OpenAPI (root document)
 ├─ info: Info (metadata)
-├─ servers: Chunk[Server]
-├─ paths: Paths (map of path strings to PathItem)
+├─ servers: Option[Chunk[Server]]
+├─ paths: Option[Paths] (map of path strings to PathItem)
 │  └─ PathItem
 │     ├─ get: Operation
 │     ├─ post: Operation
@@ -177,12 +177,12 @@ OpenAPI (root document)
 │           └─ Map[statusCode, ReferenceOr[Response]]
 │              └─ content: Map[String, MediaType]
 │                 └─ schema: ReferenceOr[SchemaObject]
-├─ components: Components
-│  ├─ schemas: Map[String, SchemaObject]
-│  ├─ responses: Map[String, ReferenceOr[Response]]
-│  ├─ parameters: Map[String, ReferenceOr[Parameter]]
-│  └─ securitySchemes: Map[String, ReferenceOr[SecurityScheme]]
-└─ security: Chunk[SecurityRequirement]
+├─ components: Option[Components]
+│  ├─ schemas: ChunkMap[String, ReferenceOr[SchemaObject]]
+│  ├─ responses: ChunkMap[String, ReferenceOr[Response]]
+│  ├─ parameters: ChunkMap[String, ReferenceOr[Parameter]]
+│  └─ securitySchemes: ChunkMap[String, ReferenceOr[SecurityScheme]]
+└─ security: Option[Chunk[SecurityRequirement]]
 ```
 
 ## Common Patterns
@@ -315,10 +315,14 @@ The OpenAPI module integrates tightly with other ZIO Blocks components:
 Every OpenAPI document requires:
 - **`openapi`**: Version string (typically `"3.1.0"`)
 - **`info`**: Metadata about the API (`Info`)
-- **`paths`**: Map of endpoint paths to operations (`Paths`)
-- **`responses`**: HTTP response definitions (`Responses`)
 
-Optional fields include servers, components, security requirements, tags, and external documentation.
+Optional top-level fields include:
+- **`servers`**: Server definitions for the API (`Chunk[Server]`)
+- **`paths`**: Map of endpoint paths to operations (`Paths`)
+- **`components`**: Reusable schemas, responses, parameters, and other components (`Components`)
+- **`security`**: Security requirements applied to the API (`Chunk[SecurityRequirement]`)
+
+Response definitions are modeled per `Operation`, not as a top-level field on `OpenAPI`.
 
 ### Creating an OpenAPI Document
 
@@ -417,11 +421,13 @@ val info = Info(
 
 ## Paths & PathItem
 
-`Paths` is a map of URL paths to their operations. `PathItem` groups HTTP methods (GET, POST, PUT, etc.) on a single path.
+`Paths` represents the collection of URL paths and their operations. `PathItem` groups HTTP methods (GET, POST, PUT, etc.) on a single path.
 
 ### Definition
 
-`Paths` is a type alias for `ChunkMap[String, PathItem]`, where keys are path strings (e.g., `"/users/{id}"`).
+`Paths` is a wrapper case class with two fields:
+- **`paths`**: `ChunkMap[String, PathItem]`, where keys are path strings (e.g., `"/users/{id}"`)
+- **`extensions`**: `ChunkMap[String, Json]`, for OpenAPI specification extensions
 
 `PathItem` contains optional fields for each HTTP method:
 - **`get`, `post`, `put`, `delete`, `patch`, `head`, `options`, `trace`**: `Operation` instances
@@ -803,7 +809,7 @@ val formMedia = MediaType(
 ### Definition
 
 Key fields:
-- **`schemas`**: Reusable schema objects (`ChunkMap[String, SchemaObject]`)
+- **`schemas`**: Reusable schema objects (`ChunkMap[String, ReferenceOr[SchemaObject]]`)
 - **`responses`**: Reusable response definitions
 - **`parameters`**: Reusable parameter definitions
 - **`securitySchemes`**: Authentication method definitions

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -151,9 +151,12 @@ val json = openAPICodec.encodeValue(api)
 
 **4. Render or serve** the JSON (e.g., to Swagger UI):
 
-```scala
-// Pseudo-code: render json to string and serve at GET /openapi.json
-val jsonString = json.render // Produces JSON string
+```scala mdoc:silent
+import zio.blocks.schema.json._
+```
+
+```scala mdoc
+val jsonString = Json.jsonCodec.encodeToString(json)
 ```
 
 ### Type Relationships Diagram

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -201,7 +201,7 @@ OpenAPI (root document)
 
 Avoid duplicating schema definitions by moving them to `components.schemas`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -220,7 +220,7 @@ val userSchemaComponent = Schema[User].toRefSchema
 
 Prefer `Ref` for reusable schemas; use `Value` for simple, one-off schemas:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -236,7 +236,7 @@ val simpleString = ReferenceOr.Value(Schema[String].toOpenAPISchema)
 
 Define authentication methods in `components.securitySchemes`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -270,7 +270,7 @@ val components = Components(
 
 Distinguish parameter locations using `ParameterLocation`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -47,7 +47,7 @@ The OpenAPI module follows a clear workflow:
 
 **1. Define your data types** using ZIO Blocks `Schema`:
 
-```scala mdoc:silent
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -67,7 +67,7 @@ object ErrorResponse {
 
 **2. Create an OpenAPI document** by composing types:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -150,7 +150,7 @@ val api = OpenAPI(
 
 **3. Serialize to JSON** for tools to consume:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -162,7 +162,7 @@ val json = openAPICodec.encodeValue(api)
 
 **4. Render or serve** the JSON (e.g., to Swagger UI):
 
-```scala mdoc:compile-only
+```scala
 // Pseudo-code: render json to string and serve at GET /openapi.json
 val jsonString = json.render // Produces JSON string
 ```

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -632,7 +632,7 @@ Key fields:
 
 ### Creating a RequestBody
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -662,7 +662,7 @@ Key fields:
 
 ### Creating a Response
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -690,7 +690,7 @@ val errorResponse = Response(
 
 `Responses` is a map of HTTP status codes to `ReferenceOr[Response]`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -727,7 +727,7 @@ Key fields:
 
 With schema and example:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -744,7 +744,7 @@ val jsonMedia = MediaType(
 
 For form data:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -777,7 +777,7 @@ Key fields:
 
 ### Creating Components
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -840,7 +840,7 @@ val components = Components(
 
 Directly from a `Schema[A]`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -851,7 +851,7 @@ val userSchema = Schema[User].toOpenAPISchema
 
 Or with additional OpenAPI metadata:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -882,7 +882,7 @@ val enrichedSchema = SchemaObject(
 
 Use the `SchemaOps` extension methods on any `Schema[A]`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -909,7 +909,7 @@ Two cases:
 
 Prefer `Ref` for reusable components:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -923,7 +923,7 @@ val responseRef = ReferenceOr.Ref(Reference(
 
 Use `Value` for inline, one-off definitions:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -938,7 +938,7 @@ val inlineError = ReferenceOr.Value(Response(
 
 ### Pattern Matching on ReferenceOr
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -968,7 +968,7 @@ Sealed trait variants:
 
 API Key authentication:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -982,7 +982,7 @@ val apiKeySecurity = SecurityScheme.APIKey(
 
 HTTP Bearer token:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -996,7 +996,7 @@ val bearerSecurity = SecurityScheme.HTTP(
 
 OAuth 2.0:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1022,7 +1022,7 @@ The `OAuthFlows` type supports multiple flow types: `implicit`, `password`, `cli
 
 OpenID Connect:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1049,7 +1049,7 @@ Key fields:
 
 Simple discriminator by property name:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1062,7 +1062,7 @@ val discriminator = Discriminator(
 
 With explicit value-to-schema mapping:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1099,7 +1099,7 @@ val mappedDiscriminator = Discriminator(
 
 Single static server:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1113,7 +1113,7 @@ val server = Server(
 
 Server with variables (showing structure without reserved keywords):
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1160,7 +1160,7 @@ Key fields:
 
 ### Creating Tags
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1187,7 +1187,7 @@ val productsTag = Tag(
 
 All types support custom `x-*` extension fields for vendor-specific metadata. These extensions are preserved during encoding/decoding:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._
@@ -1214,7 +1214,7 @@ val operationWithExtensions = Operation(
 
 All OpenAPI types have `Schema.derived` instances, enabling serialization through `DynamicValue`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.openapi._
 import zio.blocks.markdown._
 import zio.blocks.chunk._

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -151,12 +151,10 @@ val json = openAPICodec.encodeValue(api)
 
 **4. Render or serve** the JSON (e.g., to Swagger UI):
 
-```scala mdoc:silent
-import zio.blocks.schema.json._
-```
-
 ```scala mdoc
-val jsonString = Json.jsonCodec.encodeToString(json)
+import zio.blocks.schema.json._
+
+val jsonString = Json.jsonCodec.encodeToString(json, WriterConfig.withIndentionStep2)
 ```
 
 ### Type Relationships Diagram

--- a/docs/reference/resource-management/defer-handle.md
+++ b/docs/reference/resource-management/defer-handle.md
@@ -229,7 +229,7 @@ val result = Scope.global.scoped { scope =>
 
 ## See Also
 
-- [`Scope#defer`](./scope.md#registering-finalizers) — the method that returns a `DeferHandle`
+- [`Scope#defer`](./scope.md#finalizer) — the method that returns a `DeferHandle`
 - [`Finalizer`](./finalizer.md) — the trait defining `Finalizer#defer`
 - [`Finalization`](./finalization.md) — the result of running all finalizers
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -126,6 +126,7 @@ const sidebars = {
              "reference/http-model/schema",
            ]
          },
+         "reference/openapi",
          "reference/chunk",
          "path-interpolator",
          "reference/ringbuffer",


### PR DESCRIPTION
## Summary

- Added `mdoc:silent` to shared setup blocks (domain types, `api` construction, serialization) so later blocks can reference their definitions
- Added `mdoc:compile-only` to all self-contained runnable examples, making each block fully isolated with its own imports and type definitions
- Fixed numerous API mismatches discovered during compilation: `Doc("string")` → `md"..."` interpolator, `` Reference(`$ref` = "...") `` constructor, `APIKeyLocation.Header` enum, `OAuthFlow` optional URL fields, plain `ChunkMap` fields (not `Option[ChunkMap]`)
- Added `Json.jsonCodec.encodeToString(json, WriterConfig.withIndentionStep2)` for pretty-printed JSON output in the rendered docs
- Left plain ` ```scala ` only for the root `OpenAPI` type definition (structural illustration), sbt config blocks, and one pseudo-code block

## Test plan

- [x] `sbt "docs/mdoc --in docs/reference/openapi.md"` passes with 0 errors
- [x] All runnable code blocks are compile-checked by mdoc on every CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)