### PR TITLE
Splat varargs in constructor

### DIFF
--- a/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
@@ -368,9 +368,9 @@ private object SchemaCompanionVersionSpecific {
         (
           primaryConstructor(tpe).paramLists.map(_.map { param =>
             idx += 1
-            val symbol = param.asTerm
-            val name   = NameTransformer.decode(symbol.name.toString)
-            var fTpe   = symbol.typeSignature.dealias
+            val symbol   = param.asTerm
+            val name     = NameTransformer.decode(symbol.name.toString)
+            var fTpe     = symbol.typeSignature.dealias
             val repeated = fTpe.typeSymbol == definitions.RepeatedParamClass
             if (repeated) fTpe = appliedType(typeOf[Seq[Any]].typeConstructor, fTpe.typeArgs)
             if (tpeTypeArgs ne Nil) fTpe = fTpe.substituteTypes(tpeTypeParams, tpeTypeArgs)
@@ -438,7 +438,7 @@ private object SchemaCompanionVersionSpecific {
         val argss = fieldInfos.map(_.map { fieldInfo =>
           val fTpe          = fieldInfo.tpe
           val usedRegisters = fieldInfo.usedRegisters
-          val arg =
+          val arg           =
             if (fTpe =:= definitions.IntTpe) q"in.getInt(offset + $usedRegisters)"
             else if (fTpe =:= definitions.FloatTpe) q"in.getFloat(offset + $usedRegisters)"
             else if (fTpe =:= definitions.LongTpe) q"in.getLong(offset + $usedRegisters)"

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
@@ -339,7 +339,8 @@ private object SchemaCompanionVersionSpecific {
       val defaultValue: Option[Tree],
       val getter: MethodSymbol,
       val usedRegisters: RegisterOffset,
-      val modifiers: List[Tree]
+      val modifiers: List[Tree],
+      val repeated: Boolean
     )
 
     class ClassInfo(tpe: Type) {
@@ -370,6 +371,8 @@ private object SchemaCompanionVersionSpecific {
             val symbol = param.asTerm
             val name   = NameTransformer.decode(symbol.name.toString)
             var fTpe   = symbol.typeSignature.dealias
+            val repeated = fTpe.typeSymbol == definitions.RepeatedParamClass
+            if (repeated) fTpe = appliedType(typeOf[Seq[Any]].typeConstructor, fTpe.typeArgs)
             if (tpeTypeArgs ne Nil) fTpe = fTpe.substituteTypes(tpeTypeParams, tpeTypeArgs)
             val getter = getters.getOrElse(
               name,
@@ -401,7 +404,7 @@ private object SchemaCompanionVersionSpecific {
               else if (sTpe <:< definitions.ShortTpe) RegisterOffset(shorts = 1)
               else if (sTpe <:< definitions.UnitTpe) RegisterOffset.Zero
               else RegisterOffset(objects = 1)
-            val fieldInfo = new FieldInfo(name, fTpe, defaultValue, getter, usedRegisters, modifiers)
+            val fieldInfo = new FieldInfo(name, fTpe, defaultValue, getter, usedRegisters, modifiers, repeated)
             usedRegisters = RegisterOffset.add(usedRegisters, offset)
             fieldInfo
           }),
@@ -435,28 +438,30 @@ private object SchemaCompanionVersionSpecific {
         val argss = fieldInfos.map(_.map { fieldInfo =>
           val fTpe          = fieldInfo.tpe
           val usedRegisters = fieldInfo.usedRegisters
-          if (fTpe =:= definitions.IntTpe) q"in.getInt(offset + $usedRegisters)"
-          else if (fTpe =:= definitions.FloatTpe) q"in.getFloat(offset + $usedRegisters)"
-          else if (fTpe =:= definitions.LongTpe) q"in.getLong(offset + $usedRegisters)"
-          else if (fTpe =:= definitions.DoubleTpe) q"in.getDouble(offset + $usedRegisters)"
-          else if (fTpe =:= definitions.BooleanTpe) q"in.getBoolean(offset + $usedRegisters)"
-          else if (fTpe =:= definitions.ByteTpe) q"in.getByte(offset + $usedRegisters)"
-          else if (fTpe =:= definitions.CharTpe) q"in.getChar(offset + $usedRegisters)"
-          else if (fTpe =:= definitions.ShortTpe) q"in.getShort(offset + $usedRegisters)"
-          else if (fTpe =:= definitions.UnitTpe) q"()"
-          else {
-            val sTpe = dealiasOnDemand(fTpe)
-            if (sTpe <:< definitions.IntTpe) q"in.getInt(offset + $usedRegisters).asInstanceOf[$fTpe]"
-            else if (sTpe <:< definitions.FloatTpe) q"in.getFloat(offset + $usedRegisters).asInstanceOf[$fTpe]"
-            else if (sTpe <:< definitions.LongTpe) q"in.getLong(offset + $usedRegisters).asInstanceOf[$fTpe]"
-            else if (sTpe <:< definitions.DoubleTpe) q"in.getDouble(offset + $usedRegisters).asInstanceOf[$fTpe]"
-            else if (sTpe <:< definitions.BooleanTpe) q"in.getBoolean(offset + $usedRegisters).asInstanceOf[$fTpe]"
-            else if (sTpe <:< definitions.ByteTpe) q"in.getByte(offset + $usedRegisters).asInstanceOf[$fTpe]"
-            else if (sTpe <:< definitions.CharTpe) q"in.getChar(offset + $usedRegisters).asInstanceOf[$fTpe]"
-            else if (sTpe <:< definitions.ShortTpe) q"in.getShort(offset + $usedRegisters).asInstanceOf[$fTpe]"
-            else if (sTpe <:< definitions.UnitTpe) q"().asInstanceOf[$fTpe]"
-            else q"in.getObject(offset + $usedRegisters).asInstanceOf[$fTpe]"
-          }
+          val arg =
+            if (fTpe =:= definitions.IntTpe) q"in.getInt(offset + $usedRegisters)"
+            else if (fTpe =:= definitions.FloatTpe) q"in.getFloat(offset + $usedRegisters)"
+            else if (fTpe =:= definitions.LongTpe) q"in.getLong(offset + $usedRegisters)"
+            else if (fTpe =:= definitions.DoubleTpe) q"in.getDouble(offset + $usedRegisters)"
+            else if (fTpe =:= definitions.BooleanTpe) q"in.getBoolean(offset + $usedRegisters)"
+            else if (fTpe =:= definitions.ByteTpe) q"in.getByte(offset + $usedRegisters)"
+            else if (fTpe =:= definitions.CharTpe) q"in.getChar(offset + $usedRegisters)"
+            else if (fTpe =:= definitions.ShortTpe) q"in.getShort(offset + $usedRegisters)"
+            else if (fTpe =:= definitions.UnitTpe) q"()"
+            else {
+              val sTpe = dealiasOnDemand(fTpe)
+              if (sTpe <:< definitions.IntTpe) q"in.getInt(offset + $usedRegisters).asInstanceOf[$fTpe]"
+              else if (sTpe <:< definitions.FloatTpe) q"in.getFloat(offset + $usedRegisters).asInstanceOf[$fTpe]"
+              else if (sTpe <:< definitions.LongTpe) q"in.getLong(offset + $usedRegisters).asInstanceOf[$fTpe]"
+              else if (sTpe <:< definitions.DoubleTpe) q"in.getDouble(offset + $usedRegisters).asInstanceOf[$fTpe]"
+              else if (sTpe <:< definitions.BooleanTpe) q"in.getBoolean(offset + $usedRegisters).asInstanceOf[$fTpe]"
+              else if (sTpe <:< definitions.ByteTpe) q"in.getByte(offset + $usedRegisters).asInstanceOf[$fTpe]"
+              else if (sTpe <:< definitions.CharTpe) q"in.getChar(offset + $usedRegisters).asInstanceOf[$fTpe]"
+              else if (sTpe <:< definitions.ShortTpe) q"in.getShort(offset + $usedRegisters).asInstanceOf[$fTpe]"
+              else if (sTpe <:< definitions.UnitTpe) q"().asInstanceOf[$fTpe]"
+              else q"in.getObject(offset + $usedRegisters).asInstanceOf[$fTpe]"
+            }
+          if (fieldInfo.repeated) q"$arg : _*" else arg
         })
         q"new $tpe(...$argss)"
       }

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/SchemaCompanionVersionSpecific.scala
@@ -468,15 +468,16 @@ private class SchemaCompanionVersionSpecificImpl(using Quotes) {
     private val tpeClassSymbol     = tpe.classSymbol.get
     private val primaryConstructor = tpeClassSymbol.primaryConstructor
     // caching of expensive calls of field and method member gathering
-    private var fieldMembers: List[Symbol]                                       = null
-    private var methodMembers: List[Symbol]                                      = null
-    private var companionRefAndClass: (Ref, Symbol)                              = null
-    val tpeTypeArgs: List[TypeRepr]                                              = typeArgs(tpe)
-    val (fieldInfos: List[List[FieldInfo]], usedRegisters: Expr[RegisterOffset]) = {
-      val (tpeTypeParams, tpeParams) = primaryConstructor.paramSymss match {
+    private var fieldMembers: List[Symbol]                                   = null
+    private var methodMembers: List[Symbol]                                  = null
+    private var companionRefAndClass: (Ref, Symbol)                          = null
+    val tpeTypeArgs: List[TypeRepr]                                          = typeArgs(tpe)
+    private val (tpeTypeParams: List[Symbol], tpeParams: List[List[Symbol]]) =
+      primaryConstructor.paramSymss match {
         case tps :: ps if tps.exists(_.isTypeParam) => (tps, ps)
         case ps                                     => (Nil, ps)
       }
+    val (fieldInfos: List[List[FieldInfo]], usedRegisters: Expr[RegisterOffset]) = {
       val caseFields    = tpeClassSymbol.caseFields
       var usedRegisters = RegisterOffset.Zero
       var idx           = 0
@@ -580,8 +581,18 @@ private class SchemaCompanionVersionSpecificImpl(using Quotes) {
     }
 
     def constructor(in: Expr[Registers], offset: Expr[RegisterOffset])(using Quotes): Expr[T] = {
-      val constructor = Select(New(Inferred(tpe)), primaryConstructor).appliedToTypes(tpeTypeArgs)
-      val argss       = fieldInfos.map(_.map(fieldConstructor(in, offset, _)))
+      val constructor    = Select(New(Inferred(tpe)), primaryConstructor).appliedToTypes(tpeTypeArgs)
+      val constructorTpe = tpe.memberType(primaryConstructor).widen
+      val argss          = fieldInfos.zip(tpeParams).map { case (fis, params) =>
+        fis.zip(params).map { case (fi, paramSym) =>
+          val arg = fieldConstructor(in, offset, fi)
+          constructorTpe.memberType(paramSym) match {
+            case AnnotatedType(_, annot) if annot.tpe.typeSymbol == defn.RepeatedAnnot =>
+              Typed(arg, Inferred(defn.RepeatedParamClass.typeRef.appliedTo(fi.tpe.typeArgs.head)))
+            case _ => arg
+          }
+        }
+      }
       argss.tail.foldLeft(Apply(constructor, argss.head))(Apply(_, _)).asExpr.asInstanceOf[Expr[T]]
     }
 

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaVarargsSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaVarargsSpec.scala
@@ -6,6 +6,12 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package zio.blocks.schema

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaVarargsSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaVarargsSpec.scala
@@ -28,19 +28,6 @@ object SchemaVarargsSpec extends SchemaBaseSpec {
   }
 
   def spec: Spec[TestEnvironment, Any] = suite("SchemaVarargsSpec")(
-    test("compiles Schema.derived for a case class with varargs") {
-      typeCheck {
-        """
-        import zio.blocks.schema._
-
-        case class Varargs(xs: Int*)
-
-        object Varargs {
-          implicit val schema: Schema[Varargs] = Schema.derived
-        }
-        """
-      }.map(result => assert(result)(isRight))
-    },
     test("round-trips a case class with varargs through DynamicValue") {
       val schema = Varargs.schema
       assert(schema.fromDynamicValue(schema.toDynamicValue(Varargs())))(isRight(equalTo(Varargs()))) &&

--- a/schema/shared/src/test/scala/zio/blocks/schema/SchemaVarargsSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SchemaVarargsSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package zio.blocks.schema
+
+import zio.test._
+import zio.test.Assertion._
+
+object SchemaVarargsSpec extends SchemaBaseSpec {
+
+  final case class Varargs(xs: Int*)
+
+  object Varargs {
+    implicit val schema: Schema[Varargs] = Schema.derived
+  }
+
+  final case class GenericVarargs[A](xs: A*)
+
+  object GenericVarargs {
+    implicit val schema: Schema[GenericVarargs[String]] = Schema.derived
+  }
+
+  def spec: Spec[TestEnvironment, Any] = suite("SchemaVarargsSpec")(
+    test("compiles Schema.derived for a case class with varargs") {
+      typeCheck {
+        """
+        import zio.blocks.schema._
+
+        case class Varargs(xs: Int*)
+
+        object Varargs {
+          implicit val schema: Schema[Varargs] = Schema.derived
+        }
+        """
+      }.map(result => assert(result)(isRight))
+    },
+    test("round-trips a case class with varargs through DynamicValue") {
+      val schema = Varargs.schema
+      assert(schema.fromDynamicValue(schema.toDynamicValue(Varargs())))(isRight(equalTo(Varargs()))) &&
+      assert(schema.fromDynamicValue(schema.toDynamicValue(Varargs(1, 2, 3))))(isRight(equalTo(Varargs(1, 2, 3))))
+    },
+    test("round-trips a generic case class with varargs through DynamicValue") {
+      val schema = GenericVarargs.schema
+      val value  = GenericVarargs[String]("a", "b", "c")
+      assert(schema.fromDynamicValue(schema.toDynamicValue(value)))(isRight(equalTo(value)))
+    }
+  )
+}


### PR DESCRIPTION
```scala
 final case class Varargs(xs: Int*)

  object Varargs {
    implicit val schema: Schema[Varargs] = Schema.derived
  }
```
```
❯ [error] -- [E007] Type Mismatch Error: /Users/devsisters/repos/zio-blocks/schema/shared/src/test/scala/zio/blocks/schema/SchemaVarargsDebug.scala:7:43                                                                                                            
  [error]   7 |    implicit val schema: Schema[Varargs] = Schema.derived                                                                                                                                                                                            
  [error]     |                                           ^^^^^^^^^^^^^^                                                                                                                                                                                            
  [error]     |                                           Found:    Seq[Int]                                                                                                                                                                                        
  [error]     |                                           Required: Int                                                                                                                                                                                             
  [error]     |---------------------------------------------------------------------------                                                                                                                                                                          
  [error]     |Inline stack trace                                                                                                                                                                                                                                   
  [error]     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -                                                                                                                                                                          
  [error]     |This location contains code that was inlined from SchemaCompanionVersionSpecific.scala:457                                                                                                                                                           
  [error] 457 |            else '{ $in.getObject($offset + $usedRegisters).asInstanceOf[ft] }                                                                                                                                                                       
  [error]     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                         
  [error]     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -                                                                                                                                                                          
  [error]     |This location contains code that was inlined from SchemaCompanionVersionSpecific.scala:457                                                                                                                                                           
  [error] 457 |            else '{ $in.getObject($offset + $usedRegisters).asInstanceOf[ft] }                                                                                                                                                                       
  [error]     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                         
  [error]      ---------------------------------------------------------------------------                                                                                                                                                                          
  [error]     |---------------------------------------------------------------------------                                                                                                                                                                          
  [error]     | Explanation (enabled by `-explain`)                                                                                                                                                                                                                 
  [error]     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -                                                                                                                                                                          
  [error]     |                                                                                                                                                                                                                                                     
  [error]     | Tree:                                                                                                                                                                                                                                               
  [error]     |                                                                                                                                                                                                                                                     
  [error]     | in.getObject(offset + 0L).asInstanceOf[Seq[Int]]                                                                                                                                                                                                    
  [error]     |                                                                                                                                                                                                                                                     
  [error]     | I tried to show that                                                                                                                                                                                                                                
  [error]     |   Seq[Int]                                                                                                                                                                                                                                          
  [error]     | conforms to                                                                                                                                                                                                                                         
  [error]     |   Int                                                                                                                                                                                                                                               
  [error]     | but none of the attempts shown below succeeded:                                                                                                                                                                                                     
  [error]     |                                                                                                                                                                                                                                                     
  [error]     |   ==> Seq[Int]  <:  Int  = false                                                                                                                                                                                                                    
  [error]     |                                                                                                                                                                                                                                                     
  [error]     | The tests were made under the empty constraint                                                                                                                                                                                                      
  [error]      --------------------------------------------------------------------------- 
```
Deriving Schema of case class containing varargs failed, since the generated constructor didn't splat varargs.