### PR TITLE
docs(endpoint): clarify auth failure status defaults

### DIFF
--- a/docs/reference/endpoint.md
+++ b/docs/reference/endpoint.md
@@ -92,16 +92,29 @@ Two constraints are intentional:
 
 ## Typed authentication
 
-Authentication is part of the endpoint type. Built-in auth constructors keep the request requirement precise:
+Authentication is part of the endpoint type. Built-in auth constructors keep the request requirement precise. Failed authentication returns `Status.NotFound` by default as an intentional information-hiding pattern. Use `unauthorizedStatus(Status.Unauthorized)` when you want standard `401 Unauthorized` behavior:
+
+```scala mdoc:compile-only
+import zio.blocks.endpoint._
+import zio.blocks.endpoint.RoutePattern.*
+import zio.http.{Method, Status}
+
+val secured = Endpoint(Method.GET / "me")
+  .auth(AuthType.Bearer)
+  .unauthorizedStatus(Status.Unauthorized)
+
+val authCodec = secured.auth.codec
+```
+
+This makes it possible to require bearer, basic, or digest auth without dropping down to raw string headers, while still choosing whether unauthorized requests should be hidden behind `404 Not Found` or surfaced as `401 Unauthorized`.
+
+For OAuth-style scope metadata, wrap an auth type with `AuthType.Scoped`:
 
 ```scala mdoc:compile-only
 import zio.blocks.endpoint._
 import zio.blocks.endpoint.RoutePattern.*
 import zio.http.Method
 
-val secured = Endpoint(Method.GET / "me").auth(AuthType.Bearer)
-
-val authCodec = secured.auth.codec
+val scoped = Endpoint(Method.GET / "me")
+  .auth(AuthType.Scoped(AuthType.Bearer, List("profile:read", "email:read")))
 ```
-
-This makes it possible to require bearer, basic, or digest auth without dropping down to raw string headers.

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/AuthType.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/AuthType.scala
@@ -21,14 +21,32 @@ import zio.http.{Status, headers}
 
 /**
  * Authentication scheme descriptor aligned with zio-http's typed auth model.
+ *
+ * When authentication fails, the default response status is `Status.NotFound`
+ * rather than `Status.Unauthorized`. This is an intentional security pattern
+ * (information hiding) that avoids revealing whether a protected resource
+ * exists. Override [[unauthorizedStatus]] with [[withUnauthorizedStatus]] if
+ * you want standard `401 Unauthorized` behavior instead.
  */
 sealed trait AuthType { self =>
   type ClientRequirement
 
   def codec: HttpCodec[CodecKind.Request, ClientRequirement]
 
+  /**
+   * The HTTP status code returned when authentication fails.
+   *
+   * Defaults to `Status.NotFound` to avoid revealing protected resources via a
+   * distinct authentication failure response.
+   */
   def unauthorizedStatus: Status = Status.NotFound
 
+  /**
+   * Returns a copy of this auth type with a different unauthorized status.
+   *
+   * Use this to opt into standard `401 Unauthorized` behavior when information
+   * hiding is not desired.
+   */
   def withUnauthorizedStatus(status: Status): AuthType { type ClientRequirement = self.ClientRequirement } =
     AuthType.WithStatus(
       self.asInstanceOf[AuthType { type ClientRequirement = self.ClientRequirement }],


### PR DESCRIPTION
## Summary
- clarify in `AuthType` Scaladoc that failed authentication defaults to `404 Not Found` as an intentional information-hiding pattern
- document `unauthorizedStatus(Status.Unauthorized)` in the endpoint reference with a concrete typed-auth example
- keep the endpoint API shape unchanged while making the default auth-failure behavior easier to understand

## Verification
- `sbt --client -Dsbt.color=false \"++3.8.3; project endpointJVM; fmtDirty\"`
- `sbt --client -Dsbt.color=false \"++3.8.3; endpointJVM/test\"`
- `sbt --client -Dsbt.color=false \"++3.8.3; endpointJS/test\"`
- `lsp_diagnostics` on `endpoint/shared/src/main/scala/zio/blocks/endpoint/AuthType.scala`