### PR TITLE
exclude experimental annotation from typeId

### DIFF
--- a/typeid/shared/src/main/scala-3/zio/blocks/typeid/TypeIdMacros.scala
+++ b/typeid/shared/src/main/scala-3/zio/blocks/typeid/TypeIdMacros.scala
@@ -555,7 +555,8 @@ object TypeIdMacros {
       fullName.startsWith("scala.annotation.internal.") ||
       fullName.startsWith("scala.annotation.unchecked.") ||
       fullName == "scala.annotation.nowarn" ||
-      fullName == "scala.annotation.targetName"
+      fullName == "scala.annotation.targetName" ||
+      fullName == "scala.annotation.experimental"
     }
 
     annotations.flatMap(annot => analyzeAnnotation(annot))


### PR DESCRIPTION
It bloats typeId a lot if project uses experimental flags.