### PR TITLE
fix(ci): reduce JVM max heap on GitHub runners

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,5 +1,5 @@
 -Xms2g
--Xmx16g
+-Xmx12g
 -Xss2m
 -XX:+UseG1GC
 -XX:InitialCodeCacheSize=512m


### PR DESCRIPTION
## Summary
- reduce `.jvmopts` max heap from `16g` to `12g`
- match the memory limits of default GitHub Actions runners more safely
- leave more memory available for Node.js during Scala.js test execution

## Motivation
A post-merge follow-up on #1403 noted that default GitHub Actions runners have 16 GB RAM total, so allowing the JVM heap to grow to 16 GB can starve the Node.js runtime used by Scala.js tests.