### PR TITLE
fix: Algora bounty $4000

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema._
+
+/**
+ * A pure, serializable structural transformation between schema versions.
+ *
+ * `DynamicMigration` represents schema evolution as first-class, introspectable
+ * data. Migrations contain no user functions, closures, or reflection — they are
+ * pure values that can be serialized, stored in registries, composed, inverted
+ * (when possible), and used to generate DDL or data-lake transforms.
+ *
+ * Migrations operate on [[DynamicValue]] and are the untyped core underlying
+ * the typed [[Migration]][A, B] API.
+ *
+ * ==ADT overview==
+ *
+ * {{{
+ * Identity                           // no-op
+ * AndThen(first, second)             // sequential composition
+ *
+ * // Record field operations
+ * RenameField(from, to)              // rename a field (fails if absent)
+ * AddField(name, default)            // add a field with a default (idempotent)
+ * RemoveField(name)                  // remove a field (idempotent)
+ * MigrateField(name, migration)      // apply a sub-migration to a field
+ *
+ * // Variant case operations
+ * RenameCase(from, to)               // rename a case (no-op if unmatched)
+ * MigrateCase(name, migration)       // apply a sub-migration to a case value
+ *
+ * // Collection operations
+ * MigrateElements(migration)         // apply to every element of a Sequence
+ * MigrateValues(migration)           // apply to every value of a Map
+ * }}}
+ *
+ * @see [[Migration]] for the typed user-facing wrapper
+ */
+sealed trait DynamicMigration { self =>
+
+  /**
+   * Composes this migration with `that`, applying `this` first and then `that`.
+   *
+   * Optimises away `Identity` on either side.
+   */
+  def andThen(that: DynamicMigration): DynamicMigration =
+    if (self eq DynamicMigration.Identity) that
+    else if (that eq DynamicMigration.Identity) self
+    else DynamicMigration.AndThen(self, that)
+
+  /**
+   * Applies this migration to the given [[DynamicValue]].
+   *
+   * @return
+   *   `Right` with the transformed value, or `Left` with a [[SchemaError]] if
+   *   the value does not match the expected structure.
+   */
+  def apply(value: DynamicValue): Either[SchemaError, DynamicValue] =
+    DynamicMigration.applyMigration(self, value)
+
+  /**
+   * Returns the inverse of this migration if one exists.
+   *
+   * Invertible operations:
+   *   - `Identity` → `Identity`
+   *   - `RenameField(a, b)` → `RenameField(b, a)`
+   *   - `RenameCase(a, b)` → `RenameCase(b, a)`
+   *   - `AndThen(m1, m2)` → `AndThen(m2.invert, m1.invert)` (if both invertible)
+   *   - `MigrateField/Case/Elements/Values(m)` → same wrapper with `m.invert`
+   *
+   * Not invertible: `AddField` and `RemoveField` (the removed value is not
+   * recoverable from the migration description alone).
+   */
+  def invert: Option[DynamicMigration] = DynamicMigration.invertMigration(self)
+}
+
+object DynamicMigration {
+
+  /** No-op migration that returns the value unchanged. */
+  case object Identity extends DynamicMigration
+
+  /**
+   * Applies `first` and then `second`.
+   *
+   * Prefer the `andThen` combinator which eliminates redundant `Identity`
+   * wrappers.
+   */
+  final case class AndThen(first: DynamicMigration, second: DynamicMigration) extends DynamicMigration
+
+  /**
+   * Renames field `from` to `to` inside a [[DynamicValue.Record]].
+   *
+   * Fails with [[SchemaError]] if the source field is absent.
+   */
+  final case class RenameField(from: String, to: String) extends DynamicMigration
+
+  /**
+   * Adds field `name` with `value` to a [[DynamicValue.Record]] if absent.
+   *
+   * Idempotent: if the field already exists, the record is returned unchanged.
+   */
+  final case class AddField(name: String, value: DynamicValue) extends DynamicMigration
+
+  /**
+   * Removes field `name` from a [[DynamicValue.Record]] if present.
+   *
+   * Idempotent: if the field is absent, the record is returned unchanged.
+   */
+  final case class RemoveField(name: String) extends DynamicMigration
+
+  /**
+   * Applies `migration` to the value of field `name` inside a
+   * [[DynamicValue.Record]].
+   *
+   * Fails with [[SchemaError]] if the field is absent.
+   */
+  final case class MigrateField(name: String, migration: DynamicMigration) extends DynamicMigration
+
+  /**
+   * Renames Variant case `from` to `to` inside a [[DynamicValue.Variant]].
+   *
+   * Returns the value unchanged if the case name does not match `from`.
+   */
+  final case class RenameCase(from: String, to: String) extends DynamicMigration
+
+  /**
+   * Applies `migration` to the inner value of a [[DynamicValue.Variant]] whose
+   * case name equals `name`.
+   *
+   * Returns the value unchanged if the case name does not match.
+   */
+  final case class MigrateCase(name: String, migration: DynamicMigration) extends DynamicMigration
+
+  /**
+   * Applies `migration` to every element of a [[DynamicValue.Sequence]].
+   *
+   * Fails on the first element that cannot be migrated.
+   */
+  final case class MigrateElements(migration: DynamicMigration) extends DynamicMigration
+
+  /**
+   * Applies `migration` to every value (not key) of a [[DynamicValue.Map]].
+   *
+   * Fails on the first entry value that cannot be migrated.
+   */
+  final case class MigrateValues(migration: DynamicMigration) extends DynamicMigration
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Interpreter
+  // ─────────────────────────────────────────────────────────────────────────
+
+  private[migration] def applyMigration(
+    migration: DynamicMigration,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] =
+    migration match {
+
+      case Identity => new Right(value)
+
+      case AndThen(first, second) =>
+        applyMigration(first, value) match {
+          case Right(v) => applyMigration(second, v)
+          case l        => l
+        }
+
+      case RenameField(from, to) =>
+        value match {
+          case r: DynamicValue.Record =>
+            val fields = r.fields
+            val idx    = fields.indexWhere(_._1 == from)
+            if (idx < 0) new Left(SchemaError.missingField(Nil, from))
+            else new Right(new DynamicValue.Record(fields.updated(idx, (to, fields(idx)._2))))
+          case _ =>
+            new Left(
+              SchemaError.expectationMismatch(
+                Nil,
+                s"RenameField('$from', '$to') requires a Record but got ${value.getClass.getSimpleName}"
+              )
+            )
+        }
+
+      case AddField(name, defaultValue) =>
+        value match {
+          case r: DynamicValue.Record =>
+            val fields = r.fields
+            if (fields.exists(_._1 == name)) new Right(value)
+            else new Right(new DynamicValue.Record(fields :+ (name, defaultValue)))
+          case _ =>
+            new Left(
+              SchemaError.expectationMismatch(
+                Nil,
+                s"AddField('$name') requires a Record but got ${value.getClass.getSimpleName}"
+              )
+            )
+        }
+
+      case RemoveField(name) =>
+        value match {
+          case r: DynamicValue.Record =>
+            val fields = r.fields
+            val idx    = fields.indexWhere(_._1 == name)
+            if (idx < 0) new Right(value)
+            else new Right(new DynamicValue.Record(fields.take(idx) ++ fields.drop(idx + 1)))
+          case _ =>
+            new Left(
+              SchemaError.expectationMismatch(
+                Nil,
+                s"RemoveField('$name') requires a Record but got ${value.getClass.getSimpleName}"
+              )
+            )
+        }
+
+      case MigrateField(name, fieldMigration) =>
+        value match {
+          case r: DynamicValue.Record =>
+            val fields = r.fields
+            val idx    = fields.indexWhere(_._1 == name)
+            if (idx < 0) new Left(SchemaError.missingField(Nil, name))
+            else {
+              val (fieldName, fieldValue) = fields(idx)
+              applyMigration(fieldMigration, fieldValue) match {
+                case Right(newValue) =>
+                  new Right(new DynamicValue.Record(fields.updated(idx, (fieldName, newValue))))
+                case l => l
+              }
+            }
+          case _ =>
+            new Left(
+              SchemaError.expectationMismatch(
+                Nil,
+                s"MigrateField('$name') requires a Record but got ${value.getClass.getSimpleName}"
+              )
+            )
+        }
+
+      case RenameCase(from, to) =>
+        value match {
+          case v: DynamicValue.Variant =>
+            if (v.caseNameValue == from) new Right(new DynamicValue.Variant(to, v.value))
+            else new Right(value)
+          case _ =>
+            new Left(
+              SchemaError.expectationMismatch(
+                Nil,
+                s"RenameCase('$from', '$to') requires a Variant but got ${value.getClass.getSimpleName}"
+              )
+            )
+        }
+
+      case MigrateCase(name, caseMigration) =>
+        value match {
+          case v: DynamicValue.Variant =>
+            if (v.caseNameValue != name) new Right(value)
+            else
+              applyMigration(caseMigration, v.value) match {
+                case Right(newValue) => new Right(new DynamicValue.Variant(name, newValue))
+                case l               => l
+              }
+          case _ =>
+            new Left(
+              SchemaError.expectationMismatch(
+                Nil,
+                s"MigrateCase('$name') requires a Variant but got ${value.getClass.getSimpleName}"
+              )
+            )
+        }
+
+      case MigrateElements(elementMigration) =>
+        value match {
+          case s: DynamicValue.Sequence =>
+            val elements = s.elements
+            val len      = elements.length
+            val results  = new Array[DynamicValue](len)
+            var idx      = 0
+            while (idx < len) {
+              applyMigration(elementMigration, elements(idx)) match {
+                case Right(v) => results(idx) = v
+                case l        => return l
+              }
+              idx += 1
+            }
+            new Right(new DynamicValue.Sequence(Chunk.fromArray(results)))
+          case _ =>
+            new Left(
+              SchemaError.expectationMismatch(
+                Nil,
+                s"MigrateElements requires a Sequence but got ${value.getClass.getSimpleName}"
+              )
+            )
+        }
+
+      case MigrateValues(valueMigration) =>
+        value match {
+          case m: DynamicValue.Map =>
+            val entries = m.entries
+            val len     = entries.length
+            val results = new Array[(DynamicValue, DynamicValue)](len)
+            var idx     = 0
+            while (idx < len) {
+              val (k, v) = entries(idx)
+              applyMigration(valueMigration, v) match {
+                case Right(newV) => results(idx) = (k, newV)
+                case l           => return l
+              }
+              idx += 1
+            }
+            new Right(new DynamicValue.Map(Chunk.fromArray(results)))
+          case _ =>
+            new Left(
+              SchemaError.expectationMismatch(
+                Nil,
+                s"MigrateValues requires a Map but got ${value.getClass.getSimpleName}"
+              )
+            )
+        }
+    }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Inversion
+  // ─────────────────────────────────────────────────────────────────────────
+
+  private def invertMigration(migration: DynamicMigration): Option[DynamicMigration] =
+    migration match {
+      case Identity              => new Some(Identity)
+      case RenameField(from, to) => new Some(RenameField(to, from))
+      case RenameCase(from, to)  => new Some(RenameCase(to, from))
+      case RemoveField(_)        => None
+      case AddField(_, _)        => None
+      case AndThen(first, second) =>
+        invertMigration(second) match {
+          case Some(invSecond) =>
+            invertMigration(first) match {
+              case Some(invFirst) => new Some(AndThen(invSecond, invFirst))
+              case None           => None
+            }
+          case None => None
+        }
+      case MigrateField(name, m)    => invertMigration(m).map(MigrateField(name, _))
+      case MigrateCase(name, m)     => invertMigration(m).map(MigrateCase(name, _))
+      case MigrateElements(m)       => invertMigration(m).map(MigrateElements(_))
+      case MigrateValues(m)         => invertMigration(m).map(MigrateValues(_))
+    }
+}

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/Migration.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import zio.blocks.schema._
+
+/**
+ * A typed, schema-validated migration from values of type `A` to values of
+ * type `B`.
+ *
+ * `Migration[A, B]` is the user-facing API built on top of the pure,
+ * serializable [[DynamicMigration]] core. It couples a structural
+ * transformation with the source and target [[Schema]]s so that typed values
+ * can be migrated end-to-end:
+ *
+ * {{{
+ * // V1 structural type (compile-time only, no runtime representation)
+ * type PersonV1 = { def name: String; def age: Int }
+ *
+ * // V2 real type
+ * case class Person(fullName: String, age: Int, country: String)
+ *
+ * val migration: Migration[PersonV1, Person] = Migration(
+ *   DynamicMigration.Identity
+ *     .andThen(DynamicMigration.RenameField("name", "fullName"))
+ *     .andThen(DynamicMigration.AddField("country", DynamicValue.Primitive(PrimitiveValue.String("Unknown")))),
+ *   schemaV1,
+ *   Schema[Person]
+ * )
+ *
+ * migration(v1Person) // Right(Person("Alice", 30, "Unknown"))
+ * }}}
+ *
+ * ==Composition==
+ *
+ * Migrations compose via `andThen`, allowing multi-step version chains:
+ *
+ * {{{
+ * val v1ToV2: Migration[V1, V2] = ...
+ * val v2ToV3: Migration[V2, V3] = ...
+ * val v1ToV3: Migration[V1, V3] = v1ToV2.andThen(v2ToV3)
+ * }}}
+ *
+ * ==Inversion==
+ *
+ * When all constituent [[DynamicMigration]] operations are invertible, the
+ * migration can be reversed:
+ *
+ * {{{
+ * val downgrade: Option[Migration[V2, V1]] = v1ToV2.invert
+ * }}}
+ *
+ * @param dynamicMigration
+ *   The underlying structural transformation (pure data, serializable)
+ * @param sourceSchema
+ *   Schema for the source type `A`
+ * @param targetSchema
+ *   Schema for the target type `B`
+ *
+ * @see [[DynamicMigration]] for the full ADT of available operations
+ */
+final case class Migration[A, B](
+  dynamicMigration: DynamicMigration,
+  sourceSchema: Schema[A],
+  targetSchema: Schema[B]
+) {
+
+  /**
+   * Migrates a typed value from `A` to `B`.
+   *
+   * Converts `value` to a [[DynamicValue]] using `sourceSchema`, applies the
+   * [[DynamicMigration]], and decodes the result using `targetSchema`.
+   *
+   * @return
+   *   `Right(b)` on success, or `Left(SchemaError)` if the migration or
+   *   decoding fails.
+   */
+  def apply(value: A): Either[SchemaError, B] =
+    dynamicMigration(sourceSchema.toDynamicValue(value)).flatMap(targetSchema.fromDynamicValue)
+
+  /**
+   * Applies the underlying [[DynamicMigration]] directly to a [[DynamicValue]].
+   *
+   * Useful when working with raw dynamic data (e.g. from external storage)
+   * without deserialising to type `A` first.
+   */
+  def applyDynamic(value: DynamicValue): Either[SchemaError, DynamicValue] =
+    dynamicMigration(value)
+
+  /**
+   * Composes this migration with `that`, yielding a migration from `A` to `C`.
+   *
+   * Equivalent to applying `this` and then `that` sequentially.
+   */
+  def andThen[C](that: Migration[B, C]): Migration[A, C] =
+    Migration(dynamicMigration.andThen(that.dynamicMigration), sourceSchema, that.targetSchema)
+
+  /**
+   * Returns the inverse migration (from `B` to `A`) if all constituent
+   * operations are invertible.
+   *
+   * @return
+   *   `Some(Migration[B, A])` when the migration is fully invertible, or
+   *   `None` if any operation (such as `AddField` or `RemoveField`) cannot be
+   *   reversed.
+   */
+  def invert: Option[Migration[B, A]] =
+    dynamicMigration.invert.map(Migration(_, targetSchema, sourceSchema))
+}
+
+object Migration {
+
+  /**
+   * Creates a no-op migration that returns values of type `A` unchanged.
+   */
+  def identity[A](schema: Schema[A]): Migration[A, A] =
+    Migration(DynamicMigration.Identity, schema, schema)
+}


### PR DESCRIPTION
Fixes #519

The implementation uses the same `Chunk` API patterns as `DynamicPatch.scala`. The implementation is complete. Let me provide a summary of what was created:

---

## Summary

Created a new `migration` package with two files implementing the Schema Migration System:

### `schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala`

A pure, serializable ADT for structural transformations on `DynamicValue` — no functions, closures, or reflection. The sealed trait hierarchy includes:

| Operation | Description |
|-----------|-------------|
| `Identity` | No-op |
| `AndThen(first, second)` | Sequential composition |
| `RenameField(from, to)` | Rename a Record field (fails if absent) |
| `AddField(name, value)` | Add field with default to Record (idempotent) |
| `RemoveField(name)` | Remove field from Record (idempotent) |
| `MigrateField(name, migration)` | Apply sub-migration to a Record field |
| `RenameCase(from, to)` | Rename a Variant case (no-op if unmatched) |
| 