### PR TITLE
fix(schema): expose buildPartial and path expression errors

### DIFF
--- a/docs/reference/schema/migration.md
+++ b/docs/reference/schema/migration.md
@@ -221,6 +221,7 @@ For example, `transformElements(_.scores, expr)` runs `expr` separately for ever
 
 ```scala
 def build(using ev: MigrationComplete[A, B, Changeset]): Migration[A, B]
+def buildPartial: Migration[A, B]
 ```
 
 `build` runs macro validation. It checks that every field needed to transform `A` into `B` is either:
@@ -230,7 +231,9 @@ def build(using ev: MigrationComplete[A, B, Changeset]): Migration[A, B]
 
 If the migration is incomplete, the code fails to compile.
 
-This validated `build` step is the public completion path for `MigrationBuilder`. If you need unvalidated or dynamically assembled migrations, work at the `DynamicMigration` layer and wrap it with `Migration.fromDynamic`.
+Use `buildPartial` when you intentionally need to inspect or run an incomplete builder without macro completeness validation. It preserves the actions accumulated by the builder, but runtime application may still fail if the resulting dynamic value cannot be decoded by the target schema.
+
+For fully dynamic migrations assembled without the typed builder API, work at the `DynamicMigration` layer and wrap it with `Migration.fromDynamic`.
 
 ## `DynamicMigration`
 

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -259,7 +259,7 @@ final class MigrationBuilder[A, B, Changeset](
   /**
    * Build migration without full validation.
    */
-  private[migration] def buildPartial: Migration[A, B] =
+  def buildPartial: Migration[A, B] =
     new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
 
   // ----- Internal -----

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -184,7 +184,7 @@ final class MigrationBuilder[A, B, Changeset](
   ): Migration[A, B] =
     new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
 
-  private[migration] def buildPartial: Migration[A, B] =
+  def buildPartial: Migration[A, B] =
     new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
 }
 

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -145,7 +145,7 @@ private[migration] object ActionExecutor {
   def execute(action: MigrationAction, value: DynamicValue): Either[SchemaError, DynamicValue] =
     action match {
       case a @ AddField(at, default) =>
-        evalExpr(default, value).flatMap { defaultValue =>
+        evalExpr(default, value, at).flatMap { defaultValue =>
           a.fieldName match {
             case Some(fieldName) => executeAddField(at, fieldName, defaultValue, value)
             case None            => Left(SchemaError.transformFailed(at, "AddField path must end with a Field node"))
@@ -165,7 +165,7 @@ private[migration] object ActionExecutor {
         executeTransformField(at, transform, value)
 
       case MandateField(at, default) =>
-        evalExpr(default, value).flatMap { defaultValue =>
+        evalExpr(default, value, at).flatMap { defaultValue =>
           executeMandate(at, defaultValue, value)
         }
 
@@ -204,7 +204,8 @@ private[migration] object ActionExecutor {
    */
   private def evalExpr(
     expr: DynamicSchemaExpr,
-    input: DynamicValue
+    input: DynamicValue,
+    at: zio.blocks.schema.DynamicOptic
   ): Either[SchemaError, DynamicValue] =
     expr.eval(input).flatMap { results =>
       results match {
@@ -212,14 +213,14 @@ private[migration] object ActionExecutor {
         case Seq()      =>
           Left(
             SchemaError.transformFailed(
-              zio.blocks.schema.DynamicOptic.root,
+              at,
               s"Expression evaluation returned no values"
             )
           )
         case _ =>
           Left(
             SchemaError.transformFailed(
-              zio.blocks.schema.DynamicOptic.root,
+              at,
               s"Expression evaluation must return exactly one value, got ${results.size}"
             )
           )
@@ -302,7 +303,7 @@ private[migration] object ActionExecutor {
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
     modifyAt(at, value) { currentValue =>
-      evalExpr(transform, currentValue)
+      evalExpr(transform, currentValue, at)
     }
 
   private def executeChangeFieldType(
@@ -311,7 +312,7 @@ private[migration] object ActionExecutor {
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
     modifyAt(at, value) { currentValue =>
-      evalExpr(converter, currentValue)
+      evalExpr(converter, currentValue, at)
     }
 
   // ==================== Collection/Map Action Execution ====================
@@ -325,7 +326,7 @@ private[migration] object ActionExecutor {
       case DynamicValue.Sequence(elements) =>
         val transformed = elements.foldLeft[Either[SchemaError, Chunk[DynamicValue]]](Right(Chunk.empty)) {
           case (Right(acc), element) =>
-            evalExpr(transform, element).map(acc :+ _)
+            evalExpr(transform, element, at).map(acc :+ _)
           case (left, _) =>
             left
         }
@@ -344,7 +345,7 @@ private[migration] object ActionExecutor {
         val transformed =
           entries.foldLeft[Either[SchemaError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
             case (Right(acc), (key, currentValue)) =>
-              evalExpr(transform, key).map(newKey => acc :+ (newKey -> currentValue))
+              evalExpr(transform, key, at).map(newKey => acc :+ (newKey -> currentValue))
             case (left, _) =>
               left
           }
@@ -363,7 +364,7 @@ private[migration] object ActionExecutor {
         val transformed =
           entries.foldLeft[Either[SchemaError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
             case (Right(acc), (key, currentValue)) =>
-              evalExpr(transform, currentValue).map(newValue => acc :+ (key -> newValue))
+              evalExpr(transform, currentValue, at).map(newValue => acc :+ (key -> newValue))
             case (left, _) =>
               left
           }

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
@@ -1170,7 +1170,10 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
         )
 
         assertTrue(
-          migration(input).left.exists(_.message.contains("must return exactly one value, got 2"))
+          migration(input).left.exists(error =>
+            error.message.contains("must return exactly one value, got 2") &&
+              error.message.contains(".value")
+          )
         )
       },
       test("empty migration is identity") {
@@ -1565,7 +1568,12 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
         val migration     = DynamicMigration.single(
           MigrationAction.TransformField(root.field("x"), selectMissing)
         )
-        assertTrue(migration(input).isLeft)
+        assertTrue(
+          migration(input).left.exists(error =>
+            error.message.contains("Expression evaluation returned no values") &&
+              error.message.contains(".x")
+          )
+        )
       }
     ),
     suite("MigrationAction.reverse additional")(

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -346,6 +346,20 @@ object MigrationSpec extends ZIOSpecDefault {
         assertTrue(migration.size == 1 && migration.dynamicMigration == dynamicMigration)
       },
 
+      test("buildPartial is public and skips completeness validation") {
+        case class PersonV1(name: String)
+        case class PersonV2(name: String, age: Int)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .buildPartial
+
+        assertTrue(migration.size == 0 && migration(PersonV1("Alice")).isLeft)
+      },
+
       test("Migration.++ composes migrations") {
         case class PersonV1(name: String)
         case class PersonV2(name: String, age: Int)


### PR DESCRIPTION
Support patch for #966 / #519.

This does not claim #519; it targets the existing schema migration branch.

Changes:
- Makes `MigrationBuilder.buildPartial` public in both Scala 2 and Scala 3 builders, matching the issue success criteria.
- Preserves the migration action path when `DynamicSchemaExpr` evaluation returns zero or multiple values.
- Updates migration docs and adds regression coverage for public `buildPartial` and path-aware expression errors.

Verification:
- `docker run --rm -v ".../zio-blocks-pr966-full:/workspace" -w /workspace sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.12.11_3.8.3 sbt "++3.8.3" "schemaJVM/testOnly zio.blocks.schema.migration.DynamicMigrationSpec zio.blocks.schema.migration.MigrationSpec"`
- Result: 186 tests passed, 0 failed, 0 ignored.