### PR TITLE
fix(endpoint): enable Scala 2.13 cross-build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ addCommandAlias(
 lazy val testJVMScala2Command =
   "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
     "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; mediatypeJVM/test; " +
-    "openapiJVM/test; smithy/test; codegen/test; htmlJVM/test"
+    "endpointJVM/test; openapiJVM/test; smithy/test; codegen/test; htmlJVM/test"
 
 lazy val testJVMScala3Command =
   "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
@@ -108,7 +108,7 @@ lazy val testJVMScala3Command =
 
 lazy val testJSScala2Command =
   "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
-    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; htmlJS/test"
+    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; endpointJS/test; htmlJS/test"
 
 lazy val testJSScala3Command =
   "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
@@ -129,7 +129,7 @@ lazy val testJS2Scala3Command =
 lazy val docJVMScala2Command =
   "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
     "schema-thrift/doc; schema-bson/doc; schema-xmlJVM/doc; schema-yamlJVM/doc; schema-csvJVM/doc; contextJVM/doc; scopeJVM/doc; mediatypeJVM/doc; " +
-    "openapiJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc"
+    "endpointJVM/doc; openapiJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc"
 
 lazy val docJVMScala3Command =
   "typeidJVM/doc; maybeJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
@@ -138,7 +138,7 @@ lazy val docJVMScala3Command =
 
 lazy val docJSScala2Command =
   "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
-    "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; htmlJS/doc"
+    "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; endpointJS/doc; htmlJS/doc"
 
 lazy val docJSScala2Batch1Command =
   "typeidJS/doc; maybeJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc"
@@ -651,21 +651,7 @@ lazy val endpoint = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test-sbt" % "2.1.26" % Test
     ),
     coverageMinimumStmtTotal   := 0,
-    coverageMinimumBranchTotal := 0,
-    // Endpoint contains Scala 3-only endpoint DSL and macro code.
-    // Under 2.13 CI runs, skip compilation entirely.
-    Compile / sources := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) => Nil
-        case _            => (Compile / sources).value
-      }
-    },
-    Test / sources := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) => Nil
-        case _            => (Test / sources).value
-      }
-    }
+    coverageMinimumBranchTotal := 0
   )
 
 lazy val `endpoint-examples` = project

--- a/endpoint/shared/src/main/scala-2/zio/blocks/endpoint/SegmentCodecPlatformSpecific.scala
+++ b/endpoint/shared/src/main/scala-2/zio/blocks/endpoint/SegmentCodecPlatformSpecific.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import zio.blocks.combinators.Tuples
+
+private[endpoint] trait SegmentCodecPlatformSpecific {
+  import SegmentCodec._
+
+  implicit final class SegmentCodecOps[A, P <: BoundaryTag, S <: BoundaryTag](
+    private val self: WithBoundaries[A, P, S]
+  ) {
+    def ~[B, P2 <: BoundaryTag, S2 <: BoundaryTag, C](that: WithBoundaries[B, P2, S2])(
+      implicit combiner: Tuples.Tuples.WithOut[A, B, C],
+      canCombine: CanCombine[S, P2]
+    ): WithBoundaries[C, P, S2] =
+      SegmentCodec.combineValidated(self, that, combiner).asInstanceOf[WithBoundaries[C, P, S2]]
+
+    def ~[C](that: String)(
+      implicit combiner: Tuples.Tuples.WithOut[A, Unit, C],
+      canCombine: CanCombine[S, BoundaryTag.Literal]
+    ): WithBoundaries[C, P, BoundaryTag.Literal] =
+      SegmentCodec.combineValidated(self, SegmentCodec.literal(that), combiner)
+        .asInstanceOf[WithBoundaries[C, P, BoundaryTag.Literal]]
+
+    def transform[B](decode: A => B, encode: B => A): WithBoundaries[B, P, S] =
+      SegmentCodec.transformValidated[A, B](self, value => Right(decode(value)), value => Right(encode(value)))
+        .asInstanceOf[WithBoundaries[B, P, S]]
+
+    def transformOrFail[B](
+      decode: A => Either[DecodeError, B],
+      encode: B => Either[DecodeError, A]
+    ): WithBoundaries[B, P, S] =
+      SegmentCodec.transformValidated[A, B](self, decode, encode).asInstanceOf[WithBoundaries[B, P, S]]
+  }
+
+  def literal(value: String): Literal = {
+    SegmentCodec.validateLiteralValue(value)
+    SegmentCodec.literalValidated(value)
+  }
+}
+
+private[endpoint] trait CanCombinePlatformSpecific {
+  import SegmentCodec.BoundaryTag
+
+  implicit def canCombine[L <: BoundaryTag, R <: BoundaryTag]: SegmentCodec.CanCombine[L, R] =
+    new SegmentCodec.CanCombine[L, R] {}
+}

--- a/endpoint/shared/src/main/scala-2/zio/blocks/endpoint/SegmentCodecPlatformSpecific.scala
+++ b/endpoint/shared/src/main/scala-2/zio/blocks/endpoint/SegmentCodecPlatformSpecific.scala
@@ -21,24 +21,93 @@ import zio.blocks.combinators.Tuples
 private[endpoint] trait SegmentCodecPlatformSpecific {
   import SegmentCodec._
 
+  private def validateCombination(left: SegmentCodec[_], right: SegmentCodec[_]): Unit =
+    (suffixBoundary(left), prefixBoundary(right)) match {
+      case (Some((leftKind, _)), Some((rightKind, _))) if leftKind == Kind.Trailing || rightKind == Kind.Trailing =>
+        throw new IllegalArgumentException(
+          s"Cannot combine trailing path segments with `~`: ${boundaryLabel(leftKind)} ~ ${boundaryLabel(rightKind)}"
+        )
+      case (Some((Kind.String, leftName)), Some((Kind.String, rightName))) =>
+        throw new IllegalArgumentException(
+          s"Cannot combine two string segments. Their names are $leftName and $rightName"
+        )
+      case (Some((leftKind, leftName)), Some((rightKind, rightName))) if isNumeric(leftKind) && isNumeric(rightKind) =>
+        throw new IllegalArgumentException(
+          s"Cannot combine two numeric segments. Their names are $leftName and $rightName"
+        )
+      case _ => ()
+    }
+
+  private def prefixBoundary(codec: SegmentCodec[_]): Option[(Kind, String)] =
+    codec match {
+      case Empty                    => None
+      case Literal(value, _, _)     => Some((Kind.Literal, value))
+      case BoolSeg(name, _, _)      => Some((Kind.Bool, name))
+      case IntSeg(name, _, _)       => Some((Kind.Int, name))
+      case LongSeg(name, _, _)      => Some((Kind.Long, name))
+      case StringSeg(name, _, _)    => Some((Kind.String, name))
+      case UUIDSeg(name, _, _)      => Some((Kind.UUID, name))
+      case Trailing                 => Some((Kind.Trailing, "trailing"))
+      case Transform(inner, _, _)   => prefixBoundary(inner)
+      case Combined(left, right, _) =>
+        prefixBoundary(left).orElse(prefixBoundary(right))
+    }
+
+  private def suffixBoundary(codec: SegmentCodec[_]): Option[(Kind, String)] =
+    codec match {
+      case Empty                    => None
+      case Literal(value, _, _)     => Some((Kind.Literal, value))
+      case BoolSeg(name, _, _)      => Some((Kind.Bool, name))
+      case IntSeg(name, _, _)       => Some((Kind.Int, name))
+      case LongSeg(name, _, _)      => Some((Kind.Long, name))
+      case StringSeg(name, _, _)    => Some((Kind.String, name))
+      case UUIDSeg(name, _, _)      => Some((Kind.UUID, name))
+      case Trailing                 => Some((Kind.Trailing, "trailing"))
+      case Transform(inner, _, _)   => suffixBoundary(inner)
+      case Combined(left, right, _) =>
+        suffixBoundary(right).orElse(suffixBoundary(left))
+    }
+
+  private def boundaryLabel(kind: Kind): String =
+    kind match {
+      case Kind.Literal  => "literal"
+      case Kind.Bool     => "bool"
+      case Kind.Int      => "int"
+      case Kind.Long     => "long"
+      case Kind.String   => "string"
+      case Kind.UUID     => "uuid"
+      case Kind.Combined => "combined"
+      case Kind.Trailing => "trailing"
+      case Kind.Empty    => "empty"
+    }
+
+  private def isNumeric(kind: Kind): Boolean = kind == Kind.Int || kind == Kind.Long
+
   implicit final class SegmentCodecOps[A, P <: BoundaryTag, S <: BoundaryTag](
     private val self: WithBoundaries[A, P, S]
   ) {
-    def ~[B, P2 <: BoundaryTag, S2 <: BoundaryTag, C](that: WithBoundaries[B, P2, S2])(
-      implicit combiner: Tuples.Tuples.WithOut[A, B, C],
+    def ~[B, P2 <: BoundaryTag, S2 <: BoundaryTag, C](that: WithBoundaries[B, P2, S2])(implicit
+      combiner: Tuples.Tuples.WithOut[A, B, C],
       canCombine: CanCombine[S, P2]
-    ): WithBoundaries[C, P, S2] =
+    ): WithBoundaries[C, P, S2] = {
+      validateCombination(self, that)
       SegmentCodec.combineValidated(self, that, combiner).asInstanceOf[WithBoundaries[C, P, S2]]
+    }
 
-    def ~[C](that: String)(
-      implicit combiner: Tuples.Tuples.WithOut[A, Unit, C],
+    def ~[C](that: String)(implicit
+      combiner: Tuples.Tuples.WithOut[A, Unit, C],
       canCombine: CanCombine[S, BoundaryTag.Literal]
-    ): WithBoundaries[C, P, BoundaryTag.Literal] =
-      SegmentCodec.combineValidated(self, SegmentCodec.literal(that), combiner)
+    ): WithBoundaries[C, P, BoundaryTag.Literal] = {
+      val right = SegmentCodec.literal(that)
+      validateCombination(self, right)
+      SegmentCodec
+        .combineValidated(self, right, combiner)
         .asInstanceOf[WithBoundaries[C, P, BoundaryTag.Literal]]
+    }
 
     def transform[B](decode: A => B, encode: B => A): WithBoundaries[B, P, S] =
-      SegmentCodec.transformValidated[A, B](self, value => Right(decode(value)), value => Right(encode(value)))
+      SegmentCodec
+        .transformValidated[A, B](self, value => Right(decode(value)), value => Right(encode(value)))
         .asInstanceOf[WithBoundaries[B, P, S]]
 
     def transformOrFail[B](

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/SegmentCodecPlatformSpecific.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/SegmentCodecPlatformSpecific.scala
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import scala.quoted.*
+
+import zio.blocks.combinators.Tuples
+
+private[endpoint] trait SegmentCodecPlatformSpecific {
+  import SegmentCodec._
+
+  extension [A, P <: BoundaryTag, S <: BoundaryTag](self: WithBoundaries[A, P, S]) {
+    inline def ~[B, P2 <: BoundaryTag, S2 <: BoundaryTag, C](that: WithBoundaries[B, P2, S2])(using
+      combiner: Tuples.Tuples.WithOut[A, B, C],
+      canCombine: CanCombine[S, P2]
+    ): WithBoundaries[C, P, S2] =
+      ${ SegmentCodecPlatformSpecificMacros.combineImpl[A, B, C, P, S, P2, S2]('self, 'that, 'combiner) }
+
+    inline def ~[C](inline that: String)(using
+      combiner: Tuples.Tuples.WithOut[A, Unit, C],
+      canCombine: CanCombine[S, BoundaryTag.Literal]
+    ): WithBoundaries[C, P, BoundaryTag.Literal] =
+      ${ SegmentCodecPlatformSpecificMacros.combineLiteralImpl[A, C, P, S]('self, 'that, 'combiner) }
+
+    inline def transform[B](decode: A => B, encode: B => A): WithBoundaries[B, P, S] =
+      ${ SegmentCodecPlatformSpecificMacros.transformImpl[A, B, P, S]('self, 'decode, 'encode) }
+
+    inline def transformOrFail[B](
+      decode: A => Either[DecodeError, B],
+      encode: B => Either[DecodeError, A]
+    ): WithBoundaries[B, P, S] =
+      ${ SegmentCodecPlatformSpecificMacros.transformOrFailImpl[A, B, P, S]('self, 'decode, 'encode) }
+  }
+
+  inline def literal(inline value: String): Literal =
+    ${ SegmentCodecPlatformSpecificMacros.literalImpl('value) }
+}
+
+private[endpoint] trait CanCombinePlatformSpecific {
+  import SegmentCodec.BoundaryTag
+
+  transparent inline given [L <: BoundaryTag, R <: BoundaryTag]: SegmentCodec.CanCombine[L, R] =
+    ${ SegmentCodecPlatformSpecificMacros.canCombineImpl[L, R] }
+}
+
+private[endpoint] object SegmentCodecPlatformSpecificMacros {
+  import SegmentCodec.*
+
+  private sealed trait SegmentInfoKind
+  private object SegmentInfoKind {
+    case object Literal extends SegmentInfoKind
+    case object Bool extends SegmentInfoKind
+    case object Int extends SegmentInfoKind
+    case object Long extends SegmentInfoKind
+    case object String extends SegmentInfoKind
+    case object UUID extends SegmentInfoKind
+    case object Trailing extends SegmentInfoKind
+  }
+
+  private final case class SegmentInfo(kind: SegmentInfoKind, name: String)
+  private final case class BoundaryInfo(prefix: Option[SegmentInfo], suffix: Option[SegmentInfo]) {
+    def ++(that: BoundaryInfo): BoundaryInfo =
+      BoundaryInfo(prefix.orElse(that.prefix), that.suffix.orElse(suffix))
+  }
+
+  def combineImpl[
+    A: Type,
+    B: Type,
+    C: Type,
+    P <: BoundaryTag: Type,
+    S <: BoundaryTag: Type,
+    P2 <: BoundaryTag: Type,
+    S2 <: BoundaryTag: Type
+  ](
+    leftExpr: Expr[WithBoundaries[A, P, S]],
+    rightExpr: Expr[WithBoundaries[B, P2, S2]],
+    combinerExpr: Expr[Tuples.Tuples.WithOut[A, B, C]]
+  )(using Quotes): Expr[WithBoundaries[C, P, S2]] = {
+    import quotes.reflect.*
+
+    val leftInfo  = boundaryInfo(leftExpr.asTerm)
+    val rightInfo = boundaryInfo(rightExpr.asTerm)
+
+    (leftInfo, rightInfo) match {
+      case (Some(left), Some(right)) =>
+        validateBoundary(left.suffix, right.prefix)
+        '{
+          SegmentCodec.combineValidated($leftExpr, $rightExpr, $combinerExpr).asInstanceOf[WithBoundaries[C, P, S2]]
+        }
+      case _ =>
+        '{
+          SegmentCodec.combineValidated($leftExpr, $rightExpr, $combinerExpr).asInstanceOf[WithBoundaries[C, P, S2]]
+        }
+    }
+  }
+
+  def combineLiteralImpl[A: Type, C: Type, P <: BoundaryTag: Type, S <: BoundaryTag: Type](
+    leftExpr: Expr[WithBoundaries[A, P, S]],
+    rightExpr: Expr[String],
+    combinerExpr: Expr[Tuples.Tuples.WithOut[A, Unit, C]]
+  )(using Quotes): Expr[WithBoundaries[C, P, BoundaryTag.Literal]] =
+    '{
+      SegmentCodec
+        .combineValidated($leftExpr, SegmentCodec.literal($rightExpr), $combinerExpr)
+        .asInstanceOf[WithBoundaries[C, P, BoundaryTag.Literal]]
+    }
+
+  def canCombineImpl[L <: BoundaryTag: Type, R <: BoundaryTag: Type](using Quotes): Expr[CanCombine[L, R]] = {
+    import quotes.reflect.*
+
+    val left  = TypeRepr.of[L]
+    val right = TypeRepr.of[R]
+
+    def is(boundary: TypeRepr, target: TypeRepr): Boolean = boundary <:< target
+
+    def label(boundary: TypeRepr): String =
+      if is(boundary, TypeRepr.of[BoundaryTag.Literal]) then "literal"
+      else if is(boundary, TypeRepr.of[BoundaryTag.Bool]) then "bool"
+      else if is(boundary, TypeRepr.of[BoundaryTag.Int]) then "int"
+      else if is(boundary, TypeRepr.of[BoundaryTag.Long]) then "long"
+      else if is(boundary, TypeRepr.of[BoundaryTag.String]) then "string"
+      else if is(boundary, TypeRepr.of[BoundaryTag.UUID]) then "uuid"
+      else if is(boundary, TypeRepr.of[BoundaryTag.Trailing]) then "trailing"
+      else if is(boundary, TypeRepr.of[BoundaryTag.Empty]) then "empty"
+      else boundary.show
+
+    val leftTrailing  = is(left, TypeRepr.of[BoundaryTag.Trailing])
+    val rightTrailing = is(right, TypeRepr.of[BoundaryTag.Trailing])
+    val leftString    = is(left, TypeRepr.of[BoundaryTag.String])
+    val rightString   = is(right, TypeRepr.of[BoundaryTag.String])
+    val leftNumeric   = is(left, TypeRepr.of[BoundaryTag.Int]) || is(left, TypeRepr.of[BoundaryTag.Long])
+    val rightNumeric  = is(right, TypeRepr.of[BoundaryTag.Int]) || is(right, TypeRepr.of[BoundaryTag.Long])
+    val leftKnown     =
+      is(left, TypeRepr.of[BoundaryTag.Empty]) || is(left, TypeRepr.of[BoundaryTag.Literal]) ||
+        is(left, TypeRepr.of[BoundaryTag.Bool]) || leftNumeric || leftString ||
+        is(left, TypeRepr.of[BoundaryTag.UUID]) || leftTrailing
+    val rightKnown =
+      is(right, TypeRepr.of[BoundaryTag.Empty]) || is(right, TypeRepr.of[BoundaryTag.Literal]) ||
+        is(right, TypeRepr.of[BoundaryTag.Bool]) || rightNumeric || rightString ||
+        is(right, TypeRepr.of[BoundaryTag.UUID]) || rightTrailing
+
+    if leftTrailing || rightTrailing then
+      report.errorAndAbort(s"Cannot combine trailing path segments with `~`: ${label(left)} ~ ${label(right)}")
+    else if leftString && rightString then
+      report.errorAndAbort(s"Cannot combine two string segments with `~`: ${label(left)} ~ ${label(right)}")
+    else if leftNumeric && rightNumeric then
+      report.errorAndAbort(s"Cannot combine two numeric segments with `~`: ${label(left)} ~ ${label(right)}")
+    else if !leftKnown || !rightKnown then
+      report.errorAndAbort(
+        s"Cannot prove segment combination at compile time: ${label(left)} ~ ${label(right)}"
+      )
+    else '{ new CanCombine[L, R] {} }
+  }
+
+  def literalImpl(valueExpr: Expr[String])(using Quotes): Expr[Literal] = {
+    valueExpr.value match {
+      case Some(value) =>
+        SegmentCodec.validateLiteralValue(value)
+        '{ SegmentCodec.literalValidated(${ Expr(value) }) }
+      case None =>
+        quotes.reflect.report.errorAndAbort("SegmentCodec.literal requires a string literal known at compile time")
+    }
+  }
+
+  def transformImpl[A: Type, B: Type, P <: BoundaryTag: Type, S <: BoundaryTag: Type](
+    codecExpr: Expr[WithBoundaries[A, P, S]],
+    decodeExpr: Expr[A => B],
+    encodeExpr: Expr[B => A]
+  )(using Quotes): Expr[WithBoundaries[B, P, S]] =
+    '{
+      SegmentCodec
+        .transformValidated[A, B](
+          $codecExpr,
+          value => Right($decodeExpr(value)),
+          value => Right($encodeExpr(value))
+        )
+        .asInstanceOf[WithBoundaries[B, P, S]]
+    }
+
+  def transformOrFailImpl[A: Type, B: Type, P <: BoundaryTag: Type, S <: BoundaryTag: Type](
+    codecExpr: Expr[WithBoundaries[A, P, S]],
+    decodeExpr: Expr[A => Either[DecodeError, B]],
+    encodeExpr: Expr[B => Either[DecodeError, A]]
+  )(using Quotes): Expr[WithBoundaries[B, P, S]] =
+    '{
+      SegmentCodec
+        .transformValidated[A, B]($codecExpr, $decodeExpr, $encodeExpr)
+        .asInstanceOf[WithBoundaries[B, P, S]]
+    }
+
+  private def validateBoundary(using Quotes)(left: Option[SegmentInfo], right: Option[SegmentInfo]): Unit = {
+    import quotes.reflect.*
+
+    (left, right) match {
+      case (Some(SegmentInfo(SegmentInfoKind.Trailing, _)), _) |
+          (_, Some(SegmentInfo(SegmentInfoKind.Trailing, _))) =>
+        report.errorAndAbort("Cannot combine trailing path segments with `~`")
+      case (
+            Some(SegmentInfo(SegmentInfoKind.String, leftName)),
+            Some(SegmentInfo(SegmentInfoKind.String, rightName))
+          ) =>
+        report.errorAndAbort(s"Cannot combine two string segments. Their names are $leftName and $rightName")
+      case (
+            Some(SegmentInfo(SegmentInfoKind.Int | SegmentInfoKind.Long, leftName)),
+            Some(SegmentInfo(SegmentInfoKind.Int | SegmentInfoKind.Long, rightName))
+          ) =>
+        report.errorAndAbort(s"Cannot combine two numeric segments. Their names are $leftName and $rightName")
+      case _ => ()
+    }
+  }
+
+  private def boundaryInfo(using Quotes)(term: quotes.reflect.Term): Option[BoundaryInfo] = {
+    import quotes.reflect.*
+
+    val underlying = term.underlyingArgument
+    if (underlying ne term) return boundaryInfo(underlying)
+
+    def stringArg(args: List[Term], default: String): String =
+      args.collectFirst { case quotes.reflect.Literal(StringConstant(value)) => value }.getOrElse(default)
+
+    def singleInfo(kind: SegmentInfoKind, name: String): BoundaryInfo = {
+      val info = SegmentInfo(kind, name)
+      BoundaryInfo(Some(info), Some(info))
+    }
+
+    def applyInfo(name: String, args: List[Term]): Option[BoundaryInfo] = name match {
+      case "literal" | "Literal"  => Some(singleInfo(SegmentInfoKind.Literal, stringArg(args, "literal")))
+      case "bool" | "BoolSeg"     => Some(singleInfo(SegmentInfoKind.Bool, stringArg(args, "bool")))
+      case "string" | "StringSeg" => Some(singleInfo(SegmentInfoKind.String, stringArg(args, "string")))
+      case "int" | "IntSeg"       => Some(singleInfo(SegmentInfoKind.Int, stringArg(args, "int")))
+      case "long" | "LongSeg"     => Some(singleInfo(SegmentInfoKind.Long, stringArg(args, "long")))
+      case "uuid" | "UUIDSeg"     => Some(singleInfo(SegmentInfoKind.UUID, stringArg(args, "uuid")))
+      case "Trailing"              => Some(singleInfo(SegmentInfoKind.Trailing, "trailing"))
+      case "Empty"                 => Some(BoundaryInfo(None, None))
+      case _                        => None
+    }
+
+    def typeInfo(tpe: TypeRepr): Option[BoundaryInfo] = {
+      val segmentCodecSym = Symbol.requiredClass("zio.blocks.endpoint.SegmentCodec")
+      val base            = tpe.widenTermRefByName.dealias.baseType(segmentCodecSym)
+
+      if base =:= TypeRepr.of[Any] then None
+      else {
+        val prefixTpe = base.memberType(segmentCodecSym.typeMember("Prefix"))
+        val suffixTpe = base.memberType(segmentCodecSym.typeMember("Suffix"))
+
+        def kindOf(boundary: TypeRepr): Option[SegmentInfoKind] =
+          if boundary <:< TypeRepr.of[BoundaryTag.Literal] then Some(SegmentInfoKind.Literal)
+          else if boundary <:< TypeRepr.of[BoundaryTag.Bool] then Some(SegmentInfoKind.Bool)
+          else if boundary <:< TypeRepr.of[BoundaryTag.Int] then Some(SegmentInfoKind.Int)
+          else if boundary <:< TypeRepr.of[BoundaryTag.Long] then Some(SegmentInfoKind.Long)
+          else if boundary <:< TypeRepr.of[BoundaryTag.String] then Some(SegmentInfoKind.String)
+          else if boundary <:< TypeRepr.of[BoundaryTag.UUID] then Some(SegmentInfoKind.UUID)
+          else if boundary <:< TypeRepr.of[BoundaryTag.Trailing] then Some(SegmentInfoKind.Trailing)
+          else None
+
+        val prefix = kindOf(prefixTpe).map(kind => SegmentInfo(kind, "transformed"))
+        val suffix = kindOf(suffixTpe).map(kind => SegmentInfo(kind, "transformed"))
+        if (prefix.isEmpty && suffix.isEmpty) None else Some(BoundaryInfo(prefix, suffix))
+      }
+    }
+
+    def appliedBoundary(fun: Term, args: List[Term]): Option[BoundaryInfo] = {
+      val fullName = fun.symbol.fullName
+      if (
+        fullName == "zio.blocks.endpoint.SegmentCodec.literal" || fullName == "zio.blocks.endpoint.SegmentCodec.string" ||
+          fullName == "zio.blocks.endpoint.SegmentCodec.int" || fullName == "zio.blocks.endpoint.SegmentCodec.long" ||
+          fullName == "zio.blocks.endpoint.SegmentCodec.bool" || fullName == "zio.blocks.endpoint.SegmentCodec.uuid"
+      )
+        applyInfo(fun.symbol.name, args)
+      else if (
+        args.nonEmpty &&
+        (fun.symbol.owner.name == "Transform" || fullName.contains("SegmentCodec.Transform"))
+      )
+        boundaryInfo(args.head)
+      else if (
+        (fun.symbol.name == "transform" || fun.symbol.name == "transformOrFail" ||
+          fun.symbol.name == "transformValidated" ||
+          fun.symbol.name == "transform$extension" || fun.symbol.name == "transformOrFail$extension") &&
+        args.nonEmpty
+      )
+        boundaryInfo(args.head)
+      else if (
+        fullName.endsWith("SegmentCodec.Literal.apply") || fullName.endsWith("SegmentCodec.StringSeg.apply") ||
+        fullName.endsWith("SegmentCodec.IntSeg.apply") || fullName.endsWith("SegmentCodec.LongSeg.apply") ||
+        fullName.endsWith("SegmentCodec.BoolSeg.apply") || fullName.endsWith("SegmentCodec.UUIDSeg.apply")
+      )
+        applyInfo(fun.symbol.owner.name, args)
+      else if (fullName.endsWith("SegmentCodec.Transform.apply"))
+        args.headOption.flatMap(boundaryInfo)
+      else None
+    }
+
+    term match {
+      case Inlined(_, _, inner) => boundaryInfo(inner)
+      case Typed(inner, _)      => boundaryInfo(inner)
+      case Block(_, expr)       => boundaryInfo(expr)
+      case Ident(_)             =>
+        term.symbol.tree match {
+          case valDef: ValDef => valDef.rhs.flatMap(boundaryInfo)
+          case _              => None
+        }
+      case Apply(TypeApply(Select(_, "combineValidated"), _), List(left, right, _)) =>
+        for {
+          leftInfo  <- boundaryInfo(left)
+          rightInfo <- boundaryInfo(right)
+        } yield leftInfo ++ rightInfo
+      case Apply(TypeApply(Select(_, "transformValidated"), _), codec :: _) =>
+        boundaryInfo(codec)
+      case Apply(Select(_, "transformValidated"), codec :: _) =>
+        boundaryInfo(codec)
+      case Apply(TypeApply(fun, _), args) =>
+        appliedBoundary(fun, args)
+      case Apply(Select(_, "combineValidated"), List(left, right, _)) =>
+        for {
+          leftInfo  <- boundaryInfo(left)
+          rightInfo <- boundaryInfo(right)
+        } yield leftInfo ++ rightInfo
+      case Apply(Apply(TypeApply(Select(_, "transform"), _), List(left)), _) =>
+        boundaryInfo(left)
+      case Apply(Apply(Select(_, "transform"), List(left)), _) =>
+        boundaryInfo(left)
+      case Apply(TypeApply(Select(left, "transform"), _), _) =>
+        boundaryInfo(left)
+      case Apply(Select(left, "transform"), _) =>
+        boundaryInfo(left)
+      case Apply(Apply(TypeApply(Select(_, "transformOrFail"), _), List(left)), _) =>
+        boundaryInfo(left)
+      case Apply(Apply(Select(_, "transformOrFail"), List(left)), _) =>
+        boundaryInfo(left)
+      case Apply(TypeApply(Select(left, "transformOrFail"), _), _) =>
+        boundaryInfo(left)
+      case Apply(Select(left, "transformOrFail"), _) =>
+        boundaryInfo(left)
+      case Apply(fun, args) =>
+        appliedBoundary(fun, args)
+      case Select(_, "Empty") => Some(BoundaryInfo(None, None))
+      case _                  => typeInfo(term.tpe)
+    }
+  }
+}

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/SegmentCodecPlatformSpecific.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/SegmentCodecPlatformSpecific.scala
@@ -62,12 +62,12 @@ private[endpoint] object SegmentCodecPlatformSpecificMacros {
 
   private sealed trait SegmentInfoKind
   private object SegmentInfoKind {
-    case object Literal extends SegmentInfoKind
-    case object Bool extends SegmentInfoKind
-    case object Int extends SegmentInfoKind
-    case object Long extends SegmentInfoKind
-    case object String extends SegmentInfoKind
-    case object UUID extends SegmentInfoKind
+    case object Literal  extends SegmentInfoKind
+    case object Bool     extends SegmentInfoKind
+    case object Int      extends SegmentInfoKind
+    case object Long     extends SegmentInfoKind
+    case object String   extends SegmentInfoKind
+    case object UUID     extends SegmentInfoKind
     case object Trailing extends SegmentInfoKind
   }
 
@@ -166,15 +166,19 @@ private[endpoint] object SegmentCodecPlatformSpecificMacros {
     else '{ new CanCombine[L, R] {} }
   }
 
-  def literalImpl(valueExpr: Expr[String])(using Quotes): Expr[Literal] = {
+  def literalImpl(valueExpr: Expr[String])(using Quotes): Expr[Literal] =
     valueExpr.value match {
       case Some(value) =>
-        SegmentCodec.validateLiteralValue(value)
-        '{ SegmentCodec.literalValidated(${ Expr(value) }) }
+        try {
+          SegmentCodec.validateLiteralValue(value)
+          '{ SegmentCodec.literalValidated(${ Expr(value) }) }
+        } catch {
+          case error: IllegalArgumentException =>
+            quotes.reflect.report.errorAndAbort(error.getMessage)
+        }
       case None =>
         quotes.reflect.report.errorAndAbort("SegmentCodec.literal requires a string literal known at compile time")
     }
-  }
 
   def transformImpl[A: Type, B: Type, P <: BoundaryTag: Type, S <: BoundaryTag: Type](
     codecExpr: Expr[WithBoundaries[A, P, S]],
@@ -206,8 +210,7 @@ private[endpoint] object SegmentCodecPlatformSpecificMacros {
     import quotes.reflect.*
 
     (left, right) match {
-      case (Some(SegmentInfo(SegmentInfoKind.Trailing, _)), _) |
-          (_, Some(SegmentInfo(SegmentInfoKind.Trailing, _))) =>
+      case (Some(SegmentInfo(SegmentInfoKind.Trailing, _)), _) | (_, Some(SegmentInfo(SegmentInfoKind.Trailing, _))) =>
         report.errorAndAbort("Cannot combine trailing path segments with `~`")
       case (
             Some(SegmentInfo(SegmentInfoKind.String, leftName)),
@@ -244,9 +247,9 @@ private[endpoint] object SegmentCodecPlatformSpecificMacros {
       case "int" | "IntSeg"       => Some(singleInfo(SegmentInfoKind.Int, stringArg(args, "int")))
       case "long" | "LongSeg"     => Some(singleInfo(SegmentInfoKind.Long, stringArg(args, "long")))
       case "uuid" | "UUIDSeg"     => Some(singleInfo(SegmentInfoKind.UUID, stringArg(args, "uuid")))
-      case "Trailing"              => Some(singleInfo(SegmentInfoKind.Trailing, "trailing"))
-      case "Empty"                 => Some(BoundaryInfo(None, None))
-      case _                        => None
+      case "Trailing"             => Some(singleInfo(SegmentInfoKind.Trailing, "trailing"))
+      case "Empty"                => Some(BoundaryInfo(None, None))
+      case _                      => None
     }
 
     def typeInfo(tpe: TypeRepr): Option[BoundaryInfo] = {
@@ -278,8 +281,8 @@ private[endpoint] object SegmentCodecPlatformSpecificMacros {
       val fullName = fun.symbol.fullName
       if (
         fullName == "zio.blocks.endpoint.SegmentCodec.literal" || fullName == "zio.blocks.endpoint.SegmentCodec.string" ||
-          fullName == "zio.blocks.endpoint.SegmentCodec.int" || fullName == "zio.blocks.endpoint.SegmentCodec.long" ||
-          fullName == "zio.blocks.endpoint.SegmentCodec.bool" || fullName == "zio.blocks.endpoint.SegmentCodec.uuid"
+        fullName == "zio.blocks.endpoint.SegmentCodec.int" || fullName == "zio.blocks.endpoint.SegmentCodec.long" ||
+        fullName == "zio.blocks.endpoint.SegmentCodec.bool" || fullName == "zio.blocks.endpoint.SegmentCodec.uuid"
       )
         applyInfo(fun.symbol.name, args)
       else if (

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/AuthType.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/AuthType.scala
@@ -53,7 +53,7 @@ sealed trait AuthType { self =>
       status
     )
 
-  def |[ClientReq2, ClientReq](that: AuthType { type ClientRequirement = ClientReq2 })(using
+  def |[ClientReq2, ClientReq](that: AuthType { type ClientRequirement = ClientReq2 })(implicit
     alternator: Eithers.Eithers.WithOut[ClientRequirement, ClientReq2, ClientReq]
   ): AuthType { type ClientRequirement = ClientReq } =
     AuthType.Or(

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/Endpoint.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/Endpoint.scala
@@ -37,42 +37,42 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
   auth: Auth,
   doc: Doc
 ) {
-  def in[I2, I3](codec: HttpCodec[CodecKind.Request, I2])(using
+  def in[I2, I3](codec: HttpCodec[CodecKind.Request, I2])(implicit
     combiner: Tuples.Tuples.WithOut[Input, I2, I3]
   ): Endpoint[PathInput, I3, Err, Output, Auth] =
     copy(input = input ++ codec)
 
-  def in[I2, I3](schema: Schema[I2])(using
+  def in[I2, I3](schema: Schema[I2])(implicit
     combiner: Tuples.Tuples.WithOut[Input, I2, I3]
   ): Endpoint[PathInput, I3, Err, Output, Auth] =
     copy(input = input ++ HttpCodec.requestBody(schema))
 
-  def in[I2, I3](schema: Schema[I2], doc: Doc)(using
+  def in[I2, I3](schema: Schema[I2], doc: Doc)(implicit
     combiner: Tuples.Tuples.WithOut[Input, I2, I3]
   ): Endpoint[PathInput, I3, Err, Output, Auth] =
     copy(input = input ++ HttpCodec.requestBody(schema, doc = doc))
 
-  def in[I2, I3](mediaType: MediaType, schema: Schema[I2])(using
+  def in[I2, I3](mediaType: MediaType, schema: Schema[I2])(implicit
     combiner: Tuples.Tuples.WithOut[Input, I2, I3]
   ): Endpoint[PathInput, I3, Err, Output, Auth] =
     copy(input = input ++ HttpCodec.requestBody(schema, zio.blocks.chunk.Chunk.single(mediaType)))
 
-  def in[I2, I3](mediaType: MediaType, schema: Schema[I2], doc: Doc)(using
+  def in[I2, I3](mediaType: MediaType, schema: Schema[I2], doc: Doc)(implicit
     combiner: Tuples.Tuples.WithOut[Input, I2, I3]
   ): Endpoint[PathInput, I3, Err, Output, Auth] =
     copy(input = input ++ HttpCodec.requestBody(schema, zio.blocks.chunk.Chunk.single(mediaType), doc = doc))
 
-  def query[I2, I3](codec: HttpCodec.Query[I2])(using
+  def query[I2, I3](codec: HttpCodec.Query[I2])(implicit
     combiner: Tuples.Tuples.WithOut[Input, I2, I3]
   ): Endpoint[PathInput, I3, Err, Output, Auth] =
     copy(input = input ++ codec)
 
-  def header[I2, I3](codec: HttpCodec.Header[CodecKind.Request, I2])(using
+  def header[I2, I3](codec: HttpCodec.Header[CodecKind.Request, I2])(implicit
     combiner: Tuples.Tuples.WithOut[Input, I2, I3]
   ): Endpoint[PathInput, I3, Err, Output, Auth] =
     copy(input = input ++ codec)
 
-  def header[A, I2](name: String, schema: Schema[A])(using
+  def header[A, I2](name: String, schema: Schema[A])(implicit
     combiner: Tuples.Tuples.WithOut[Input, A, I2]
   ): Endpoint[PathInput, I2, Err, Output, Auth] =
     header(HttpCodec.requestHeader(name, schema))
@@ -80,49 +80,49 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
   /**
    * Adds a typed request header using a [[zio.http.Header.Codec]].
    */
-  def header[A, I2](headerCodec: Header.Codec[A])(using
+  def header[A, I2](headerCodec: Header.Codec[A])(implicit
     combiner: Tuples.Tuples.WithOut[Input, A, I2]
   ): Endpoint[PathInput, I2, Err, Output, Auth] =
     header(HttpCodec.requestHeader(headerCodec))
 
-  def header[A, I2](name: String, schema: Schema[A], doc: Doc)(using
+  def header[A, I2](name: String, schema: Schema[A], doc: Doc)(implicit
     combiner: Tuples.Tuples.WithOut[Input, A, I2]
   ): Endpoint[PathInput, I2, Err, Output, Auth] =
     header(HttpCodec.requestHeader(name, schema, doc = doc))
 
-  def out[O2, O3](codec: HttpCodec[CodecKind.Response, O2])(using
+  def out[O2, O3](codec: HttpCodec[CodecKind.Response, O2])(implicit
     alternator: Eithers.Eithers.WithOut[O2, Output, O3]
   ): Endpoint[PathInput, Input, Err, O3, Auth] =
     copy(output = codec | output)
 
-  def out[O2, O3](schema: Schema[O2])(using
+  def out[O2, O3](schema: Schema[O2])(implicit
     alternator: Eithers.Eithers.WithOut[O2, Output, O3]
   ): Endpoint[PathInput, Input, Err, O3, Auth] =
     copy(output = (HttpCodec.responseBody(schema) ++ HttpCodec.Ok) | output)
 
-  def out[O2, O3](schema: Schema[O2], doc: Doc)(using
+  def out[O2, O3](schema: Schema[O2], doc: Doc)(implicit
     alternator: Eithers.Eithers.WithOut[O2, Output, O3]
   ): Endpoint[PathInput, Input, Err, O3, Auth] =
     copy(output = (HttpCodec.responseBody(schema, doc = doc) ++ HttpCodec.Ok) | output)
 
-  def out[O2, O3](status: Status, schema: Schema[O2])(using
+  def out[O2, O3](status: Status, schema: Schema[O2])(implicit
     alternator: Eithers.Eithers.WithOut[O2, Output, O3]
   ): Endpoint[PathInput, Input, Err, O3, Auth] =
     copy(output = (HttpCodec.responseBody(schema) ++ HttpCodec.status(status)) | output)
 
-  def out[O2, O3](mediaType: MediaType, schema: Schema[O2])(using
+  def out[O2, O3](mediaType: MediaType, schema: Schema[O2])(implicit
     alternator: Eithers.Eithers.WithOut[O2, Output, O3]
   ): Endpoint[PathInput, Input, Err, O3, Auth] =
     copy(output =
       (HttpCodec.responseBody(schema, mediaTypes = zio.blocks.chunk.Chunk.single(mediaType)) ++ HttpCodec.Ok) | output
     )
 
-  def out[O2, O3](status: Status, schema: Schema[O2], doc: Doc)(using
+  def out[O2, O3](status: Status, schema: Schema[O2], doc: Doc)(implicit
     alternator: Eithers.Eithers.WithOut[O2, Output, O3]
   ): Endpoint[PathInput, Input, Err, O3, Auth] =
     copy(output = (HttpCodec.responseBody(schema, doc = doc) ++ HttpCodec.status(status, doc)) | output)
 
-  def out[O2, O3](mediaType: MediaType, schema: Schema[O2], doc: Doc)(using
+  def out[O2, O3](mediaType: MediaType, schema: Schema[O2], doc: Doc)(implicit
     alternator: Eithers.Eithers.WithOut[O2, Output, O3]
   ): Endpoint[PathInput, Input, Err, O3, Auth] =
     copy(
@@ -133,7 +133,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       ) ++ HttpCodec.Ok) | output
     )
 
-  def out[O2, O3](status: Status, mediaType: MediaType, schema: Schema[O2])(using
+  def out[O2, O3](status: Status, mediaType: MediaType, schema: Schema[O2])(implicit
     alternator: Eithers.Eithers.WithOut[O2, Output, O3]
   ): Endpoint[PathInput, Input, Err, O3, Auth] =
     copy(
@@ -143,7 +143,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
         )) | output
     )
 
-  def out[O2, O3](status: Status, mediaType: MediaType, schema: Schema[O2], doc: Doc)(using
+  def out[O2, O3](status: Status, mediaType: MediaType, schema: Schema[O2], doc: Doc)(implicit
     alternator: Eithers.Eithers.WithOut[O2, Output, O3]
   ): Endpoint[PathInput, Input, Err, O3, Auth] =
     copy(
@@ -152,27 +152,27 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
           .status(status, doc)) | output
     )
 
-  def outError[E2, E3](codec: HttpCodec[CodecKind.Response, E2])(using
+  def outError[E2, E3](codec: HttpCodec[CodecKind.Response, E2])(implicit
     alternator: Eithers.Eithers.WithOut[E2, Err, E3]
   ): Endpoint[PathInput, Input, E3, Output, Auth] =
     copy(error = codec | error)
 
-  def orOutError[E2, E3](codec: HttpCodec[CodecKind.Response, E2])(using
+  def orOutError[E2, E3](codec: HttpCodec[CodecKind.Response, E2])(implicit
     builder: EndpointUnionErrorBuilder.ErrorBuilder.WithOut[Err, E2, E3]
   ): Endpoint[PathInput, Input, E3, Output, Auth] =
     copy(error = builder.add(error, codec))
 
-  def outError[E2, E3](status: Status, schema: Schema[E2])(using
+  def outError[E2, E3](status: Status, schema: Schema[E2])(implicit
     alternator: Eithers.Eithers.WithOut[E2, Err, E3]
   ): Endpoint[PathInput, Input, E3, Output, Auth] =
     copy(error = (HttpCodec.responseBody(schema, name = Some("error-response")) ++ HttpCodec.status(status)) | error)
 
-  def orOutError[E2, E3](status: Status, schema: Schema[E2])(using
+  def orOutError[E2, E3](status: Status, schema: Schema[E2])(implicit
     builder: EndpointUnionErrorBuilder.ErrorBuilder.WithOut[Err, E2, E3]
   ): Endpoint[PathInput, Input, E3, Output, Auth] =
     orOutError(HttpCodec.responseBody(schema, name = Some("error-response")) ++ HttpCodec.status(status))
 
-  def outError[E2, E3](status: Status, schema: Schema[E2], doc: Doc)(using
+  def outError[E2, E3](status: Status, schema: Schema[E2], doc: Doc)(implicit
     alternator: Eithers.Eithers.WithOut[E2, Err, E3]
   ): Endpoint[PathInput, Input, E3, Output, Auth] =
     copy(error =
@@ -180,14 +180,14 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
         .status(status, doc))) | error
     )
 
-  def orOutError[E2, E3](status: Status, schema: Schema[E2], doc: Doc)(using
+  def orOutError[E2, E3](status: Status, schema: Schema[E2], doc: Doc)(implicit
     builder: EndpointUnionErrorBuilder.ErrorBuilder.WithOut[Err, E2, E3]
   ): Endpoint[PathInput, Input, E3, Output, Auth] =
     orOutError(
       HttpCodec.responseBody(schema, name = Some("error-response"), doc = doc) ++ HttpCodec.status(status, doc)
     )
 
-  def outError[E2, E3](status: Status, mediaType: MediaType, schema: Schema[E2])(using
+  def outError[E2, E3](status: Status, mediaType: MediaType, schema: Schema[E2])(implicit
     alternator: Eithers.Eithers.WithOut[E2, Err, E3]
   ): Endpoint[PathInput, Input, E3, Output, Auth] =
     copy(
@@ -198,7 +198,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       ) ++ HttpCodec.status(status))) | error
     )
 
-  def orOutError[E2, E3](status: Status, mediaType: MediaType, schema: Schema[E2])(using
+  def orOutError[E2, E3](status: Status, mediaType: MediaType, schema: Schema[E2])(implicit
     builder: EndpointUnionErrorBuilder.ErrorBuilder.WithOut[Err, E2, E3]
   ): Endpoint[PathInput, Input, E3, Output, Auth] =
     orOutError(
@@ -209,7 +209,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       ) ++ HttpCodec.status(status)
     )
 
-  def outError[E2, E3](status: Status, mediaType: MediaType, schema: Schema[E2], doc: Doc)(using
+  def outError[E2, E3](status: Status, mediaType: MediaType, schema: Schema[E2], doc: Doc)(implicit
     alternator: Eithers.Eithers.WithOut[E2, Err, E3]
   ): Endpoint[PathInput, Input, E3, Output, Auth] =
     copy(
@@ -221,7 +221,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       ) ++ HttpCodec.status(status, doc))) | error
     )
 
-  def orOutError[E2, E3](status: Status, mediaType: MediaType, schema: Schema[E2], doc: Doc)(using
+  def orOutError[E2, E3](status: Status, mediaType: MediaType, schema: Schema[E2], doc: Doc)(implicit
     builder: EndpointUnionErrorBuilder.ErrorBuilder.WithOut[Err, E2, E3]
   ): Endpoint[PathInput, Input, E3, Output, Auth] =
     orOutError(
@@ -233,12 +233,12 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       ) ++ HttpCodec.status(status, doc)
     )
 
-  def outHeader[O2, O3](codec: HttpCodec.Header[CodecKind.Response, O2])(using
+  def outHeader[O2, O3](codec: HttpCodec.Header[CodecKind.Response, O2])(implicit
     combiner: Tuples.Tuples.WithOut[Output, O2, O3]
   ): Endpoint[PathInput, Input, Err, O3, Auth] =
     copy(output = output ++ codec)
 
-  def outHeader[A, O2](name: String, schema: Schema[A])(using
+  def outHeader[A, O2](name: String, schema: Schema[A])(implicit
     combiner: Tuples.Tuples.WithOut[Output, A, O2]
   ): Endpoint[PathInput, Input, Err, O2, Auth] =
     outHeader(HttpCodec.responseHeader(name, schema))
@@ -246,12 +246,12 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
   /**
    * Adds a typed response header using a [[zio.http.Header.Codec]].
    */
-  def outHeader[A, O2](headerCodec: Header.Codec[A])(using
+  def outHeader[A, O2](headerCodec: Header.Codec[A])(implicit
     combiner: Tuples.Tuples.WithOut[Output, A, O2]
   ): Endpoint[PathInput, Input, Err, O2, Auth] =
     outHeader(HttpCodec.responseHeader(headerCodec))
 
-  def outHeader[A, O2](name: String, schema: Schema[A], doc: Doc)(using
+  def outHeader[A, O2](name: String, schema: Schema[A], doc: Doc)(implicit
     combiner: Tuples.Tuples.WithOut[Output, A, O2]
   ): Endpoint[PathInput, Input, Err, O2, Auth] =
     outHeader(HttpCodec.responseHeader(name, schema, doc = doc))
@@ -267,7 +267,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
   def doc(documentation: Doc): Endpoint[PathInput, Input, Err, Output, Auth] =
     copy(doc = documentation)
 
-  def query[A, I2](name: String, schema: Schema[A])(using
+  def query[A, I2](name: String, schema: Schema[A])(implicit
     combiner: Tuples.Tuples.WithOut[Input, A, I2]
   ): Endpoint[PathInput, I2, Err, Output, Auth] =
     copy(input = input ++ HttpCodec.query(name, schema))

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/HttpCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/HttpCodec.scala
@@ -52,12 +52,12 @@ object CodecKind {
  * introducing dedicated interpreter-only AST nodes.
  */
 sealed trait HttpCodec[+K <: CodecKind, A] { self =>
-  def ++[B, C](that: HttpCodec[K @uncheckedVariance, B])(using
+  def ++[B, C](that: HttpCodec[K @uncheckedVariance, B])(implicit
     combiner: Tuples.Tuples.WithOut[A, B, C]
   ): HttpCodec[K, C] =
     HttpCodec.Combine(self, that, combiner)
 
-  def |[B, C](that: HttpCodec[K @uncheckedVariance, B])(using
+  def |[B, C](that: HttpCodec[K @uncheckedVariance, B])(implicit
     alternator: Eithers.Eithers.WithOut[A, B, C]
   ): HttpCodec[K, C] =
     HttpCodec.Fallback(self, that, Alternator.fromEithers(alternator))

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/PathCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/PathCodec.scala
@@ -36,22 +36,22 @@ object PathCodec {
   private type DecodeError = String
   private type AnyCombiner = Tuples.Tuples.WithOut[Any, Any, Any]
 
-  given unitUnit: Tuples.Tuples.WithOut[Unit, Unit, Unit] = Tuples.Tuples.leftUnit[Unit]
+  implicit val unitUnit: Tuples.Tuples.WithOut[Unit, Unit, Unit] = Tuples.Tuples.leftUnit[Unit]
 
-  extension [A](self: PathCodec[A]) {
-    def ++[B, C](that: PathCodec[B])(using
+  implicit final class PathCodecOps[A](private val self: PathCodec[A]) extends AnyVal {
+    def ++[B, C](that: PathCodec[B])(implicit
       combiner: Tuples.Tuples.WithOut[A, B, C]
     ): PathCodec[C] =
       if (self == empty) that.asInstanceOf[PathCodec[C]]
       else if (that == empty) self.asInstanceOf[PathCodec[C]]
       else Concat(self, that, combiner)
 
-    def /[B, C](that: PathCodec[B])(using
+    def /[B, C](that: PathCodec[B])(implicit
       combiner: Tuples.Tuples.WithOut[A, B, C]
     ): PathCodec[C] =
       self ++ that
 
-    def orElse(that: PathCodec[Unit])(using ev: A =:= Unit): PathCodec[Unit] =
+    def orElse(that: PathCodec[Unit])(implicit ev: A =:= Unit): PathCodec[Unit] =
       Fallback(self.asInstanceOf[PathCodec[Unit]], that)
 
     def alternatives: List[PathCodec[A]] =
@@ -87,7 +87,7 @@ object PathCodec {
      *   a path codec with the transformed value type and the same route shape
      *   as `self`
      */
-    inline def transform[B](decode: A => B, encode: B => A): PathCodec[B] =
+    def transform[B](decode: A => B, encode: B => A): PathCodec[B] =
       transformOrFail[B](value => Right(decode(value)), value => Right(encode(value)))
 
     /**
@@ -111,7 +111,7 @@ object PathCodec {
      *   a path codec with the transformed value type and the same route shape
      *   as `self`
      */
-    inline def transformOrFail[B](
+    def transformOrFail[B](
       decode: A => Either[DecodeError, B],
       encode: B => Either[DecodeError, A]
     ): PathCodec[B] =
@@ -130,8 +130,8 @@ object PathCodec {
   def apply[A](segment: SegmentCodec[A]): PathCodec[A] =
     Segment(segment)
 
-  given Conversion[String, PathCodec[Unit]]            = apply(_)
-  given [A]: Conversion[SegmentCodec[A], PathCodec[A]] = Segment(_)
+  implicit def stringToPathCodec(value: String): PathCodec[Unit]           = apply(value)
+  implicit def segmentToPathCodec[A](value: SegmentCodec[A]): PathCodec[A] = Segment(value)
 
   final case class Segment[A](segment: SegmentCodec[A]) extends PathCodec[A]
   final case class Concat[A, B, C](
@@ -148,13 +148,13 @@ object PathCodec {
 
   val empty: PathCodec[Unit] = Segment(SegmentCodec.Empty)
 
-  inline def literal(inline value: String): PathCodec[Unit] = Segment(SegmentCodec.literal(value))
-  def bool(name: String): PathCodec[Boolean]                = Segment(SegmentCodec.bool(name))
-  def int(name: String): PathCodec[Int]                     = Segment(SegmentCodec.int(name))
-  def long(name: String): PathCodec[Long]                   = Segment(SegmentCodec.long(name))
-  def string(name: String): PathCodec[String]               = Segment(SegmentCodec.string(name))
-  def uuid(name: String): PathCodec[java.util.UUID]         = Segment(SegmentCodec.uuid(name))
-  val trailing: PathCodec[Path]                             = Segment(SegmentCodec.Trailing)
+  def literal(value: String): PathCodec[Unit]       = Segment(SegmentCodec.literalValidated(value))
+  def bool(name: String): PathCodec[Boolean]        = Segment(SegmentCodec.bool(name))
+  def int(name: String): PathCodec[Int]             = Segment(SegmentCodec.int(name))
+  def long(name: String): PathCodec[Long]           = Segment(SegmentCodec.long(name))
+  def string(name: String): PathCodec[String]       = Segment(SegmentCodec.string(name))
+  def uuid(name: String): PathCodec[java.util.UUID] = Segment(SegmentCodec.uuid(name))
+  val trailing: PathCodec[Path]                     = Segment(SegmentCodec.Trailing)
 
   def render(codec: PathCodec[_], prefix: String = "{", suffix: String = "}"): String = {
     def loop(current: PathCodec[_]): String =
@@ -217,7 +217,7 @@ object PathCodec {
             (typed.combine(leftValue, rightValue), end)
           }
         }
-      case transformed: Transform[?, ?] =>
+      case transformed: Transform[_, _] =>
         val codec  = transformed.codec.asInstanceOf[PathCodec[Any]]
         val decode = transformed.decode.asInstanceOf[Any => Either[DecodeError, Any]]
         decodeCodec(codec, segments, index).flatMap { case (value, end) =>
@@ -258,7 +258,7 @@ object PathCodec {
           if (index >= segments.length) Path.root
           else Path(segments.drop(index), hasLeadingSlash = true, trailingSlash = false)
         List((path, segments.length))
-      case transformed: SegmentCodec.Transform[?, ?] =>
+      case transformed: SegmentCodec.Transform[_, _] =>
         if (index >= segments.length) Nil
         else {
           val segment = segments(index)
@@ -266,7 +266,7 @@ object PathCodec {
             case (value, end) if end == segment.length => (value, index + 1)
           }
         }
-      case combined: SegmentCodec.Combined[?, ?, ?] =>
+      case combined: SegmentCodec.Combined[_, _, _] =>
         if (index >= segments.length) Nil
         else {
           val segment = segments(index)
@@ -286,7 +286,7 @@ object PathCodec {
           leftPath  <- formatCodec(left, leftValue)
           rightPath <- formatCodec(right, rightValue)
         } yield leftPath ++ rightPath.dropLeadingSlash
-      case transformed: Transform[?, ?] =>
+      case transformed: Transform[_, _] =>
         val codec  = transformed.codec.asInstanceOf[PathCodec[Any]]
         val encode = transformed.encode.asInstanceOf[Any => Either[DecodeError, Any]]
         encode(value).flatMap(inner => formatCodec(codec, inner))

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/PathCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/PathCodec.scala
@@ -24,10 +24,9 @@ import zio.http.Path
 
 /**
  * Composable path descriptor. Segments are combined with `/` or `++`, literal
- * alternatives with `orElse`. Use [[PathCodec.decode decode]] /
- * [[PathCodec.format format]] for bidirectional path conversion, and
- * [[PathCodec.alternatives alternatives]] to expand `orElse` branches for
- * routing-trie insertion.
+ * alternatives with `orElse`. Use `decode` / `format` for bidirectional path
+ * conversion, and `alternatives` to expand `orElse` branches for routing-trie
+ * insertion.
  */
 sealed trait PathCodec[A]
 
@@ -82,7 +81,7 @@ object PathCodec {
      *   maps the decoded path value into the exposed type
      * @param encode
      *   maps the exposed type back into the original path representation used
-     *   by [[format]]
+     *   by `format`
      * @return
      *   a path codec with the transformed value type and the same route shape
      *   as `self`
@@ -95,8 +94,8 @@ object PathCodec {
      * path structure.
      *
      * `decode` returning `Left` causes path decoding / matching to fail.
-     * [[format]] remains effectful, so `encode` returning `Left` is propagated
-     * as the `Left` result of [[format]].
+     * `format` remains effectful, so `encode` returning `Left` is propagated as
+     * the `Left` result of `format`.
      *
      * Example: {{ val customerPath = PathCodec .string("id")
      * .transformOrFail[CustomerId](CustomerId.parse, value =>
@@ -106,7 +105,7 @@ object PathCodec {
      *   validates and maps the decoded path value into the exposed type
      * @param encode
      *   validates and maps the exposed type back into the original path
-     *   representation used by [[format]]
+     *   representation used by `format`
      * @return
      *   a path codec with the transformed value type and the same route shape
      *   as `self`
@@ -148,7 +147,10 @@ object PathCodec {
 
   val empty: PathCodec[Unit] = Segment(SegmentCodec.Empty)
 
-  def literal(value: String): PathCodec[Unit]       = Segment(SegmentCodec.literalValidated(value))
+  def literal(value: String): PathCodec[Unit] = {
+    SegmentCodec.validateLiteralValue(value)
+    Segment(SegmentCodec.literalValidated(value))
+  }
   def bool(name: String): PathCodec[Boolean]        = Segment(SegmentCodec.bool(name))
   def int(name: String): PathCodec[Int]             = Segment(SegmentCodec.int(name))
   def long(name: String): PathCodec[Long]           = Segment(SegmentCodec.long(name))

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/RoutePattern.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/RoutePattern.scala
@@ -22,10 +22,9 @@ import zio.http.{Method, Path}
 
 /**
  * HTTP method paired with a typed path pattern. The primary constructor is
- * `Method.GET / "users" / PathCodec.int("id")`. Use
- * [[RoutePattern.alternatives alternatives]] to expand `orElse` branches,
- * [[RoutePattern.any any]] for catch-all trailing routes, and
- * [[RoutePattern.nest nest]] to prepend a path prefix.
+ * `Method.GET / "users" / PathCodec.int("id")`. Use `alternatives` to expand
+ * `orElse` branches, `RoutePattern.any(Method)` or `RoutePattern.any` for
+ * catch-all trailing routes, and `nest` to prepend a path prefix.
  */
 final case class RoutePattern[A](
   method: Method,

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/RoutePattern.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/RoutePattern.scala
@@ -32,7 +32,7 @@ final case class RoutePattern[A](
   pathCodec: PathCodec[A],
   doc: Doc = Doc.empty
 ) {
-  def /[B, C](that: PathCodec[B])(using combiner: Tuples.Tuples.WithOut[A, B, C]): RoutePattern[C] =
+  def /[B, C](that: PathCodec[B])(implicit combiner: Tuples.Tuples.WithOut[A, B, C]): RoutePattern[C] =
     if (that == PathCodec.empty) this.asInstanceOf[RoutePattern[C]]
     else if (pathCodec == PathCodec.empty) copy(pathCodec = that.asInstanceOf[PathCodec[C]])
     else copy(pathCodec = pathCodec ++ that)
@@ -83,7 +83,7 @@ object RoutePattern {
 
   def apply(method: Method, path: Path): RoutePattern[Unit] =
     path.segments.foldLeft(fromMethod(method))((acc, segment) =>
-      acc./[Unit, Unit](PathCodec(SegmentCodec.literalValidated(segment)))(using Tuples.Tuples.leftUnit[Unit])
+      acc./[Unit, Unit](PathCodec(SegmentCodec.literalValidated(segment)))(Tuples.Tuples.leftUnit[Unit])
     )
 
   def apply(method: Method, pathString: String): RoutePattern[Unit] =
@@ -98,7 +98,7 @@ object RoutePattern {
   def any(method: Method): RoutePattern[Path] =
     RoutePattern(method, PathCodec.trailing)
 
-  extension (method: Method) {
+  implicit final class MethodSyntax(private val method: Method) extends AnyVal {
     def /[A](path: PathCodec[A]): RoutePattern[A] =
       RoutePattern(method, path)
   }

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/RouteTree.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/RouteTree.scala
@@ -69,6 +69,7 @@ object RouteTree {
     codec match {
       case PathCodec.Segment(seg)           => Chunk(seg)
       case PathCodec.Concat(left, right, _) => flattenPathCodec(left) ++ flattenPathCodec(right)
+      case PathCodec.Transform(inner, _, _) => flattenPathCodec(inner)
       case PathCodec.Fallback(_, _)         =>
         throw new IllegalStateException("Fallback paths must be expanded before flattening")
     }

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
@@ -16,8 +16,6 @@
 
 package zio.blocks.endpoint
 
-import scala.quoted.*
-
 import zio.blocks.chunk.Chunk
 import zio.blocks.combinators.Tuples
 import zio.blocks.docs.Doc
@@ -44,16 +42,13 @@ sealed trait SegmentCodec[A] { self =>
     SegmentCodec.render(self, prefix, suffix)
 }
 
-object SegmentCodec {
+object SegmentCodec extends SegmentCodecPlatformSpecific {
 
-  private type DecodeError                                   = String
+  private[endpoint] type DecodeError                         = String
   type WithBoundaries[A, P <: BoundaryTag, S <: BoundaryTag] = SegmentCodec[A] { type Prefix = P; type Suffix = S }
 
-  sealed trait CanCombine[L <: BoundaryTag, R <: BoundaryTag]
-  object CanCombine {
-    transparent inline given [L <: BoundaryTag, R <: BoundaryTag]: CanCombine[L, R] =
-      ${ SegmentCodecMacros.canCombineImpl[L, R] }
-  }
+  trait CanCombine[L <: BoundaryTag, R <: BoundaryTag]
+  object CanCombine extends CanCombinePlatformSpecific
 
   sealed trait BoundaryTag
   object BoundaryTag {
@@ -68,16 +63,17 @@ object SegmentCodec {
     sealed trait Unknown  extends BoundaryTag
   }
 
-  enum Kind {
-    case Empty
-    case Literal
-    case Bool
-    case Int
-    case Long
-    case String
-    case UUID
-    case Combined
-    case Trailing
+  sealed trait Kind
+  object Kind {
+    case object Empty    extends Kind
+    case object Literal  extends Kind
+    case object Bool     extends Kind
+    case object Int      extends Kind
+    case object Long     extends Kind
+    case object String   extends Kind
+    case object Combined extends Kind
+    case object UUID     extends Kind
+    case object Trailing extends Kind
   }
 
   sealed trait Key
@@ -93,82 +89,6 @@ object SegmentCodec {
     case object Trailing                         extends Key
   }
 
-  extension [A, P <: BoundaryTag, S <: BoundaryTag](self: WithBoundaries[A, P, S]) {
-    inline def ~[B, P2 <: BoundaryTag, S2 <: BoundaryTag, C](that: WithBoundaries[B, P2, S2])(using
-      combiner: Tuples.Tuples.WithOut[A, B, C],
-      canCombine: CanCombine[S, P2]
-    ): WithBoundaries[C, P, S2] =
-      ${ SegmentCodecMacros.combineImpl[A, B, C, P, S, P2, S2]('self, 'that, 'combiner) }
-
-    inline def ~[C](inline that: String)(using
-      combiner: Tuples.Tuples.WithOut[A, Unit, C],
-      canCombine: CanCombine[S, BoundaryTag.Literal]
-    ): WithBoundaries[C, P, BoundaryTag.Literal] =
-      ${ SegmentCodecMacros.combineLiteralImpl[A, C, P, S]('self, 'that, 'combiner) }
-
-    /**
-     * Maps the decoded segment value without changing the underlying segment
-     * boundary shape.
-     *
-     * The returned codec keeps the same compile-time `~` combinability metadata
-     * as `self`, so transformed codecs still participate in compile-time
-     * boundary validation.
-     *
-     * Example: {{ val customerId =
-     * SegmentCodec.uuid("id").transform[CustomerId](CustomerId(_), _.value) }}
-     *
-     * @param decode
-     *   maps the parsed segment value into the exposed type
-     * @param encode
-     *   maps the exposed type back into the original segment representation
-     *   used by [[format]]
-     * @return
-     *   a segment codec with the transformed value type and the same boundary
-     *   semantics as `self`
-     */
-    inline def transform[B](decode: A => B, encode: B => A): WithBoundaries[B, P, S] =
-      ${ SegmentCodecMacros.transformImpl[A, B, P, S]('self, 'decode, 'encode) }
-
-    /**
-     * Effectfully maps the decoded segment value without changing the
-     * underlying segment boundary shape.
-     *
-     * `decode` returning `Left` causes path decoding / matching to fail for
-     * that segment. Because [[format]] is not effectful, `encode` returning
-     * `Left` is surfaced as an `IllegalArgumentException` when formatting the
-     * transformed value back into a path.
-     *
-     * Example: {{ val customerId = SegmentCodec .string("id")
-     * .transformOrFail[CustomerId](CustomerId.parse, value =>
-     * Right(value.value)) }}
-     *
-     * @param decode
-     *   validates and maps the parsed segment value into the exposed type
-     * @param encode
-     *   validates and maps the exposed type back into the original segment
-     *   representation used by [[format]]
-     * @return
-     *   a segment codec with the transformed value type and the same boundary
-     *   semantics as `self`
-     */
-    inline def transformOrFail[B](
-      decode: A => Either[DecodeError, B],
-      encode: B => Either[DecodeError, A]
-    ): WithBoundaries[B, P, S] =
-      ${ SegmentCodecMacros.transformOrFailImpl[A, B, P, S]('self, 'decode, 'encode) }
-  }
-
-  /**
-   * Creates a fixed literal delimiter inside a single path segment.
-   *
-   * The `value` must be a compile-time string literal. Delimiters containing
-   * `/` or characters that would require URL encoding are rejected at compile
-   * time. For runtime path strings, use
-   * [[zio.blocks.endpoint.PathCodec.apply PathCodec.apply]] or build from
-   * parsed [[zio.http.Path]] segments.
-   */
-  inline def literal(inline value: String): Literal =
-    ${ SegmentCodecMacros.literalImpl('value) }
   def bool(name: String): BoolSeg     = BoolSeg(name)
   def int(name: String): IntSeg       = IntSeg(name)
   def long(name: String): LongSeg     = LongSeg(name)
@@ -197,6 +117,20 @@ object SegmentCodec {
 
   private[endpoint] def literalValidated(value: String): Literal = Literal(value)
 
+  private[endpoint] def validateLiteralValue(value: String): Unit = {
+    val path          = Path(s"/$value")
+    val singleSegment = path.segments.length == 1 && path.segments.headOption.contains(value)
+    val preserved     = path.encode.stripPrefix("/") == value
+
+    if (value.isEmpty) {
+      throw new IllegalArgumentException("SegmentCodec.literal cannot be empty")
+    } else if (!singleSegment || !preserved) {
+      throw new IllegalArgumentException(
+        s"SegmentCodec.literal must be a valid single path segment without `/` or characters that require URL encoding: $value"
+      )
+    }
+  }
+
   private[endpoint] def transformValidated[A, B](
     codec: SegmentCodec[A],
     decode: A => Either[DecodeError, B],
@@ -206,28 +140,30 @@ object SegmentCodec {
 
   private[endpoint] def kind(codec: SegmentCodec[_]): Kind =
     codec match {
-      case Empty              => Kind.Empty
-      case Literal(_, _, _)   => Kind.Literal
-      case BoolSeg(_, _, _)   => Kind.Bool
-      case IntSeg(_, _, _)    => Kind.Int
-      case LongSeg(_, _, _)   => Kind.Long
-      case StringSeg(_, _, _) => Kind.String
-      case UUIDSeg(_, _, _)   => Kind.UUID
-      case Combined(_, _, _)  => Kind.Combined
-      case Trailing           => Kind.Trailing
+      case Empty                  => Kind.Empty
+      case Literal(_, _, _)       => Kind.Literal
+      case BoolSeg(_, _, _)       => Kind.Bool
+      case IntSeg(_, _, _)        => Kind.Int
+      case LongSeg(_, _, _)       => Kind.Long
+      case StringSeg(_, _, _)     => Kind.String
+      case UUIDSeg(_, _, _)       => Kind.UUID
+      case Combined(_, _, _)      => Kind.Combined
+      case Transform(inner, _, _) => kind(inner)
+      case Trailing               => Kind.Trailing
     }
 
   private[endpoint] def key(codec: SegmentCodec[_]): Key =
     codec match {
-      case Empty                => Key.Empty
-      case Literal(value, _, _) => Key.Literal(value)
-      case BoolSeg(_, _, _)     => Key.Bool
-      case IntSeg(_, _, _)      => Key.Int
-      case LongSeg(_, _, _)     => Key.Long
-      case StringSeg(_, _, _)   => Key.String
-      case UUIDSeg(_, _, _)     => Key.UUID
-      case Combined(_, _, _)    => Key.Combined(flatten(codec).map(key))
-      case Trailing             => Key.Trailing
+      case Empty                  => Key.Empty
+      case Literal(value, _, _)   => Key.Literal(value)
+      case BoolSeg(_, _, _)       => Key.Bool
+      case IntSeg(_, _, _)        => Key.Int
+      case LongSeg(_, _, _)       => Key.Long
+      case StringSeg(_, _, _)     => Key.String
+      case UUIDSeg(_, _, _)       => Key.UUID
+      case Combined(_, _, _)      => Key.Combined(flatten(codec).map(key))
+      case Transform(inner, _, _) => key(inner)
+      case Trailing               => Key.Trailing
     }
 
   implicit val segmentCodecOrdering: Ordering[Kind] = Ordering.by {
@@ -242,29 +178,32 @@ object SegmentCodec {
     case Kind.Empty    => 7
   }
 
-  given keyOrdering: Ordering[Key] = (a: Key, b: Key) => {
-    def rank(k: Key): Int = k match {
-      case Key.Literal(_)  => 0
-      case Key.Int         => 1
-      case Key.Long        => 2
-      case Key.UUID        => 3
-      case Key.Bool        => 4
-      case Key.String      => 5
-      case Key.Combined(_) => 6
-      case Key.Trailing    => 7
-      case Key.Empty       => 8
-    }
-    val cmp = rank(a) - rank(b)
-    if (cmp != 0) cmp
-    else
-      (a, b) match {
-        case (Key.Literal(x), Key.Literal(y))   => x.compareTo(y)
-        case (Key.Combined(x), Key.Combined(y)) =>
-          val len = x.length.compareTo(y.length)
-          if (len != 0) len
-          else x.iterator.zip(y.iterator).map { case (l, r) => keyOrdering.compare(l, r) }.find(_ != 0).getOrElse(0)
-        case _ => 0
+  implicit val keyOrdering: Ordering[Key] = new Ordering[Key] {
+    def compare(a: Key, b: Key): Int = {
+      def rank(k: Key): Int = k match {
+        case Key.Literal(_)  => 0
+        case Key.Int         => 1
+        case Key.Long        => 2
+        case Key.UUID        => 3
+        case Key.Bool        => 4
+        case Key.String      => 5
+        case Key.Combined(_) => 6
+        case Key.Trailing    => 7
+        case Key.Empty       => 8
       }
+
+      val cmp = rank(a) - rank(b)
+      if (cmp != 0) cmp
+      else
+        (a, b) match {
+          case (Key.Literal(x), Key.Literal(y))   => x.compareTo(y)
+          case (Key.Combined(x), Key.Combined(y)) =>
+            val len = x.length.compareTo(y.length)
+            if (len != 0) len
+            else x.iterator.zip(y.iterator).map { case (l, r) => compare(l, r) }.find(_ != 0).getOrElse(0)
+          case _ => 0
+        }
+    }
   }
 
   case object Empty extends SegmentCodec[Unit] {
@@ -342,7 +281,7 @@ object SegmentCodec {
     val examples: Chunk[(String, Path)] = Chunk.empty
   }
 
-  def render(codec: SegmentCodec[_], prefix: String = "{", suffix: String = "}"): String = {
+  def render(codec: SegmentCodec[_], prefix: String, suffix: String): String = {
     val out                                  = new StringBuilder
     def loop(current: SegmentCodec[_]): Unit =
       current match {
@@ -385,7 +324,7 @@ object SegmentCodec {
               case _: IllegalArgumentException => -1
             }
           }
-        case transformed: Transform[?, ?] =>
+        case transformed: Transform[_, _] =>
           val inner  = transformed.codec.asInstanceOf[SegmentCodec[Any]]
           val decode = transformed.decode.asInstanceOf[Any => Either[DecodeError, Any]]
           if (index >= segments.length) -1
@@ -394,7 +333,7 @@ object SegmentCodec {
               end == segments(index).length && decode(value).isRight
             }.compare(false)
         case Trailing                    => (segments.length - index).max(0)
-        case combined: Combined[?, ?, ?] =>
+        case combined: Combined[_, _, _] =>
           if (index >= segments.length) -1
           else if (decodeCombined(combined, segments(index), 0).exists(_._2 == segments(index).length)) 1
           else -1
@@ -428,14 +367,14 @@ object SegmentCodec {
           try List((java.util.UUID.fromString(candidate), from + 36))
           catch { case _: IllegalArgumentException => Nil }
         }
-      case transformed: Transform[?, ?] =>
+      case transformed: Transform[_, _] =>
         val inner  = transformed.codec.asInstanceOf[SegmentCodec[Any]]
         val decode = transformed.decode.asInstanceOf[Any => Either[DecodeError, Any]]
         decodeCombined(inner, segment, from).flatMap { case (value, end) =>
           decode(value).toOption.map(_ -> end)
         }
       case Trailing                    => List((Path(segment.substring(from)).addLeadingSlash, segment.length))
-      case combined: Combined[?, ?, ?] =>
+      case combined: Combined[_, _, _] =>
         decodeCombined(combined.left, segment, from).flatMap { case (leftValue, next) =>
           decodeCombined(combined.right, segment, next).map { case (rightValue, end) =>
             val typed = combined.combiner.asInstanceOf[Tuples.Tuples.WithOut[Any, Any, Any]]
@@ -453,7 +392,7 @@ object SegmentCodec {
       case LongSeg(_, _, _)             => value.toString
       case StringSeg(_, _, _)           => value.asInstanceOf[String]
       case UUIDSeg(_, _, _)             => value.toString
-      case transformed: Transform[?, ?] =>
+      case transformed: Transform[_, _] =>
         val inner  = transformed.codec.asInstanceOf[SegmentCodec[Any]]
         val encode = transformed.encode.asInstanceOf[Any => Either[DecodeError, Any]]
         encode(value) match {
@@ -461,7 +400,7 @@ object SegmentCodec {
           case Left(message)     => throw new IllegalArgumentException(message)
         }
       case Trailing                    => value.asInstanceOf[Path].render.stripPrefix("/")
-      case combined: Combined[?, ?, ?] =>
+      case combined: Combined[_, _, _] =>
         val typed                   = combined.combiner.asInstanceOf[Tuples.Tuples.WithOut[Any, Any, Any]]
         val (leftValue, rightValue) = typed.separate(value)
         formatSegment(combined.left, leftValue) + formatSegment(combined.right, rightValue)
@@ -489,315 +428,4 @@ object SegmentCodec {
         results.result()
       }
     }
-
-  private object SegmentCodecMacros {
-    private sealed trait SegmentInfoKind
-    private object SegmentInfoKind {
-      case object Literal  extends SegmentInfoKind
-      case object Bool     extends SegmentInfoKind
-      case object Int      extends SegmentInfoKind
-      case object Long     extends SegmentInfoKind
-      case object String   extends SegmentInfoKind
-      case object UUID     extends SegmentInfoKind
-      case object Trailing extends SegmentInfoKind
-    }
-
-    private final case class SegmentInfo(kind: SegmentInfoKind, name: String)
-    private final case class BoundaryInfo(prefix: Option[SegmentInfo], suffix: Option[SegmentInfo]) {
-      def ++(that: BoundaryInfo): BoundaryInfo =
-        BoundaryInfo(prefix.orElse(that.prefix), that.suffix.orElse(suffix))
-    }
-
-    def combineImpl[
-      A: Type,
-      B: Type,
-      C: Type,
-      P <: BoundaryTag: Type,
-      S <: BoundaryTag: Type,
-      P2 <: BoundaryTag: Type,
-      S2 <: BoundaryTag: Type
-    ](
-      leftExpr: Expr[WithBoundaries[A, P, S]],
-      rightExpr: Expr[WithBoundaries[B, P2, S2]],
-      combinerExpr: Expr[Tuples.Tuples.WithOut[A, B, C]]
-    )(using Quotes): Expr[WithBoundaries[C, P, S2]] = {
-      import quotes.reflect.*
-
-      val leftInfo  = boundaryInfo(leftExpr.asTerm)
-      val rightInfo = boundaryInfo(rightExpr.asTerm)
-
-      (leftInfo, rightInfo) match {
-        case (Some(left), Some(right)) =>
-          validateBoundary(left.suffix, right.prefix)
-          '{
-            SegmentCodec.combineValidated($leftExpr, $rightExpr, $combinerExpr).asInstanceOf[WithBoundaries[C, P, S2]]
-          }
-        case _ =>
-          '{
-            SegmentCodec.combineValidated($leftExpr, $rightExpr, $combinerExpr).asInstanceOf[WithBoundaries[C, P, S2]]
-          }
-      }
-    }
-
-    def combineLiteralImpl[A: Type, C: Type, P <: BoundaryTag: Type, S <: BoundaryTag: Type](
-      leftExpr: Expr[WithBoundaries[A, P, S]],
-      rightExpr: Expr[String],
-      combinerExpr: Expr[Tuples.Tuples.WithOut[A, Unit, C]]
-    )(using Quotes): Expr[WithBoundaries[C, P, BoundaryTag.Literal]] =
-      '{
-        SegmentCodec
-          .combineValidated($leftExpr, SegmentCodec.literal($rightExpr), $combinerExpr)
-          .asInstanceOf[WithBoundaries[C, P, BoundaryTag.Literal]]
-      }
-
-    def canCombineImpl[L <: BoundaryTag: Type, R <: BoundaryTag: Type](using Quotes): Expr[CanCombine[L, R]] = {
-      import quotes.reflect.*
-
-      val left  = TypeRepr.of[L]
-      val right = TypeRepr.of[R]
-
-      def is(boundary: TypeRepr, target: TypeRepr): Boolean = boundary <:< target
-
-      def label(boundary: TypeRepr): String =
-        if is(boundary, TypeRepr.of[BoundaryTag.Literal]) then "literal"
-        else if is(boundary, TypeRepr.of[BoundaryTag.Bool]) then "bool"
-        else if is(boundary, TypeRepr.of[BoundaryTag.Int]) then "int"
-        else if is(boundary, TypeRepr.of[BoundaryTag.Long]) then "long"
-        else if is(boundary, TypeRepr.of[BoundaryTag.String]) then "string"
-        else if is(boundary, TypeRepr.of[BoundaryTag.UUID]) then "uuid"
-        else if is(boundary, TypeRepr.of[BoundaryTag.Trailing]) then "trailing"
-        else if is(boundary, TypeRepr.of[BoundaryTag.Empty]) then "empty"
-        else boundary.show
-
-      val leftTrailing  = is(left, TypeRepr.of[BoundaryTag.Trailing])
-      val rightTrailing = is(right, TypeRepr.of[BoundaryTag.Trailing])
-      val leftString    = is(left, TypeRepr.of[BoundaryTag.String])
-      val rightString   = is(right, TypeRepr.of[BoundaryTag.String])
-      val leftNumeric   = is(left, TypeRepr.of[BoundaryTag.Int]) || is(left, TypeRepr.of[BoundaryTag.Long])
-      val rightNumeric  = is(right, TypeRepr.of[BoundaryTag.Int]) || is(right, TypeRepr.of[BoundaryTag.Long])
-      val leftKnown     =
-        is(left, TypeRepr.of[BoundaryTag.Empty]) || is(left, TypeRepr.of[BoundaryTag.Literal]) ||
-          is(left, TypeRepr.of[BoundaryTag.Bool]) || leftNumeric || leftString ||
-          is(left, TypeRepr.of[BoundaryTag.UUID]) || leftTrailing
-      val rightKnown =
-        is(right, TypeRepr.of[BoundaryTag.Empty]) || is(right, TypeRepr.of[BoundaryTag.Literal]) ||
-          is(right, TypeRepr.of[BoundaryTag.Bool]) || rightNumeric || rightString ||
-          is(right, TypeRepr.of[BoundaryTag.UUID]) || rightTrailing
-
-      if leftTrailing || rightTrailing then
-        report.errorAndAbort(s"Cannot combine trailing path segments with `~`: ${label(left)} ~ ${label(right)}")
-      else if leftString && rightString then
-        report.errorAndAbort(s"Cannot combine two string segments with `~`: ${label(left)} ~ ${label(right)}")
-      else if leftNumeric && rightNumeric then
-        report.errorAndAbort(s"Cannot combine two numeric segments with `~`: ${label(left)} ~ ${label(right)}")
-      else if !leftKnown || !rightKnown then
-        report.errorAndAbort(
-          s"Cannot prove segment combination at compile time: ${label(left)} ~ ${label(right)}"
-        )
-      else '{ new CanCombine[L, R] {} }
-    }
-
-    def literalImpl(valueExpr: Expr[String])(using Quotes): Expr[Literal] = {
-      import quotes.reflect.*
-
-      valueExpr.value match {
-        case Some(value) =>
-          validateLiteralValue(value)
-          '{ SegmentCodec.literalValidated(${ Expr(value) }) }
-        case None =>
-          report.errorAndAbort("SegmentCodec.literal requires a string literal known at compile time")
-      }
-    }
-
-    def transformImpl[A: Type, B: Type, P <: BoundaryTag: Type, S <: BoundaryTag: Type](
-      codecExpr: Expr[WithBoundaries[A, P, S]],
-      decodeExpr: Expr[A => B],
-      encodeExpr: Expr[B => A]
-    )(using Quotes): Expr[WithBoundaries[B, P, S]] =
-      '{
-        SegmentCodec
-          .transformValidated[A, B](
-            $codecExpr,
-            value => Right($decodeExpr(value)),
-            value => Right($encodeExpr(value))
-          )
-          .asInstanceOf[WithBoundaries[B, P, S]]
-      }
-
-    def transformOrFailImpl[A: Type, B: Type, P <: BoundaryTag: Type, S <: BoundaryTag: Type](
-      codecExpr: Expr[WithBoundaries[A, P, S]],
-      decodeExpr: Expr[A => Either[DecodeError, B]],
-      encodeExpr: Expr[B => Either[DecodeError, A]]
-    )(using Quotes): Expr[WithBoundaries[B, P, S]] =
-      '{
-        SegmentCodec
-          .transformValidated[A, B]($codecExpr, $decodeExpr, $encodeExpr)
-          .asInstanceOf[WithBoundaries[B, P, S]]
-      }
-
-    private def validateBoundary(using Quotes)(left: Option[SegmentInfo], right: Option[SegmentInfo]): Unit = {
-      import quotes.reflect.*
-
-      (left, right) match {
-        case (Some(SegmentInfo(SegmentInfoKind.Trailing, _)), _) |
-            (_, Some(SegmentInfo(SegmentInfoKind.Trailing, _))) =>
-          report.errorAndAbort("Cannot combine trailing path segments with `~`")
-        case (
-              Some(SegmentInfo(SegmentInfoKind.String, leftName)),
-              Some(SegmentInfo(SegmentInfoKind.String, rightName))
-            ) =>
-          report.errorAndAbort(s"Cannot combine two string segments. Their names are $leftName and $rightName")
-        case (
-              Some(SegmentInfo(SegmentInfoKind.Int | SegmentInfoKind.Long, leftName)),
-              Some(SegmentInfo(SegmentInfoKind.Int | SegmentInfoKind.Long, rightName))
-            ) =>
-          report.errorAndAbort(s"Cannot combine two numeric segments. Their names are $leftName and $rightName")
-        case _ => ()
-      }
-    }
-
-    private def boundaryInfo(using Quotes)(term: quotes.reflect.Term): Option[BoundaryInfo] = {
-      import quotes.reflect.*
-
-      val underlying = term.underlyingArgument
-      if (underlying ne term) return boundaryInfo(underlying)
-
-      def stringArg(args: List[Term], default: String): String =
-        args.collectFirst { case quotes.reflect.Literal(StringConstant(value)) => value }.getOrElse(default)
-
-      def singleInfo(kind: SegmentInfoKind, name: String): BoundaryInfo = {
-        val info = SegmentInfo(kind, name)
-        BoundaryInfo(Some(info), Some(info))
-      }
-
-      def applyInfo(name: String, args: List[Term]): Option[BoundaryInfo] = name match {
-        case "literal" | "Literal"  => Some(singleInfo(SegmentInfoKind.Literal, stringArg(args, "literal")))
-        case "bool" | "BoolSeg"     => Some(singleInfo(SegmentInfoKind.Bool, stringArg(args, "bool")))
-        case "string" | "StringSeg" => Some(singleInfo(SegmentInfoKind.String, stringArg(args, "string")))
-        case "int" | "IntSeg"       => Some(singleInfo(SegmentInfoKind.Int, stringArg(args, "int")))
-        case "long" | "LongSeg"     => Some(singleInfo(SegmentInfoKind.Long, stringArg(args, "long")))
-        case "uuid" | "UUIDSeg"     => Some(singleInfo(SegmentInfoKind.UUID, stringArg(args, "uuid")))
-        case "Trailing"             => Some(singleInfo(SegmentInfoKind.Trailing, "trailing"))
-        case "Empty"                => Some(BoundaryInfo(None, None))
-        case _                      => None
-      }
-
-      def typeInfo(tpe: TypeRepr): Option[BoundaryInfo] = {
-        val segmentCodecSym = Symbol.requiredClass("zio.blocks.endpoint.SegmentCodec")
-        val base            = tpe.widenTermRefByName.dealias.baseType(segmentCodecSym)
-
-        if base =:= TypeRepr.of[Any] then None
-        else {
-          val prefixTpe = base.memberType(segmentCodecSym.typeMember("Prefix"))
-          val suffixTpe = base.memberType(segmentCodecSym.typeMember("Suffix"))
-
-          def kindOf(boundary: TypeRepr): Option[SegmentInfoKind] =
-            if boundary <:< TypeRepr.of[BoundaryTag.Literal] then Some(SegmentInfoKind.Literal)
-            else if boundary <:< TypeRepr.of[BoundaryTag.Bool] then Some(SegmentInfoKind.Bool)
-            else if boundary <:< TypeRepr.of[BoundaryTag.Int] then Some(SegmentInfoKind.Int)
-            else if boundary <:< TypeRepr.of[BoundaryTag.Long] then Some(SegmentInfoKind.Long)
-            else if boundary <:< TypeRepr.of[BoundaryTag.String] then Some(SegmentInfoKind.String)
-            else if boundary <:< TypeRepr.of[BoundaryTag.UUID] then Some(SegmentInfoKind.UUID)
-            else if boundary <:< TypeRepr.of[BoundaryTag.Trailing] then Some(SegmentInfoKind.Trailing)
-            else None
-
-          val prefix = kindOf(prefixTpe).map(kind => SegmentInfo(kind, "transformed"))
-          val suffix = kindOf(suffixTpe).map(kind => SegmentInfo(kind, "transformed"))
-          if (prefix.isEmpty && suffix.isEmpty) None else Some(BoundaryInfo(prefix, suffix))
-        }
-      }
-
-      def appliedBoundary(fun: Term, args: List[Term]): Option[BoundaryInfo] = {
-        val fullName = fun.symbol.fullName
-        if (
-          fullName == "zio.blocks.endpoint.SegmentCodec.literal" || fullName == "zio.blocks.endpoint.SegmentCodec.string" ||
-          fullName == "zio.blocks.endpoint.SegmentCodec.int" || fullName == "zio.blocks.endpoint.SegmentCodec.long" ||
-          fullName == "zio.blocks.endpoint.SegmentCodec.bool" || fullName == "zio.blocks.endpoint.SegmentCodec.uuid"
-        )
-          applyInfo(fun.symbol.name, args)
-        else if (
-          args.nonEmpty &&
-          (fun.symbol.owner.name == "Transform" || fullName.contains("SegmentCodec.Transform"))
-        )
-          boundaryInfo(args.head)
-        else if (
-          (fun.symbol.name == "transform" || fun.symbol.name == "transformOrFail" ||
-            fun.symbol.name == "transformValidated" ||
-            fun.symbol.name == "transform$extension" || fun.symbol.name == "transformOrFail$extension") &&
-          args.nonEmpty
-        )
-          boundaryInfo(args.head)
-        else if (
-          fullName.endsWith("SegmentCodec.Literal.apply") || fullName.endsWith("SegmentCodec.StringSeg.apply") ||
-          fullName.endsWith("SegmentCodec.IntSeg.apply") || fullName.endsWith("SegmentCodec.LongSeg.apply") ||
-          fullName.endsWith("SegmentCodec.BoolSeg.apply") || fullName.endsWith("SegmentCodec.UUIDSeg.apply")
-        )
-          applyInfo(fun.symbol.owner.name, args)
-        else if (fullName.endsWith("SegmentCodec.Transform.apply"))
-          args.headOption.flatMap(boundaryInfo)
-        else None
-      }
-
-      term match {
-        case Inlined(_, _, inner) => boundaryInfo(inner)
-        case Typed(inner, _)      => boundaryInfo(inner)
-        case Block(_, expr)       => boundaryInfo(expr)
-        case Ident(_)             =>
-          term.symbol.tree match {
-            case valDef: ValDef => valDef.rhs.flatMap(boundaryInfo)
-            case _              => None
-          }
-        case Apply(TypeApply(Select(_, "combineValidated"), _), List(left, right, _)) =>
-          for {
-            leftInfo  <- boundaryInfo(left)
-            rightInfo <- boundaryInfo(right)
-          } yield leftInfo ++ rightInfo
-        case Apply(TypeApply(Select(_, "transformValidated"), _), codec :: _) =>
-          boundaryInfo(codec)
-        case Apply(Select(_, "transformValidated"), codec :: _) =>
-          boundaryInfo(codec)
-        case Apply(TypeApply(fun, _), args) =>
-          appliedBoundary(fun, args)
-        case Apply(Select(_, "combineValidated"), List(left, right, _)) =>
-          for {
-            leftInfo  <- boundaryInfo(left)
-            rightInfo <- boundaryInfo(right)
-          } yield leftInfo ++ rightInfo
-        case Apply(Apply(TypeApply(Select(_, "transform"), _), List(left)), _) =>
-          boundaryInfo(left)
-        case Apply(Apply(Select(_, "transform"), List(left)), _) =>
-          boundaryInfo(left)
-        case Apply(TypeApply(Select(left, "transform"), _), _) =>
-          boundaryInfo(left)
-        case Apply(Select(left, "transform"), _) =>
-          boundaryInfo(left)
-        case Apply(Apply(TypeApply(Select(_, "transformOrFail"), _), List(left)), _) =>
-          boundaryInfo(left)
-        case Apply(Apply(Select(_, "transformOrFail"), List(left)), _) =>
-          boundaryInfo(left)
-        case Apply(TypeApply(Select(left, "transformOrFail"), _), _) =>
-          boundaryInfo(left)
-        case Apply(Select(left, "transformOrFail"), _) =>
-          boundaryInfo(left)
-        case Apply(fun, args) =>
-          appliedBoundary(fun, args)
-        case Select(_, "Empty") => Some(BoundaryInfo(None, None))
-        case _                  => typeInfo(term.tpe)
-      }
-    }
-
-    private def validateLiteralValue(value: String)(using Quotes): Unit = {
-      import quotes.reflect.*
-
-      val path          = Path(s"/$value")
-      val singleSegment = path.segments.length == 1 && path.segments.headOption.contains(value)
-      val preserved     = path.encode.stripPrefix("/") == value
-
-      if value.isEmpty then report.errorAndAbort("SegmentCodec.literal cannot be empty")
-      else if !singleSegment || !preserved then
-        report.errorAndAbort(
-          s"SegmentCodec.literal must be a valid single path segment without `/` or characters that require URL encoding: $value"
-        )
-    }
-  }
 }

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
@@ -281,7 +281,7 @@ object SegmentCodec extends SegmentCodecPlatformSpecific {
     val examples: Chunk[(String, Path)] = Chunk.empty
   }
 
-  def render(codec: SegmentCodec[_], prefix: String, suffix: String): String = {
+  def render(codec: SegmentCodec[_], prefix: String = "{", suffix: String = "}"): String = {
     val out                                  = new StringBuilder
     def loop(current: SegmentCodec[_]): Unit =
       current match {


### PR DESCRIPTION
## Summary
- remove the Scala 2 build/test source suppression from `endpoint` and include endpoint in the Scala 2 JVM/JS test and doc aliases
- make the shared endpoint DSL sources Scala-2-compatible while keeping Scala 3 compile-time validation by splitting `SegmentCodec` into shared runtime logic plus scala-2 and scala-3 platform-specific layers
- preserve route/path semantics across both versions so endpoint now builds and tests on Scala 2.13 as well as Scala 3

## Notes
- the actual blocker was not `streams`; `endpoint` had been explicitly skipped on Scala 2 in `build.sbt`
- `PathCodec.literal` now uses runtime validation for shared path construction, while Scala 3 retains compile-time literal validation in the platform-specific `SegmentCodec` layer

## Verification
- `fmtDirty`
- `scalafmtSbt`
- `++2.13.18 endpointJVM/test`
- `++2.13.18 endpointJS/test`
- `++3.8.3 endpointJVM/test`
- `++3.8.3 endpointJS/test`