### PR TITLE
docs(optics): add Search Optic documentation

### DIFF
--- a/docs/reference/schema/dynamic-optic.md
+++ b/docs/reference/schema/dynamic-optic.md
@@ -520,10 +520,12 @@ val allInts = nested.get(p"#int").toChunk
 
 ### Known Limitation: Nominal Matching in Untyped Contexts
 
-`Nominal` pattern matching (e.g., `#Person`) returns `false` when applied to `DynamicValue` or `Json` because these untyped structures carry no type identity. To match nominally-typed data:
+`Nominal` pattern matching (e.g., `#Person`) returns `false` when applied to `DynamicValue` or `Json` because these untyped structures carry no type identity. To match nominally-typed data, use one of these approaches:
 
 - **Use the typed API**: `optic(_.searchFor[Person])`
 - **Or use structural patterns**: `p"#record { name: string, age: int }"`
+
+Here's how the two approaches differ in practice:
 
 ```scala mdoc:compile-only
 import zio.blocks.schema._

--- a/docs/reference/schema/dynamic-optic.md
+++ b/docs/reference/schema/dynamic-optic.md
@@ -482,8 +482,8 @@ Search optics support both **type-based** and **schema-based** patterns:
 
 | Pattern                        | Matches                                | Example                    |
 |--------------------------------|----------------------------------------|---------------------------|
-| `#Nominal` (type name)         | Values of that type name               | `#Person`, `#String`       |
-| `#int`, `#string`, `#boolean`  | Specific primitive types               | `#int`, `#string`, `#boolean` |
+| `#Nominal` (type name)         | Values of that type name               | `#Person`                  |
+| `#int`, `#string`, `#boolean`  | Specific primitive types (case-insensitive) | `#int`, `#string`, `#boolean` |
 | `#record { ... }`              | Records with matching fields           | `#record { name: string }` |
 | `#variant { ... }`             | Variant cases with matching content    | `#variant { Error: string }` |
 | `#list(...)`                   | Lists/sequences with element type     | `#list(string)`            |

--- a/docs/reference/schema/dynamic-optic.md
+++ b/docs/reference/schema/dynamic-optic.md
@@ -411,9 +411,9 @@ Search optics address scenarios where you need to:
 
 ### Typed API: `.searchFor[T]`
 
-Use the `.searchFor[T]` extension method to search for all values of type `T`:
+Use the `.searchFor[T]` extension method on a `CompanionOptics` to search for all values of type `T`:
 
-```scala mdoc:compile-only
+```scala
 import zio.blocks.schema._
 
 case class Person(name: String, age: Int)
@@ -434,7 +434,7 @@ val company = Company(
 )
 
 // Modify all persons (increment their age)
-val updated: Company = personSearch.modify(company)(p => p.copy(age = p.age + 1))
+val updated: Company = personSearch.modify(company, p => p.copy(age = p.age + 1))
 // Company("Acme", List(Person("Alice", 31), Person("Bob", 26)), Address("NYC"))
 ```
 

--- a/docs/reference/schema/dynamic-optic.md
+++ b/docs/reference/schema/dynamic-optic.md
@@ -433,12 +433,9 @@ val company = Company(
   Address("NYC")
 )
 
-// Collect all persons
-val allPersons: Chunk[Person] = personSearch.collect(company)
-// Chunk(Person("Alice", 30), Person("Bob", 25))
-
-// Modify all persons
-val updated = personSearch.modify(company)(p => p.copy(age = p.age + 1))
+// Modify all persons (increment their age)
+val updated: Company = personSearch.modify(company)(p => p.copy(age = p.age + 1))
+// Company("Acme", List(Person("Alice", 31), Person("Bob", 26)), Address("NYC"))
 ```
 
 ### Dynamic API: Path Strings with `#` Prefix
@@ -486,12 +483,12 @@ Search optics support both **type-based** and **schema-based** patterns:
 | Pattern                        | Matches                                | Example                    |
 |--------------------------------|----------------------------------------|---------------------------|
 | `#Nominal` (type name)         | Values of that type name               | `#Person`, `#String`       |
-| `#primitive`                   | Any primitive value                    | `#int`, `#string`, `#bool` |
+| `#int`, `#string`, `#boolean`  | Specific primitive types               | `#int`, `#string`, `#boolean` |
 | `#record { ... }`              | Records with matching fields           | `#record { name: string }` |
-| `#variant`                     | Any variant/case instance              | `#variant`                 |
-| `#sequence`                    | Any sequence/list                      | `#sequence`                |
-| `#map`                         | Any map                                | `#map`                     |
-| `#optional`                    | Optional/wrapped values                | `#optional`                |
+| `#variant { ... }`             | Variant cases with matching content    | `#variant { Error: string }` |
+| `#list(...)`                   | Lists/sequences with element type     | `#list(string)`            |
+| `#map(...)`                    | Maps with key and value types          | `#map(string, int)`        |
+| `#option(...)`                 | Optional values with inner type       | `#option(int)`             |
 
 ### Traversal Order
 

--- a/docs/reference/schema/dynamic-optic.md
+++ b/docs/reference/schema/dynamic-optic.md
@@ -413,7 +413,7 @@ Search optics address scenarios where you need to:
 
 Use the `.searchFor[T]` extension method on a `CompanionOptics` to search for all values of type `T`:
 
-```scala
+```scala mdoc:compile-only
 import zio.blocks.schema._
 
 case class Person(name: String, age: Int)

--- a/docs/reference/schema/dynamic-optic.md
+++ b/docs/reference/schema/dynamic-optic.md
@@ -396,6 +396,146 @@ val serialized: DynamicValue = opticSchema.toDynamicValue(path)
 ```
 
 
+## Search Optics
+
+A **Search optic** recursively traverses a data structure to find **all occurrences** matching a type or schema. It produces a `Traversal[S, A]` that collects matches in depth-first, left-to-right order.
+
+### Motivation
+
+Search optics address scenarios where you need to:
+
+- **Find all values of a specific type** across deeply nested structures (e.g., all `String` fields in a nested record)
+- **Extract all data matching a structural pattern** (e.g., all records with `{ name: string, age: int }` schema)
+- **Transform all matching occurrences** in untyped or partially-typed data
+- **Query data without knowing the exact path** — the search discovers all paths automatically
+
+### Typed API: `.searchFor[T]`
+
+Use the `.searchFor[T]` extension method to search for all values of type `T`:
+
+```scala mdoc:compile-only
+import zio.blocks.schema._
+
+case class Person(name: String, age: Int)
+case class Address(city: String)
+case class Company(name: String, employees: List[Person], hq: Address)
+
+object Company extends CompanionOptics[Company] {
+  implicit val schema: Schema[Company] = Schema.derived
+}
+
+// Find all Person instances within a Company
+val personSearch: Traversal[Company, Person] = Company.optic(_.searchFor[Person])
+
+val company = Company(
+  "Acme",
+  List(Person("Alice", 30), Person("Bob", 25)),
+  Address("NYC")
+)
+
+// Collect all persons
+val allPersons: Chunk[Person] = personSearch.collect(company)
+// Chunk(Person("Alice", 30), Person("Bob", 25))
+
+// Modify all persons
+val updated = personSearch.modify(company)(p => p.copy(age = p.age + 1))
+```
+
+### Dynamic API: Path Strings with `#` Prefix
+
+Use the `#` prefix in path strings to specify type or schema patterns:
+
+```scala mdoc:compile-only
+import zio.blocks.schema._
+
+val data = DynamicValue.Record(
+  "company" -> DynamicValue.Record(
+    "name" -> DynamicValue.string("Acme"),
+    "employees" -> DynamicValue.Sequence(
+      DynamicValue.Record("name" -> DynamicValue.string("Alice")),
+      DynamicValue.Record("name" -> DynamicValue.string("Bob"))
+    )
+  )
+)
+
+// Find all strings in the data
+val allStrings = data.get(p"#string").toChunk
+// Chunk(
+//   DynamicValue.string("Acme"),
+//   DynamicValue.string("Alice"),
+//   DynamicValue.string("Bob")
+// )
+
+// Find all records matching a schema
+val recordsWithName = data.get(p"#record { name: string }").toChunk
+
+// Modify all matching values
+val modified = data.modify(p"#string")(dv =>
+  dv match {
+    case DynamicValue.Primitive(PrimitiveValue.String(s)) =>
+      DynamicValue.string(s.toUpperCase)
+    case other => other
+  }
+)
+```
+
+### Supported Patterns
+
+Search optics support both **type-based** and **schema-based** patterns:
+
+| Pattern                        | Matches                                | Example                    |
+|--------------------------------|----------------------------------------|---------------------------|
+| `#Nominal` (type name)         | Values of that type name               | `#Person`, `#String`       |
+| `#primitive`                   | Any primitive value                    | `#int`, `#string`, `#bool` |
+| `#record { ... }`              | Records with matching fields           | `#record { name: string }` |
+| `#variant`                     | Any variant/case instance              | `#variant`                 |
+| `#sequence`                    | Any sequence/list                      | `#sequence`                |
+| `#map`                         | Any map                                | `#map`                     |
+| `#optional`                    | Optional/wrapped values                | `#optional`                |
+
+### Traversal Order
+
+Results are collected in **depth-first, left-to-right order**:
+
+```scala mdoc:compile-only
+import zio.blocks.schema._
+
+val nested = DynamicValue.Record(
+  "a" -> DynamicValue.int(1),
+  "b" -> DynamicValue.Record(
+    "c" -> DynamicValue.int(2),
+    "d" -> DynamicValue.int(3)
+  ),
+  "e" -> DynamicValue.int(4)
+)
+
+// Depth-first, left-to-right: 1, 2, 3, 4
+val allInts = nested.get(p"#int").toChunk
+// Chunk(1, 2, 3, 4)
+```
+
+### Known Limitation: Nominal Matching in Untyped Contexts
+
+`Nominal` pattern matching (e.g., `#Person`) returns `false` when applied to `DynamicValue` or `Json` because these untyped structures carry no type identity. To match nominally-typed data:
+
+- **Use the typed API**: `optic(_.searchFor[Person])`
+- **Or use structural patterns**: `p"#record { name: string, age: int }"`
+
+```scala mdoc:compile-only
+import zio.blocks.schema._
+
+val dynamicData: DynamicValue = ???
+
+// This won't match — no type identity available
+val nominalMatch = dynamicData.get(p"#Person").toChunk
+// Chunk()
+
+// This works — structural matching
+val structuralMatch = dynamicData.get(p"#record { name: string, age: int }").toChunk
+// Chunk(...matching records...)
+```
+
 ## See Also
 
 - [DynamicSchema](./dynamic-schema.md) — use `DynamicSchema#get` with a `DynamicOptic` to navigate schema trees and inspect nested type structures.
+- [Optics](./optics.md) — reference page for typed `Optic[S, A]` and reflective optics concepts.

--- a/docs/reference/schema/dynamic-optic.md
+++ b/docs/reference/schema/dynamic-optic.md
@@ -417,9 +417,16 @@ Use the `.searchFor[T]` extension method on a `CompanionOptics` to search for al
 import zio.blocks.schema._
 
 case class Person(name: String, age: Int)
-case class Address(city: String)
-case class Company(name: String, employees: List[Person], hq: Address)
+object Person {
+  implicit val schema: Schema[Person] = Schema.derived
+}
 
+case class Address(city: String)
+object Address {
+  implicit val schema: Schema[Address] = Schema.derived
+}
+
+case class Company(name: String, employees: List[Person], hq: Address)
 object Company extends CompanionOptics[Company] {
   implicit val schema: Schema[Company] = Schema.derived
 }


### PR DESCRIPTION
## Summary

Documents the new Search Optic feature from PR #1035 by adding a comprehensive subsection to the DynamicOptic reference page.

## Changes

- Added "Search Optics" subsection to `docs/reference/schema/dynamic-optic.md`
- Covers typed API (`.searchFor[T]`) and dynamic API (`p"#..."` patterns)
- Includes pattern matching reference, traversal order guarantees, and known limitations
- Cross-references to related optics documentation

Complements #1035 with user-facing documentation for the Search Optic feature and closes #910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)