### PR TITLE
feat(schema): JSON modifier parity with zio json for annotations

### DIFF
--- a/docs/guides/zio-schema-migration.md
+++ b/docs/guides/zio-schema-migration.md
@@ -488,7 +488,7 @@ sealed trait Event
 @caseName("user_created")
 case class UserCreated(userId: String) extends Event
 
-// ZIO Blocks Schema — use Modifier.rename on the case, Modifier.config for discriminator
+// ZIO Blocks Schema — use Modifier.rename on the case, Modifier.discriminator on the sealed trait
 import zio.blocks.schema._
 
 sealed trait Event
@@ -496,11 +496,14 @@ sealed trait Event
 case class UserCreated(userId: String) extends Event
 ```
 
-For discriminator key configuration on the enclosing sealed trait, use `Modifier.config` on the reflect node after derivation:
+For discriminator key configuration on the enclosing sealed trait, use `Modifier.discriminator` on the sealed trait:
 
 ```scala
+@Modifier.discriminator("type")
+sealed trait Event
+
 implicit val schema: Schema[Event] =
-  Schema.derived[Event].modifier(Modifier.config("json.discriminator", "type"))
+  Schema.derived[Event]
 ```
 
 ### Programmatic Annotation

--- a/docs/reference/schema/modifier.md
+++ b/docs/reference/schema/modifier.md
@@ -238,7 +238,7 @@ object Person {
 
 ### JSON reflect modifiers
 
-These modifiers are consumed by `JsonCodecDeriver` and let you keep JSON-specific settings next to the annotated type instead of passing them programmatically at every call site.
+These reflect modifiers are consumed by `JsonCodecDeriver` and let you keep JSON-specific settings next to the annotated type instead of passing them programmatically at every call site.
 
 ```scala mdoc:compile-only
 import zio.blocks.schema._
@@ -260,7 +260,8 @@ case class UserProfile(
 - `Modifier.noExtraFields()` rejects unknown object fields during decoding.
 - `Modifier.fieldNaming(strategy)` applies a naming strategy to direct record fields.
 - `Modifier.caseNaming(strategy)` applies a naming strategy to variant case names.
-- `Modifier.encodeTransient()` skips a field during encoding but still accepts it during decoding; like `transient`, it requires a default value when the field is neither optional nor a collection.
+
+For field-level JSON behavior, `Modifier.encodeTransient()` skips a field during encoding but still accepts it during decoding; like `transient`, it requires a default value when the field is neither optional nor a collection.
 
 Or add multiple modifiers at once:
 

--- a/docs/reference/schema/modifier.md
+++ b/docs/reference/schema/modifier.md
@@ -218,7 +218,7 @@ The `config` modifier extends both `Term` and `Reflect`, making it usable on bot
 
 ## Reflect Modifiers
 
-Reflect modifiers annotate reflect values (types themselves). Currently, only `config` is a reflect modifier.
+Reflect modifiers annotate reflect values (types themselves). Alongside `config`, JSON derivation also understands dedicated reflect modifiers for discriminator selection, field naming, case naming, and rejecting extra fields.
 
 ### config
 
@@ -235,6 +235,32 @@ object Person {
     .modifier(Modifier.config("schema.version", "v2"))
 }
 ```
+
+### JSON reflect modifiers
+
+These modifiers are consumed by `JsonCodecDeriver` and let you keep JSON-specific settings next to the annotated type instead of passing them programmatically at every call site.
+
+```scala mdoc:compile-only
+import zio.blocks.schema._
+
+@Modifier.discriminator("type")
+@Modifier.caseNaming("snake_case")
+sealed trait Event
+
+@Modifier.noExtraFields()
+@Modifier.fieldNaming("snake_case")
+case class UserProfile(
+  @Modifier.rename("userId") id: String,
+  @Modifier.encodeTransient() checksum: Int = 0,
+  displayName: String
+)
+```
+
+- `Modifier.discriminator(name)` overrides the JSON discriminator field for sealed hierarchies.
+- `Modifier.noExtraFields()` rejects unknown object fields during decoding.
+- `Modifier.fieldNaming(strategy)` applies a naming strategy to direct record fields.
+- `Modifier.caseNaming(strategy)` applies a naming strategy to variant case names.
+- `Modifier.encodeTransient()` skips a field during encoding but still accepts it during decoding; like `transient`, it requires a default value when the field is neither optional nor a collection.
 
 Or add multiple modifiers at once:
 
@@ -305,8 +331,13 @@ import zio.blocks.schema._
 
 // Schema instances for individual modifiers
 Schema[Modifier.transient]
+Schema[Modifier.encodeTransient]
 Schema[Modifier.rename]
 Schema[Modifier.alias]
+Schema[Modifier.discriminator]
+Schema[Modifier.noExtraFields]
+Schema[Modifier.fieldNaming]
+Schema[Modifier.caseNaming]
 Schema[Modifier.config]
 
 // Schema instances for modifier traits

--- a/schema-examples/src/main/scala/ziosschemamigration/Step2ModifiersAndTransform.scala
+++ b/schema-examples/src/main/scala/ziosschemamigration/Step2ModifiersAndTransform.scala
@@ -157,7 +157,7 @@ object Step2ModifiersAndTransform extends App {
   // ─────────────────────────────────────────────────────────────────────────
   // 6. Programmatic modifier attachment (schema.modifier)
   //    ZIO Schema: schema.annotate(annotation)
-  //    ZIO Blocks: schema.modifier(Modifier.config(...))
+  //    ZIO Blocks: schema.modifier(Modifier.discriminator(...))
   // ─────────────────────────────────────────────────────────────────────────
 
   sealed trait Event

--- a/schema-examples/src/main/scala/ziosschemamigration/Step2ModifiersAndTransform.scala
+++ b/schema-examples/src/main/scala/ziosschemamigration/Step2ModifiersAndTransform.scala
@@ -167,7 +167,7 @@ object Step2ModifiersAndTransform extends App {
     implicit val schema: Schema[Event] =
       Schema
         .derived[Event]
-        .modifier(Modifier.config("json.discriminator", "type"))
+        .modifier(Modifier.discriminator("type"))
   }
 
   println(s"\nEvent schema modifiers: ${Event.schema.reflect.modifiers}")

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
@@ -380,11 +380,12 @@ private object SchemaCompanionVersionSpecific {
               if (symbol.isParamWithDefault) new Some(q"$module.${TermName("$lessinit$greater$default$" + idx)}")
               else {
                 if (
-                  modifiers.exists(m => m.tpe <:< typeOf[Modifier.transient] || m.tpe <:< typeOf[Modifier.encodeTransient]) &&
-                    !isOption(fTpe) &&
-                    !isCollection(fTpe)
+                  modifiers
+                    .exists(m => m.tpe <:< typeOf[Modifier.transient] || m.tpe <:< typeOf[Modifier.encodeTransient]) &&
+                  !isOption(fTpe) &&
+                  !isCollection(fTpe)
                 ) {
-                  fail(s"Missing default value for transient field '$name' in '$tpe'")
+                  fail(s"Missing default value for transient or encodeTransient field '$name' in '$tpe'")
                 }
                 None
               }

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
@@ -379,7 +379,11 @@ private object SchemaCompanionVersionSpecific {
             val defaultValue =
               if (symbol.isParamWithDefault) new Some(q"$module.${TermName("$lessinit$greater$default$" + idx)}")
               else {
-                if (modifiers.exists(_.tpe <:< typeOf[Modifier.transient]) && !isOption(fTpe) && !isCollection(fTpe)) {
+                if (
+                  modifiers.exists(m => m.tpe <:< typeOf[Modifier.transient] || m.tpe <:< typeOf[Modifier.encodeTransient]) &&
+                    !isOption(fTpe) &&
+                    !isCollection(fTpe)
+                ) {
                   fail(s"Missing default value for transient field '$name' in '$tpe'")
                 }
                 None

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
@@ -526,7 +526,7 @@ private class SchemaCompanionVersionSpecificImpl(using Quotes) {
               !isOption(fTpe) &&
               !isCollection(fTpe)
             ) {
-              fail(s"Missing default value for transient field '$name' in '${tpe.show}'")
+              fail(s"Missing default value for transient or encodeTransient field '$name' in '${tpe.show}'")
             }
             None
           }

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
@@ -50,36 +50,37 @@ private class SchemaCompanionVersionSpecificImpl(using Quotes) {
   import quotes.reflect._
   import zio.blocks.schema.SchemaCompanionVersionSpecificImpl.fullTermNameOrdering
 
-  private val intTpe                = defn.IntClass.typeRef
-  private val floatTpe              = defn.FloatClass.typeRef
-  private val longTpe               = defn.LongClass.typeRef
-  private val doubleTpe             = defn.DoubleClass.typeRef
-  private val booleanTpe            = defn.BooleanClass.typeRef
-  private val byteTpe               = defn.ByteClass.typeRef
-  private val charTpe               = defn.CharClass.typeRef
-  private val shortTpe              = defn.ShortClass.typeRef
-  private val unitTpe               = defn.UnitClass.typeRef
-  private val anyRefTpe             = defn.AnyRefClass.typeRef
-  private val anyTpe                = defn.AnyClass.typeRef
-  private val stringTpe             = defn.StringClass.typeRef
-  private val schemaTpe             = Symbol.requiredClass("zio.blocks.schema.Schema").typeRef
-  private val tupleTpe              = Symbol.requiredClass("scala.Tuple").typeRef
-  private val arrayClass            = defn.ArrayClass
-  private val arrayOfAnyTpe         = arrayClass.typeRef.appliedTo(anyTpe)
-  private val newArray              = Select(New(TypeIdent(arrayClass)), arrayClass.primaryConstructor)
-  private val newArrayOfAny         = newArray.appliedToType(anyTpe)
-  private val wildcard              = TypeBounds(defn.NothingClass.typeRef, anyTpe)
-  private val arrayOfWildcardTpe    = arrayClass.typeRef.appliedTo(wildcard)
-  private val iterableOfWildcardTpe = Symbol.requiredClass("scala.collection.Iterable").typeRef.appliedTo(wildcard)
-  private val iteratorOfWildcardTpe = Symbol.requiredClass("scala.collection.Iterator").typeRef.appliedTo(wildcard)
-  private val modifierReflectTpe    = Symbol.requiredClass("zio.blocks.schema.Modifier.Reflect").typeRef
-  private val modifierTermTpe       = Symbol.requiredClass("zio.blocks.schema.Modifier.Term").typeRef
-  private val modifierTransientTpe  = Symbol.requiredClass("zio.blocks.schema.Modifier.transient").typeRef
-  private val iArrayOfAnyRefTpe     = TypeRepr.of[IArray[AnyRef]]
-  private val fromIArrayMethod      = Select.unique(Ref(Symbol.requiredModule("scala.runtime.TupleXXL")), "fromIArray")
-  private val asInstanceOfMethod    = anyTpe.typeSymbol.declaredMethod("asInstanceOf").head
-  private val productElementMethod  = tupleTpe.typeSymbol.methodMember("productElement").head
-  private lazy val toTupleMethod    = Select.unique(Ref(Symbol.requiredModule("scala.NamedTuple")), "toTuple")
+  private val intTpe                     = defn.IntClass.typeRef
+  private val floatTpe                   = defn.FloatClass.typeRef
+  private val longTpe                    = defn.LongClass.typeRef
+  private val doubleTpe                  = defn.DoubleClass.typeRef
+  private val booleanTpe                 = defn.BooleanClass.typeRef
+  private val byteTpe                    = defn.ByteClass.typeRef
+  private val charTpe                    = defn.CharClass.typeRef
+  private val shortTpe                   = defn.ShortClass.typeRef
+  private val unitTpe                    = defn.UnitClass.typeRef
+  private val anyRefTpe                  = defn.AnyRefClass.typeRef
+  private val anyTpe                     = defn.AnyClass.typeRef
+  private val stringTpe                  = defn.StringClass.typeRef
+  private val schemaTpe                  = Symbol.requiredClass("zio.blocks.schema.Schema").typeRef
+  private val tupleTpe                   = Symbol.requiredClass("scala.Tuple").typeRef
+  private val arrayClass                 = defn.ArrayClass
+  private val arrayOfAnyTpe              = arrayClass.typeRef.appliedTo(anyTpe)
+  private val newArray                   = Select(New(TypeIdent(arrayClass)), arrayClass.primaryConstructor)
+  private val newArrayOfAny              = newArray.appliedToType(anyTpe)
+  private val wildcard                   = TypeBounds(defn.NothingClass.typeRef, anyTpe)
+  private val arrayOfWildcardTpe         = arrayClass.typeRef.appliedTo(wildcard)
+  private val iterableOfWildcardTpe      = Symbol.requiredClass("scala.collection.Iterable").typeRef.appliedTo(wildcard)
+  private val iteratorOfWildcardTpe      = Symbol.requiredClass("scala.collection.Iterator").typeRef.appliedTo(wildcard)
+  private val modifierReflectTpe         = Symbol.requiredClass("zio.blocks.schema.Modifier.Reflect").typeRef
+  private val modifierTermTpe            = Symbol.requiredClass("zio.blocks.schema.Modifier.Term").typeRef
+  private val modifierTransientTpe       = Symbol.requiredClass("zio.blocks.schema.Modifier.transient").typeRef
+  private val modifierEncodeTransientTpe = Symbol.requiredClass("zio.blocks.schema.Modifier.encodeTransient").typeRef
+  private val iArrayOfAnyRefTpe          = TypeRepr.of[IArray[AnyRef]]
+  private val fromIArrayMethod           = Select.unique(Ref(Symbol.requiredModule("scala.runtime.TupleXXL")), "fromIArray")
+  private val asInstanceOfMethod         = anyTpe.typeSymbol.declaredMethod("asInstanceOf").head
+  private val productElementMethod       = tupleTpe.typeSymbol.methodMember("productElement").head
+  private lazy val toTupleMethod         = Select.unique(Ref(Symbol.requiredModule("scala.NamedTuple")), "toTuple")
 
   private def fail(msg: String): Nothing = CommonMacroOps.fail(msg)
 
@@ -520,7 +521,11 @@ private class SchemaCompanionVersionSpecificImpl(using Quotes) {
                 }
             })
           } else {
-            if (modifiers.exists(_.tpe <:< modifierTransientTpe) && !isOption(fTpe) && !isCollection(fTpe)) {
+            if (
+              modifiers.exists(m => m.tpe <:< modifierTransientTpe || m.tpe <:< modifierEncodeTransientTpe) &&
+              !isOption(fTpe) &&
+              !isCollection(fTpe)
+            ) {
               fail(s"Missing default value for transient field '$name' in '${tpe.show}'")
             }
             None

--- a/schema/shared/src/main/scala/zio/blocks/schema/DynamicSchema.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/DynamicSchema.scala
@@ -1413,6 +1413,28 @@ object DynamicSchema extends TypeIdSchemas {
     def docToDV(doc: Doc): DynamicValue = Schema.schemaDoc.toDynamicValue(doc)
 
     def modifierToDV(m: Modifier.Reflect): DynamicValue = m match {
+      case d: Modifier.discriminator =>
+        new DynamicValue.Variant(
+          "discriminator",
+          new DynamicValue.Record(
+            Chunk.single("name" -> new DynamicValue.Primitive(new PrimitiveValue.String(d.name)))
+          )
+        )
+      case _: Modifier.noExtraFields => new DynamicValue.Variant("noExtraFields", emptyDynamicRecord)
+      case n: Modifier.fieldNaming   =>
+        new DynamicValue.Variant(
+          "fieldNaming",
+          new DynamicValue.Record(
+            Chunk.single("strategy" -> new DynamicValue.Primitive(new PrimitiveValue.String(n.strategy)))
+          )
+        )
+      case n: Modifier.caseNaming =>
+        new DynamicValue.Variant(
+          "caseNaming",
+          new DynamicValue.Record(
+            Chunk.single("strategy" -> new DynamicValue.Primitive(new PrimitiveValue.String(n.strategy)))
+          )
+        )
       case c: Modifier.config =>
         new DynamicValue.Variant(
           "config",
@@ -1508,8 +1530,9 @@ object DynamicSchema extends TypeIdSchemas {
         "value"     -> reflectToDynamicValue(term.value),
         "doc"       -> docToDV(term.doc),
         "modifiers" -> new DynamicValue.Sequence(Chunk.from(term.modifiers).map {
-          case _: Modifier.transient => new DynamicValue.Variant("transient", emptyDynamicRecord)
-          case r: Modifier.rename    =>
+          case _: Modifier.transient       => new DynamicValue.Variant("transient", emptyDynamicRecord)
+          case _: Modifier.encodeTransient => new DynamicValue.Variant("encodeTransient", emptyDynamicRecord)
+          case r: Modifier.rename          =>
             new DynamicValue.Variant(
               "rename",
               new DynamicValue.Record(
@@ -1640,6 +1663,19 @@ object DynamicSchema extends TypeIdSchemas {
     def dvToModifiers(dv: DynamicValue): Seq[Modifier.Reflect] = dv match {
       case DynamicValue.Sequence(elems) =>
         elems.flatMap {
+          case DynamicValue.Variant("discriminator", DynamicValue.Record(fields)) =>
+            getFieldValue(fields, "name").collect { case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+              Modifier.discriminator(s)
+            }
+          case DynamicValue.Variant("noExtraFields", _)                         => new Some(Modifier.noExtraFields())
+          case DynamicValue.Variant("fieldNaming", DynamicValue.Record(fields)) =>
+            getFieldValue(fields, "strategy").collect { case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+              Modifier.fieldNaming(s)
+            }
+          case DynamicValue.Variant("caseNaming", DynamicValue.Record(fields)) =>
+            getFieldValue(fields, "strategy").collect { case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+              Modifier.caseNaming(s)
+            }
           case DynamicValue.Variant("config", DynamicValue.Record(fields)) =>
             for {
               key   <- getFieldValue(fields, "key").collect { case DynamicValue.Primitive(PrimitiveValue.String(s)) => s }
@@ -1656,6 +1692,7 @@ object DynamicSchema extends TypeIdSchemas {
       case DynamicValue.Sequence(elems) =>
         elems.flatMap {
           case DynamicValue.Variant("transient", _)                        => new Some(Modifier.transient())
+          case DynamicValue.Variant("encodeTransient", _)                  => new Some(Modifier.encodeTransient())
           case DynamicValue.Variant("rename", DynamicValue.Record(fields)) =>
             getFieldValue(fields, "name").collect { case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
               new Modifier.rename(s)

--- a/schema/shared/src/main/scala/zio/blocks/schema/Modifier.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Modifier.scala
@@ -275,20 +275,20 @@ object Modifier {
     reflect = new Reflect.Variant[Binding, Term](
       cases = Chunk(
         transientSchema.reflect.asTerm("transient"),
-        encodeTransientSchema.reflect.asTerm("encodeTransient"),
         renameSchema.reflect.asTerm("rename"),
         aliasSchema.reflect.asTerm("alias"),
-        configSchema.reflect.asTerm("config")
+        configSchema.reflect.asTerm("config"),
+        encodeTransientSchema.reflect.asTerm("encodeTransient")
       ),
       typeId = TypeId.of[Term],
       variantBinding = new Binding.Variant(
         discriminator = new Discriminator[Term] {
           def discriminate(a: Term): Int = a match {
             case _: transient       => 0
-            case _: encodeTransient => 1
-            case _: rename          => 2
-            case _: alias           => 3
-            case _: config          => 4
+            case _: rename          => 1
+            case _: alias           => 2
+            case _: config          => 3
+            case _: encodeTransient => 4
           }
         },
         matchers = Matchers(
@@ -296,12 +296,6 @@ object Modifier {
             def downcastOrNull(a: Any): transient = a match {
               case x: transient => x
               case _            => null.asInstanceOf[transient]
-            }
-          },
-          new Matcher[encodeTransient] {
-            def downcastOrNull(a: Any): encodeTransient = a match {
-              case x: encodeTransient => x
-              case _                  => null.asInstanceOf[encodeTransient]
             }
           },
           new Matcher[rename] {
@@ -321,6 +315,12 @@ object Modifier {
               case x: config => x
               case _         => null.asInstanceOf[config]
             }
+          },
+          new Matcher[encodeTransient] {
+            def downcastOrNull(a: Any): encodeTransient = a match {
+              case x: encodeTransient => x
+              case _                  => null.asInstanceOf[encodeTransient]
+            }
           }
         )
       ),
@@ -331,24 +331,30 @@ object Modifier {
   implicit lazy val reflectSchema: Schema[Reflect] = new Schema(
     reflect = new Reflect.Variant[Binding, Reflect](
       cases = Chunk(
+        configSchema.reflect.asTerm("config"),
         discriminatorSchema.reflect.asTerm("discriminator"),
         noExtraFieldsSchema.reflect.asTerm("noExtraFields"),
         fieldNamingSchema.reflect.asTerm("fieldNaming"),
-        caseNamingSchema.reflect.asTerm("caseNaming"),
-        configSchema.reflect.asTerm("config")
+        caseNamingSchema.reflect.asTerm("caseNaming")
       ),
       typeId = TypeId.of[Reflect],
       variantBinding = new Binding.Variant(
         discriminator = new Discriminator[Reflect] {
           def discriminate(a: Reflect): Int = a match {
-            case _: discriminator => 0
-            case _: noExtraFields => 1
-            case _: fieldNaming   => 2
-            case _: caseNaming    => 3
-            case _: config        => 4
+            case _: config        => 0
+            case _: discriminator => 1
+            case _: noExtraFields => 2
+            case _: fieldNaming   => 3
+            case _: caseNaming    => 4
           }
         },
         matchers = Matchers(
+          new Matcher[config] {
+            def downcastOrNull(a: Any): config = a match {
+              case x: config => x
+              case _         => null.asInstanceOf[config]
+            }
+          },
           new Matcher[discriminator] {
             def downcastOrNull(a: Any): discriminator = a match {
               case x: discriminator => x
@@ -371,12 +377,6 @@ object Modifier {
             def downcastOrNull(a: Any): caseNaming = a match {
               case x: caseNaming => x
               case _             => null.asInstanceOf[caseNaming]
-            }
-          },
-          new Matcher[config] {
-            def downcastOrNull(a: Any): config = a match {
-              case x: config => x
-              case _         => null.asInstanceOf[config]
             }
           }
         )
@@ -389,28 +389,28 @@ object Modifier {
     reflect = new Reflect.Variant[Binding, Modifier](
       cases = Chunk(
         transientSchema.reflect.asTerm("transient"),
-        encodeTransientSchema.reflect.asTerm("encodeTransient"),
         renameSchema.reflect.asTerm("rename"),
         aliasSchema.reflect.asTerm("alias"),
+        configSchema.reflect.asTerm("config"),
+        encodeTransientSchema.reflect.asTerm("encodeTransient"),
         discriminatorSchema.reflect.asTerm("discriminator"),
         noExtraFieldsSchema.reflect.asTerm("noExtraFields"),
         fieldNamingSchema.reflect.asTerm("fieldNaming"),
-        caseNamingSchema.reflect.asTerm("caseNaming"),
-        configSchema.reflect.asTerm("config")
+        caseNamingSchema.reflect.asTerm("caseNaming")
       ),
       typeId = TypeId.of[Modifier],
       variantBinding = new Binding.Variant(
         discriminator = new Discriminator[Modifier] {
           def discriminate(a: Modifier): Int = a match {
             case _: transient       => 0
-            case _: encodeTransient => 1
-            case _: rename          => 2
-            case _: alias           => 3
-            case _: discriminator   => 4
-            case _: noExtraFields   => 5
-            case _: fieldNaming     => 6
-            case _: caseNaming      => 7
-            case _: config          => 8
+            case _: rename          => 1
+            case _: alias           => 2
+            case _: config          => 3
+            case _: encodeTransient => 4
+            case _: discriminator   => 5
+            case _: noExtraFields   => 6
+            case _: fieldNaming     => 7
+            case _: caseNaming      => 8
           }
         },
         matchers = Matchers(
@@ -418,12 +418,6 @@ object Modifier {
             def downcastOrNull(a: Any): transient = a match {
               case x: transient => x
               case _            => null.asInstanceOf[transient]
-            }
-          },
-          new Matcher[encodeTransient] {
-            def downcastOrNull(a: Any): encodeTransient = a match {
-              case x: encodeTransient => x
-              case _                  => null.asInstanceOf[encodeTransient]
             }
           },
           new Matcher[rename] {
@@ -436,6 +430,18 @@ object Modifier {
             def downcastOrNull(a: Any): alias = a match {
               case x: alias => x
               case _        => null.asInstanceOf[alias]
+            }
+          },
+          new Matcher[config] {
+            def downcastOrNull(a: Any): config = a match {
+              case x: config => x
+              case _         => null.asInstanceOf[config]
+            }
+          },
+          new Matcher[encodeTransient] {
+            def downcastOrNull(a: Any): encodeTransient = a match {
+              case x: encodeTransient => x
+              case _                  => null.asInstanceOf[encodeTransient]
             }
           },
           new Matcher[discriminator] {
@@ -460,12 +466,6 @@ object Modifier {
             def downcastOrNull(a: Any): caseNaming = a match {
               case x: caseNaming => x
               case _             => null.asInstanceOf[caseNaming]
-            }
-          },
-          new Matcher[config] {
-            def downcastOrNull(a: Any): config = a match {
-              case x: config => x
-              case _         => null.asInstanceOf[config]
             }
           }
         )

--- a/schema/shared/src/main/scala/zio/blocks/schema/Modifier.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Modifier.scala
@@ -39,6 +39,7 @@ object Modifier {
    * The following are the known subtypes of `Term`:
    *   - `transient`: Used to indicate that a field should not be persisted or
    *     serialized.
+   *   - `encodeTransient`: Used to indicate that a field should not be encoded.
    *   - `rename`: Used to specify a new name for a term, typically useful in
    *     serialization scenarios.
    *   - `alias`: Provides an alternative name (alias) for a term.
@@ -51,6 +52,11 @@ object Modifier {
    * A modifier that marks a term (such as a field) as transient.
    */
   @field case class transient() extends Term
+
+  /**
+   * A modifier that marks a term (such as a field) as excluded from encoding.
+   */
+  @field case class encodeTransient() extends Term
 
   /**
    * A modifier used to specify a new name for a term.
@@ -74,6 +80,26 @@ object Modifier {
   sealed trait Reflect extends Modifier
 
   /**
+   * A modifier that specifies the discriminator field name for JSON variants.
+   */
+  case class discriminator(name: String) extends Reflect
+
+  /**
+   * A modifier that rejects unrecognized fields during decoding.
+   */
+  case class noExtraFields() extends Reflect
+
+  /**
+   * A modifier that configures field name transformation for JSON records.
+   */
+  case class fieldNaming(strategy: String) extends Reflect
+
+  /**
+   * A modifier that configures case name transformation for JSON variants.
+   */
+  case class caseNaming(strategy: String) extends Reflect
+
+  /**
    * A configuration key-value pair, which can be attached to any type of
    * reflect values. The convention for keys is `<format>.<property>`. For
    * example, `protobuf.field-id` is a key that specifies the field id for a
@@ -88,6 +114,18 @@ object Modifier {
       recordBinding = new Binding.Record(
         constructor = new ConstantConstructor[transient](transient()),
         deconstructor = new ConstantDeconstructor[transient]
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val encodeTransientSchema: Schema[encodeTransient] = new Schema(
+    reflect = new Reflect.Record[Binding, encodeTransient](
+      fields = Chunk.empty,
+      typeId = TypeId.of[encodeTransient],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[encodeTransient](encodeTransient()),
+        deconstructor = new ConstantDeconstructor[encodeTransient]
       ),
       modifiers = Chunk.empty
     )
@@ -133,6 +171,78 @@ object Modifier {
     )
   )
 
+  implicit lazy val discriminatorSchema: Schema[discriminator] = new Schema(
+    reflect = new Reflect.Record[Binding, discriminator](
+      fields = Chunk.single(Schema[String].reflect.asTerm("name")),
+      typeId = TypeId.of[discriminator],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[discriminator] {
+          def usedRegisters: RegisterOffset                                   = 1
+          def construct(in: Registers, offset: RegisterOffset): discriminator =
+            new discriminator(in.getObject(offset).asInstanceOf[String])
+        },
+        deconstructor = new Deconstructor[discriminator] {
+          def usedRegisters: RegisterOffset                                                = 1
+          def deconstruct(out: Registers, offset: RegisterOffset, in: discriminator): Unit =
+            out.setObject(offset, in.name)
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val noExtraFieldsSchema: Schema[noExtraFields] = new Schema(
+    reflect = new Reflect.Record[Binding, noExtraFields](
+      fields = Chunk.empty,
+      typeId = TypeId.of[noExtraFields],
+      recordBinding = new Binding.Record(
+        constructor = new ConstantConstructor[noExtraFields](noExtraFields()),
+        deconstructor = new ConstantDeconstructor[noExtraFields]
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val fieldNamingSchema: Schema[fieldNaming] = new Schema(
+    reflect = new Reflect.Record[Binding, fieldNaming](
+      fields = Chunk.single(Schema[String].reflect.asTerm("strategy")),
+      typeId = TypeId.of[fieldNaming],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[fieldNaming] {
+          def usedRegisters: RegisterOffset                                 = 1
+          def construct(in: Registers, offset: RegisterOffset): fieldNaming =
+            new fieldNaming(in.getObject(offset).asInstanceOf[String])
+        },
+        deconstructor = new Deconstructor[fieldNaming] {
+          def usedRegisters: RegisterOffset                                              = 1
+          def deconstruct(out: Registers, offset: RegisterOffset, in: fieldNaming): Unit =
+            out.setObject(offset, in.strategy)
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
+  implicit lazy val caseNamingSchema: Schema[caseNaming] = new Schema(
+    reflect = new Reflect.Record[Binding, caseNaming](
+      fields = Chunk.single(Schema[String].reflect.asTerm("strategy")),
+      typeId = TypeId.of[caseNaming],
+      recordBinding = new Binding.Record(
+        constructor = new Constructor[caseNaming] {
+          def usedRegisters: RegisterOffset                                = 1
+          def construct(in: Registers, offset: RegisterOffset): caseNaming =
+            new caseNaming(in.getObject(offset).asInstanceOf[String])
+        },
+        deconstructor = new Deconstructor[caseNaming] {
+          def usedRegisters: RegisterOffset                                             = 1
+          def deconstruct(out: Registers, offset: RegisterOffset, in: caseNaming): Unit =
+            out.setObject(offset, in.strategy)
+        }
+      ),
+      modifiers = Chunk.empty
+    )
+  )
+
   implicit lazy val configSchema: Schema[config] = new Schema(
     reflect = new Reflect.Record[Binding, config](
       fields = Chunk(
@@ -165,6 +275,7 @@ object Modifier {
     reflect = new Reflect.Variant[Binding, Term](
       cases = Chunk(
         transientSchema.reflect.asTerm("transient"),
+        encodeTransientSchema.reflect.asTerm("encodeTransient"),
         renameSchema.reflect.asTerm("rename"),
         aliasSchema.reflect.asTerm("alias"),
         configSchema.reflect.asTerm("config")
@@ -173,10 +284,11 @@ object Modifier {
       variantBinding = new Binding.Variant(
         discriminator = new Discriminator[Term] {
           def discriminate(a: Term): Int = a match {
-            case _: transient => 0
-            case _: rename    => 1
-            case _: alias     => 2
-            case _: config    => 3
+            case _: transient       => 0
+            case _: encodeTransient => 1
+            case _: rename          => 2
+            case _: alias           => 3
+            case _: config          => 4
           }
         },
         matchers = Matchers(
@@ -184,6 +296,12 @@ object Modifier {
             def downcastOrNull(a: Any): transient = a match {
               case x: transient => x
               case _            => null.asInstanceOf[transient]
+            }
+          },
+          new Matcher[encodeTransient] {
+            def downcastOrNull(a: Any): encodeTransient = a match {
+              case x: encodeTransient => x
+              case _                  => null.asInstanceOf[encodeTransient]
             }
           },
           new Matcher[rename] {
@@ -212,15 +330,49 @@ object Modifier {
 
   implicit lazy val reflectSchema: Schema[Reflect] = new Schema(
     reflect = new Reflect.Variant[Binding, Reflect](
-      cases = Chunk.single(configSchema.reflect.asTerm("config")),
+      cases = Chunk(
+        discriminatorSchema.reflect.asTerm("discriminator"),
+        noExtraFieldsSchema.reflect.asTerm("noExtraFields"),
+        fieldNamingSchema.reflect.asTerm("fieldNaming"),
+        caseNamingSchema.reflect.asTerm("caseNaming"),
+        configSchema.reflect.asTerm("config")
+      ),
       typeId = TypeId.of[Reflect],
       variantBinding = new Binding.Variant(
         discriminator = new Discriminator[Reflect] {
           def discriminate(a: Reflect): Int = a match {
-            case _: config => 0
+            case _: discriminator => 0
+            case _: noExtraFields => 1
+            case _: fieldNaming   => 2
+            case _: caseNaming    => 3
+            case _: config        => 4
           }
         },
         matchers = Matchers(
+          new Matcher[discriminator] {
+            def downcastOrNull(a: Any): discriminator = a match {
+              case x: discriminator => x
+              case _                => null.asInstanceOf[discriminator]
+            }
+          },
+          new Matcher[noExtraFields] {
+            def downcastOrNull(a: Any): noExtraFields = a match {
+              case x: noExtraFields => x
+              case _                => null.asInstanceOf[noExtraFields]
+            }
+          },
+          new Matcher[fieldNaming] {
+            def downcastOrNull(a: Any): fieldNaming = a match {
+              case x: fieldNaming => x
+              case _              => null.asInstanceOf[fieldNaming]
+            }
+          },
+          new Matcher[caseNaming] {
+            def downcastOrNull(a: Any): caseNaming = a match {
+              case x: caseNaming => x
+              case _             => null.asInstanceOf[caseNaming]
+            }
+          },
           new Matcher[config] {
             def downcastOrNull(a: Any): config = a match {
               case x: config => x
@@ -237,18 +389,28 @@ object Modifier {
     reflect = new Reflect.Variant[Binding, Modifier](
       cases = Chunk(
         transientSchema.reflect.asTerm("transient"),
+        encodeTransientSchema.reflect.asTerm("encodeTransient"),
         renameSchema.reflect.asTerm("rename"),
         aliasSchema.reflect.asTerm("alias"),
+        discriminatorSchema.reflect.asTerm("discriminator"),
+        noExtraFieldsSchema.reflect.asTerm("noExtraFields"),
+        fieldNamingSchema.reflect.asTerm("fieldNaming"),
+        caseNamingSchema.reflect.asTerm("caseNaming"),
         configSchema.reflect.asTerm("config")
       ),
       typeId = TypeId.of[Modifier],
       variantBinding = new Binding.Variant(
         discriminator = new Discriminator[Modifier] {
           def discriminate(a: Modifier): Int = a match {
-            case _: transient => 0
-            case _: rename    => 1
-            case _: alias     => 2
-            case _: config    => 3
+            case _: transient       => 0
+            case _: encodeTransient => 1
+            case _: rename          => 2
+            case _: alias           => 3
+            case _: discriminator   => 4
+            case _: noExtraFields   => 5
+            case _: fieldNaming     => 6
+            case _: caseNaming      => 7
+            case _: config          => 8
           }
         },
         matchers = Matchers(
@@ -256,6 +418,12 @@ object Modifier {
             def downcastOrNull(a: Any): transient = a match {
               case x: transient => x
               case _            => null.asInstanceOf[transient]
+            }
+          },
+          new Matcher[encodeTransient] {
+            def downcastOrNull(a: Any): encodeTransient = a match {
+              case x: encodeTransient => x
+              case _                  => null.asInstanceOf[encodeTransient]
             }
           },
           new Matcher[rename] {
@@ -268,6 +436,30 @@ object Modifier {
             def downcastOrNull(a: Any): alias = a match {
               case x: alias => x
               case _        => null.asInstanceOf[alias]
+            }
+          },
+          new Matcher[discriminator] {
+            def downcastOrNull(a: Any): discriminator = a match {
+              case x: discriminator => x
+              case _                => null.asInstanceOf[discriminator]
+            }
+          },
+          new Matcher[noExtraFields] {
+            def downcastOrNull(a: Any): noExtraFields = a match {
+              case x: noExtraFields => x
+              case _                => null.asInstanceOf[noExtraFields]
+            }
+          },
+          new Matcher[fieldNaming] {
+            def downcastOrNull(a: Any): fieldNaming = a match {
+              case x: fieldNaming => x
+              case _              => null.asInstanceOf[fieldNaming]
+            }
+          },
+          new Matcher[caseNaming] {
+            def downcastOrNull(a: Any): caseNaming = a match {
+              case x: caseNaming => x
+              case _             => null.asInstanceOf[caseNaming]
             }
           },
           new Matcher[config] {

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonCodecDeriver.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonCodecDeriver.scala
@@ -725,7 +725,7 @@ class JsonCodecDeriver private[json] (
                 var idx = 0
                 while (idx < len) {
                   val fieldInfo = fieldInfos(idx)
-                  if (fieldInfo.nonTransient && fieldInfo.nonEncodeTransient) {
+                  if (fieldInfo.nonEncodeTransient) {
                     if (skipDefaultValue && fieldInfo.hasDefault) fieldInfo.writeDefaultValue(out, baseOffset)
                     else if (skipNone && fieldInfo.isOptional) fieldInfo.writeOptional(out, baseOffset)
                     else if (skipEmptyCollection && fieldInfo.isCollection) fieldInfo.writeCollection(out, baseOffset)
@@ -810,7 +810,7 @@ class JsonCodecDeriver private[json] (
               var idx = 0
               while (idx < len) {
                 val fieldInfo = fieldInfos(idx)
-                if (fieldInfo.nonTransient && fieldInfo.nonEncodeTransient) {
+                if (fieldInfo.nonEncodeTransient) {
                   if (skipDefaultValue && fieldInfo.hasDefault) fieldInfo.writeDefaultValue(regs, builder)
                   else if (skipNone && fieldInfo.isOptional) fieldInfo.writeOptional(regs, builder)
                   else if (skipEmptyCollection && fieldInfo.isCollection) fieldInfo.writeCollection(regs, builder)

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonCodecDeriver.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonCodecDeriver.scala
@@ -336,8 +336,10 @@ class JsonCodecDeriver private[json] (
     examples: Seq[A]
   )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[JsonCodec[A]] = {
     if (binding.isInstanceOf[Binding[?, ?]]) {
-      val recordBinding = binding.asInstanceOf[Binding.Record[A]]
-      val len           = fields.length
+      val recordBinding           = binding.asInstanceOf[Binding.Record[A]]
+      val len                     = fields.length
+      val resolvedFieldNameMapper = resolveFieldNameMapper(modifiers, fieldNameMapper)
+      val resolvedRejectExtra     = resolveRejectExtraFields(modifiers, rejectExtraFields)
       if (typeId.isTuple) Lazy {
         val fieldRegisterOffsets = new Array[RegisterOffset](len)
         val fieldTypeTags        = new Array[Int](len)
@@ -623,10 +625,13 @@ class JsonCodecDeriver private[json] (
             field.modifiers.foreach {
               case m: Modifier.rename    => if (name eq null) name = m.name
               case m: Modifier.alias     => map.put(m.name, fieldInfo)
-              case _: Modifier.transient => fieldInfo.nonTransient = false
-              case _                     =>
+              case _: Modifier.transient =>
+                fieldInfo.nonTransient = false
+                fieldInfo.nonEncodeTransient = false
+              case _: Modifier.encodeTransient => fieldInfo.nonEncodeTransient = false
+              case _                           =>
             }
-            if (name eq null) name = fieldNameMapper(field.name)
+            if (name eq null) name = resolvedFieldNameMapper(field.name)
             map.put(name, fieldInfo)
             fieldInfo.setName(name)
             idx += 1
@@ -642,7 +647,7 @@ class JsonCodecDeriver private[json] (
             private[this] val skipNone            = transientNone
             private[this] val skipEmptyCollection = transientEmptyCollection
             private[this] val skipDefaultValue    = transientDefaultValue
-            private[this] val doReject            = rejectExtraFields
+            private[this] val doReject            = resolvedRejectExtra
 
             require(fieldInfos.length <= 128, "expected up to 128 fields")
 
@@ -720,7 +725,7 @@ class JsonCodecDeriver private[json] (
                 var idx = 0
                 while (idx < len) {
                   val fieldInfo = fieldInfos(idx)
-                  if (fieldInfo.nonTransient) {
+                  if (fieldInfo.nonTransient && fieldInfo.nonEncodeTransient) {
                     if (skipDefaultValue && fieldInfo.hasDefault) fieldInfo.writeDefaultValue(out, baseOffset)
                     else if (skipNone && fieldInfo.isOptional) fieldInfo.writeOptional(out, baseOffset)
                     else if (skipEmptyCollection && fieldInfo.isCollection) fieldInfo.writeCollection(out, baseOffset)
@@ -805,7 +810,7 @@ class JsonCodecDeriver private[json] (
               var idx = 0
               while (idx < len) {
                 val fieldInfo = fieldInfos(idx)
-                if (fieldInfo.nonTransient) {
+                if (fieldInfo.nonTransient && fieldInfo.nonEncodeTransient) {
                   if (skipDefaultValue && fieldInfo.hasDefault) fieldInfo.writeDefaultValue(regs, builder)
                   else if (skipNone && fieldInfo.isOptional) fieldInfo.writeOptional(regs, builder)
                   else if (skipEmptyCollection && fieldInfo.isCollection) fieldInfo.writeCollection(regs, builder)
@@ -999,7 +1004,9 @@ class JsonCodecDeriver private[json] (
           }
         }
       } else {
-        val discr = binding.asInstanceOf[Binding.Variant[A]].discriminator
+        val discr                     = binding.asInstanceOf[Binding.Variant[A]].discriminator
+        val resolvedCaseNameMapper    = resolveCaseNameMapper(modifiers, caseNameMapper)
+        val resolvedDiscriminatorKind = resolveDiscriminatorKind(modifiers, discriminatorKind)
         if (isEnumeration(cases)) Lazy {
           val map = new StringMap[Constructor[?]](cases.length)
 
@@ -1027,7 +1034,7 @@ class JsonCodecDeriver private[json] (
                   case m: Modifier.alias  => map.put(m.name, constructor)
                   case _                  =>
                 }
-                if (name eq null) name = caseNameMapper(case_.name)
+                if (name eq null) name = resolvedCaseNameMapper(case_.name)
                 map.put(name, constructor)
                 new EnumLeafInfo(name, constructor)
               }
@@ -1069,7 +1076,7 @@ class JsonCodecDeriver private[json] (
           }
         }
         else {
-          discriminatorKind match {
+          resolvedDiscriminatorKind match {
             case DiscriminatorKind.Field(fieldName) if hasOnlyRecordAndVariantCases(cases) =>
               Lazy {
                 val map = new StringMap[CaseLeafInfo](cases.length)
@@ -1100,7 +1107,7 @@ class JsonCodecDeriver private[json] (
                           aliases.addOne(alias)
                         case _ =>
                       }
-                      if (name eq null) name = caseNameMapper(case_.name)
+                      if (name eq null) name = resolvedCaseNameMapper(case_.name)
                       caseLeafInfo.setName(name)
                       caseLeafInfo.setAliases(aliases.result())
                       map.put(name, caseLeafInfo)
@@ -1292,7 +1299,7 @@ class JsonCodecDeriver private[json] (
                           aliases.addOne(alias)
                         case _ =>
                       }
-                      if (name eq null) name = caseNameMapper(case_.name)
+                      if (name eq null) name = resolvedCaseNameMapper(case_.name)
                       map.put(name, caseLeafInfo)
                       caseLeafInfo.setName(name)
                       caseLeafInfo.setAliases(aliases.result())
@@ -2979,6 +2986,21 @@ class JsonCodecDeriver private[json] (
     if (requireDefaultValueFields) None
     else fieldReflect.asInstanceOf[Reflect[Binding, A]].getDefaultValue
 
+  private[this] def resolveFieldNameMapper(modifiers: Seq[Modifier.Reflect], fallback: NameMapper): NameMapper =
+    modifiers.collectFirst { case m: Modifier.fieldNaming => NameMapper.fromString(m.strategy) }.getOrElse(fallback)
+
+  private[this] def resolveCaseNameMapper(modifiers: Seq[Modifier.Reflect], fallback: NameMapper): NameMapper =
+    modifiers.collectFirst { case m: Modifier.caseNaming => NameMapper.fromString(m.strategy) }.getOrElse(fallback)
+
+  private[this] def resolveDiscriminatorKind(
+    modifiers: Seq[Modifier.Reflect],
+    fallback: DiscriminatorKind
+  ): DiscriminatorKind =
+    modifiers.collectFirst { case m: Modifier.discriminator => DiscriminatorKind.Field(m.name) }.getOrElse(fallback)
+
+  private[this] def resolveRejectExtraFields(modifiers: Seq[Modifier.Reflect], fallback: Boolean): Boolean =
+    if (modifiers.exists(_.isInstanceOf[Modifier.noExtraFields])) true else fallback
+
   private[this] def discriminator[F[_, _], A](caseReflect: Reflect[F, A]): Discriminator[?] =
     caseReflect.asVariant.get.variantBinding
       .asInstanceOf[BindingInstance[TC, ?, ?]]
@@ -2998,6 +3020,7 @@ private class FieldInfo(
   val usesNullSentinel: Boolean = false
 ) {
   var nonTransient: Boolean                        = true
+  var nonEncodeTransient: Boolean                  = true
   private[this] var isPredefinedCodec: Boolean     = false
   private[this] var isNonEscapedAsciiName: Boolean = false
   private[this] var name: String                   = null

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/NameMapper.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/NameMapper.scala
@@ -191,6 +191,16 @@ object NameMapper {
     override def apply(memberName: String): String = memberName
   }
 
+  /**
+   * Parses a built-in naming strategy string into a [[NameMapper]].
+   *
+   * Accepted values are `identity`, `snake_case`, `camelCase`, `kebab-case`,
+   * and `PascalCase`.
+   *
+   * @throws java.lang.IllegalArgumentException
+   *   if the provided strategy name does not match one of the supported
+   *   built-in strategies.
+   */
   def fromString(s: String): NameMapper = s match {
     case "identity"   => Identity
     case "snake_case" => SnakeCase

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/NameMapper.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/NameMapper.scala
@@ -49,6 +49,8 @@ sealed trait NameMapper extends (String => String)
  *     function to the input string.
  */
 object NameMapper {
+  private[this] val validStrategies = "identity, snake_case, camelCase, kebab-case, PascalCase"
+
   private[this] def enforceCamelOrPascalCase(s: String, toPascal: Boolean): String =
     if (s.indexOf('_') == -1 && s.indexOf('-') == -1) {
       if (s.isEmpty) s
@@ -187,5 +189,17 @@ object NameMapper {
    */
   case object Identity extends NameMapper {
     override def apply(memberName: String): String = memberName
+  }
+
+  def fromString(s: String): NameMapper = s match {
+    case "identity"   => Identity
+    case "snake_case" => SnakeCase
+    case "camelCase"  => CamelCase
+    case "kebab-case" => KebabCase
+    case "PascalCase" => PascalCase
+    case other        =>
+      throw new IllegalArgumentException(
+        s"Unknown naming strategy '$other'. Expected one of: $validStrategies"
+      )
   }
 }

--- a/schema/shared/src/test/scala/zio/blocks/schema/DynamicSchemaRebindSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/DynamicSchemaRebindSpec.scala
@@ -54,6 +54,16 @@ object DynamicSchemaRebindSpec extends SchemaBaseSpec {
     implicit val schema: Schema[Config] = Schema.derived[Config]
   }
 
+  @Modifier.discriminator("type")
+  sealed trait AnnotatedAnimal
+  case class AnnotatedDog(name: String) extends AnnotatedAnimal
+  object AnnotatedDog {
+    implicit val schema: Schema[AnnotatedDog] = Schema.derived[AnnotatedDog]
+  }
+  object AnnotatedAnimal {
+    implicit val schema: Schema[AnnotatedAnimal] = Schema.derived[AnnotatedAnimal]
+  }
+
   def spec: Spec[TestEnvironment, Any] = suite("DynamicSchemaRebindSpec")(
     suite("DynamicSchema.rebind")(
       test("rebinds a simple record schema") {
@@ -104,6 +114,21 @@ object DynamicSchemaRebindSpec extends SchemaBaseSpec {
         val result      = rebound.fromDynamicValue(dynamic)
 
         assertTrue(result == Right(dog))
+      },
+      test("preserves json modifiers through dynamic schema") {
+        val dynamicSchema   = Schema[AnnotatedAnimal].toDynamicSchema
+        val reboundRegistry = BindingResolver.defaults
+          .bind(Binding.of[AnnotatedAnimal])
+          .bind(Binding.of[AnnotatedDog])
+
+        val rebound                = dynamicSchema.rebind[AnnotatedAnimal](reboundRegistry)
+        val value: AnnotatedAnimal = AnnotatedDog("Buddy")
+
+        assertTrue(
+          dynamicSchema.reflect.modifiers.contains(Modifier.discriminator("type")),
+          rebound.reflect.modifiers.contains(Modifier.discriminator("type")),
+          rebound.fromDynamicValue(rebound.toDynamicValue(value)) == Right(value)
+        )
       },
       test("throws RebindException when binding is missing") {
         val dynamicSchema = Schema[Person].toDynamicSchema

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
@@ -1944,7 +1944,7 @@ object SchemaSpec extends SchemaBaseSpec {
         assert(_)(
           isLeft(
             containsString(
-              "Missing default value for transient field 'a' in 'WrongTransientField'"
+              "Missing default value for transient or encodeTransient field 'a' in 'WrongTransientField'"
             )
           )
         )
@@ -1961,7 +1961,7 @@ object SchemaSpec extends SchemaBaseSpec {
         assert(_)(
           isLeft(
             containsString(
-              "Missing default value for transient field 'a' in 'WrongEncodeTransientField'"
+              "Missing default value for transient or encodeTransient field 'a' in 'WrongEncodeTransientField'"
             )
           )
         )

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaSpec.scala
@@ -1950,6 +1950,23 @@ object SchemaSpec extends SchemaBaseSpec {
         )
       )
     },
+    test(
+      "doesn't generate schema for classes with encode transient fields that are neither optional nor collection nor have default value"
+    ) {
+      typeCheck {
+        """case class WrongEncodeTransientField(i: Int, @Modifier.encodeTransient() a: String)
+
+           Schema.derived[WrongEncodeTransientField]"""
+      }.map(
+        assert(_)(
+          isLeft(
+            containsString(
+              "Missing default value for transient field 'a' in 'WrongEncodeTransientField'"
+            )
+          )
+        )
+      )
+    },
     typeIdConsistencySuite
   )
 

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonCodecDeriverSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonCodecDeriverSpec.scala
@@ -3971,6 +3971,68 @@ object JsonCodecDeriverSpec extends SchemaBaseSpec {
     implicit val schema: Schema[CamelPascalSnakeKebabCases] = Schema.derived
   }
 
+  @Modifier.fieldNaming("snake_case")
+  case class AnnotatedFieldNaming(firstName: String, lastName: String)
+
+  object AnnotatedFieldNaming {
+    implicit val schema: Schema[AnnotatedFieldNaming] = Schema.derived
+  }
+
+  @Modifier.fieldNaming("snake_case")
+  case class AnnotatedFieldNamingWithRename(@Modifier.rename("customName") firstName: String, lastName: String)
+
+  object AnnotatedFieldNamingWithRename {
+    implicit val schema: Schema[AnnotatedFieldNamingWithRename] = Schema.derived
+  }
+
+  @Modifier.fieldNaming("snake_case")
+  case class NestedFieldNaming(outerValue: AnnotatedFieldNaming, innerValue: AnnotatedFieldNaming)
+
+  object NestedFieldNaming {
+    implicit val schema: Schema[NestedFieldNaming] = Schema.derived
+  }
+
+  @Modifier.noExtraFields()
+  case class StrictRecord(name: String)
+
+  object StrictRecord {
+    implicit val schema: Schema[StrictRecord] = Schema.derived
+  }
+
+  @Modifier.noExtraFields()
+  case class StrictRecordWithAlias(@Modifier.alias("nickname") name: String)
+
+  object StrictRecordWithAlias {
+    implicit val schema: Schema[StrictRecordWithAlias] = Schema.derived
+  }
+
+  case class EncodeTransientRecord(@Modifier.encodeTransient() computed: Int = 0, name: String)
+
+  object EncodeTransientRecord {
+    implicit val schema: Schema[EncodeTransientRecord] = Schema.derived
+  }
+
+  @Modifier.discriminator("type")
+  sealed trait AnnotatedPet
+
+  object AnnotatedPet {
+    implicit val schema: Schema[AnnotatedPet] = Schema.derived
+
+    case class Dog(name: String) extends AnnotatedPet
+  }
+
+  @Modifier.caseNaming("snake_case")
+  sealed trait AnnotatedStatus
+
+  object AnnotatedStatus {
+    implicit val schema: Schema[AnnotatedStatus] = Schema.derived
+
+    case object ActiveNow extends AnnotatedStatus
+
+    @Modifier.rename("custom_retry")
+    case object RetryLater extends AnnotatedStatus
+  }
+
   sealed trait Pet {
     def name: String
 

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonCodecDeriverSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonCodecDeriverSpec.scala
@@ -1569,6 +1569,59 @@ object JsonCodecDeriverSpec extends SchemaBaseSpec {
           Schema[CamelPascalSnakeKebabCases].derive(JsonCodecDeriver.withFieldNameMapper(CamelCase))
         )
       },
+      test("record with annotation-driven json modifiers") {
+        roundTrip(
+          AnnotatedFieldNaming("Ada", "Lovelace"),
+          """{"first_name":"Ada","last_name":"Lovelace"}"""
+        ) &&
+        roundTrip(
+          AnnotatedFieldNamingWithRename("Ada", "Lovelace"),
+          """{"customName":"Ada","last_name":"Lovelace"}"""
+        ) &&
+        roundTrip(
+          NestedFieldNaming(AnnotatedFieldNaming("Ada", "Lovelace"), AnnotatedFieldNaming("Grace", "Hopper")),
+          """{"outer_value":{"first_name":"Ada","last_name":"Lovelace"},"inner_value":{"first_name":"Grace","last_name":"Hopper"}}"""
+        ) &&
+        roundTrip(
+          EncodeTransientRecord(0, "Ada"),
+          """{"name":"Ada"}"""
+        ) &&
+        decode(
+          """{"computed":7,"name":"Ada"}""",
+          EncodeTransientRecord(7, "Ada")
+        ) &&
+        decodeError(
+          """{"name":"Ada","extra":1}""",
+          "unexpected field \"extra\" at: .",
+          Schema[StrictRecord].derive(JsonCodecDeriver)
+        ) &&
+        decode(
+          """{"nickname":"Ada"}""",
+          StrictRecordWithAlias("Ada")
+        ) &&
+        decodeError(
+          """{"nickname":"Ada","name":"Ada"}""",
+          "duplicated field \"name\" at: .",
+          Schema[StrictRecordWithAlias].derive(JsonCodecDeriver)
+        )
+      },
+      test("record annotation-driven field naming overrides deriver defaults") {
+        val codec = Schema[AnnotatedFieldNaming].derive(JsonCodecDeriver.withFieldNameMapper(KebabCase))
+        roundTrip(
+          AnnotatedFieldNaming("Ada", "Lovelace"),
+          """{"first_name":"Ada","last_name":"Lovelace"}""",
+          codec
+        )
+      },
+      test("invalid annotation-driven field naming strategy fails clearly") {
+        assert(scala.util.Try(Schema[InvalidFieldNaming].derive(JsonCodecDeriver)).toEither)(
+          isLeft(
+            hasError(
+              "Unknown naming strategy 'LOUD_SNAKE'. Expected one of: identity, snake_case, camelCase, kebab-case, PascalCase"
+            )
+          )
+        )
+      },
       test("record with a custom codec for primitives injected by optic and field renaming using modifier overriding") {
         val codec1 = Record1.schema
           .deriving(JsonCodecDeriver)
@@ -3322,6 +3375,42 @@ object JsonCodecDeriverSpec extends SchemaBaseSpec {
           codec
         )
       },
+      test("ADT with annotation-driven discriminator and case naming") {
+        roundTrip[AnnotatedPet](
+          AnnotatedPet.Dog("Rex"),
+          """{"type":"Dog","name":"Rex"}""",
+          Schema[AnnotatedPet].derive(JsonCodecDeriver)
+        ) &&
+        roundTrip[AnnotatedStatus](
+          AnnotatedStatus.ActiveNow,
+          """"active_now"""",
+          Schema[AnnotatedStatus].derive(JsonCodecDeriver)
+        ) &&
+        roundTrip[AnnotatedStatus](
+          AnnotatedStatus.RetryLater,
+          """"custom_retry"""",
+          Schema[AnnotatedStatus].derive(JsonCodecDeriver)
+        )
+      },
+      test("annotation-driven discriminator and case naming override deriver defaults") {
+        val codec = Schema[AnnotatedStatus].derive(
+          JsonCodecDeriver
+            .withCaseNameMapper(NameMapper.KebabCase)
+            .withDiscriminatorKind(DiscriminatorKind.Field("kind"))
+        )
+
+        roundTrip[AnnotatedStatus](AnnotatedStatus.ActiveNow, """"active_now"""", codec) &&
+        roundTrip[AnnotatedStatus](AnnotatedStatus.RetryLater, """"custom_retry"""", codec)
+      },
+      test("invalid annotation-driven case naming strategy fails clearly") {
+        assert(scala.util.Try(Schema[InvalidCaseNaming].derive(JsonCodecDeriver)).toEither)(
+          isLeft(
+            hasError(
+              "Unknown naming strategy 'LOUD_SNAKE'. Expected one of: identity, snake_case, camelCase, kebab-case, PascalCase"
+            )
+          )
+        )
+      },
       test("option") {
         roundTrip(Option(42), """42""") &&
         roundTrip[Option[Int]](None, """null""") &&
@@ -4031,6 +4120,22 @@ object JsonCodecDeriverSpec extends SchemaBaseSpec {
 
     @Modifier.rename("custom_retry")
     case object RetryLater extends AnnotatedStatus
+  }
+
+  @Modifier.fieldNaming("LOUD_SNAKE")
+  case class InvalidFieldNaming(name: String)
+
+  object InvalidFieldNaming {
+    implicit val schema: Schema[InvalidFieldNaming] = Schema.derived
+  }
+
+  @Modifier.caseNaming("LOUD_SNAKE")
+  sealed trait InvalidCaseNaming
+
+  object InvalidCaseNaming {
+    implicit val schema: Schema[InvalidCaseNaming] = Schema.derived
+
+    case object ActiveNow extends InvalidCaseNaming
   }
 
   sealed trait Pet {


### PR DESCRIPTION
## Summary
- add dedicated schema modifiers for JSON discriminator, case naming, field naming, strict extra-field rejection, and encode-only transient fields
- wire JsonCodecDeriver, DynamicSchema, and Scala 2/3 schema derivation validation to honor the new annotation-driven JSON behavior
- add coverage for the new modifier semantics and update schema migration docs plus the modifiers example

## Verification
- `sbt --client -Dsbt.color=false '++3.8.3; fmtDirty'`
- `sbt --client -Dsbt.color=false '++3.8.3; schemaJVM/test'`
- `sbt --client -Dsbt.color=false '++2.13.18; schemaJVM/test'`
- `sbt --client -Dsbt.color=false '++3.8.3; schema-examples/compile'`
- `sbt --client -Dsbt.color=false '++3.8.3; schema-examples/runMain ziosschemamigration.Step2ModifiersAndTransform'`