### PR TITLE
feat(http): split endpoint/html/datastar namespaces

### DIFF
--- a/datastar/shared/src/main/scala-2/zio/blocks/datastar/SignalVersionSpecific.scala
+++ b/datastar/shared/src/main/scala-2/zio/blocks/datastar/SignalVersionSpecific.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
@@ -34,9 +34,9 @@ private[datastar] object SignalMacros {
         if (!Signal.isValidName(signalName)) {
           c.abort(c.enclosingPosition, Signal.invalidNameMessage(signalName))
         }
-        c.Expr[Signal[A]](q"_root_.zio.blocks.datastar.Signal.unsafeApply[$aTpe]($signalName)")
+        c.Expr[Signal[A]](q"_root_.zio.http.datastar.Signal.unsafeApply[$aTpe]($signalName)")
       case _ =>
-        c.Expr[Signal[A]](q"_root_.zio.blocks.datastar.Signal.checkedApply[$aTpe]($name)")
+        c.Expr[Signal[A]](q"_root_.zio.http.datastar.Signal.checkedApply[$aTpe]($name)")
     }
   }
 }

--- a/datastar/shared/src/main/scala-3/zio/blocks/datastar/SignalVersionSpecific.scala
+++ b/datastar/shared/src/main/scala-3/zio/blocks/datastar/SignalVersionSpecific.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 import scala.quoted.*
 

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/CaseModifier.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/CaseModifier.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 /**
  * Modifies how a Datastar attribute key is cased when rendered by the DSL.

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DataInit.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DataInit.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.Dom
+import zio.blocks.html._
 import zio.blocks.maybe.Maybe
 
 /**

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DataInit.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DataInit.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.Dom
+import zio.http.html.Dom
 import zio.blocks.maybe.Maybe
 
 /**

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DataOn.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DataOn.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.Dom
+import zio.blocks.html._
 import zio.blocks.maybe.Maybe
 
 /**

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DataOn.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DataOn.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.Dom
+import zio.http.html.Dom
 import zio.blocks.maybe.Maybe
 
 /**

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DataOnIntersect.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DataOnIntersect.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.Dom
+import zio.blocks.html._
 import zio.blocks.maybe.Maybe
 
 /**

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DataOnIntersect.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DataOnIntersect.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.Dom
+import zio.http.html.Dom
 import zio.blocks.maybe.Maybe
 
 /**

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DataOnInterval.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DataOnInterval.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.Dom
+import zio.blocks.html._
 import zio.blocks.maybe.Maybe
 
 /**

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DataOnInterval.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DataOnInterval.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.Dom
+import zio.http.html.Dom
 import zio.blocks.maybe.Maybe
 
 /**

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DataOnSignalPatch.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DataOnSignalPatch.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.Dom
+import zio.blocks.html._
 import zio.blocks.maybe.Maybe
 
 /**

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DataOnSignalPatch.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DataOnSignalPatch.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.Dom
+import zio.http.html.Dom
 import zio.blocks.maybe.Maybe
 
 /**

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DataSignalsBuilder.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DataSignalsBuilder.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.Dom
+import zio.blocks.html._
 
 /**
  * Builds `data-signals:<name>` attributes for a named signal key.

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DataSignalsBuilder.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DataSignalsBuilder.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.Dom
+import zio.http.html.Dom
 
 /**
  * Builds `data-signals:<name>` attributes for a named signal key.

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarAttrKey.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarAttrKey.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.Dom
+import zio.blocks.html._
 
 /**
  * Low-level key for constructing Datastar `data-*` attributes directly.

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarAttrKey.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarAttrKey.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.Dom
+import zio.http.html.Dom
 
 /**
  * Low-level key for constructing Datastar `data-*` attributes directly.

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarAttributes.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarAttributes.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.Dom
+import zio.blocks.html._
 import zio.blocks.maybe.Maybe
 
 /**

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarAttributes.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarAttributes.scala
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.Dom
+import zio.http.html.Dom
 import zio.blocks.maybe.Maybe
 
 /**
  * Mixin providing Datastar `data-*` attribute constructors for the HTML DSL.
  *
- * Typical usage is through the package object via
- * `import zio.blocks.datastar._`. The methods in this trait build the Datastar
- * attribute DSL surface, including signal initialization (`dataSignals`),
- * bindings (`dataBind`), event handlers (`dataOn`), DOM updates (`dataText`,
- * `dataShow`, `dataClass`, `dataStyle`, `dataAttr`), and lifecycle hooks
- * (`dataInit`, `dataOnIntersect`, `dataOnInterval`, `dataOnSignalPatch`).
+ * Typical usage is through the package object via `import zio.http.datastar._`.
+ * The methods in this trait build the Datastar attribute DSL surface, including
+ * signal initialization (`dataSignals`), bindings (`dataBind`), event handlers
+ * (`dataOn`), DOM updates (`dataText`, `dataShow`, `dataClass`, `dataStyle`,
+ * `dataAttr`), and lifecycle hooks (`dataInit`, `dataOnIntersect`,
+ * `dataOnInterval`, `dataOnSignalPatch`).
  *
  * Attribute values are rendered as Datastar expressions, not as generic HTML
  * string values. In expression positions use typed values such as [[Signal]],

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarEvent.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarEvent.scala
@@ -17,7 +17,7 @@
 package zio.http.datastar
 
 import zio.blocks.chunk.Chunk
-import zio.http.html.{CssSelector, Dom, Js}
+import zio.blocks.html._
 import zio.blocks.maybe.Maybe
 import zio.http.ServerSentEvent
 

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarEvent.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarEvent.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 import zio.blocks.chunk.Chunk
-import zio.blocks.html.{CssSelector, Dom, Js}
+import zio.http.html.{CssSelector, Dom, Js}
 import zio.blocks.maybe.Maybe
 import zio.http.ServerSentEvent
 

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarRef.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarRef.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.ToJs
+import zio.http.html.ToJs
 
 final class DatastarRef private[datastar] (val signalName: String) {
   val value: String = "$" + signalName

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarRef.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarRef.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.ToJs
+import zio.blocks.html._
 
 final class DatastarRef private[datastar] (val signalName: String) {
   val value: String = "$" + signalName

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarStringEscape.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/DatastarStringEscape.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 private[datastar] object DatastarStringEscape {
 

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/ElementPatchMode.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/ElementPatchMode.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 /**
  * Describes how Datastar should patch rendered content into the target element.

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/EventModifier.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/EventModifier.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 import zio.blocks.maybe.Maybe
 

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/EventType.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/EventType.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 /**
  * Datastar event types emitted via the SSE `event:` field.

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/InitModifier.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/InitModifier.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 import zio.blocks.maybe.Maybe
 

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/IntersectModifier.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/IntersectModifier.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 import zio.blocks.maybe.Maybe
 

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/OnIntervalModifier.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/OnIntervalModifier.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 import zio.blocks.maybe.Maybe
 

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/OnSignalPatchModifier.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/OnSignalPatchModifier.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 import zio.blocks.maybe.Maybe
 

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/Signal.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/Signal.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.ToJs
+import zio.http.html.ToJs
 import zio.blocks.schema.Schema
 
 /**

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/Signal.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/Signal.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.ToJs
+import zio.blocks.html._
 import zio.blocks.schema.Schema
 
 /**

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/SignalUpdate.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/SignalUpdate.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.ToJs
+import zio.http.html.ToJs
 
 /**
  * A signal name paired with its JSON-serialized value.

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/SignalUpdate.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/SignalUpdate.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.ToJs
+import zio.blocks.html._
 
 /**
  * A signal name paired with its JSON-serialized value.

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/ToDatastarExpr.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/ToDatastarExpr.scala
@@ -17,7 +17,7 @@
 package zio.http.datastar
 
 import scala.annotation.{implicitAmbiguous, implicitNotFound}
-import zio.http.html.ToJs
+import zio.blocks.html._
 
 @implicitNotFound(
   "No ToDatastarExpr instance found for type ${A}. Use js\"...\" for Datastar expressions or typed Signal/SignalUpdate values."

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/ToDatastarExpr.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/ToDatastarExpr.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 import scala.annotation.{implicitAmbiguous, implicitNotFound}
-import zio.blocks.html.ToJs
+import zio.http.html.ToJs
 
 @implicitNotFound(
   "No ToDatastarExpr instance found for type ${A}. Use js\"...\" for Datastar expressions or typed Signal/SignalUpdate values."

--- a/datastar/shared/src/main/scala/zio/blocks/datastar/package.scala
+++ b/datastar/shared/src/main/scala/zio/blocks/datastar/package.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package zio.blocks
+package zio.http
 
 package object datastar extends DatastarAttributes {
 

--- a/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarAttributesSpec.scala
+++ b/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarAttributesSpec.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.{dataAttr => _, _}
+import zio.blocks.html.{dataAttr => _, _}
 import zio.blocks.schema.Schema
 import zio.test._
 
@@ -80,7 +80,7 @@ object DatastarAttributesSpec extends ZIOSpecDefault {
       test("dataText := raw String does not compile") {
         typeCheck("""
           import zio.http.datastar._
-          import zio.http.html._
+          import zio.blocks.html._
           div(dataText := "$count")
         """).map { result =>
           assertTrue(result.isLeft) &&
@@ -134,7 +134,7 @@ object DatastarAttributesSpec extends ZIOSpecDefault {
       test("dataOn.click := raw String does not compile") {
         typeCheck("""
           import zio.http.datastar._
-          import zio.http.html._
+          import zio.blocks.html._
           div(dataOn.click := "$count++")
         """).map { result =>
           assertTrue(result.isLeft) &&
@@ -267,7 +267,7 @@ object DatastarAttributesSpec extends ZIOSpecDefault {
       test("dataInit := raw String does not compile") {
         typeCheck("""
           import zio.http.datastar._
-          import zio.http.html._
+          import zio.blocks.html._
           div(dataInit := "@get('/data')")
         """).map { result =>
           assertTrue(result.isLeft) &&

--- a/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarAttributesSpec.scala
+++ b/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarAttributesSpec.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.{dataAttr => _, _}
+import zio.http.html.{dataAttr => _, _}
 import zio.blocks.schema.Schema
 import zio.test._
 
@@ -79,8 +79,8 @@ object DatastarAttributesSpec extends ZIOSpecDefault {
       },
       test("dataText := raw String does not compile") {
         typeCheck("""
-          import zio.blocks.datastar._
-          import zio.blocks.html._
+          import zio.http.datastar._
+          import zio.http.html._
           div(dataText := "$count")
         """).map { result =>
           assertTrue(result.isLeft) &&
@@ -133,8 +133,8 @@ object DatastarAttributesSpec extends ZIOSpecDefault {
       },
       test("dataOn.click := raw String does not compile") {
         typeCheck("""
-          import zio.blocks.datastar._
-          import zio.blocks.html._
+          import zio.http.datastar._
+          import zio.http.html._
           div(dataOn.click := "$count++")
         """).map { result =>
           assertTrue(result.isLeft) &&
@@ -266,8 +266,8 @@ object DatastarAttributesSpec extends ZIOSpecDefault {
       },
       test("dataInit := raw String does not compile") {
         typeCheck("""
-          import zio.blocks.datastar._
-          import zio.blocks.html._
+          import zio.http.datastar._
+          import zio.http.html._
           div(dataInit := "@get('/data')")
         """).map { result =>
           assertTrue(result.isLeft) &&

--- a/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarCoreTypesSpec.scala
+++ b/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarCoreTypesSpec.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.ToJs
+import zio.blocks.html._
 import zio.test._
 
 object DatastarCoreTypesSpec extends ZIOSpecDefault {

--- a/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarCoreTypesSpec.scala
+++ b/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarCoreTypesSpec.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.ToJs
+import zio.http.html.ToJs
 import zio.test._
 
 object DatastarCoreTypesSpec extends ZIOSpecDefault {
@@ -76,7 +76,7 @@ object DatastarCoreTypesSpec extends ZIOSpecDefault {
       test("SignalUpdate constructor is not public") {
         typeCheck("""
           package external
-          import zio.blocks.datastar.SignalUpdate
+          import zio.http.datastar.SignalUpdate
           new SignalUpdate[Int]("count", "42")
         """).map(result => assertTrue(result.isLeft))
       },

--- a/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarEventSpec.scala
+++ b/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarEventSpec.scala
@@ -17,7 +17,7 @@
 package zio.http.datastar
 
 import zio.blocks.chunk.Chunk
-import zio.http.html._
+import zio.blocks.html._
 import zio.blocks.schema.Schema
 import zio.test._
 

--- a/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarEventSpec.scala
+++ b/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarEventSpec.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 import zio.blocks.chunk.Chunk
-import zio.blocks.html._
+import zio.http.html._
 import zio.blocks.schema.Schema
 import zio.test._
 

--- a/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarInternalsSpec.scala
+++ b/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarInternalsSpec.scala
@@ -17,7 +17,7 @@
 package zio.http.datastar
 
 import zio.blocks.chunk.Chunk
-import zio.http.html.{CssSelector, Dom, ToJs, _}
+import zio.blocks.html._
 import zio.blocks.maybe.Maybe
 import zio.blocks.schema.Schema
 import zio.test._

--- a/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarInternalsSpec.scala
+++ b/datastar/shared/src/test/scala/zio/blocks/datastar/DatastarInternalsSpec.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
 import zio.blocks.chunk.Chunk
-import zio.blocks.html.{CssSelector, Dom, ToJs, _}
+import zio.http.html.{CssSelector, Dom, ToJs, _}
 import zio.blocks.maybe.Maybe
 import zio.blocks.schema.Schema
 import zio.test._
@@ -69,7 +69,7 @@ object DatastarInternalsSpec extends ZIOSpecDefault {
       },
       test("raw String is rejected in Datastar expression positions") {
         typeCheck("""
-          import zio.blocks.datastar._
+          import zio.http.datastar._
           ToDatastarExpr[String]
         """).map { result =>
           assertTrue(result.isLeft) &&

--- a/datastar/shared/src/test/scala/zio/blocks/datastar/SchemaIntegrationSpec.scala
+++ b/datastar/shared/src/test/scala/zio/blocks/datastar/SchemaIntegrationSpec.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package zio.blocks.datastar
+package zio.http.datastar
 
-import zio.blocks.html.ToJs
+import zio.http.html.ToJs
 import zio.blocks.schema.Schema
 import zio.test._
 

--- a/datastar/shared/src/test/scala/zio/blocks/datastar/SchemaIntegrationSpec.scala
+++ b/datastar/shared/src/test/scala/zio/blocks/datastar/SchemaIntegrationSpec.scala
@@ -16,7 +16,7 @@
 
 package zio.http.datastar
 
-import zio.http.html.ToJs
+import zio.blocks.html._
 import zio.blocks.schema.Schema
 import zio.test._
 

--- a/docs/reference/datastar.md
+++ b/docs/reference/datastar.md
@@ -3,7 +3,7 @@ id: datastar
 title: "Datastar"
 ---
 
-`zio-blocks-datastar` provides a type-safe Scala SDK for [Datastar](https://data-star.dev/), the hypermedia framework that brings reactive UIs via server-sent events (SSE). It builds on `zio-blocks-http-html` for DOM construction and `zio-blocks-schema` for JSON serialization.
+`zio-blocks-datastar` provides a type-safe Scala SDK for [Datastar](https://data-star.dev/), the hypermedia framework that brings reactive UIs via server-sent events (SSE). It builds on `zio-blocks-html` for DOM construction and `zio-blocks-schema` for JSON serialization.
 
 ## Installation
 
@@ -63,7 +63,7 @@ val sseWithOptions = DatastarEvent
 Send DOM fragments to the client:
 
 ```scala
-import zio.http.html._
+import zio.blocks.html._
 
 val sse = DatastarEvent
   .patchElements(div(id := "status")("Online"))
@@ -95,10 +95,10 @@ val sse = DatastarEvent
 
 ## Attribute DSL
 
-Import `zio.http.datastar._` to get all `data-*` attribute constructors. These integrate with the `zio-blocks-http-html` DSL:
+Import `zio.http.datastar._` to get all `data-*` attribute constructors. These integrate with the `zio-blocks-html` DSL:
 
 ```scala
-import zio.http.html._
+import zio.blocks.html._
 import zio.http.datastar._
 
 val count    = Signal[Int]("count")
@@ -289,10 +289,10 @@ DatastarEvent
 
 ## CssSelector
 
-`CssSelector` (from `zio.http.html`) constructs CSS selectors with type-safe combinators:
+`CssSelector` (from `zio.blocks.html`) constructs CSS selectors with type-safe combinators:
 
 ```scala
-import zio.http.html._
+import zio.blocks.html._
 
 CssSelector.id("main")          // #main
 CssSelector.`class`("active")   // .active

--- a/docs/reference/datastar.md
+++ b/docs/reference/datastar.md
@@ -3,7 +3,7 @@ id: datastar
 title: "Datastar"
 ---
 
-`zio-blocks-datastar` provides a type-safe Scala SDK for [Datastar](https://data-star.dev/), the hypermedia framework that brings reactive UIs via server-sent events (SSE). It builds on `zio-blocks-html` for DOM construction and `zio-blocks-schema` for JSON serialization.
+`zio-blocks-datastar` provides a type-safe Scala SDK for [Datastar](https://data-star.dev/), the hypermedia framework that brings reactive UIs via server-sent events (SSE). It builds on `zio-blocks-http-html` for DOM construction and `zio-blocks-schema` for JSON serialization.
 
 ## Installation
 
@@ -20,7 +20,7 @@ libraryDependencies += "dev.zio" %%% "zio-blocks-datastar" % "@VERSION@"
 A `Signal[A]` represents a named reactive signal on the client. Use `:=` to pair it with a value, producing a `SignalUpdate` ready for SSE transmission:
 
 ```scala
-import zio.blocks.datastar._
+import zio.http.datastar._
 import zio.blocks.schema.Schema
 
 case class User(name: String, age: Int)
@@ -63,7 +63,7 @@ val sseWithOptions = DatastarEvent
 Send DOM fragments to the client:
 
 ```scala
-import zio.blocks.html._
+import zio.http.html._
 
 val sse = DatastarEvent
   .patchElements(div(id := "status")("Online"))
@@ -95,11 +95,11 @@ val sse = DatastarEvent
 
 ## Attribute DSL
 
-Import `zio.blocks.datastar._` to get all `data-*` attribute constructors. These integrate with the `zio-blocks-html` DSL:
+Import `zio.http.datastar._` to get all `data-*` attribute constructors. These integrate with the `zio-blocks-http-html` DSL:
 
 ```scala
-import zio.blocks.html._
-import zio.blocks.datastar._
+import zio.http.html._
+import zio.http.datastar._
 
 val count    = Signal[Int]("count")
 val username = Signal[String]("username")
@@ -289,10 +289,10 @@ DatastarEvent
 
 ## CssSelector
 
-`CssSelector` (from `zio.blocks.html`) constructs CSS selectors with type-safe combinators:
+`CssSelector` (from `zio.http.html`) constructs CSS selectors with type-safe combinators:
 
 ```scala
-import zio.blocks.html._
+import zio.http.html._
 
 CssSelector.id("main")          // #main
 CssSelector.`class`("active")   // .active


### PR DESCRIPTION
## Summary
- move the endpoint DSL under `zio.http.endpoint`
- move the HTML DSL under `zio.http.html`
- move the Datastar DSL under `zio.http.datastar`
- keep the auth failure status documentation aligned with the endpoint auth behavior