### PR TITLE
Enable Scala 2 builds for Streams dependents

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -386,22 +386,6 @@ lazy val streams = crossProject(JSPlatform, JVMPlatform)
   .settings(crossProjectSettings)
   .settings(buildInfoSettings("zio.blocks.streams"))
   .enablePlugins(BuildInfoPlugin)
-  .settings(
-    // Streams source requires Scala 3 (inline, summonFrom, etc.).
-    // Under 2.13 CI runs, skip compilation entirely.
-    Compile / sources := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) => Nil
-        case _            => (Compile / sources).value
-      }
-    },
-    Test / sources := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) => Nil
-        case _            => (Test / sources).value
-      }
-    }
-  )
   .jvmSettings(
     mimaSettings(failOnProblem = false),
     // Streams requires JDK 21+ (Project Loom virtual threads).
@@ -501,20 +485,7 @@ lazy val `http-model` = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test-sbt" % "2.1.25" % Test
     ),
     coverageMinimumStmtTotal   := 95,
-    coverageMinimumBranchTotal := 94,
-    // HTTP model requires streams, which is Scala 3 only.
-    Compile / sources := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) => Nil
-        case _            => (Compile / sources).value
-      }
-    },
-    Test / sources := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) => Nil
-        case _            => (Test / sources).value
-      }
-    }
+    coverageMinimumBranchTotal := 94
   )
 
 lazy val `http-model-schema` = crossProject(JSPlatform, JVMPlatform)
@@ -532,20 +503,7 @@ lazy val `http-model-schema` = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test-sbt" % "2.1.25" % Test
     ),
     coverageMinimumStmtTotal   := 67,
-    coverageMinimumBranchTotal := 51,
-    // Depends on http-model which is Scala 3 only.
-    Compile / sources := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) => Nil
-        case _            => (Compile / sources).value
-      }
-    },
-    Test / sources := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) => Nil
-        case _            => (Test / sources).value
-      }
-    }
+    coverageMinimumBranchTotal := 51
   )
 
 lazy val `http-model-examples` = project
@@ -575,7 +533,8 @@ lazy val endpoint = crossProject(JSPlatform, JVMPlatform)
     ),
     coverageMinimumStmtTotal   := 0,
     coverageMinimumBranchTotal := 0,
-    // Endpoint depends on http-model, which requires streams (Scala 3 only).
+    // Endpoint contains Scala 3-only endpoint DSL and macro code.
+    // Under 2.13 CI runs, skip compilation entirely.
     Compile / sources := {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, _)) => Nil

--- a/build.sbt
+++ b/build.sbt
@@ -386,20 +386,21 @@ lazy val streams = crossProject(JSPlatform, JVMPlatform)
   .settings(crossProjectSettings)
   .settings(buildInfoSettings("zio.blocks.streams"))
   .enablePlugins(BuildInfoPlugin)
+  .settings(
+    Compile / doc / scalacOptions ~= (_.filterNot(_ == "-Xfatal-warnings"))
+  )
   .jvmSettings(
     mimaSettings(failOnProblem = false),
     // Streams requires JDK 21+ (Project Loom virtual threads).
     // Override the default -release flag so Thread.ofVirtual() is available.
     // Only set -release 21 when running on JDK 21+; on JDK 17 CI, skip
     // compilation of streams (tests will be skipped due to compilation failure).
-    scalacOptions ~= { opts =>
-      opts.zipWithIndex.flatMap { case (o, i) => if (o == "-release") None else Some((o, i)) }
-        .map(_._1)
-    },
+    scalacOptions ~= (opts => removeOptionWithValue(opts, "-release")),
     scalacOptions ++= {
       val jdkVersion = System.getProperty("java.specification.version", "17").toInt
       if (jdkVersion >= 21) Seq("-release", "21") else Seq("-release", jdkVersion.toString)
     },
+    Compile / doc / scalacOptions ~= (opts => removeOptionWithValue(opts, "-release")),
     scalacOptions ++= Seq(
       // scope.leak is used intentionally throughout Streams internals
       "-Wconf:msg=being leaked from scope:s",

--- a/streams/shared/src/main/scala-2/zio/blocks/streams/Sink.scala
+++ b/streams/shared/src/main/scala-2/zio/blocks/streams/Sink.scala
@@ -79,7 +79,7 @@ object Sink {
     }
   }
 
-  /** A sink that collects all elements into a [[Chunk]]. */
+  /** A sink that collects all elements into a `Chunk`. */
   def collectAll[A]: Sink[Nothing, A, Chunk[A]] =
     new Sink[Nothing, A, Chunk[A]] {
       private[streams] def drain(reader: Reader[_]): Chunk[A] =
@@ -117,9 +117,9 @@ object Sink {
     }
 
   /**
-   * Creates a sink from a function that directly consumes a [[Reader]]. Use
-   * this when none of the built-in sinks (`foldLeft`, `foreach`, `collectAll`,
-   * etc.) meet your needs.
+   * Creates a sink from a function that directly consumes a `Reader`. Use this
+   * when none of the built-in sinks (`foldLeft`, `foreach`, `collectAll`, etc.)
+   * meet your needs.
    */
   def create[E, A, Z](f: Reader[A] => Z): Sink[E, A, Z] =
     new Sink[E, A, Z] {
@@ -456,7 +456,7 @@ object Sink {
    */
   val sumLong: Sink[Nothing, Long, Long] = loopLongToLong(0L)((acc, a) => acc + a)
 
-  /** A sink that collects the first `n` elements into a [[Chunk]]. */
+  /** A sink that collects the first `n` elements into a `Chunk`. */
   def take[A](n: Int): Sink[Nothing, A, Chunk[A]] =
     new Sink[Nothing, A, Chunk[A]] {
       private[streams] def drain(reader: Reader[_]): Chunk[A] = {

--- a/streams/shared/src/main/scala-2/zio/blocks/streams/Stream.scala
+++ b/streams/shared/src/main/scala-2/zio/blocks/streams/Stream.scala
@@ -43,7 +43,7 @@ abstract class Stream[+E, +A] {
   def render: String
 
   /**
-   * Returns the underlying [[Chunk]] if this stream wraps a known, materialized
+   * Returns the underlying `Chunk` if this stream wraps a known, materialized
    * chunk, `None` otherwise. O(1).
    *
    * Only streams created via [[Stream.fromChunk]], [[Stream.fromArray]], or
@@ -190,7 +190,7 @@ abstract class Stream[+E, +A] {
   def foreach(f: A => Unit): Either[E, Unit] = runForeach(f)
 
   /**
-   * Groups elements into [[Chunk]]s of size `n`. The last group may be smaller.
+   * Groups elements into `Chunk`s of size `n`. The last group may be smaller.
    */
   def grouped(n: Int): Stream[E, Chunk[A]] = {
     require(n >= 1, s"grouped requires n >= 1, got n=$n")
@@ -387,7 +387,7 @@ abstract class Stream[+E, +A] {
       case e: StreamError => Left(e.value.asInstanceOf[E2])
     }
 
-  /** Runs the stream and collects all elements into a [[Chunk]]. */
+  /** Runs the stream and collects all elements into a `Chunk`. */
   def runCollect: Either[E, Chunk[A]] = run(Sink.collectAll)
 
   /** Runs the stream, discarding all elements. */
@@ -790,7 +790,7 @@ abstract class Stream[+E, +A] {
   /**
    * Opens this stream for manual pull-based consumption within a
    * [[zio.blocks.scope.Scope]]. Use this when you need element-by-element
-   * control rather than running through a [[Sink]]. The returned [[Reader]] is
+   * control rather than running through a [[Sink]]. The returned `Reader` is
    * closed automatically when the scope closes.
    */
   def start(implicit scope: Scope): scope.$[Reader[A]] =
@@ -916,7 +916,7 @@ object Stream {
   def fromArray[A](array: Array[A])(implicit jt: JvmType.Infer[A]): Stream[Nothing, A] =
     fromChunk(Chunk.fromArray(array))
 
-  /** Creates a stream backed by a [[Chunk]]. */
+  /** Creates a stream backed by a `Chunk`. */
   def fromChunk[A](chunk: Chunk[A])(implicit jt: JvmType.Infer[A]): Stream[Nothing, A] =
     new FromChunkStream(chunk, jt)
 
@@ -941,8 +941,8 @@ object Stream {
     new FromReader(() => Reader.fromInputStream(is), "Stream.fromInputStreamUnmanaged(...)")
 
   /**
-   * Creates a stream backed by an [[Iterable]]. If the iterable has a known
-   * size, `knownLength` is set.
+   * Creates a stream backed by an `Iterable`. If the iterable has a known size,
+   * `knownLength` is set.
    */
   def fromIterable[A](it: Iterable[A]): Stream[Nothing, A] = {
     val size = it.knownSize
@@ -954,7 +954,7 @@ object Stream {
       new FromReader(() => Reader.fromIterable[A](it), "Stream.fromIterable(...)")
   }
 
-  /** Creates a stream from a lazily-evaluated [[Iterator]]. */
+  /** Creates a stream from a lazily-evaluated `Iterator`. */
   def fromIterator[A](it: => Iterator[A]): Stream[Nothing, A] =
     new FromReader(
       () => {
@@ -991,20 +991,20 @@ object Stream {
     new FromReader(() => Reader.fromReader(r), "Stream.fromJavaReaderUnmanaged(...)")
 
   /**
-   * Creates a stream of integers from a Scala [[Range]]. The `knownLength` is
-   * set from the range size.
+   * Creates a stream of integers from a Scala `Range`. The `knownLength` is set
+   * from the range size.
    */
   def fromRange(range: Range): Stream[Nothing, Int] =
     new FromReader(() => Reader.fromRange(range), "Stream.fromRange(...)") {
       override def knownLength: Option[Long] = Some(range.size.toLong)
     }
 
-  /** Creates a stream from a lazily-evaluated [[Reader]] (advanced API). */
+  /** Creates a stream from a lazily-evaluated `Reader` (advanced API). */
   def fromReader[E, A](mkReader: => Reader[A]): Stream[E, A] =
     new FromReader(() => mkReader)
 
   /**
-   * Creates a resource-safe stream from a [[Resource]] managed by a [[Scope]].
+   * Creates a resource-safe stream from a `Resource` managed by a [[Scope]].
    */
   def fromResource[R, E, A](resource: Resource[R])(use: R => Stream[E, A]): Stream[E, A] =
     new FromResource(resource, use)

--- a/streams/shared/src/main/scala-2/zio/blocks/streams/internal/Interpreter.scala
+++ b/streams/shared/src/main/scala-2/zio/blocks/streams/internal/Interpreter.scala
@@ -24,7 +24,7 @@ import StreamState.{stageStart => ss, incomingLen => il, stageEnd => se, outgoin
  * An optimized interpreter that compiles a chain of stream operations (map,
  * filter, flatMap, source reads) into a flat-array representation for efficient
  * dispatch. This is the fallback compilation strategy for deep pipelines
- * (beyond `Stream.DepthCutoff`) and is used by [[Interpreter.fromStream]].
+ * (beyond `Stream.DepthCutoff`) and is used by `Interpreter.fromStream`.
  *
  * Internally, each op is a (Long, AnyRef) pair stored at the same index in two
  * parallel arrays. The Long's bottom 8 bits hold the [[OpTag]]; the upper 56

--- a/streams/shared/src/main/scala-2/zio/blocks/streams/io/Reader.scala
+++ b/streams/shared/src/main/scala-2/zio/blocks/streams/io/Reader.scala
@@ -207,7 +207,7 @@ abstract class Reader[+Elem] {
   /**
    * Box-free bulk byte pull into a caller-supplied buffer.
    *
-   * Contract mirrors [[java.io.InputStream#read(byte[],int,int)]]:
+   * Contract mirrors `java.io.InputStream.read(byte[], int, int)`:
    *   - Blocks until at least 1 byte is available.
    *   - Returns the number of bytes read (`1 <= r <= len`).
    *   - Returns `-1` when closed and empty.


### PR DESCRIPTION
## Summary
- Remove stale Scala 2 source suppression from Streams now that Scala 2 sources are available.
- Enable Scala 2 builds for `http-model` and `http-model-schema`, which depend on Streams.
- Keep endpoint Scala-2-skipped because its own DSL/macro sources remain Scala 3-only.

## Verification
- `sbt --client -Dsbt.color=false scalafmtSbt`
- `sbt --client -Dsbt.color=false "++2.13.18; streamsJVM/compile; streamsJS/compile; http-modelJVM/compile; http-modelJS/compile; http-model-schemaJVM/compile; http-model-schemaJS/compile; endpointJVM/compile; endpointJS/compile"`
- `sbt --client -Dsbt.color=false "++3.8.3; streamsJVM/compile; http-modelJVM/compile; http-model-schemaJVM/compile; endpointJVM/compile"`