### PR TITLE
docs(ringbuffer): fix broken internal links

### DIFF
--- a/docs/reference/ringbuffer/index.mdx
+++ b/docs/reference/ringbuffer/index.mdx
@@ -137,9 +137,9 @@ libraryDependencies += "dev.zio" %%% "zio-blocks-ringbuffer" % "@VERSION@"
 
 ZIO Blocks provides four optimized ring buffer implementations. Choose the one matching your producer/consumer thread counts:
 
-- **[SPSC](/docs/reference/ringbuffer/spsc)** — Single Producer, Single Consumer (⚡⚡⚡ **Fastest**)
-- **[SPMC](/docs/reference/ringbuffer/spmc)** — Single Producer, Multiple Consumers
-- **[MPSC](/docs/reference/ringbuffer/mpsc)** — Multiple Producers, Single Consumer
-- **[MPMC](/docs/reference/ringbuffer/mpmc)** — Multiple Producers, Multiple Consumers
+- **[SPSC](./spsc)** — Single Producer, Single Consumer (⚡⚡⚡ **Fastest**)
+- **[SPMC](./spmc)** — Single Producer, Multiple Consumers
+- **[MPSC](./mpsc)** — Multiple Producers, Single Consumer
+- **[MPMC](./mpmc)** — Multiple Producers, Multiple Consumers
 
-For advanced topics including thread safety, cache-line padding, design patterns, and performance characteristics, see [Advanced Usage](/docs/reference/ringbuffer/advanced).
+For advanced topics including thread safety, cache-line padding, design patterns, and performance characteristics, see [Advanced Usage](./advanced).


### PR DESCRIPTION
## Summary
- switch the RingBuffer index page from hardcoded `/docs/reference/ringbuffer/*` URLs to local doc-relative links
- fix the broken Docusaurus routes introduced after the ringbuffer docs were reorganized into nested pages
- keep the change surgical to the owning docs page only

## Verification
- reproduced the CI root cause from the failing job log: `/reference/ringbuffer/` linked to missing `/docs/reference/ringbuffer/{spsc,spmc,mpsc,mpmc,advanced}` pages
- manually validated the fix in a repo-shaped disposable Docusaurus build using the updated docs content; the site build completed successfully and no broken ringbuffer links remained