### PR TITLE
fix(ci): restore JS lane behavior and remove unused matrix field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,19 +146,15 @@ jobs:
       matrix:
         include:
           - java: 17
-            platform: JS
             scala: '2.13.x'
             command: 'testJS docJS'
           - java: 17
-            platform: JS
             scala: '3.3.x'
             command: 'testJS docJS'
           - java: 17
-            platform: JS
             scala: '3.8.x'
             command: 'testJS1 docJS1'
           - java: 17
-            platform: JS
             scala: '3.8.x'
             command: 'testJS2 docJS2'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,11 @@ jobs:
           - java: 17
             platform: JS
             scala: '3.3.x'
-            command: 'testJS docJS'
+            command: 'testJS1 docJS1'
+          - java: 17
+            platform: JS
+            scala: '3.3.x'
+            command: 'testJS2 docJS2'
           - java: 17
             platform: JS
             scala: '3.8.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,11 +152,7 @@ jobs:
           - java: 17
             platform: JS
             scala: '3.3.x'
-            command: 'testJS1 docJS1'
-          - java: 17
-            platform: JS
-            scala: '3.3.x'
-            command: 'testJS2 docJS2'
+            command: 'testJS docJS'
           - java: 17
             platform: JS
             scala: '3.8.x'

--- a/build.sbt
+++ b/build.sbt
@@ -148,13 +148,13 @@ lazy val docJSScala2Batch2Command =
 
 lazy val docJSScala3Command =
   "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
-    "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; htmlJS/doc; datastarJS/doc; htmxJS/doc"
+    "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; endpointJS/doc; htmlJS/doc; datastarJS/doc; htmxJS/doc"
 
 lazy val docJSScala3Batch1Command =
   "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc"
 
 lazy val docJSScala3Batch2Command =
-  "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; htmlJS/doc; datastarJS/doc"
+  "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; endpointJS/doc; htmlJS/doc; datastarJS/doc; htmxJS/doc"
 
 def commandForScalaVersion(name: String, scala2Command: String, scala3Command: String): Command =
   Command.command(name) { state =>


### PR DESCRIPTION
## Summary
- keep the Scala 3.3 JS lane unsplit while preserving the Scala 3.8 split commands
- remove the unused `platform` field from the `testJS` matrix so the workflow inputs match the command step
- keep the original 35 minute timeout instead of masking behavior changes with a larger timeout