### PR TITLE
fix(ci): revert JS workflow split and stabilize Scala.js JS lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,27 +140,13 @@ jobs:
 
   testJS:
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - java: 17
-            platform: JS
-            scala: '2.13.x'
-            command: 'testJS docJS'
-          - java: 17
-            platform: JS
-            scala: '3.3.x'
-            command: 'testJS docJS'
-          - java: 17
-            platform: JS
-            scala: '3.8.x'
-            command: 'testJS1 docJS1'
-          - java: 17
-            platform: JS
-            scala: '3.8.x'
-            command: 'testJS2 docJS2'
+        java: [17]
+        platform: ['JS']
+        scala: ['2.13.x', '3.3.x', '3.8.x']
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v6.0.2
@@ -175,7 +161,7 @@ jobs:
       - name: Cache scala dependencies
         uses: coursier/cache-action@v8
       - name: Run Scala JS tests
-        run: sbt ++${{ matrix.scala }} ${{ matrix.command }}
+        run: sbt ++${{ matrix.scala }} testJS docJS
 
   testGolem:
     name: Test Golem (Scala 3.8.x / 2.13.x)

--- a/build.sbt
+++ b/build.sbt
@@ -584,6 +584,10 @@ lazy val `http-model` = crossProject(JSPlatform, JVMPlatform)
   .enablePlugins(BuildInfoPlugin)
   .jvmSettings(mimaSettings(failOnProblem = false))
   .jsSettings(jsSettings)
+  .jsSettings(
+    Compile / scalaJSLinkerConfig ~= (_.withOptimizer(false).withParallel(false)),
+    Test / scalaJSLinkerConfig ~= (_.withOptimizer(false).withParallel(false))
+  )
   .dependsOn(chunk, mediatype, streams, maybe)
   .settings(
     libraryDependencies ++= Seq(
@@ -602,6 +606,10 @@ lazy val `http-model-schema` = crossProject(JSPlatform, JVMPlatform)
   .enablePlugins(BuildInfoPlugin)
   .jvmSettings(mimaSettings(failOnProblem = false))
   .jsSettings(jsSettings)
+  .jsSettings(
+    Compile / scalaJSLinkerConfig ~= (_.withOptimizer(false).withParallel(false)),
+    Test / scalaJSLinkerConfig ~= (_.withOptimizer(false).withParallel(false))
+  )
   .dependsOn(`http-model`, schema)
   .settings(
     libraryDependencies ++= Seq(
@@ -631,6 +639,10 @@ lazy val endpoint = crossProject(JSPlatform, JVMPlatform)
   .enablePlugins(BuildInfoPlugin)
   .jvmSettings(mimaSettings(failOnProblem = false))
   .jsSettings(jsSettings)
+  .jsSettings(
+    Compile / scalaJSLinkerConfig ~= (_.withOptimizer(false).withParallel(false)),
+    Test / scalaJSLinkerConfig ~= (_.withOptimizer(false).withParallel(false))
+  )
   .dependsOn(`http-model`, schema, combinators, mediatype, markdown)
   .settings(
     libraryDependencies ++= Seq(
@@ -1413,6 +1425,10 @@ lazy val datastar = crossProject(JSPlatform, JVMPlatform)
   .enablePlugins(BuildInfoPlugin)
   .jvmSettings(mimaSettings(failOnProblem = false))
   .jsSettings(jsSettings)
+  .jsSettings(
+    Compile / scalaJSLinkerConfig ~= (_.withOptimizer(false).withParallel(false)),
+    Test / scalaJSLinkerConfig ~= (_.withOptimizer(false).withParallel(false))
+  )
   .dependsOn(html, `http-model`)
   .settings(
     libraryDependencies ++= Seq(
@@ -1433,6 +1449,10 @@ lazy val htmx = crossProject(JSPlatform, JVMPlatform)
   .enablePlugins(BuildInfoPlugin)
   .jvmSettings(mimaSettings(failOnProblem = false))
   .jsSettings(jsSettings)
+  .jsSettings(
+    Compile / scalaJSLinkerConfig ~= (_.withOptimizer(false).withParallel(false)),
+    Test / scalaJSLinkerConfig ~= (_.withOptimizer(false).withParallel(false))
+  )
   .dependsOn(html, schema, `http-model`)
   .settings(
     libraryDependencies ++= Seq(


### PR DESCRIPTION
## Summary
- revert the JS workflow split back to the codegen-docs shape
- throttle the remaining heavy Scala.js hotspot linkers in the Scala 3.3 JS lane
- raise the JS workflow timeout because the patched 3.3.x lane was timing out at the job boundary rather than failing on a Scala error
