### PR TITLE
fix(http-model-examples): replace removed Body.data API usage

### DIFF
--- a/http-model-examples/src/main/scala/httpmodel/FormAndCookies.scala
+++ b/http-model-examples/src/main/scala/httpmodel/FormAndCookies.scala
@@ -46,7 +46,7 @@ import zio.http._
   println(s"Form Request:")
   println(s"  Method: ${formRequest.method}")
   println(s"  URL: ${formRequest.url}")
-  println(s"  Body size: ${formBody.data.length} bytes")
+  println(s"  Body size: ${formBody.toChunk.length} bytes")
   println()
 
   // Create response with cookies


### PR DESCRIPTION
## Summary

Fixes a compilation failure in `http-model-examples` caused by outdated `Body.data` API usage after the internal `zio.http.Body` refactor.

## Changes

Replaced:

```scala id="obmquj"
formBody.data.length
```

with:

```scala id="1i3yyl"
formBody.toChunk.length
```

in:

```text id="2sjq2d"
http-model-examples/src/main/scala/httpmodel/FormAndCookies.scala
```

## Root Cause

`zio.http.Body` no longer exposes the `data` field after the migration to the stream-backed implementation. The example file still referenced the old API and failed during compilation.

## Verification

* Ran `sbt compile`
* Full repository compilation completed successfully
* No unrelated files modified
