### PR TITLE
fix(endpoint): enforce compile-time segment rules

### DIFF
--- a/endpoint/shared/src/main/scala-2/zio/blocks/endpoint/EndpointUnionErrorBuilder.scala
+++ b/endpoint/shared/src/main/scala-2/zio/blocks/endpoint/EndpointUnionErrorBuilder.scala
@@ -17,6 +17,7 @@
 package zio.blocks.endpoint
 
 object EndpointUnionErrorBuilder {
+  /** Scala 2 declaration mirror for the Scala 3 `orOutError` builder API. */
   trait ErrorBuilder[Err, E2] {
     type Out
 

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointUnionErrorBuilder.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointUnionErrorBuilder.scala
@@ -19,10 +19,22 @@ package zio.blocks.endpoint
 import zio.blocks.combinators.Unions
 
 object EndpointUnionErrorBuilder {
+
+  /**
+   * Endpoint-specific helper for `orOutError`.
+   *
+   * This is intentionally narrower than the generic `combinators` typeclasses:
+   * it handles the domain rule that the first `orOutError` replaces the initial
+   * `Unit` error channel, while subsequent calls build fallback codecs backed
+   * by Scala 3 union derivation from [[zio.blocks.combinators.Unions]].
+   */
   trait ErrorBuilder[Err, E2] {
     type Out
 
-    def add(existing: HttpCodec[CodecKind.Response, Err], next: HttpCodec[CodecKind.Response, E2]): HttpCodec[CodecKind.Response, Out]
+    def add(
+      existing: HttpCodec[CodecKind.Response, Err],
+      next: HttpCodec[CodecKind.Response, E2]
+    ): HttpCodec[CodecKind.Response, Out]
   }
 
   object ErrorBuilder {

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/Alternator.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/Alternator.scala
@@ -18,6 +18,15 @@ package zio.blocks.endpoint
 
 import zio.blocks.combinators.Eithers
 
+/**
+ * Endpoint-local adapter for fallback output shapes.
+ *
+ * The endpoint AST stores one abstraction that can be backed by either
+ * [[zio.blocks.combinators.Eithers]] on all Scala versions or
+ * `zio.blocks.combinators.Unions` on Scala 3. This keeps `HttpCodec.Fallback`
+ * and auth/error composition platform-agnostic while still delegating all
+ * combine / separate logic to the `combinators` block library.
+ */
 trait Alternator[L, R] {
   type Out
 
@@ -29,6 +38,10 @@ trait Alternator[L, R] {
 object Alternator extends AlternatorPlatformSpecific {
   type WithOut[L, R, O] = Alternator[L, R] { type Out = O }
 
+  /**
+   * Adapts an [[zio.blocks.combinators.Eithers]] instance into endpoint
+   * fallback shape.
+   */
   def fromEithers[L, R, O](eithers: Eithers.Eithers.WithOut[L, R, O]): WithOut[L, R, O] =
     new Alternator[L, R] {
       type Out = O
@@ -38,6 +51,10 @@ object Alternator extends AlternatorPlatformSpecific {
       def separate(out: O): Either[L, R] = eithers.separate(out)
     }
 
+  /**
+   * Reuses the canonical [[zio.blocks.combinators.Eithers]] derivation for
+   * endpoint fallbacks.
+   */
   implicit def fromEithersImplicit[L, R, O](implicit eithers: Eithers.Eithers.WithOut[L, R, O]): WithOut[L, R, O] =
     fromEithers(eithers)
 }

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/HttpCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/HttpCodec.scala
@@ -18,6 +18,8 @@ package zio.blocks.endpoint
 
 import scala.annotation.unchecked.uncheckedVariance
 
+import java.util.Locale
+
 import zio.blocks.chunk.Chunk
 import zio.blocks.combinators.{Eithers, Tuples}
 import zio.blocks.docs.Doc
@@ -66,6 +68,9 @@ sealed trait HttpCodec[+K <: CodecKind, A] { self =>
 
 object HttpCodec {
 
+  private def canonicalHeaderName(name: String): String =
+    name.toLowerCase(Locale.ROOT)
+
   private def validationFailure(message: String): Nothing =
     throw SchemaError.validationFailed(message)
 
@@ -83,8 +88,10 @@ object HttpCodec {
       value =>
         headers.Authorization.parse(value) match {
           case Right(auth) if extract.isDefinedAt(auth) => extract(auth)
-          case Right(other) =>
-            validationFailure(s"Expected $expectedScheme authorization header but found ${other.getClass.getSimpleName}")
+          case Right(other)                             =>
+            validationFailure(
+              s"Expected $expectedScheme authorization header but found ${other.getClass.getSimpleName}"
+            )
           case Left(error) => validationFailure(error)
         },
       value => headers.Authorization.render(value)
@@ -169,10 +176,10 @@ object HttpCodec {
     examples: Chunk[(String, A)] = Chunk.empty,
     deprecated: Option[Doc] = None
   ): HttpCodec.Header[CodecKind.Request, A] =
-    Header[CodecKind.Request, A](name, schema, default, doc, examples, deprecated)
+    Header[CodecKind.Request, A](canonicalHeaderName(name), schema, default, doc, examples, deprecated)
 
   def requestHeader[A <: zio.http.Header](headerType: HttpHeader.Typed[A]): HttpCodec.Header[CodecKind.Request, A] =
-    Header[CodecKind.Request, A](headerType.name, headerSchema(headerType))
+    Header[CodecKind.Request, A](canonicalHeaderName(headerType.name), headerSchema(headerType))
 
   def responseHeader[A](
     name: String,
@@ -182,10 +189,10 @@ object HttpCodec {
     examples: Chunk[(String, A)] = Chunk.empty,
     deprecated: Option[Doc] = None
   ): HttpCodec.Header[CodecKind.Response, A] =
-    Header[CodecKind.Response, A](name, schema, default, doc, examples, deprecated)
+    Header[CodecKind.Response, A](canonicalHeaderName(name), schema, default, doc, examples, deprecated)
 
   def responseHeader[A <: zio.http.Header](headerType: HttpHeader.Typed[A]): HttpCodec.Header[CodecKind.Response, A] =
-    Header[CodecKind.Response, A](headerType.name, headerSchema(headerType))
+    Header[CodecKind.Response, A](canonicalHeaderName(headerType.name), headerSchema(headerType))
 
   def requestBody[A](
     schema: Schema[A],
@@ -215,26 +222,34 @@ object HttpCodec {
   ): HttpCodec[CodecKind.Response, Unit] =
     StatusCodec(Some(status), doc, examples, deprecated)
 
-  val authorization: HttpCodec[CodecKind.Request, headers.Authorization]          = requestHeader(headers.Authorization)
+  val authorization: HttpCodec[CodecKind.Request, headers.Authorization]   = requestHeader(headers.Authorization)
   val basicAuth: HttpCodec[CodecKind.Request, headers.Authorization.Basic] =
     requestHeader("authorization", authorizationSchema("Basic", { case basic: headers.Authorization.Basic => basic }))
   val bearerAuth: HttpCodec[CodecKind.Request, headers.Authorization.Bearer] =
-    requestHeader("authorization", authorizationSchema("Bearer", { case bearer: headers.Authorization.Bearer => bearer }))
+    requestHeader(
+      "authorization",
+      authorizationSchema("Bearer", { case bearer: headers.Authorization.Bearer => bearer })
+    )
   val digestAuth: HttpCodec[CodecKind.Request, headers.Authorization.Digest] =
-    requestHeader("authorization", authorizationSchema("Digest", { case digest: headers.Authorization.Digest => digest }))
-  val proxyAuthorization: HttpCodec[CodecKind.Request, headers.ProxyAuthorization] = requestHeader(headers.ProxyAuthorization)
+    requestHeader(
+      "authorization",
+      authorizationSchema("Digest", { case digest: headers.Authorization.Digest => digest })
+    )
+  val proxyAuthorization: HttpCodec[CodecKind.Request, headers.ProxyAuthorization] = requestHeader(
+    headers.ProxyAuthorization
+  )
 
-  val Continue: HttpCodec[CodecKind.Response, Unit]                      = status(Status.Continue)
-  val SwitchingProtocols: HttpCodec[CodecKind.Response, Unit]            = status(Status.SwitchingProtocols)
-  val Processing: HttpCodec[CodecKind.Response, Unit]                    = status(Status.Processing)
-  val Ok: HttpCodec[CodecKind.Response, Unit]                            = status(Status.Ok)
-  val Created: HttpCodec[CodecKind.Response, Unit]                       = status(Status.Created)
-  val Accepted: HttpCodec[CodecKind.Response, Unit]                      = status(Status.Accepted)
-  val NoContent: HttpCodec[CodecKind.Response, Unit]                     = status(Status.NoContent)
-  val BadRequest: HttpCodec[CodecKind.Response, Unit]                    = status(Status.BadRequest)
-  val Unauthorized: HttpCodec[CodecKind.Response, Unit]                  = status(Status.Unauthorized)
-  val Forbidden: HttpCodec[CodecKind.Response, Unit]                     = status(Status.Forbidden)
-  val NotFound: HttpCodec[CodecKind.Response, Unit]                      = status(Status.NotFound)
-  val InternalServerError: HttpCodec[CodecKind.Response, Unit]           = status(Status.InternalServerError)
+  val Continue: HttpCodec[CodecKind.Response, Unit]                = status(Status.Continue)
+  val SwitchingProtocols: HttpCodec[CodecKind.Response, Unit]      = status(Status.SwitchingProtocols)
+  val Processing: HttpCodec[CodecKind.Response, Unit]              = status(Status.Processing)
+  val Ok: HttpCodec[CodecKind.Response, Unit]                      = status(Status.Ok)
+  val Created: HttpCodec[CodecKind.Response, Unit]                 = status(Status.Created)
+  val Accepted: HttpCodec[CodecKind.Response, Unit]                = status(Status.Accepted)
+  val NoContent: HttpCodec[CodecKind.Response, Unit]               = status(Status.NoContent)
+  val BadRequest: HttpCodec[CodecKind.Response, Unit]              = status(Status.BadRequest)
+  val Unauthorized: HttpCodec[CodecKind.Response, Unit]            = status(Status.Unauthorized)
+  val Forbidden: HttpCodec[CodecKind.Response, Unit]               = status(Status.Forbidden)
+  val NotFound: HttpCodec[CodecKind.Response, Unit]                = status(Status.NotFound)
+  val InternalServerError: HttpCodec[CodecKind.Response, Unit]     = status(Status.InternalServerError)
   def CustomStatus(code: Int): HttpCodec[CodecKind.Response, Unit] = status(Status.fromInt(code))
 }

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/HttpCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/HttpCodec.scala
@@ -18,8 +18,6 @@ package zio.blocks.endpoint
 
 import scala.annotation.unchecked.uncheckedVariance
 
-import java.util.Locale
-
 import zio.blocks.chunk.Chunk
 import zio.blocks.combinators.{Eithers, Tuples}
 import zio.blocks.docs.Doc
@@ -67,9 +65,6 @@ sealed trait HttpCodec[+K <: CodecKind, A] { self =>
 }
 
 object HttpCodec {
-
-  private def canonicalHeaderName(name: String): String =
-    name.toLowerCase(Locale.ROOT)
 
   private def validationFailure(message: String): Nothing =
     throw SchemaError.validationFailed(message)
@@ -176,10 +171,10 @@ object HttpCodec {
     examples: Chunk[(String, A)] = Chunk.empty,
     deprecated: Option[Doc] = None
   ): HttpCodec.Header[CodecKind.Request, A] =
-    Header[CodecKind.Request, A](canonicalHeaderName(name), schema, default, doc, examples, deprecated)
+    Header[CodecKind.Request, A](name, schema, default, doc, examples, deprecated)
 
   def requestHeader[A <: zio.http.Header](headerType: HttpHeader.Typed[A]): HttpCodec.Header[CodecKind.Request, A] =
-    Header[CodecKind.Request, A](canonicalHeaderName(headerType.name), headerSchema(headerType))
+    Header[CodecKind.Request, A](headerType.name, headerSchema(headerType))
 
   def responseHeader[A](
     name: String,
@@ -189,10 +184,10 @@ object HttpCodec {
     examples: Chunk[(String, A)] = Chunk.empty,
     deprecated: Option[Doc] = None
   ): HttpCodec.Header[CodecKind.Response, A] =
-    Header[CodecKind.Response, A](canonicalHeaderName(name), schema, default, doc, examples, deprecated)
+    Header[CodecKind.Response, A](name, schema, default, doc, examples, deprecated)
 
   def responseHeader[A <: zio.http.Header](headerType: HttpHeader.Typed[A]): HttpCodec.Header[CodecKind.Response, A] =
-    Header[CodecKind.Response, A](canonicalHeaderName(headerType.name), headerSchema(headerType))
+    Header[CodecKind.Response, A](headerType.name, headerSchema(headerType))
 
   def requestBody[A](
     schema: Schema[A],

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/PathCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/PathCodec.scala
@@ -84,7 +84,10 @@ object PathCodec {
   def apply(value: String): PathCodec[Unit] = {
     val path = Path(value)
     if (path.segments.isEmpty) empty
-    else path.segments.foldLeft(empty: PathCodec[Unit])((acc, segment) => acc / literal(segment))
+    else
+      path.segments.foldLeft(empty: PathCodec[Unit])((acc, segment) =>
+        acc / Segment(SegmentCodec.literalValidated(segment))
+      )
   }
 
   def apply[A](segment: SegmentCodec[A]): PathCodec[A] =
@@ -108,13 +111,13 @@ object PathCodec {
 
   val empty: PathCodec[Unit] = Segment(SegmentCodec.Empty)
 
-  def literal(value: String): PathCodec[Unit]       = Segment(SegmentCodec.literal(value))
-  def bool(name: String): PathCodec[Boolean]        = Segment(SegmentCodec.bool(name))
-  def int(name: String): PathCodec[Int]             = Segment(SegmentCodec.int(name))
-  def long(name: String): PathCodec[Long]           = Segment(SegmentCodec.long(name))
-  def string(name: String): PathCodec[String]       = Segment(SegmentCodec.string(name))
-  def uuid(name: String): PathCodec[java.util.UUID] = Segment(SegmentCodec.uuid(name))
-  val trailing: PathCodec[Path]                     = Segment(SegmentCodec.Trailing)
+  inline def literal(inline value: String): PathCodec[Unit] = Segment(SegmentCodec.literal(value))
+  def bool(name: String): PathCodec[Boolean]                = Segment(SegmentCodec.bool(name))
+  def int(name: String): PathCodec[Int]                     = Segment(SegmentCodec.int(name))
+  def long(name: String): PathCodec[Long]                   = Segment(SegmentCodec.long(name))
+  def string(name: String): PathCodec[String]               = Segment(SegmentCodec.string(name))
+  def uuid(name: String): PathCodec[java.util.UUID]         = Segment(SegmentCodec.uuid(name))
+  val trailing: PathCodec[Path]                             = Segment(SegmentCodec.Trailing)
 
   def render(codec: PathCodec[_], prefix: String = "{", suffix: String = "}"): String = {
     def loop(current: PathCodec[_]): String =

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/PathCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/PathCodec.scala
@@ -23,14 +23,17 @@ import zio.blocks.combinators.Tuples
 import zio.http.Path
 
 /**
- * Composable path descriptor. Segments are combined with `/` or `++`, literal alternatives with `orElse`.
- * Use [[PathCodec.decode decode]] / [[PathCodec.format format]] for bidirectional path conversion,
- * and [[PathCodec.alternatives alternatives]] to expand `orElse` branches for routing-trie insertion.
+ * Composable path descriptor. Segments are combined with `/` or `++`, literal
+ * alternatives with `orElse`. Use [[PathCodec.decode decode]] /
+ * [[PathCodec.format format]] for bidirectional path conversion, and
+ * [[PathCodec.alternatives alternatives]] to expand `orElse` branches for
+ * routing-trie insertion.
  */
 sealed trait PathCodec[A]
 
 object PathCodec {
 
+  private type DecodeError = String
   private type AnyCombiner = Tuples.Tuples.WithOut[Any, Any, Any]
 
   given unitUnit: Tuples.Tuples.WithOut[Unit, Unit, Unit] = Tuples.Tuples.leftUnit[Unit]
@@ -67,6 +70,15 @@ object PathCodec {
       decode(path).isRight
 
     def render: String = PathCodec.render(codec = self)
+
+    inline def transform[B](decode: A => B, encode: B => A): PathCodec[B] =
+      transformOrFail[B](value => Right(decode(value)), value => Right(encode(value)))
+
+    inline def transformOrFail[B](
+      decode: A => Either[DecodeError, B],
+      encode: B => Either[DecodeError, A]
+    ): PathCodec[B] =
+      Transform(self, decode, encode)
   }
 
   def apply(value: String): PathCodec[Unit] = {
@@ -87,6 +99,11 @@ object PathCodec {
     right: PathCodec[B],
     combiner: Tuples.Tuples.WithOut[A, B, C]
   ) extends PathCodec[C]
+  final case class Transform[A, B](
+    codec: PathCodec[A],
+    decode: A => Either[DecodeError, B],
+    encode: B => Either[DecodeError, A]
+  ) extends PathCodec[B]
   final case class Fallback(left: PathCodec[Unit], right: PathCodec[Unit]) extends PathCodec[Unit]
 
   val empty: PathCodec[Unit] = Segment(SegmentCodec.Empty)
@@ -104,6 +121,7 @@ object PathCodec {
       current match {
         case Segment(segment)       => segment.render(prefix, suffix)
         case Concat(left, right, _) => loop(left) + loop(right)
+        case Transform(inner, _, _) => loop(inner)
         case Fallback(left, right)  => loop(left) + " | " + loop(right)
       }
     val rendered = loop(codec)
@@ -137,6 +155,14 @@ object PathCodec {
           r.asInstanceOf[PathCodec[Any]],
           combiner.asInstanceOf[AnyCombiner]
         )
+      case Transform(codec, decode, encode) =>
+        expand(codec).map(inner =>
+          Transform(
+            inner.asInstanceOf[PathCodec[Any]],
+            decode.asInstanceOf[Any => Either[DecodeError, Any]],
+            encode.asInstanceOf[Any => Either[DecodeError, Any]]
+          )
+        )
       case Segment(SegmentCodec.Empty) => Nil
       case other                       => List(other)
     }
@@ -150,6 +176,12 @@ object PathCodec {
             val typed = combiner.asInstanceOf[AnyCombiner]
             (typed.combine(leftValue, rightValue), end)
           }
+        }
+      case transformed: Transform[?, ?] =>
+        val codec  = transformed.codec.asInstanceOf[PathCodec[Any]]
+        val decode = transformed.decode.asInstanceOf[Any => Either[DecodeError, Any]]
+        decodeCodec(codec, segments, index).flatMap { case (value, end) =>
+          decode(value).toOption.map(_ -> end)
         }
       case Fallback(left, right) => decodeCodec(left, segments, index) ++ decodeCodec(right, segments, index)
     }
@@ -186,6 +218,14 @@ object PathCodec {
           if (index >= segments.length) Path.root
           else Path(segments.drop(index), hasLeadingSlash = true, trailingSlash = false)
         List((path, segments.length))
+      case transformed: SegmentCodec.Transform[?, ?] =>
+        if (index >= segments.length) Nil
+        else {
+          val segment = segments(index)
+          SegmentCodec.decodeCombined(transformed, segment, 0).collect {
+            case (value, end) if end == segment.length => (value, index + 1)
+          }
+        }
       case combined: SegmentCodec.Combined[?, ?, ?] =>
         if (index >= segments.length) Nil
         else {
@@ -206,6 +246,10 @@ object PathCodec {
           leftPath  <- formatCodec(left, leftValue)
           rightPath <- formatCodec(right, rightValue)
         } yield leftPath ++ rightPath.dropLeadingSlash
+      case transformed: Transform[?, ?] =>
+        val codec  = transformed.codec.asInstanceOf[PathCodec[Any]]
+        val encode = transformed.encode.asInstanceOf[Any => Either[DecodeError, Any]]
+        encode(value).flatMap(inner => formatCodec(codec, inner))
       case Fallback(left, _) => formatCodec(left, value)
     }
 }

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/RoutePattern.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/RoutePattern.scala
@@ -21,9 +21,11 @@ import zio.blocks.combinators.Tuples
 import zio.http.{Method, Path}
 
 /**
- * HTTP method paired with a typed path pattern. The primary constructor is `Method.GET / "users" / PathCodec.int("id")`.
- * Use [[RoutePattern.alternatives alternatives]] to expand `orElse` branches, [[RoutePattern.any any]] for
- * catch-all trailing routes, and [[RoutePattern.nest nest]] to prepend a path prefix.
+ * HTTP method paired with a typed path pattern. The primary constructor is
+ * `Method.GET / "users" / PathCodec.int("id")`. Use
+ * [[RoutePattern.alternatives alternatives]] to expand `orElse` branches,
+ * [[RoutePattern.any any]] for catch-all trailing routes, and
+ * [[RoutePattern.nest nest]] to prepend a path prefix.
  */
 final case class RoutePattern[A](
   method: Method,
@@ -81,7 +83,7 @@ object RoutePattern {
 
   def apply(method: Method, path: Path): RoutePattern[Unit] =
     path.segments.foldLeft(fromMethod(method))((acc, segment) =>
-      acc./[Unit, Unit](PathCodec.literal(segment))(using Tuples.Tuples.leftUnit[Unit])
+      acc./[Unit, Unit](PathCodec(SegmentCodec.literalValidated(segment)))(using Tuples.Tuples.leftUnit[Unit])
     )
 
   def apply(method: Method, pathString: String): RoutePattern[Unit] =

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
@@ -31,6 +31,9 @@ import zio.http.Path
  * (captures remaining path).
  */
 sealed trait SegmentCodec[A] { self =>
+  type Prefix <: SegmentCodec.BoundaryTag
+  type Suffix <: SegmentCodec.BoundaryTag
+
   def doc: Doc
   def examples: Chunk[(String, A)]
 
@@ -42,6 +45,21 @@ sealed trait SegmentCodec[A] { self =>
 }
 
 object SegmentCodec {
+
+  private type DecodeError = String
+
+  sealed trait BoundaryTag
+  object BoundaryTag {
+    sealed trait Empty    extends BoundaryTag
+    sealed trait Literal  extends BoundaryTag
+    sealed trait Bool     extends BoundaryTag
+    sealed trait Int      extends BoundaryTag
+    sealed trait Long     extends BoundaryTag
+    sealed trait String   extends BoundaryTag
+    sealed trait UUID     extends BoundaryTag
+    sealed trait Trailing extends BoundaryTag
+    sealed trait Unknown  extends BoundaryTag
+  }
 
   enum Kind {
     case Empty
@@ -76,6 +94,15 @@ object SegmentCodec {
 
     inline def ~[C](that: String)(using combiner: Tuples.Tuples.WithOut[A, Unit, C]): SegmentCodec[C] =
       ${ SegmentCodecMacros.combineImpl[A, Unit, C]('self, '{ literal(that) }, 'combiner) }
+
+    inline def transform[B](decode: A => B, encode: B => A): SegmentCodec[B] =
+      ${ SegmentCodecMacros.transformImpl[A, B]('self, 'decode, 'encode) }
+
+    inline def transformOrFail[B](
+      decode: A => Either[DecodeError, B],
+      encode: B => Either[DecodeError, A]
+    ): SegmentCodec[B] =
+      ${ SegmentCodecMacros.transformOrFailImpl[A, B]('self, 'decode, 'encode) }
   }
 
   def literal(value: String): Literal = Literal(value)
@@ -106,6 +133,13 @@ object SegmentCodec {
         validateBoundary(trailingLeaf(left), leadingLeaf(right))
         Combined(left, right, combiner)
     }
+
+  private[endpoint] def transformValidated[A, B](
+    codec: SegmentCodec[A],
+    decode: A => Either[DecodeError, B],
+    encode: B => Either[DecodeError, A]
+  ): SegmentCodec[B] =
+    Transform(codec, decode, encode)
 
   private[endpoint] def kind(codec: SegmentCodec[_]): Kind =
     codec match {
@@ -171,41 +205,76 @@ object SegmentCodec {
   }
 
   case object Empty extends SegmentCodec[Unit] {
+    type Prefix = BoundaryTag.Empty
+    type Suffix = BoundaryTag.Empty
     val doc: Doc                        = Doc.empty
     val examples: Chunk[(String, Unit)] = Chunk.empty
   }
 
   final case class Literal(value: String, doc: Doc = Doc.empty, examples: Chunk[(String, Unit)] = Chunk.empty)
-      extends SegmentCodec[Unit]
+      extends SegmentCodec[Unit] {
+    type Prefix = BoundaryTag.Literal
+    type Suffix = BoundaryTag.Literal
+  }
 
   final case class BoolSeg(name: String, doc: Doc = Doc.empty, examples: Chunk[(String, Boolean)] = Chunk.empty)
-      extends SegmentCodec[Boolean]
+      extends SegmentCodec[Boolean] {
+    type Prefix = BoundaryTag.Bool
+    type Suffix = BoundaryTag.Bool
+  }
 
   final case class IntSeg(name: String, doc: Doc = Doc.empty, examples: Chunk[(String, Int)] = Chunk.empty)
-      extends SegmentCodec[Int]
+      extends SegmentCodec[Int] {
+    type Prefix = BoundaryTag.Int
+    type Suffix = BoundaryTag.Int
+  }
 
   final case class LongSeg(name: String, doc: Doc = Doc.empty, examples: Chunk[(String, Long)] = Chunk.empty)
-      extends SegmentCodec[Long]
+      extends SegmentCodec[Long] {
+    type Prefix = BoundaryTag.Long
+    type Suffix = BoundaryTag.Long
+  }
 
   final case class StringSeg(name: String, doc: Doc = Doc.empty, examples: Chunk[(String, String)] = Chunk.empty)
-      extends SegmentCodec[String]
+      extends SegmentCodec[String] {
+    type Prefix = BoundaryTag.String
+    type Suffix = BoundaryTag.String
+  }
 
   final case class UUIDSeg(
     name: String,
     doc: Doc = Doc.empty,
     examples: Chunk[(String, java.util.UUID)] = Chunk.empty
-  ) extends SegmentCodec[java.util.UUID]
+  ) extends SegmentCodec[java.util.UUID] {
+    type Prefix = BoundaryTag.UUID
+    type Suffix = BoundaryTag.UUID
+  }
 
   final case class Combined[A, B, C](
     left: SegmentCodec[A],
     right: SegmentCodec[B],
     combiner: Tuples.Tuples.WithOut[A, B, C]
   ) extends SegmentCodec[C] {
+    type Prefix = left.Prefix
+    type Suffix = right.Suffix
     val doc: Doc                     = left.doc ++ right.doc
     val examples: Chunk[(String, C)] = Chunk.empty
   }
 
+  final case class Transform[A, B](
+    codec: SegmentCodec[A],
+    decode: A => Either[DecodeError, B],
+    encode: B => Either[DecodeError, A]
+  ) extends SegmentCodec[B] {
+    type Prefix = codec.Prefix
+    type Suffix = codec.Suffix
+    val doc: Doc                     = codec.doc
+    val examples: Chunk[(String, B)] = Chunk.empty
+  }
+
   case object Trailing extends SegmentCodec[Path] {
+    type Prefix = BoundaryTag.Trailing
+    type Suffix = BoundaryTag.Trailing
     val doc: Doc                        = Doc.empty
     val examples: Chunk[(String, Path)] = Chunk.empty
   }
@@ -224,6 +293,8 @@ object SegmentCodec {
         case Combined(left, right, _) =>
           loop(left)
           loop(right)
+        case Transform(inner, _, _) =>
+          loop(inner)
         case Trailing => out.append("...")
       }
     loop(codec)
@@ -251,6 +322,14 @@ object SegmentCodec {
               case _: IllegalArgumentException => -1
             }
           }
+        case transformed: Transform[?, ?] =>
+          val inner  = transformed.codec.asInstanceOf[SegmentCodec[Any]]
+          val decode = transformed.decode.asInstanceOf[Any => Either[DecodeError, Any]]
+          if (index >= segments.length) -1
+          else
+            decodeCombined(inner, segments(index), 0).exists { case (value, end) =>
+              end == segments(index).length && decode(value).isRight
+            }.compare(false)
         case Trailing                    => (segments.length - index).max(0)
         case combined: Combined[?, ?, ?] =>
           if (index >= segments.length) -1
@@ -286,6 +365,12 @@ object SegmentCodec {
           try List((java.util.UUID.fromString(candidate), from + 36))
           catch { case _: IllegalArgumentException => Nil }
         }
+      case transformed: Transform[?, ?] =>
+        val inner  = transformed.codec.asInstanceOf[SegmentCodec[Any]]
+        val decode = transformed.decode.asInstanceOf[Any => Either[DecodeError, Any]]
+        decodeCombined(inner, segment, from).flatMap { case (value, end) =>
+          decode(value).toOption.map(_ -> end)
+        }
       case Trailing                    => List((Path(segment.substring(from)).addLeadingSlash, segment.length))
       case combined: Combined[?, ?, ?] =>
         decodeCombined(combined.left, segment, from).flatMap { case (leftValue, next) =>
@@ -298,13 +383,20 @@ object SegmentCodec {
 
   def formatSegment(codec: SegmentCodec[_], value: Any): String =
     codec match {
-      case Empty                       => ""
-      case Literal(value, _, _)        => value
-      case BoolSeg(_, _, _)            => value.toString
-      case IntSeg(_, _, _)             => value.toString
-      case LongSeg(_, _, _)            => value.toString
-      case StringSeg(_, _, _)          => value.asInstanceOf[String]
-      case UUIDSeg(_, _, _)            => value.toString
+      case Empty                        => ""
+      case Literal(value, _, _)         => value
+      case BoolSeg(_, _, _)             => value.toString
+      case IntSeg(_, _, _)              => value.toString
+      case LongSeg(_, _, _)             => value.toString
+      case StringSeg(_, _, _)           => value.asInstanceOf[String]
+      case UUIDSeg(_, _, _)             => value.toString
+      case transformed: Transform[?, ?] =>
+        val inner  = transformed.codec.asInstanceOf[SegmentCodec[Any]]
+        val encode = transformed.encode.asInstanceOf[Any => Either[DecodeError, Any]]
+        encode(value) match {
+          case Right(innerValue) => formatSegment(inner, innerValue)
+          case Left(message)     => throw new IllegalArgumentException(message)
+        }
       case Trailing                    => value.asInstanceOf[Path].render.stripPrefix("/")
       case combined: Combined[?, ?, ?] =>
         val typed                   = combined.combiner.asInstanceOf[Tuples.Tuples.WithOut[Any, Any, Any]]
@@ -315,6 +407,7 @@ object SegmentCodec {
   def flatten(codec: SegmentCodec[_]): Chunk[SegmentCodec[_]] =
     codec match {
       case Combined(left, right, _) => flatten(left) ++ flatten(right)
+      case Transform(inner, _, _)   => flatten(inner)
       case other                    => Chunk(other)
     }
 
@@ -362,6 +455,7 @@ object SegmentCodec {
   private def leadingLeaf(codec: SegmentCodec[_]): Option[SegmentCodec[_]] =
     codec match {
       case Combined(left, right, _) => leadingLeaf(left).orElse(leadingLeaf(right))
+      case Transform(inner, _, _)   => leadingLeaf(inner)
       case Empty                    => None
       case other                    => Some(other)
     }
@@ -369,6 +463,7 @@ object SegmentCodec {
   private def trailingLeaf(codec: SegmentCodec[_]): Option[SegmentCodec[_]] =
     codec match {
       case Combined(left, right, _) => trailingLeaf(right).orElse(trailingLeaf(left))
+      case Transform(inner, _, _)   => trailingLeaf(inner)
       case Empty                    => None
       case other                    => Some(other)
     }
@@ -409,6 +504,26 @@ object SegmentCodec {
       }
     }
 
+    def transformImpl[A: Type, B: Type](
+      codecExpr: Expr[SegmentCodec[A]],
+      decodeExpr: Expr[A => B],
+      encodeExpr: Expr[B => A]
+    )(using Quotes): Expr[SegmentCodec[B]] =
+      '{
+        SegmentCodec.transformValidated[A, B](
+          $codecExpr,
+          value => Right($decodeExpr(value)),
+          value => Right($encodeExpr(value))
+        )
+      }
+
+    def transformOrFailImpl[A: Type, B: Type](
+      codecExpr: Expr[SegmentCodec[A]],
+      decodeExpr: Expr[A => Either[DecodeError, B]],
+      encodeExpr: Expr[B => Either[DecodeError, A]]
+    )(using Quotes): Expr[SegmentCodec[B]] =
+      '{ SegmentCodec.transformValidated[A, B]($codecExpr, $decodeExpr, $encodeExpr) }
+
     private def validateBoundary(using Quotes)(left: Option[SegmentInfo], right: Option[SegmentInfo]): Unit = {
       import quotes.reflect.*
 
@@ -430,6 +545,9 @@ object SegmentCodec {
     private def boundaryInfo(using Quotes)(term: quotes.reflect.Term): Option[BoundaryInfo] = {
       import quotes.reflect.*
 
+      val underlying = term.underlyingArgument
+      if (underlying ne term) return boundaryInfo(underlying)
+
       def stringArg(args: List[Term], default: String): String =
         args.collectFirst { case quotes.reflect.Literal(StringConstant(value)) => value }.getOrElse(default)
 
@@ -449,6 +567,61 @@ object SegmentCodec {
         case _                      => None
       }
 
+      def typeInfo(tpe: TypeRepr): Option[BoundaryInfo] = {
+        val segmentCodecSym = Symbol.requiredClass("zio.blocks.endpoint.SegmentCodec")
+        val base            = tpe.widenTermRefByName.dealias.baseType(segmentCodecSym)
+
+        if base =:= TypeRepr.of[Any] then None
+        else {
+          val prefixTpe = base.memberType(segmentCodecSym.typeMember("Prefix"))
+          val suffixTpe = base.memberType(segmentCodecSym.typeMember("Suffix"))
+
+          def kindOf(boundary: TypeRepr): Option[SegmentInfoKind] =
+            if boundary <:< TypeRepr.of[BoundaryTag.Literal] then Some(SegmentInfoKind.Literal)
+            else if boundary <:< TypeRepr.of[BoundaryTag.Bool] then Some(SegmentInfoKind.Bool)
+            else if boundary <:< TypeRepr.of[BoundaryTag.Int] then Some(SegmentInfoKind.Int)
+            else if boundary <:< TypeRepr.of[BoundaryTag.Long] then Some(SegmentInfoKind.Long)
+            else if boundary <:< TypeRepr.of[BoundaryTag.String] then Some(SegmentInfoKind.String)
+            else if boundary <:< TypeRepr.of[BoundaryTag.UUID] then Some(SegmentInfoKind.UUID)
+            else None
+
+          val prefix = kindOf(prefixTpe).map(kind => SegmentInfo(kind, "transformed"))
+          val suffix = kindOf(suffixTpe).map(kind => SegmentInfo(kind, "transformed"))
+          if (prefix.isEmpty && suffix.isEmpty) None else Some(BoundaryInfo(prefix, suffix))
+        }
+      }
+
+      def appliedBoundary(fun: Term, args: List[Term]): Option[BoundaryInfo] = {
+        val fullName = fun.symbol.fullName
+        if (
+          fullName == "zio.blocks.endpoint.SegmentCodec.literal" || fullName == "zio.blocks.endpoint.SegmentCodec.string" ||
+          fullName == "zio.blocks.endpoint.SegmentCodec.int" || fullName == "zio.blocks.endpoint.SegmentCodec.long" ||
+          fullName == "zio.blocks.endpoint.SegmentCodec.bool" || fullName == "zio.blocks.endpoint.SegmentCodec.uuid"
+        )
+          applyInfo(fun.symbol.name, args)
+        else if (
+          args.nonEmpty &&
+          (fun.symbol.owner.name == "Transform" || fullName.contains("SegmentCodec.Transform"))
+        )
+          boundaryInfo(args.head)
+        else if (
+          (fun.symbol.name == "transform" || fun.symbol.name == "transformOrFail" ||
+            fun.symbol.name == "transformValidated" ||
+            fun.symbol.name == "transform$extension" || fun.symbol.name == "transformOrFail$extension") &&
+          args.nonEmpty
+        )
+          boundaryInfo(args.head)
+        else if (
+          fullName.endsWith("SegmentCodec.Literal.apply") || fullName.endsWith("SegmentCodec.StringSeg.apply") ||
+          fullName.endsWith("SegmentCodec.IntSeg.apply") || fullName.endsWith("SegmentCodec.LongSeg.apply") ||
+          fullName.endsWith("SegmentCodec.BoolSeg.apply") || fullName.endsWith("SegmentCodec.UUIDSeg.apply")
+        )
+          applyInfo(fun.symbol.owner.name, args)
+        else if (fullName.endsWith("SegmentCodec.Transform.apply"))
+          args.headOption.flatMap(boundaryInfo)
+        else None
+      }
+
       term match {
         case Inlined(_, _, inner) => boundaryInfo(inner)
         case Typed(inner, _)      => boundaryInfo(inner)
@@ -463,28 +636,37 @@ object SegmentCodec {
             leftInfo  <- boundaryInfo(left)
             rightInfo <- boundaryInfo(right)
           } yield leftInfo ++ rightInfo
+        case Apply(TypeApply(Select(_, "transformValidated"), _), codec :: _) =>
+          boundaryInfo(codec)
+        case Apply(Select(_, "transformValidated"), codec :: _) =>
+          boundaryInfo(codec)
+        case Apply(TypeApply(fun, _), args) =>
+          appliedBoundary(fun, args)
         case Apply(Select(_, "combineValidated"), List(left, right, _)) =>
           for {
             leftInfo  <- boundaryInfo(left)
             rightInfo <- boundaryInfo(right)
           } yield leftInfo ++ rightInfo
+        case Apply(Apply(TypeApply(Select(_, "transform"), _), List(left)), _) =>
+          boundaryInfo(left)
+        case Apply(Apply(Select(_, "transform"), List(left)), _) =>
+          boundaryInfo(left)
+        case Apply(TypeApply(Select(left, "transform"), _), _) =>
+          boundaryInfo(left)
+        case Apply(Select(left, "transform"), _) =>
+          boundaryInfo(left)
+        case Apply(Apply(TypeApply(Select(_, "transformOrFail"), _), List(left)), _) =>
+          boundaryInfo(left)
+        case Apply(Apply(Select(_, "transformOrFail"), List(left)), _) =>
+          boundaryInfo(left)
+        case Apply(TypeApply(Select(left, "transformOrFail"), _), _) =>
+          boundaryInfo(left)
+        case Apply(Select(left, "transformOrFail"), _) =>
+          boundaryInfo(left)
         case Apply(fun, args) =>
-          val fullName = fun.symbol.fullName
-          if (
-            fullName == "zio.blocks.endpoint.SegmentCodec.literal" || fullName == "zio.blocks.endpoint.SegmentCodec.string" ||
-            fullName == "zio.blocks.endpoint.SegmentCodec.int" || fullName == "zio.blocks.endpoint.SegmentCodec.long" ||
-            fullName == "zio.blocks.endpoint.SegmentCodec.bool" || fullName == "zio.blocks.endpoint.SegmentCodec.uuid"
-          )
-            applyInfo(fun.symbol.name, args)
-          else if (
-            fullName.endsWith("SegmentCodec.Literal.apply") || fullName.endsWith("SegmentCodec.StringSeg.apply") ||
-            fullName.endsWith("SegmentCodec.IntSeg.apply") || fullName.endsWith("SegmentCodec.LongSeg.apply") ||
-            fullName.endsWith("SegmentCodec.BoolSeg.apply") || fullName.endsWith("SegmentCodec.UUIDSeg.apply")
-          )
-            applyInfo(fun.symbol.owner.name, args)
-          else None
+          appliedBoundary(fun, args)
         case Select(_, "Empty") => Some(BoundaryInfo(None, None))
-        case _                  => None
+        case _                  => typeInfo(term.tpe)
       }
     }
   }

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
@@ -24,9 +24,11 @@ import zio.blocks.docs.Doc
 import zio.http.Path
 
 /**
- * Typed descriptor for a single URL path segment. Subtypes include [[SegmentCodec.Literal Literal]],
- * [[SegmentCodec.IntSeg Int]], [[SegmentCodec.StringSeg String]], [[SegmentCodec.Combined Combined]] (intra-segment
- * composition via `~`), and [[SegmentCodec.Trailing Trailing]] (captures remaining path).
+ * Typed descriptor for a single URL path segment. Subtypes include
+ * [[SegmentCodec.Literal Literal]], [[SegmentCodec.IntSeg Int]],
+ * [[SegmentCodec.StringSeg String]], [[SegmentCodec.Combined Combined]]
+ * (intra-segment composition via `~`), and [[SegmentCodec.Trailing Trailing]]
+ * (captures remaining path).
  */
 sealed trait SegmentCodec[A] { self =>
   def doc: Doc
@@ -76,12 +78,12 @@ object SegmentCodec {
       ${ SegmentCodecMacros.combineImpl[A, Unit, C]('self, '{ literal(that) }, 'combiner) }
   }
 
-  def literal(value: String): Literal       = Literal(value)
-  def bool(name: String): BoolSeg           = BoolSeg(name)
-  def int(name: String): IntSeg             = IntSeg(name)
-  def long(name: String): LongSeg           = LongSeg(name)
-  def string(name: String): StringSeg       = StringSeg(name)
-  def uuid(name: String): UUIDSeg           = UUIDSeg(name)
+  def literal(value: String): Literal = Literal(value)
+  def bool(name: String): BoolSeg     = BoolSeg(name)
+  def int(name: String): IntSeg       = IntSeg(name)
+  def long(name: String): LongSeg     = LongSeg(name)
+  def string(name: String): StringSeg = StringSeg(name)
+  def uuid(name: String): UUIDSeg     = UUIDSeg(name)
 
   private[endpoint] def combineValidated[A, B, C](
     left: SegmentCodec[A],
@@ -89,8 +91,8 @@ object SegmentCodec {
     combiner: Tuples.Tuples.WithOut[A, B, C]
   ): SegmentCodec[C] =
     (left, right) match {
-      case (Empty, _)          => right.asInstanceOf[SegmentCodec[C]]
-      case (_, Empty)          => left.asInstanceOf[SegmentCodec[C]]
+      case (Empty, _)                                => right.asInstanceOf[SegmentCodec[C]]
+      case (_, Empty)                                => left.asInstanceOf[SegmentCodec[C]]
       case (Literal(lv, ld, le), Literal(rv, rd, _)) =>
         Literal(lv + rv, ld ++ rd, le).asInstanceOf[SegmentCodec[C]]
       case (Combined(l, r, existing), Literal(rv, rd, _)) if r.isInstanceOf[Literal] =>
@@ -100,16 +102,9 @@ object SegmentCodec {
             .asInstanceOf[SegmentCodec[Any]],
           existing.asInstanceOf[Tuples.Tuples.WithOut[Any, Any, Any]]
         ).asInstanceOf[SegmentCodec[C]]
-      case (_, StringSeg(name, _, _)) =>
-        rejectTrailingString(left, name)
+      case _ =>
+        validateAmbiguousChain(flatten(left) ++ flatten(right))
         Combined(left, right, combiner)
-      case (_, IntSeg(name, _, _)) =>
-        rejectTrailingNumeric(left, name)
-        Combined(left, right, combiner)
-      case (_, LongSeg(name, _, _)) =>
-        rejectTrailingNumeric(left, name)
-        Combined(left, right, combiner)
-      case _ => Combined(left, right, combiner)
     }
 
   private[endpoint] def kind(codec: SegmentCodec[_]): Kind =
@@ -339,40 +334,47 @@ object SegmentCodec {
       }
     }
 
-  private def rejectTrailingString(codec: SegmentCodec[_], newName: String): Unit =
-    trailingLeaf(codec) match {
-      case Some(StringSeg(name, _, _)) =>
-        throw new IllegalArgumentException(s"Cannot combine two string segments. Their names are $name and $newName")
+  private def validateAmbiguousChain(codecs: Chunk[SegmentCodec[_]]): Unit = {
+    var firstString: Option[String]  = None
+    var firstNumeric: Option[String] = None
+
+    codecs.foreach {
+      case StringSeg(name, _, _) =>
+        firstString match {
+          case Some(existing) =>
+            throw new IllegalArgumentException(
+              s"Cannot combine two string segments. Their names are $existing and $name"
+            )
+          case None =>
+            firstString = Some(name)
+        }
+      case IntSeg(name, _, _) =>
+        firstNumeric match {
+          case Some(existing) =>
+            throw new IllegalArgumentException(
+              s"Cannot combine two numeric segments. Their names are $existing and $name"
+            )
+          case None =>
+            firstNumeric = Some(name)
+        }
+      case LongSeg(name, _, _) =>
+        firstNumeric match {
+          case Some(existing) =>
+            throw new IllegalArgumentException(
+              s"Cannot combine two numeric segments. Their names are $existing and $name"
+            )
+          case None =>
+            firstNumeric = Some(name)
+        }
       case _ => ()
     }
-
-  private def rejectTrailingNumeric(codec: SegmentCodec[_], newName: String): Unit =
-    trailingLeaf(codec) match {
-      case Some(IntSeg(name, _, _)) =>
-        throw new IllegalArgumentException(s"Cannot combine two numeric segments. Their names are $name and $newName")
-      case Some(LongSeg(name, _, _)) =>
-        throw new IllegalArgumentException(s"Cannot combine two numeric segments. Their names are $name and $newName")
-      case _ => ()
-    }
-
-  private def trailingLeaf(codec: SegmentCodec[_]): Option[SegmentCodec[_]] =
-    codec match {
-      case Combined(_, right, _) => trailingLeaf(right)
-      case Empty                 => None
-      case other                 => Some(other)
-    }
+  }
 
   private object SegmentCodecMacros {
     private sealed trait SegmentInfoKind
     private object SegmentInfoKind {
-      case object Empty   extends SegmentInfoKind
-      case object Literal extends SegmentInfoKind
       case object String  extends SegmentInfoKind
-      case object Int     extends SegmentInfoKind
-      case object Long    extends SegmentInfoKind
-      case object Bool    extends SegmentInfoKind
-      case object UUID    extends SegmentInfoKind
-      case object Unknown extends SegmentInfoKind
+      case object Numeric extends SegmentInfoKind
     }
 
     private final case class SegmentInfo(kind: SegmentInfoKind, name: String)
@@ -384,78 +386,92 @@ object SegmentCodec {
     )(using Quotes): Expr[SegmentCodec[C]] = {
       import quotes.reflect.*
 
-      val leftInfo  = segmentInfo(leftExpr.asTerm)
-      val rightInfo = segmentInfo(rightExpr.asTerm)
+      val leftInfos  = segmentInfos(leftExpr.asTerm)
+      val rightInfos = segmentInfos(rightExpr.asTerm)
 
-      (leftInfo, rightInfo) match {
-        case (Some(SegmentInfo(SegmentInfoKind.String, leftName)), Some(SegmentInfo(SegmentInfoKind.String, rightName))) =>
-          report.errorAndAbort(s"Cannot combine two string segments. Their names are $leftName and $rightName")
-        case (Some(SegmentInfo(SegmentInfoKind.Int | SegmentInfoKind.Long, leftName)),
-              Some(SegmentInfo(SegmentInfoKind.Int | SegmentInfoKind.Long, rightName))) =>
-          report.errorAndAbort(s"Cannot combine two numeric segments. Their names are $leftName and $rightName")
+      (leftInfos, rightInfos) match {
+        case (Some(left), Some(right)) =>
+          validateInfos(left ++ right)
+          '{ SegmentCodec.combineValidated($leftExpr, $rightExpr, $combinerExpr) }
         case _ =>
           '{ SegmentCodec.combineValidated($leftExpr, $rightExpr, $combinerExpr) }
       }
     }
 
-    private def segmentInfo(using Quotes)(term: quotes.reflect.Term): Option[SegmentInfo] = {
+    private def validateInfos(using Quotes)(infos: List[SegmentInfo]): Unit = {
+      import quotes.reflect.*
+
+      var firstString: Option[String]  = None
+      var firstNumeric: Option[String] = None
+
+      infos.foreach {
+        case SegmentInfo(SegmentInfoKind.String, name) =>
+          firstString match {
+            case Some(existing) =>
+              report.errorAndAbort(s"Cannot combine two string segments. Their names are $existing and $name")
+            case None =>
+              firstString = Some(name)
+          }
+        case SegmentInfo(SegmentInfoKind.Numeric, name) =>
+          firstNumeric match {
+            case Some(existing) =>
+              report.errorAndAbort(s"Cannot combine two numeric segments. Their names are $existing and $name")
+            case None =>
+              firstNumeric = Some(name)
+          }
+      }
+    }
+
+    private def segmentInfos(using Quotes)(term: quotes.reflect.Term): Option[List[SegmentInfo]] = {
       import quotes.reflect.*
 
       def stringArg(args: List[Term], default: String): String =
         args.collectFirst { case quotes.reflect.Literal(StringConstant(value)) => value }.getOrElse(default)
 
-      def applyInfo(name: String, args: List[Term]): Option[SegmentInfo] = name match {
-        case "literal" | "Literal" => Some(SegmentInfo(SegmentInfoKind.Literal, stringArg(args, "literal")))
-        case "string" | "StringSeg" => Some(SegmentInfo(SegmentInfoKind.String, stringArg(args, "string")))
-        case "int" | "IntSeg"       => Some(SegmentInfo(SegmentInfoKind.Int, stringArg(args, "int")))
-        case "long" | "LongSeg"     => Some(SegmentInfo(SegmentInfoKind.Long, stringArg(args, "long")))
-        case "bool" | "BoolSeg"     => Some(SegmentInfo(SegmentInfoKind.Bool, stringArg(args, "bool")))
-        case "uuid" | "UUIDSeg"     => Some(SegmentInfo(SegmentInfoKind.UUID, stringArg(args, "uuid")))
-        case "Empty"                 => Some(SegmentInfo(SegmentInfoKind.Empty, "empty"))
-        case _                       => None
+      def applyInfos(name: String, args: List[Term]): Option[List[SegmentInfo]] = name match {
+        case "string" | "StringSeg"                                                    => Some(List(SegmentInfo(SegmentInfoKind.String, stringArg(args, "string"))))
+        case "int" | "IntSeg"                                                          => Some(List(SegmentInfo(SegmentInfoKind.Numeric, stringArg(args, "int"))))
+        case "long" | "LongSeg"                                                        => Some(List(SegmentInfo(SegmentInfoKind.Numeric, stringArg(args, "long"))))
+        case "literal" | "Literal" | "bool" | "BoolSeg" | "uuid" | "UUIDSeg" | "Empty" => Some(Nil)
+        case _                                                                         => None
       }
 
-      def combineInfo(left: SegmentInfo, right: SegmentInfo): SegmentInfo =
-        (left.kind, right.kind) match {
-          case (SegmentInfoKind.Empty, _)    => right
-          case (_, SegmentInfoKind.Empty)    => left
-          case (_, SegmentInfoKind.Literal)  => right
-          case (_, SegmentInfoKind.Unknown)  => right
-          case _                             => right
-        }
-
       term match {
-        case Inlined(_, _, inner) => segmentInfo(inner)
-        case Typed(inner, _)      => segmentInfo(inner)
-        case Block(_, expr)       => segmentInfo(expr)
+        case Inlined(_, _, inner) => segmentInfos(inner)
+        case Typed(inner, _)      => segmentInfos(inner)
+        case Block(_, expr)       => segmentInfos(expr)
         case Ident(_)             =>
           term.symbol.tree match {
-            case valDef: ValDef => valDef.rhs.flatMap(segmentInfo)
+            case valDef: ValDef => valDef.rhs.flatMap(segmentInfos)
             case _              => None
           }
         case Apply(TypeApply(Select(_, "combineValidated"), _), List(left, right, _)) =>
           for {
-            leftInfo  <- segmentInfo(left)
-            rightInfo <- segmentInfo(right)
-          } yield combineInfo(leftInfo, rightInfo)
+            leftInfos  <- segmentInfos(left)
+            rightInfos <- segmentInfos(right)
+          } yield leftInfos ++ rightInfos
         case Apply(Select(_, "combineValidated"), List(left, right, _)) =>
           for {
-            leftInfo  <- segmentInfo(left)
-            rightInfo <- segmentInfo(right)
-          } yield combineInfo(leftInfo, rightInfo)
+            leftInfos  <- segmentInfos(left)
+            rightInfos <- segmentInfos(right)
+          } yield leftInfos ++ rightInfos
         case Apply(fun, args) =>
           val fullName = fun.symbol.fullName
-          if (fullName == "zio.blocks.endpoint.SegmentCodec.literal" || fullName == "zio.blocks.endpoint.SegmentCodec.string" ||
+          if (
+            fullName == "zio.blocks.endpoint.SegmentCodec.literal" || fullName == "zio.blocks.endpoint.SegmentCodec.string" ||
             fullName == "zio.blocks.endpoint.SegmentCodec.int" || fullName == "zio.blocks.endpoint.SegmentCodec.long" ||
-            fullName == "zio.blocks.endpoint.SegmentCodec.bool" || fullName == "zio.blocks.endpoint.SegmentCodec.uuid")
-            applyInfo(fun.symbol.name, args)
-          else if (fullName.endsWith("SegmentCodec.Literal.apply") || fullName.endsWith("SegmentCodec.StringSeg.apply") ||
+            fullName == "zio.blocks.endpoint.SegmentCodec.bool" || fullName == "zio.blocks.endpoint.SegmentCodec.uuid"
+          )
+            applyInfos(fun.symbol.name, args)
+          else if (
+            fullName.endsWith("SegmentCodec.Literal.apply") || fullName.endsWith("SegmentCodec.StringSeg.apply") ||
             fullName.endsWith("SegmentCodec.IntSeg.apply") || fullName.endsWith("SegmentCodec.LongSeg.apply") ||
-            fullName.endsWith("SegmentCodec.BoolSeg.apply") || fullName.endsWith("SegmentCodec.UUIDSeg.apply"))
-            applyInfo(fun.symbol.owner.name, args)
+            fullName.endsWith("SegmentCodec.BoolSeg.apply") || fullName.endsWith("SegmentCodec.UUIDSeg.apply")
+          )
+            applyInfos(fun.symbol.owner.name, args)
           else None
-        case Select(_, "Empty") => Some(SegmentInfo(SegmentInfoKind.Empty, "empty"))
-        case _                   => None
+        case Select(_, "Empty") => Some(Nil)
+        case _                  => None
       }
     }
   }

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
@@ -46,7 +46,14 @@ sealed trait SegmentCodec[A] { self =>
 
 object SegmentCodec {
 
-  private type DecodeError = String
+  private type DecodeError                                   = String
+  type WithBoundaries[A, P <: BoundaryTag, S <: BoundaryTag] = SegmentCodec[A] { type Prefix = P; type Suffix = S }
+
+  sealed trait CanCombine[L <: BoundaryTag, R <: BoundaryTag]
+  object CanCombine {
+    transparent inline given [L <: BoundaryTag, R <: BoundaryTag]: CanCombine[L, R] =
+      ${ SegmentCodecMacros.canCombineImpl[L, R] }
+  }
 
   sealed trait BoundaryTag
   object BoundaryTag {
@@ -86,26 +93,31 @@ object SegmentCodec {
     case object Trailing                         extends Key
   }
 
-  extension [A](self: SegmentCodec[A]) {
-    inline def ~[B, C](that: SegmentCodec[B])(using
-      combiner: Tuples.Tuples.WithOut[A, B, C]
-    ): SegmentCodec[C] =
-      ${ SegmentCodecMacros.combineImpl[A, B, C]('self, 'that, 'combiner) }
+  extension [A, P <: BoundaryTag, S <: BoundaryTag](self: WithBoundaries[A, P, S]) {
+    inline def ~[B, P2 <: BoundaryTag, S2 <: BoundaryTag, C](that: WithBoundaries[B, P2, S2])(using
+      combiner: Tuples.Tuples.WithOut[A, B, C],
+      canCombine: CanCombine[S, P2]
+    ): WithBoundaries[C, P, S2] =
+      ${ SegmentCodecMacros.combineImpl[A, B, C, P, S, P2, S2]('self, 'that, 'combiner) }
 
-    inline def ~[C](that: String)(using combiner: Tuples.Tuples.WithOut[A, Unit, C]): SegmentCodec[C] =
-      ${ SegmentCodecMacros.combineImpl[A, Unit, C]('self, '{ literal(that) }, 'combiner) }
+    inline def ~[C](inline that: String)(using
+      combiner: Tuples.Tuples.WithOut[A, Unit, C],
+      canCombine: CanCombine[S, BoundaryTag.Literal]
+    ): WithBoundaries[C, P, BoundaryTag.Literal] =
+      ${ SegmentCodecMacros.combineLiteralImpl[A, C, P, S]('self, 'that, 'combiner) }
 
-    inline def transform[B](decode: A => B, encode: B => A): SegmentCodec[B] =
-      ${ SegmentCodecMacros.transformImpl[A, B]('self, 'decode, 'encode) }
+    inline def transform[B](decode: A => B, encode: B => A): WithBoundaries[B, P, S] =
+      ${ SegmentCodecMacros.transformImpl[A, B, P, S]('self, 'decode, 'encode) }
 
     inline def transformOrFail[B](
       decode: A => Either[DecodeError, B],
       encode: B => Either[DecodeError, A]
-    ): SegmentCodec[B] =
-      ${ SegmentCodecMacros.transformOrFailImpl[A, B]('self, 'decode, 'encode) }
+    ): WithBoundaries[B, P, S] =
+      ${ SegmentCodecMacros.transformOrFailImpl[A, B, P, S]('self, 'decode, 'encode) }
   }
 
-  def literal(value: String): Literal = Literal(value)
+  inline def literal(inline value: String): Literal =
+    ${ SegmentCodecMacros.literalImpl('value) }
   def bool(name: String): BoolSeg     = BoolSeg(name)
   def int(name: String): IntSeg       = IntSeg(name)
   def long(name: String): LongSeg     = LongSeg(name)
@@ -129,10 +141,10 @@ object SegmentCodec {
             .asInstanceOf[SegmentCodec[Any]],
           existing.asInstanceOf[Tuples.Tuples.WithOut[Any, Any, Any]]
         ).asInstanceOf[SegmentCodec[C]]
-      case _ =>
-        validateBoundary(trailingLeaf(left), leadingLeaf(right))
-        Combined(left, right, combiner)
+      case _ => Combined(left, right, combiner)
     }
+
+  private[endpoint] def literalValidated(value: String): Literal = Literal(value)
 
   private[endpoint] def transformValidated[A, B](
     codec: SegmentCodec[A],
@@ -427,56 +439,16 @@ object SegmentCodec {
       }
     }
 
-  private def validateBoundary(left: Option[SegmentCodec[_]], right: Option[SegmentCodec[_]]): Unit =
-    (left, right) match {
-      case (Some(StringSeg(leftName, _, _)), Some(StringSeg(rightName, _, _))) =>
-        throw new IllegalArgumentException(
-          s"Cannot combine two string segments. Their names are $leftName and $rightName"
-        )
-      case (Some(IntSeg(leftName, _, _)), Some(IntSeg(rightName, _, _))) =>
-        throw new IllegalArgumentException(
-          s"Cannot combine two numeric segments. Their names are $leftName and $rightName"
-        )
-      case (Some(IntSeg(leftName, _, _)), Some(LongSeg(rightName, _, _))) =>
-        throw new IllegalArgumentException(
-          s"Cannot combine two numeric segments. Their names are $leftName and $rightName"
-        )
-      case (Some(LongSeg(leftName, _, _)), Some(IntSeg(rightName, _, _))) =>
-        throw new IllegalArgumentException(
-          s"Cannot combine two numeric segments. Their names are $leftName and $rightName"
-        )
-      case (Some(LongSeg(leftName, _, _)), Some(LongSeg(rightName, _, _))) =>
-        throw new IllegalArgumentException(
-          s"Cannot combine two numeric segments. Their names are $leftName and $rightName"
-        )
-      case _ => ()
-    }
-
-  private def leadingLeaf(codec: SegmentCodec[_]): Option[SegmentCodec[_]] =
-    codec match {
-      case Combined(left, right, _) => leadingLeaf(left).orElse(leadingLeaf(right))
-      case Transform(inner, _, _)   => leadingLeaf(inner)
-      case Empty                    => None
-      case other                    => Some(other)
-    }
-
-  private def trailingLeaf(codec: SegmentCodec[_]): Option[SegmentCodec[_]] =
-    codec match {
-      case Combined(left, right, _) => trailingLeaf(right).orElse(trailingLeaf(left))
-      case Transform(inner, _, _)   => trailingLeaf(inner)
-      case Empty                    => None
-      case other                    => Some(other)
-    }
-
   private object SegmentCodecMacros {
     private sealed trait SegmentInfoKind
     private object SegmentInfoKind {
-      case object Literal extends SegmentInfoKind
-      case object Bool    extends SegmentInfoKind
-      case object Int     extends SegmentInfoKind
-      case object Long    extends SegmentInfoKind
-      case object String  extends SegmentInfoKind
-      case object UUID    extends SegmentInfoKind
+      case object Literal  extends SegmentInfoKind
+      case object Bool     extends SegmentInfoKind
+      case object Int      extends SegmentInfoKind
+      case object Long     extends SegmentInfoKind
+      case object String   extends SegmentInfoKind
+      case object UUID     extends SegmentInfoKind
+      case object Trailing extends SegmentInfoKind
     }
 
     private final case class SegmentInfo(kind: SegmentInfoKind, name: String)
@@ -485,11 +457,19 @@ object SegmentCodec {
         BoundaryInfo(prefix.orElse(that.prefix), that.suffix.orElse(suffix))
     }
 
-    def combineImpl[A: Type, B: Type, C: Type](
-      leftExpr: Expr[SegmentCodec[A]],
-      rightExpr: Expr[SegmentCodec[B]],
+    def combineImpl[
+      A: Type,
+      B: Type,
+      C: Type,
+      P <: BoundaryTag: Type,
+      S <: BoundaryTag: Type,
+      P2 <: BoundaryTag: Type,
+      S2 <: BoundaryTag: Type
+    ](
+      leftExpr: Expr[WithBoundaries[A, P, S]],
+      rightExpr: Expr[WithBoundaries[B, P2, S2]],
       combinerExpr: Expr[Tuples.Tuples.WithOut[A, B, C]]
-    )(using Quotes): Expr[SegmentCodec[C]] = {
+    )(using Quotes): Expr[WithBoundaries[C, P, S2]] = {
       import quotes.reflect.*
 
       val leftInfo  = boundaryInfo(leftExpr.asTerm)
@@ -498,36 +478,119 @@ object SegmentCodec {
       (leftInfo, rightInfo) match {
         case (Some(left), Some(right)) =>
           validateBoundary(left.suffix, right.prefix)
-          '{ SegmentCodec.combineValidated($leftExpr, $rightExpr, $combinerExpr) }
+          '{
+            SegmentCodec.combineValidated($leftExpr, $rightExpr, $combinerExpr).asInstanceOf[WithBoundaries[C, P, S2]]
+          }
         case _ =>
-          '{ SegmentCodec.combineValidated($leftExpr, $rightExpr, $combinerExpr) }
+          '{
+            SegmentCodec.combineValidated($leftExpr, $rightExpr, $combinerExpr).asInstanceOf[WithBoundaries[C, P, S2]]
+          }
       }
     }
 
-    def transformImpl[A: Type, B: Type](
-      codecExpr: Expr[SegmentCodec[A]],
-      decodeExpr: Expr[A => B],
-      encodeExpr: Expr[B => A]
-    )(using Quotes): Expr[SegmentCodec[B]] =
+    def combineLiteralImpl[A: Type, C: Type, P <: BoundaryTag: Type, S <: BoundaryTag: Type](
+      leftExpr: Expr[WithBoundaries[A, P, S]],
+      rightExpr: Expr[String],
+      combinerExpr: Expr[Tuples.Tuples.WithOut[A, Unit, C]]
+    )(using Quotes): Expr[WithBoundaries[C, P, BoundaryTag.Literal]] =
       '{
-        SegmentCodec.transformValidated[A, B](
-          $codecExpr,
-          value => Right($decodeExpr(value)),
-          value => Right($encodeExpr(value))
-        )
+        SegmentCodec
+          .combineValidated($leftExpr, SegmentCodec.literal($rightExpr), $combinerExpr)
+          .asInstanceOf[WithBoundaries[C, P, BoundaryTag.Literal]]
       }
 
-    def transformOrFailImpl[A: Type, B: Type](
-      codecExpr: Expr[SegmentCodec[A]],
+    def canCombineImpl[L <: BoundaryTag: Type, R <: BoundaryTag: Type](using Quotes): Expr[CanCombine[L, R]] = {
+      import quotes.reflect.*
+
+      val left  = TypeRepr.of[L]
+      val right = TypeRepr.of[R]
+
+      def is(boundary: TypeRepr, target: TypeRepr): Boolean = boundary <:< target
+
+      def label(boundary: TypeRepr): String =
+        if is(boundary, TypeRepr.of[BoundaryTag.Literal]) then "literal"
+        else if is(boundary, TypeRepr.of[BoundaryTag.Bool]) then "bool"
+        else if is(boundary, TypeRepr.of[BoundaryTag.Int]) then "int"
+        else if is(boundary, TypeRepr.of[BoundaryTag.Long]) then "long"
+        else if is(boundary, TypeRepr.of[BoundaryTag.String]) then "string"
+        else if is(boundary, TypeRepr.of[BoundaryTag.UUID]) then "uuid"
+        else if is(boundary, TypeRepr.of[BoundaryTag.Trailing]) then "trailing"
+        else if is(boundary, TypeRepr.of[BoundaryTag.Empty]) then "empty"
+        else boundary.show
+
+      val leftTrailing  = is(left, TypeRepr.of[BoundaryTag.Trailing])
+      val rightTrailing = is(right, TypeRepr.of[BoundaryTag.Trailing])
+      val leftString    = is(left, TypeRepr.of[BoundaryTag.String])
+      val rightString   = is(right, TypeRepr.of[BoundaryTag.String])
+      val leftNumeric   = is(left, TypeRepr.of[BoundaryTag.Int]) || is(left, TypeRepr.of[BoundaryTag.Long])
+      val rightNumeric  = is(right, TypeRepr.of[BoundaryTag.Int]) || is(right, TypeRepr.of[BoundaryTag.Long])
+      val leftKnown     =
+        is(left, TypeRepr.of[BoundaryTag.Empty]) || is(left, TypeRepr.of[BoundaryTag.Literal]) ||
+          is(left, TypeRepr.of[BoundaryTag.Bool]) || leftNumeric || leftString ||
+          is(left, TypeRepr.of[BoundaryTag.UUID]) || leftTrailing
+      val rightKnown =
+        is(right, TypeRepr.of[BoundaryTag.Empty]) || is(right, TypeRepr.of[BoundaryTag.Literal]) ||
+          is(right, TypeRepr.of[BoundaryTag.Bool]) || rightNumeric || rightString ||
+          is(right, TypeRepr.of[BoundaryTag.UUID]) || rightTrailing
+
+      if leftTrailing || rightTrailing then
+        report.errorAndAbort(s"Cannot combine trailing path segments with `~`: ${label(left)} ~ ${label(right)}")
+      else if leftString && rightString then
+        report.errorAndAbort(s"Cannot combine two string segments with `~`: ${label(left)} ~ ${label(right)}")
+      else if leftNumeric && rightNumeric then
+        report.errorAndAbort(s"Cannot combine two numeric segments with `~`: ${label(left)} ~ ${label(right)}")
+      else if !leftKnown || !rightKnown then
+        report.errorAndAbort(
+          s"Cannot prove segment combination at compile time: ${label(left)} ~ ${label(right)}"
+        )
+      else '{ new CanCombine[L, R] {} }
+    }
+
+    def literalImpl(valueExpr: Expr[String])(using Quotes): Expr[Literal] = {
+      import quotes.reflect.*
+
+      valueExpr.value match {
+        case Some(value) =>
+          validateLiteralValue(value)
+          '{ SegmentCodec.literalValidated(${ Expr(value) }) }
+        case None =>
+          report.errorAndAbort("SegmentCodec.literal requires a string literal known at compile time")
+      }
+    }
+
+    def transformImpl[A: Type, B: Type, P <: BoundaryTag: Type, S <: BoundaryTag: Type](
+      codecExpr: Expr[WithBoundaries[A, P, S]],
+      decodeExpr: Expr[A => B],
+      encodeExpr: Expr[B => A]
+    )(using Quotes): Expr[WithBoundaries[B, P, S]] =
+      '{
+        SegmentCodec
+          .transformValidated[A, B](
+            $codecExpr,
+            value => Right($decodeExpr(value)),
+            value => Right($encodeExpr(value))
+          )
+          .asInstanceOf[WithBoundaries[B, P, S]]
+      }
+
+    def transformOrFailImpl[A: Type, B: Type, P <: BoundaryTag: Type, S <: BoundaryTag: Type](
+      codecExpr: Expr[WithBoundaries[A, P, S]],
       decodeExpr: Expr[A => Either[DecodeError, B]],
       encodeExpr: Expr[B => Either[DecodeError, A]]
-    )(using Quotes): Expr[SegmentCodec[B]] =
-      '{ SegmentCodec.transformValidated[A, B]($codecExpr, $decodeExpr, $encodeExpr) }
+    )(using Quotes): Expr[WithBoundaries[B, P, S]] =
+      '{
+        SegmentCodec
+          .transformValidated[A, B]($codecExpr, $decodeExpr, $encodeExpr)
+          .asInstanceOf[WithBoundaries[B, P, S]]
+      }
 
     private def validateBoundary(using Quotes)(left: Option[SegmentInfo], right: Option[SegmentInfo]): Unit = {
       import quotes.reflect.*
 
       (left, right) match {
+        case (Some(SegmentInfo(SegmentInfoKind.Trailing, _)), _) |
+            (_, Some(SegmentInfo(SegmentInfoKind.Trailing, _))) =>
+          report.errorAndAbort("Cannot combine trailing path segments with `~`")
         case (
               Some(SegmentInfo(SegmentInfoKind.String, leftName)),
               Some(SegmentInfo(SegmentInfoKind.String, rightName))
@@ -563,6 +626,7 @@ object SegmentCodec {
         case "int" | "IntSeg"       => Some(singleInfo(SegmentInfoKind.Int, stringArg(args, "int")))
         case "long" | "LongSeg"     => Some(singleInfo(SegmentInfoKind.Long, stringArg(args, "long")))
         case "uuid" | "UUIDSeg"     => Some(singleInfo(SegmentInfoKind.UUID, stringArg(args, "uuid")))
+        case "Trailing"             => Some(singleInfo(SegmentInfoKind.Trailing, "trailing"))
         case "Empty"                => Some(BoundaryInfo(None, None))
         case _                      => None
       }
@@ -583,6 +647,7 @@ object SegmentCodec {
             else if boundary <:< TypeRepr.of[BoundaryTag.Long] then Some(SegmentInfoKind.Long)
             else if boundary <:< TypeRepr.of[BoundaryTag.String] then Some(SegmentInfoKind.String)
             else if boundary <:< TypeRepr.of[BoundaryTag.UUID] then Some(SegmentInfoKind.UUID)
+            else if boundary <:< TypeRepr.of[BoundaryTag.Trailing] then Some(SegmentInfoKind.Trailing)
             else None
 
           val prefix = kindOf(prefixTpe).map(kind => SegmentInfo(kind, "transformed"))
@@ -668,6 +733,20 @@ object SegmentCodec {
         case Select(_, "Empty") => Some(BoundaryInfo(None, None))
         case _                  => typeInfo(term.tpe)
       }
+    }
+
+    private def validateLiteralValue(value: String)(using Quotes): Unit = {
+      import quotes.reflect.*
+
+      val path          = Path(s"/$value")
+      val singleSegment = path.segments.length == 1 && path.segments.headOption.contains(value)
+      val preserved     = path.encode.stripPrefix("/") == value
+
+      if value.isEmpty then report.errorAndAbort("SegmentCodec.literal cannot be empty")
+      else if !singleSegment || !preserved then
+        report.errorAndAbort(
+          s"SegmentCodec.literal must be a valid single path segment without `/` or characters that require URL encoding: $value"
+        )
     }
   }
 }

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
@@ -103,7 +103,7 @@ object SegmentCodec {
           existing.asInstanceOf[Tuples.Tuples.WithOut[Any, Any, Any]]
         ).asInstanceOf[SegmentCodec[C]]
       case _ =>
-        validateAmbiguousChain(flatten(left) ++ flatten(right))
+        validateBoundary(trailingLeaf(left), leadingLeaf(right))
         Combined(left, right, combiner)
     }
 
@@ -334,50 +334,61 @@ object SegmentCodec {
       }
     }
 
-  private def validateAmbiguousChain(codecs: Chunk[SegmentCodec[_]]): Unit = {
-    var firstString: Option[String]  = None
-    var firstNumeric: Option[String] = None
-
-    codecs.foreach {
-      case StringSeg(name, _, _) =>
-        firstString match {
-          case Some(existing) =>
-            throw new IllegalArgumentException(
-              s"Cannot combine two string segments. Their names are $existing and $name"
-            )
-          case None =>
-            firstString = Some(name)
-        }
-      case IntSeg(name, _, _) =>
-        firstNumeric match {
-          case Some(existing) =>
-            throw new IllegalArgumentException(
-              s"Cannot combine two numeric segments. Their names are $existing and $name"
-            )
-          case None =>
-            firstNumeric = Some(name)
-        }
-      case LongSeg(name, _, _) =>
-        firstNumeric match {
-          case Some(existing) =>
-            throw new IllegalArgumentException(
-              s"Cannot combine two numeric segments. Their names are $existing and $name"
-            )
-          case None =>
-            firstNumeric = Some(name)
-        }
+  private def validateBoundary(left: Option[SegmentCodec[_]], right: Option[SegmentCodec[_]]): Unit =
+    (left, right) match {
+      case (Some(StringSeg(leftName, _, _)), Some(StringSeg(rightName, _, _))) =>
+        throw new IllegalArgumentException(
+          s"Cannot combine two string segments. Their names are $leftName and $rightName"
+        )
+      case (Some(IntSeg(leftName, _, _)), Some(IntSeg(rightName, _, _))) =>
+        throw new IllegalArgumentException(
+          s"Cannot combine two numeric segments. Their names are $leftName and $rightName"
+        )
+      case (Some(IntSeg(leftName, _, _)), Some(LongSeg(rightName, _, _))) =>
+        throw new IllegalArgumentException(
+          s"Cannot combine two numeric segments. Their names are $leftName and $rightName"
+        )
+      case (Some(LongSeg(leftName, _, _)), Some(IntSeg(rightName, _, _))) =>
+        throw new IllegalArgumentException(
+          s"Cannot combine two numeric segments. Their names are $leftName and $rightName"
+        )
+      case (Some(LongSeg(leftName, _, _)), Some(LongSeg(rightName, _, _))) =>
+        throw new IllegalArgumentException(
+          s"Cannot combine two numeric segments. Their names are $leftName and $rightName"
+        )
       case _ => ()
     }
-  }
+
+  private def leadingLeaf(codec: SegmentCodec[_]): Option[SegmentCodec[_]] =
+    codec match {
+      case Combined(left, right, _) => leadingLeaf(left).orElse(leadingLeaf(right))
+      case Empty                    => None
+      case other                    => Some(other)
+    }
+
+  private def trailingLeaf(codec: SegmentCodec[_]): Option[SegmentCodec[_]] =
+    codec match {
+      case Combined(left, right, _) => trailingLeaf(right).orElse(trailingLeaf(left))
+      case Empty                    => None
+      case other                    => Some(other)
+    }
 
   private object SegmentCodecMacros {
     private sealed trait SegmentInfoKind
     private object SegmentInfoKind {
+      case object Literal extends SegmentInfoKind
+      case object Bool    extends SegmentInfoKind
+      case object Int     extends SegmentInfoKind
+      case object Long    extends SegmentInfoKind
       case object String  extends SegmentInfoKind
-      case object Numeric extends SegmentInfoKind
+      case object UUID    extends SegmentInfoKind
     }
 
     private final case class SegmentInfo(kind: SegmentInfoKind, name: String)
+    private final case class BoundaryInfo(prefix: Option[SegmentInfo], suffix: Option[SegmentInfo]) {
+      def ++(that: BoundaryInfo): BoundaryInfo =
+        BoundaryInfo(prefix.orElse(that.prefix), that.suffix.orElse(suffix))
+    }
 
     def combineImpl[A: Type, B: Type, C: Type](
       leftExpr: Expr[SegmentCodec[A]],
@@ -386,75 +397,77 @@ object SegmentCodec {
     )(using Quotes): Expr[SegmentCodec[C]] = {
       import quotes.reflect.*
 
-      val leftInfos  = segmentInfos(leftExpr.asTerm)
-      val rightInfos = segmentInfos(rightExpr.asTerm)
+      val leftInfo  = boundaryInfo(leftExpr.asTerm)
+      val rightInfo = boundaryInfo(rightExpr.asTerm)
 
-      (leftInfos, rightInfos) match {
+      (leftInfo, rightInfo) match {
         case (Some(left), Some(right)) =>
-          validateInfos(left ++ right)
+          validateBoundary(left.suffix, right.prefix)
           '{ SegmentCodec.combineValidated($leftExpr, $rightExpr, $combinerExpr) }
         case _ =>
           '{ SegmentCodec.combineValidated($leftExpr, $rightExpr, $combinerExpr) }
       }
     }
 
-    private def validateInfos(using Quotes)(infos: List[SegmentInfo]): Unit = {
+    private def validateBoundary(using Quotes)(left: Option[SegmentInfo], right: Option[SegmentInfo]): Unit = {
       import quotes.reflect.*
 
-      var firstString: Option[String]  = None
-      var firstNumeric: Option[String] = None
-
-      infos.foreach {
-        case SegmentInfo(SegmentInfoKind.String, name) =>
-          firstString match {
-            case Some(existing) =>
-              report.errorAndAbort(s"Cannot combine two string segments. Their names are $existing and $name")
-            case None =>
-              firstString = Some(name)
-          }
-        case SegmentInfo(SegmentInfoKind.Numeric, name) =>
-          firstNumeric match {
-            case Some(existing) =>
-              report.errorAndAbort(s"Cannot combine two numeric segments. Their names are $existing and $name")
-            case None =>
-              firstNumeric = Some(name)
-          }
+      (left, right) match {
+        case (
+              Some(SegmentInfo(SegmentInfoKind.String, leftName)),
+              Some(SegmentInfo(SegmentInfoKind.String, rightName))
+            ) =>
+          report.errorAndAbort(s"Cannot combine two string segments. Their names are $leftName and $rightName")
+        case (
+              Some(SegmentInfo(SegmentInfoKind.Int | SegmentInfoKind.Long, leftName)),
+              Some(SegmentInfo(SegmentInfoKind.Int | SegmentInfoKind.Long, rightName))
+            ) =>
+          report.errorAndAbort(s"Cannot combine two numeric segments. Their names are $leftName and $rightName")
+        case _ => ()
       }
     }
 
-    private def segmentInfos(using Quotes)(term: quotes.reflect.Term): Option[List[SegmentInfo]] = {
+    private def boundaryInfo(using Quotes)(term: quotes.reflect.Term): Option[BoundaryInfo] = {
       import quotes.reflect.*
 
       def stringArg(args: List[Term], default: String): String =
         args.collectFirst { case quotes.reflect.Literal(StringConstant(value)) => value }.getOrElse(default)
 
-      def applyInfos(name: String, args: List[Term]): Option[List[SegmentInfo]] = name match {
-        case "string" | "StringSeg"                                                    => Some(List(SegmentInfo(SegmentInfoKind.String, stringArg(args, "string"))))
-        case "int" | "IntSeg"                                                          => Some(List(SegmentInfo(SegmentInfoKind.Numeric, stringArg(args, "int"))))
-        case "long" | "LongSeg"                                                        => Some(List(SegmentInfo(SegmentInfoKind.Numeric, stringArg(args, "long"))))
-        case "literal" | "Literal" | "bool" | "BoolSeg" | "uuid" | "UUIDSeg" | "Empty" => Some(Nil)
-        case _                                                                         => None
+      def singleInfo(kind: SegmentInfoKind, name: String): BoundaryInfo = {
+        val info = SegmentInfo(kind, name)
+        BoundaryInfo(Some(info), Some(info))
+      }
+
+      def applyInfo(name: String, args: List[Term]): Option[BoundaryInfo] = name match {
+        case "literal" | "Literal"  => Some(singleInfo(SegmentInfoKind.Literal, stringArg(args, "literal")))
+        case "bool" | "BoolSeg"     => Some(singleInfo(SegmentInfoKind.Bool, stringArg(args, "bool")))
+        case "string" | "StringSeg" => Some(singleInfo(SegmentInfoKind.String, stringArg(args, "string")))
+        case "int" | "IntSeg"       => Some(singleInfo(SegmentInfoKind.Int, stringArg(args, "int")))
+        case "long" | "LongSeg"     => Some(singleInfo(SegmentInfoKind.Long, stringArg(args, "long")))
+        case "uuid" | "UUIDSeg"     => Some(singleInfo(SegmentInfoKind.UUID, stringArg(args, "uuid")))
+        case "Empty"                => Some(BoundaryInfo(None, None))
+        case _                      => None
       }
 
       term match {
-        case Inlined(_, _, inner) => segmentInfos(inner)
-        case Typed(inner, _)      => segmentInfos(inner)
-        case Block(_, expr)       => segmentInfos(expr)
+        case Inlined(_, _, inner) => boundaryInfo(inner)
+        case Typed(inner, _)      => boundaryInfo(inner)
+        case Block(_, expr)       => boundaryInfo(expr)
         case Ident(_)             =>
           term.symbol.tree match {
-            case valDef: ValDef => valDef.rhs.flatMap(segmentInfos)
+            case valDef: ValDef => valDef.rhs.flatMap(boundaryInfo)
             case _              => None
           }
         case Apply(TypeApply(Select(_, "combineValidated"), _), List(left, right, _)) =>
           for {
-            leftInfos  <- segmentInfos(left)
-            rightInfos <- segmentInfos(right)
-          } yield leftInfos ++ rightInfos
+            leftInfo  <- boundaryInfo(left)
+            rightInfo <- boundaryInfo(right)
+          } yield leftInfo ++ rightInfo
         case Apply(Select(_, "combineValidated"), List(left, right, _)) =>
           for {
-            leftInfos  <- segmentInfos(left)
-            rightInfos <- segmentInfos(right)
-          } yield leftInfos ++ rightInfos
+            leftInfo  <- boundaryInfo(left)
+            rightInfo <- boundaryInfo(right)
+          } yield leftInfo ++ rightInfo
         case Apply(fun, args) =>
           val fullName = fun.symbol.fullName
           if (
@@ -462,15 +475,15 @@ object SegmentCodec {
             fullName == "zio.blocks.endpoint.SegmentCodec.int" || fullName == "zio.blocks.endpoint.SegmentCodec.long" ||
             fullName == "zio.blocks.endpoint.SegmentCodec.bool" || fullName == "zio.blocks.endpoint.SegmentCodec.uuid"
           )
-            applyInfos(fun.symbol.name, args)
+            applyInfo(fun.symbol.name, args)
           else if (
             fullName.endsWith("SegmentCodec.Literal.apply") || fullName.endsWith("SegmentCodec.StringSeg.apply") ||
             fullName.endsWith("SegmentCodec.IntSeg.apply") || fullName.endsWith("SegmentCodec.LongSeg.apply") ||
             fullName.endsWith("SegmentCodec.BoolSeg.apply") || fullName.endsWith("SegmentCodec.UUIDSeg.apply")
           )
-            applyInfos(fun.symbol.owner.name, args)
+            applyInfo(fun.symbol.owner.name, args)
           else None
-        case Select(_, "Empty") => Some(Nil)
+        case Select(_, "Empty") => Some(BoundaryInfo(None, None))
         case _                  => None
       }
     }

--- a/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
+++ b/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
@@ -179,6 +179,57 @@ object EndpointSpec extends ZIOSpecDefault {
         }
 
         assertTrue(result.failed.toOption.exists(_.getMessage.contains("Cannot combine two string segments")))
+      },
+      test("allows transformed size-delimited boundaries at compile time") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+
+            val valid: SegmentCodec[?] =
+              SegmentCodec.string("prefix").transform(identity, identity) ~
+                SegmentCodec.uuid("id") ~
+                SegmentCodec.string("suffix").transform(identity, identity)
+          """)
+        )(isRight)
+      },
+      test("transformed segment codec decodes and formats") {
+        val uuid  = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+        val codec = PathCodec(
+          SegmentCodec
+            .uuid("id")
+            .transform[String](_.toString, UUID.fromString)
+        )
+
+        assertTrue(
+          codec.decode(zio.http.Path(s"/$uuid")) == Right(uuid.toString),
+          codec.format(uuid.toString).map(_.render) == Right(s"/$uuid")
+        )
+      },
+      test("runtime validation rejects transformed string boundaries") {
+        val left: SegmentCodec[Any] =
+          SegmentCodec
+            .string("left")
+            .transform[Any](value => value, value => value.asInstanceOf[String])
+            .asInstanceOf[SegmentCodec[Any]]
+        val right: SegmentCodec[Any] = SegmentCodec.string("right").asInstanceOf[SegmentCodec[Any]]
+
+        val result = scala.util.Try {
+          SegmentCodec.combineValidated(
+            left,
+            right,
+            summon[zio.blocks.combinators.Tuples.Tuples.WithOut[Any, Any, (Any, Any)]]
+          )
+        }
+
+        assertTrue(result.failed.toOption.exists(_.getMessage.contains("Cannot combine two string segments")))
+      },
+      test("transformed path codec decodes and formats") {
+        val codec = PathCodec.int("id").transform[String](_.toString, _.toInt)
+
+        assertTrue(
+          codec.decode(zio.http.Path("/42")) == Right("42"),
+          codec.format("42").map(_.render) == Right("/42")
+        )
       }
     ),
     suite("PathCodec")(

--- a/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
+++ b/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
@@ -24,6 +24,7 @@ import zio.blocks.chunk.Chunk
 import zio.blocks.docs.Doc
 import zio.blocks.endpoint.RoutePattern.*
 import zio.blocks.schema.Schema
+import zio.http.Header
 import zio.http.{Method, Status}
 import zio.test._
 import zio.test.Assertion.{isLeft, isRight}
@@ -239,7 +240,7 @@ object EndpointSpec extends ZIOSpecDefault {
 
         assertTrue(
           q == HttpCodec.Query("limit", Schema.int),
-          h == HttpCodec.Header[CodecKind.Request, String]("Authorization", Schema.string),
+          h == HttpCodec.Header[CodecKind.Request, String]("authorization", Schema.string),
           b == HttpCodec.Body[CodecKind.Response, String](Schema.string),
           s == HttpCodec.StatusCodec(Some(Status.Created)),
           a.isInstanceOf[HttpCodec[CodecKind.Request, zio.http.headers.Authorization.Bearer]]
@@ -252,6 +253,30 @@ object EndpointSpec extends ZIOSpecDefault {
       test("header codec") {
         val h = HttpCodec.Header[CodecKind.Request, String]("Authorization", Schema.string)
         assertTrue(h.name == "Authorization")
+      },
+      test("explicit header constructors normalize names to lowercase") {
+        val requestHeader  = HttpCodec.requestHeader("Authorization", Schema.string)
+        val responseHeader = HttpCodec.responseHeader("X-Trace-Id", Schema.string)
+
+        assertTrue(
+          requestHeader.name == "authorization",
+          responseHeader.name == "x-trace-id"
+        )
+      },
+      test("typed header constructors normalize names to lowercase") {
+        object MixedCaseHeaderType extends Header.Typed[Header.Custom] {
+          def name: String                                        = "X-Trace-Id"
+          def parse(value: String): Either[String, Header.Custom] = Right(Header.Custom(name, value))
+          def render(h: Header.Custom): String                    = h.renderedValue
+        }
+
+        val requestHeader  = HttpCodec.requestHeader(MixedCaseHeaderType)
+        val responseHeader = HttpCodec.responseHeader(MixedCaseHeaderType)
+
+        assertTrue(
+          requestHeader.name == "x-trace-id",
+          responseHeader.name == "x-trace-id"
+        )
       },
       test("body codec") {
         val b = HttpCodec.Body[CodecKind.Request, String](Schema.string)

--- a/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
+++ b/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
@@ -86,21 +86,32 @@ object EndpointSpec extends ZIOSpecDefault {
           """)
         )(isLeft)
       },
-      test("rejects non-adjacent repeated string segments at compile time") {
+      test("allows string followed by uuid followed by string at compile time") {
         assertZIO(
           typeCheck("""
             import zio.blocks.endpoint._
 
-            val invalid = SegmentCodec.string("prefix") ~ SegmentCodec.uuid("id") ~ SegmentCodec.string("suffix")
+            val valid: SegmentCodec[?] =
+              SegmentCodec.string("prefix") ~ SegmentCodec.uuid("id") ~ SegmentCodec.string("suffix")
           """)
-        )(isLeft)
+        )(isRight)
       },
-      test("rejects non-adjacent repeated numeric segments at compile time") {
+      test("allows string followed by int followed by string at compile time") {
         assertZIO(
           typeCheck("""
             import zio.blocks.endpoint._
 
-            val invalid = SegmentCodec.int("prefix") ~ SegmentCodec.uuid("id") ~ SegmentCodec.long("suffix")
+            val valid: SegmentCodec[?] =
+              SegmentCodec.string("prefix") ~ SegmentCodec.int("id") ~ SegmentCodec.string("suffix")
+          """)
+        )(isRight)
+      },
+      test("rejects grouped combinations with an ambiguous boundary at compile time") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+
+            val invalid = SegmentCodec.string("prefix") ~ (SegmentCodec.string("middle") ~ SegmentCodec.uuid("id"))
           """)
         )(isLeft)
       },
@@ -128,10 +139,36 @@ object EndpointSpec extends ZIOSpecDefault {
 
         assertTrue(result.failed.toOption.exists(_.getMessage.contains("Cannot combine two string segments")))
       },
-      test("runtime validation rejects non-adjacent opaque string combinations") {
+      test("runtime validation allows non-adjacent string boundaries") {
         val left: SegmentCodec[Any] =
           (SegmentCodec.string("prefix") ~ SegmentCodec.uuid("id")).asInstanceOf[SegmentCodec[Any]]
         val right: SegmentCodec[Any] = SegmentCodec.string("suffix").asInstanceOf[SegmentCodec[Any]]
+
+        val result = scala.util.Try {
+          SegmentCodec.combineValidated(
+            left,
+            right,
+            summon[zio.blocks.combinators.Tuples.Tuples.WithOut[Any, Any, (Any, Any)]]
+          )
+        }
+
+        assertTrue(result.isSuccess)
+      },
+      test("string followed by uuid followed by string decodes") {
+        val uuid  = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+        val codec = PathCodec(SegmentCodec.string("prefix") ~ SegmentCodec.uuid("id") ~ SegmentCodec.string("suffix"))
+
+        assertTrue(codec.decode(zio.http.Path(s"/pre${uuid}post")).isRight)
+      },
+      test("string followed by int followed by string decodes") {
+        val codec = PathCodec(SegmentCodec.string("prefix") ~ SegmentCodec.int("id") ~ SegmentCodec.string("suffix"))
+
+        assertTrue(codec.decode(zio.http.Path("/pre123post")).isRight)
+      },
+      test("runtime validation rejects grouped ambiguous boundaries") {
+        val left: SegmentCodec[Any]  = SegmentCodec.string("prefix").asInstanceOf[SegmentCodec[Any]]
+        val right: SegmentCodec[Any] =
+          (SegmentCodec.string("middle") ~ SegmentCodec.uuid("id")).asInstanceOf[SegmentCodec[Any]]
 
         val result = scala.util.Try {
           SegmentCodec.combineValidated(

--- a/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
+++ b/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
@@ -86,6 +86,24 @@ object EndpointSpec extends ZIOSpecDefault {
           """)
         )(isLeft)
       },
+      test("rejects non-adjacent repeated string segments at compile time") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+
+            val invalid = SegmentCodec.string("prefix") ~ SegmentCodec.uuid("id") ~ SegmentCodec.string("suffix")
+          """)
+        )(isLeft)
+      },
+      test("rejects non-adjacent repeated numeric segments at compile time") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+
+            val invalid = SegmentCodec.int("prefix") ~ SegmentCodec.uuid("id") ~ SegmentCodec.long("suffix")
+          """)
+        )(isLeft)
+      },
       test("allows valid mixed combinations") {
         assertZIO(
           typeCheck("""
@@ -99,6 +117,21 @@ object EndpointSpec extends ZIOSpecDefault {
       test("runtime validation still rejects opaque invalid combinations") {
         val left: SegmentCodec[Any]  = SegmentCodec.string("a").asInstanceOf[SegmentCodec[Any]]
         val right: SegmentCodec[Any] = SegmentCodec.string("b").asInstanceOf[SegmentCodec[Any]]
+
+        val result = scala.util.Try {
+          SegmentCodec.combineValidated(
+            left,
+            right,
+            summon[zio.blocks.combinators.Tuples.Tuples.WithOut[Any, Any, (Any, Any)]]
+          )
+        }
+
+        assertTrue(result.failed.toOption.exists(_.getMessage.contains("Cannot combine two string segments")))
+      },
+      test("runtime validation rejects non-adjacent opaque string combinations") {
+        val left: SegmentCodec[Any] =
+          (SegmentCodec.string("prefix") ~ SegmentCodec.uuid("id")).asInstanceOf[SegmentCodec[Any]]
+        val right: SegmentCodec[Any] = SegmentCodec.string("suffix").asInstanceOf[SegmentCodec[Any]]
 
         val result = scala.util.Try {
           SegmentCodec.combineValidated(

--- a/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
+++ b/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
@@ -310,7 +310,7 @@ object EndpointSpec extends ZIOSpecDefault {
 
         assertTrue(
           q == HttpCodec.Query("limit", Schema.int),
-          h == HttpCodec.Header[CodecKind.Request, String]("authorization", Schema.string),
+          h == HttpCodec.Header[CodecKind.Request, String]("Authorization", Schema.string),
           b == HttpCodec.Body[CodecKind.Response, String](Schema.string),
           s == HttpCodec.StatusCodec(Some(Status.Created)),
           a.isInstanceOf[HttpCodec[CodecKind.Request, zio.http.headers.Authorization.Bearer]]
@@ -324,16 +324,16 @@ object EndpointSpec extends ZIOSpecDefault {
         val h = HttpCodec.Header[CodecKind.Request, String]("Authorization", Schema.string)
         assertTrue(h.name == "Authorization")
       },
-      test("explicit header constructors normalize names to lowercase") {
+      test("explicit header constructors preserve provided names") {
         val requestHeader  = HttpCodec.requestHeader("Authorization", Schema.string)
         val responseHeader = HttpCodec.responseHeader("X-Trace-Id", Schema.string)
 
         assertTrue(
-          requestHeader.name == "authorization",
-          responseHeader.name == "x-trace-id"
+          requestHeader.name == "Authorization",
+          responseHeader.name == "X-Trace-Id"
         )
       },
-      test("typed header constructors normalize names to lowercase") {
+      test("typed header constructors preserve typed names") {
         object MixedCaseHeaderType extends Header.Typed[Header.Custom] {
           def name: String                                        = "X-Trace-Id"
           def parse(value: String): Either[String, Header.Custom] = Right(Header.Custom(name, value))
@@ -344,8 +344,8 @@ object EndpointSpec extends ZIOSpecDefault {
         val responseHeader = HttpCodec.responseHeader(MixedCaseHeaderType)
 
         assertTrue(
-          requestHeader.name == "x-trace-id",
-          responseHeader.name == "x-trace-id"
+          requestHeader.name == "X-Trace-Id",
+          responseHeader.name == "X-Trace-Id"
         )
       },
       test("body codec") {

--- a/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
+++ b/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
@@ -115,6 +115,24 @@ object EndpointSpec extends ZIOSpecDefault {
           """)
         )(isLeft)
       },
+      test("rejects trailing combinations at compile time") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+
+            val invalid = SegmentCodec.Trailing ~ SegmentCodec.string("suffix")
+          """)
+        )(isLeft)
+      },
+      test("rejects slash literals at compile time") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+
+            val invalid = SegmentCodec.literal("foo/bar")
+          """)
+        )(isLeft)
+      },
       test("allows valid mixed combinations") {
         assertZIO(
           typeCheck("""
@@ -124,35 +142,6 @@ object EndpointSpec extends ZIOSpecDefault {
               SegmentCodec.literal("v") ~ SegmentCodec.int("major") ~ SegmentCodec.string("suffix")
           """)
         )(isRight)
-      },
-      test("runtime validation still rejects opaque invalid combinations") {
-        val left: SegmentCodec[Any]  = SegmentCodec.string("a").asInstanceOf[SegmentCodec[Any]]
-        val right: SegmentCodec[Any] = SegmentCodec.string("b").asInstanceOf[SegmentCodec[Any]]
-
-        val result = scala.util.Try {
-          SegmentCodec.combineValidated(
-            left,
-            right,
-            summon[zio.blocks.combinators.Tuples.Tuples.WithOut[Any, Any, (Any, Any)]]
-          )
-        }
-
-        assertTrue(result.failed.toOption.exists(_.getMessage.contains("Cannot combine two string segments")))
-      },
-      test("runtime validation allows non-adjacent string boundaries") {
-        val left: SegmentCodec[Any] =
-          (SegmentCodec.string("prefix") ~ SegmentCodec.uuid("id")).asInstanceOf[SegmentCodec[Any]]
-        val right: SegmentCodec[Any] = SegmentCodec.string("suffix").asInstanceOf[SegmentCodec[Any]]
-
-        val result = scala.util.Try {
-          SegmentCodec.combineValidated(
-            left,
-            right,
-            summon[zio.blocks.combinators.Tuples.Tuples.WithOut[Any, Any, (Any, Any)]]
-          )
-        }
-
-        assertTrue(result.isSuccess)
       },
       test("string followed by uuid followed by string decodes") {
         val uuid  = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
@@ -164,21 +153,6 @@ object EndpointSpec extends ZIOSpecDefault {
         val codec = PathCodec(SegmentCodec.string("prefix") ~ SegmentCodec.int("id") ~ SegmentCodec.string("suffix"))
 
         assertTrue(codec.decode(zio.http.Path("/pre123post")).isRight)
-      },
-      test("runtime validation rejects grouped ambiguous boundaries") {
-        val left: SegmentCodec[Any]  = SegmentCodec.string("prefix").asInstanceOf[SegmentCodec[Any]]
-        val right: SegmentCodec[Any] =
-          (SegmentCodec.string("middle") ~ SegmentCodec.uuid("id")).asInstanceOf[SegmentCodec[Any]]
-
-        val result = scala.util.Try {
-          SegmentCodec.combineValidated(
-            left,
-            right,
-            summon[zio.blocks.combinators.Tuples.Tuples.WithOut[Any, Any, (Any, Any)]]
-          )
-        }
-
-        assertTrue(result.failed.toOption.exists(_.getMessage.contains("Cannot combine two string segments")))
       },
       test("allows transformed size-delimited boundaries at compile time") {
         assertZIO(
@@ -205,23 +179,15 @@ object EndpointSpec extends ZIOSpecDefault {
           codec.format(uuid.toString).map(_.render) == Right(s"/$uuid")
         )
       },
-      test("runtime validation rejects transformed string boundaries") {
-        val left: SegmentCodec[Any] =
-          SegmentCodec
-            .string("left")
-            .transform[Any](value => value, value => value.asInstanceOf[String])
-            .asInstanceOf[SegmentCodec[Any]]
-        val right: SegmentCodec[Any] = SegmentCodec.string("right").asInstanceOf[SegmentCodec[Any]]
+      test("rejects transformed string boundaries at compile time") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
 
-        val result = scala.util.Try {
-          SegmentCodec.combineValidated(
-            left,
-            right,
-            summon[zio.blocks.combinators.Tuples.Tuples.WithOut[Any, Any, (Any, Any)]]
-          )
-        }
-
-        assertTrue(result.failed.toOption.exists(_.getMessage.contains("Cannot combine two string segments")))
+            val left = SegmentCodec.string("left").transform(identity, identity)
+            val invalid = left ~ SegmentCodec.string("right")
+          """)
+        )(isLeft)
       },
       test("transformed path codec decodes and formats") {
         val codec = PathCodec.int("id").transform[String](_.toString, _.toInt)


### PR DESCRIPTION
## Summary
- add `SegmentCodec` and `PathCodec` transform support while preserving segment boundary metadata through transformed codecs
- enforce `SegmentCodec.~` rules at compile time, including rejecting trailing combinations and invalid ambiguous boundaries
- require public `literal(...)` delimiters to be compile-time string literals and reject slash-containing or URL-invalid literal segments at compile time

## Details
- transformed codecs preserve `Prefix` / `Suffix` boundary information so compile-time `~` checks still work after `transform` and `transformOrFail`
- public delimiter construction is compile-time-only, while internal path builders that already work from parsed `Path` segments use validated internal helpers
- explicit header name normalization was reverted; caller-provided casing is preserved because runtime lookup is already case-insensitive

## Verification
- sbt --client -Dsbt.color=false "++3.8.3; endpointJVM/test"
- sbt --client -Dsbt.color=false "++2.13.16; endpointJVM/test"
- sbt --client -Dsbt.color=false "++3.8.3; project endpointJVM; fmtDirty"
- GitHub CI green on head `6d0b6838`