### PR TITLE
Scope Reflect.Deferred.transform cache to prevent ReflectTransformer retention across derivations

### DIFF
--- a/schema/jvm/src/test/scala/zio/blocks/schema/derive/DerivationCacheLeakSpec.scala
+++ b/schema/jvm/src/test/scala/zio/blocks/schema/derive/DerivationCacheLeakSpec.scala
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.derive
+
+import zio.blocks.schema._
+import zio.blocks.schema.binding._
+import zio.blocks.typeid.TypeId
+import zio.test._
+
+import java.lang.ref.WeakReference
+
+/**
+ * Regression test: a `DerivationBuilder.derive` call must not leave its
+ * anonymous `ReflectTransformer` (with the captured override maps) pinned in
+ * any per-`Reflect.Deferred` `ThreadLocal` cache after the call returns.
+ *
+ * Before the cache was scoped via `Reflect.withTransformCache`, every
+ * derivation against a recursive schema permanently retained the transformer on
+ * each `Deferred` of the schema's `Reflect` tree, accumulating across the
+ * lifetime of long-lived worker threads (e.g. ZIO's `ZScheduler`).
+ */
+object DerivationCacheLeakSpec extends SchemaBaseSpec {
+
+  case class Simple(name: String, value: Int)
+  object Simple {
+    implicit val schema: Schema[Simple] = Schema.derived
+  }
+
+  case class Tree(left: Option[Tree], right: Option[Tree])
+  object Tree {
+    implicit val schema: Schema[Tree] = Schema.derived
+  }
+
+  // A throwaway type class with no captured state of its own — the deriver under test only
+  // needs to walk every `Reflect.Deferred` once.
+  trait Marker[A] {
+    def name: String
+  }
+
+  private def freshDeriver(): Deriver[Marker] =
+    new Deriver[Marker] {
+
+      private def named[A](n: String): Lazy[Marker[A]] =
+        Lazy(new Marker[A] { val name: String = n })
+
+      override def derivePrimitive[A](
+        primitiveType: PrimitiveType[A],
+        typeId: TypeId[A],
+        binding: Binding.Primitive[A],
+        doc: zio.blocks.docs.Doc,
+        modifiers: Seq[Modifier.Reflect],
+        defaultValue: Option[A],
+        examples: Seq[A]
+      ): Lazy[Marker[A]] = named(s"primitive:${typeId.name}")
+
+      override def deriveRecord[F[_, _], A](
+        fields: IndexedSeq[Term[F, A, ?]],
+        typeId: TypeId[A],
+        binding: Binding.Record[A],
+        doc: zio.blocks.docs.Doc,
+        modifiers: Seq[Modifier.Reflect],
+        defaultValue: Option[A],
+        examples: Seq[A]
+      )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[Marker[A]] = named(s"record:${typeId.name}")
+
+      override def deriveVariant[F[_, _], A](
+        cases: IndexedSeq[Term[F, A, ?]],
+        typeId: TypeId[A],
+        binding: Binding.Variant[A],
+        doc: zio.blocks.docs.Doc,
+        modifiers: Seq[Modifier.Reflect],
+        defaultValue: Option[A],
+        examples: Seq[A]
+      )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[Marker[A]] = named(s"variant:${typeId.name}")
+
+      override def deriveSequence[F[_, _], C[_], A](
+        element: Reflect[F, A],
+        typeId: TypeId[C[A]],
+        binding: Binding.Seq[C, A],
+        doc: zio.blocks.docs.Doc,
+        modifiers: Seq[Modifier.Reflect],
+        defaultValue: Option[C[A]],
+        examples: Seq[C[A]]
+      )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[Marker[C[A]]] = named(s"seq:${typeId.name}")
+
+      override def deriveMap[F[_, _], M[_, _], K, V](
+        key: Reflect[F, K],
+        value: Reflect[F, V],
+        typeId: TypeId[M[K, V]],
+        binding: Binding.Map[M, K, V],
+        doc: zio.blocks.docs.Doc,
+        modifiers: Seq[Modifier.Reflect],
+        defaultValue: Option[M[K, V]],
+        examples: Seq[M[K, V]]
+      )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[Marker[M[K, V]]] = named(s"map:${typeId.name}")
+
+      override def deriveDynamic[F[_, _]](
+        binding: Binding.Dynamic,
+        doc: zio.blocks.docs.Doc,
+        modifiers: Seq[Modifier.Reflect],
+        defaultValue: Option[DynamicValue],
+        examples: Seq[DynamicValue]
+      )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[Marker[DynamicValue]] = named("dynamic")
+
+      override def deriveWrapper[F[_, _], A, B](
+        wrapped: Reflect[F, B],
+        typeId: TypeId[A],
+        binding: Binding.Wrapper[A, B],
+        doc: zio.blocks.docs.Doc,
+        modifiers: Seq[Modifier.Reflect],
+        defaultValue: Option[A],
+        examples: Seq[A]
+      )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[Marker[A]] = named(s"wrapper:${typeId.name}")
+    }
+
+  private def gcUntilCleared(ref: WeakReference[?], maxRounds: Int = 50): Boolean = {
+    var rounds = 0
+    while (ref.get != null && rounds < maxRounds) {
+      System.gc()
+      System.runFinalization()
+      Thread.sleep(20)
+      rounds += 1
+    }
+    ref.get == null
+  }
+
+  // Run derivation in its own frame so that the only references that survive are the
+  // returned `Marker` and the `WeakReference` to the builder.
+  private def deriveAndWeakRef[A](
+    schema: Schema[A]
+  ): (Marker[A], WeakReference[DerivationBuilder[Marker, A]]) = {
+    val builder = schema.deriving[Marker](freshDeriver())
+    val marker  = builder.derive
+    (marker, new WeakReference[DerivationBuilder[Marker, A]](builder))
+  }
+
+  def spec: Spec[TestEnvironment, Any] = suite("DerivationCacheLeakSpec")(
+    test("transformCache is empty after derive on a simple schema") {
+      val (marker, _) = deriveAndWeakRef(Simple.schema)
+      assertTrue(marker.name == "record:Simple") &&
+      assertTrue(Reflect.transformCache.get.isEmpty)
+    },
+    test("transformCache is empty after derive on a recursive schema") {
+      val (marker, _) = deriveAndWeakRef(Tree.schema)
+      assertTrue(marker.name == "record:Tree") &&
+      assertTrue(Reflect.transformCache.get.isEmpty)
+    },
+    test("DerivationBuilder.derive does not pin its ReflectTransformer after returning (simple)") {
+      val (marker, ref) = deriveAndWeakRef(Simple.schema)
+      assertTrue(marker.name == "record:Simple") &&
+      assertTrue(gcUntilCleared(ref))
+    },
+    test("DerivationBuilder.derive does not pin its ReflectTransformer after returning (recursive)") {
+      val (marker, ref) = deriveAndWeakRef(Tree.schema)
+      assertTrue(marker.name == "record:Tree") &&
+      assertTrue(gcUntilCleared(ref))
+    }
+  )
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/DynamicSchema.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/DynamicSchema.scala
@@ -261,7 +261,7 @@ final case class DynamicSchema(reflect: Reflect.Unbound[_]) {
    *   }}}
    */
   def rebind[A](resolver: BindingResolver): Schema[A] = {
-    val bound = reflect.transform(DynamicOptic.root, new RebindTransformer(resolver)).force
+    val bound = Reflect.withTransformCache(reflect.transform(DynamicOptic.root, new RebindTransformer(resolver)).force)
     new Schema(bound.asInstanceOf[Reflect.Bound[A]])
   }
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -1475,8 +1475,10 @@ object Reflect {
     transformDepth.set(Integer.valueOf(depth + 1))
     try thunk
     finally {
-      transformDepth.set(Integer.valueOf(depth))
-      if (depth == 0) transformCache.get.clear()
+      if (depth == 0) {
+        transformDepth.remove()
+        transformCache.remove()
+      } else transformDepth.set(Integer.valueOf(depth))
     }
   }
 

--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -199,7 +199,8 @@ sealed trait Reflect[F[_, _], A] extends Reflectable[A] { self =>
 
   def nodeType: Reflect.Type { type NodeBinding = self.NodeBinding }
 
-  lazy val noBinding: Reflect[NoBinding, A] = transform(DynamicOptic.root, ReflectTransformer.noBinding()).force
+  lazy val noBinding: Reflect[NoBinding, A] =
+    Reflect.withTransformCache(transform(DynamicOptic.root, ReflectTransformer.noBinding()).force)
 
   def toDynamicValue(value: A)(implicit F: HasBinding[F]): DynamicValue
 
@@ -1201,7 +1202,7 @@ object Reflect {
 
     def transform[G[_, _]](path: DynamicOptic, f: ReflectTransformer[F, G]): Lazy[Reflect[G, A]] =
       Lazy {
-        val c      = cache.get
+        val c      = Reflect.transformCache.get
         val key    = new IdentityTuple(this, f)
         val cached = c.get(key)
         if (cached ne null) cached.asInstanceOf[Reflect[G, A]]
@@ -1415,11 +1416,6 @@ object Reflect {
         override def initialValue: java.util.IdentityHashMap[AnyRef, Unit] = new java.util.IdentityHashMap
       }
 
-    private[this] val cache =
-      new ThreadLocal[java.util.HashMap[IdentityTuple, AnyRef]] {
-        override def initialValue: java.util.HashMap[IdentityTuple, AnyRef] = new java.util.HashMap
-      }
-
     def nodeType = value.nodeType
 
     override def toString: String = {
@@ -1433,7 +1429,11 @@ object Reflect {
     }
   }
 
-  private class IdentityTuple(val v1: AnyRef, val v2: AnyRef) {
+  object Deferred {
+    type Bound[A] = Deferred[Binding, A]
+  }
+
+  private[schema] class IdentityTuple(val v1: AnyRef, val v2: AnyRef) {
     override def equals(obj: Any): Boolean = obj match {
       case that: IdentityTuple => (this.v1 eq that.v1) && (this.v2 eq that.v2)
       case _                   => false
@@ -1442,8 +1442,42 @@ object Reflect {
     override def hashCode(): Int = System.identityHashCode(v1) * 31 + System.identityHashCode(v2)
   }
 
-  object Deferred {
-    type Bound[A] = Deferred[Binding, A]
+  // Per-thread memoization map shared across all `Reflect.Deferred` instances during a single
+  // top-level `transform` walk. Used as a cycle-breaker so that recursive schemas terminate
+  // and so that a `Deferred` reached via multiple paths is shared in the result.
+  //
+  // Keeping it scoped (cleared by `withTransformCache` on outermost exit) prevents transformers
+  // and their captured state — e.g. the override maps held by `DerivationBuilder`'s anonymous
+  // `ReflectTransformer` — from being pinned for the lifetime of the thread.
+  private[schema] val transformCache: ThreadLocal[java.util.HashMap[IdentityTuple, AnyRef]] =
+    new ThreadLocal[java.util.HashMap[IdentityTuple, AnyRef]] {
+      override def initialValue: java.util.HashMap[IdentityTuple, AnyRef] = new java.util.HashMap
+    }
+
+  private[this] val transformDepth: ThreadLocal[Integer] =
+    new ThreadLocal[Integer] {
+      override def initialValue: Integer = Integer.valueOf(0)
+    }
+
+  /**
+   * Establishes a scope around a top-level `transform` (or chain of `transform`
+   * calls) so that the per-thread cache used to break cycles is cleared once
+   * the outermost call returns.
+   *
+   * The block must encompass the entire `Lazy.force` chain that triggers the
+   * transformation, not just the construction of the outer `Lazy`, since the
+   * transform recursion happens lazily inside the result `Deferred`s.
+   *
+   * Re-entrant: only the outermost call clears the cache.
+   */
+  private[schema] def withTransformCache[A](thunk: => A): A = {
+    val depth = transformDepth.get.intValue
+    transformDepth.set(Integer.valueOf(depth + 1))
+    try thunk
+    finally {
+      transformDepth.set(Integer.valueOf(depth))
+      if (depth == 0) transformCache.get.clear()
+    }
   }
 
   def unit[F[_, _]](implicit F: FromBinding[F]): Reflect[F, Unit] = primitive(PrimitiveType.Unit)

--- a/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/derive/DerivationBuilder.scala
@@ -121,7 +121,7 @@ final case class DerivationBuilder[TC[_], A](
   def modifier[B](typeId: TypeId[B], termName: String, modifier: Modifier.Term): DerivationBuilder[TC, A] =
     copy(modifierOverrides = modifierOverrides :+ new ModifierTermOverrideByType(typeId, termName, modifier))
 
-  lazy val derive: TC[A] = {
+  lazy val derive: TC[A] = Reflect.withTransformCache {
     val allInstanceOverrides = instanceOverrides ++ deriver.instanceOverrides
     val allModifierOverrides = modifierOverrides ++ deriver.modifierOverrides
     val instanceByOpticMap   =


### PR DESCRIPTION
### Problem

`Reflect.Deferred.transform` memoises results in a per-Deferred `ThreadLocal[HashMap[(Deferred, Transformer), Reflect[?,_]]]` that is never cleared. The map keys strongly reference the ReflectTransformer passed to transform.

This is benign for stateless singleton transformers, but for `DerivationBuilder.derive` it means every call permanently pins its anonymous `ReflectTransformer` — together with the override maps it captures (`modifierReflectByTypeMap`, `modifierTermByTypeMap`, etc.) — onto every `Reflect.Deferred` of the schema, on every worker thread that touched it.

Observed in production via heap analysis:

```
  zio.internal.ZScheduler$$anon$3
    → java.lang.ThreadLocal$ThreadLocalMap
      → ThreadLocalMap$Entry[]
        → java.util.HashMap (Reflect.Deferred.cache)
          → DerivationBuilder$$anon$4   ← retained, with full modifier maps
```

It was taking nearly 1GB of memory for my pretty heavy usage of derivation and modifiers.

### Fix
The cache is needed as a cycle-breaker for recursive schemas, but only for the duration of one top-level transform walk:
  - Move the cache from a per-Deferred `ThreadLocal` to a single companion-level `ThreadLocal` (`Reflect.transformCache`).
  - Add a re-entrant `Reflect.withTransformCache(thunk)` helper that clears the cache when the outermost call returns.
  - Wrap the two known top-level entry points (`DerivationBuilder.derive` and `Reflect#noBinding`) in `withTransformCache`. The wrapper must encompass the entire `.force` chain, not just the `transform call`, since the recursion fires inside `Lazy` lambdas during the force.

Once the outermost call returns, the transformer becomes unreachable and is collected normally.