### PR TITLE
fix(schema): honor migration target and case selectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
           check-latest: true
       - name: Setup SBT
         uses: sbt/setup-sbt@v1
+        env:
+          JDK_JAVA_OPTIONS: ''
       - name: Cache Dependencies
         uses: coursier/cache-action@v8
       - name: Setup Node.js
@@ -249,6 +251,8 @@ jobs:
           check-latest: true
       - name: Setup SBT
         uses: sbt/setup-sbt@v1
+        env:
+          JDK_JAVA_OPTIONS: ''
       - name: Cache Dependencies
         uses: coursier/cache-action@v8
       - name: Setup NodeJs

--- a/docs/reference/schema/migration.md
+++ b/docs/reference/schema/migration.md
@@ -168,7 +168,9 @@ val userMigration = Migration
   .build
 ```
 
-`transformField` and `changeFieldType` evaluate their `SchemaExpr` against the currently focused field value, not the entire root record. In practice, that means the expression should be written in terms of the value being replaced.
+`transformField`, `mandateField`, `optionalizeField`, and `changeFieldType` write the computed value to the target selector. When the source and target selectors differ, the original source field remains available as migration input while the target field is added or replaced in the dynamic record.
+
+`transformField` and `changeFieldType` evaluate their `SchemaExpr` against the currently focused source field value, not the entire root record. In practice, that means the expression should be written in terms of the value being transformed.
 
 ### Nested migration with `migrateField`
 

--- a/docs/reference/schema/schema-expr.md
+++ b/docs/reference/schema/schema-expr.md
@@ -3,7 +3,7 @@ id: schema-expr
 title: "SchemaExpr"
 ---
 
-`SchemaExpr[A, B]` is a **schema-aware expression** that computes a result of type `B` from an input value of type `A`. The input type `A` must be fully described by a [`Schema`](./schema.md), and the expression is built from [optics](./optics.md), literal values, and operators. The fundamental operations are `eval` and `evalDynamic`.
+`SchemaExpr[A, B]` is a **schema-aware expression** that computes a result of type `B` from an input value of type `A`. It is invariant in both type parameters. The input type `A` must be fully described by a [`Schema`](./schema.md), and the expression is built from [optics](./optics.md), literal values, and operators. The fundamental operations are `eval` and `evalDynamic`.
 
 At runtime, `SchemaExpr` is a typed wrapper around `DynamicSchemaExpr`. The typed layer carries the input and output schemas, while the dynamic layer stores the serializable AST. This split is why you will sometimes see both `.dynamic` and `DynamicSchemaExpr` in advanced examples: `SchemaExpr` is the public typed API, and `DynamicSchemaExpr` is the untyped transport/runtime form underneath it.
 

--- a/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/StructuralMigrationTypeCheckSpec.scala
+++ b/schema/jvm/src/test/scala-3/zio/blocks/schema/migration/StructuralMigrationTypeCheckSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.migration
+
+import scala.language.reflectiveCalls
+import scala.reflect.Selectable.reflectiveSelectable
+import zio.blocks.schema._
+import zio.test._
+
+object StructuralMigrationTypeCheckSpec extends ZIOSpecDefault {
+  def spec: Spec[TestEnvironment, Any] = suite("StructuralMigrationTypeCheckSpec")(
+    test("build fails to compile when structural target field is missing") {
+      typeCheck {
+        """
+        import scala.language.reflectiveCalls
+        import scala.reflect.Selectable.reflectiveSelectable
+        import zio.blocks.schema.Schema
+        import zio.blocks.schema.migration.Migration
+
+        type PersonV1 = { def name: String }
+        type PersonV2 = { def name: String; def age: Int }
+
+        given Schema[PersonV1] = Schema.derived[PersonV1]
+        given Schema[PersonV2] = Schema.derived[PersonV2]
+
+        Migration.newBuilder[PersonV1, PersonV2].build
+        """
+      }.map(result => assertTrue(result.isLeft))
+    }
+  )
+}

--- a/schema/jvm/src/test/scala/zio/blocks/schema/migration/StructuralMigrationSpec.scala
+++ b/schema/jvm/src/test/scala/zio/blocks/schema/migration/StructuralMigrationSpec.scala
@@ -17,9 +17,8 @@
 package zio.blocks.schema.migration
 
 import scala.language.reflectiveCalls
-import scala.reflect.Selectable.reflectiveSelectable
-import zio.blocks.schema.*
-import zio.test.*
+import zio.blocks.schema._
+import zio.test._
 
 object StructuralMigrationSpec extends ZIOSpecDefault {
 
@@ -33,10 +32,10 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
     suite("Structural → Case Class")(
       test("addField works with structural target selectors") {
         case class PersonV1(name: String)
-        given Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
 
         type PersonV2 = { def name: String; def age: Int }
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
@@ -48,11 +47,11 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
       },
       test("renameField works with structural source selectors") {
         type PersonV0 = { def firstName: String }
-        def makePersonV0(name: String): PersonV0 = new { def firstName: String = name }
-        given Schema[PersonV0]                   = Schema.derived[PersonV0]
+        def makePersonV0(name: String): PersonV0      = new { def firstName: String = name }
+        implicit val personV0Schema: Schema[PersonV0] = Schema.derived[PersonV0]
 
         case class PersonV2(fullName: String)
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV0, PersonV2]
@@ -63,11 +62,11 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
       },
       test("transformField works with structural source selectors") {
         type PersonV0 = { def age: Int }
-        def makePersonV0(value: Int): PersonV0 = new { def age: Int = value }
-        given Schema[PersonV0]                 = Schema.derived[PersonV0]
+        def makePersonV0(value: Int): PersonV0        = new { def age: Int = value }
+        implicit val personV0Schema: Schema[PersonV0] = Schema.derived[PersonV0]
 
         case class PersonV2(age: Long)
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV0, PersonV2]
@@ -78,40 +77,45 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
       },
       test("dropField works with structural source selectors") {
         type PersonV1 = { def name: String; def age: Int }
+        def makePersonV1(n: String, a: Int): PersonV1 = new {
+          def name: String = n
+          def age: Int     = a
+        }
         case class PersonV2(name: String)
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
           .dropField(_.age, literal(0))
           .buildPartial
 
-        assertTrue(migration.size == 1)
+        assertTrue(migration.dynamicMigration(Schema[PersonV1].toDynamicValue(makePersonV1("Alice", 30))).isRight)
       },
       test("changeFieldType works with structural source selectors") {
         type PersonV1 = { def score: Int }
+        def makePersonV1(s: Int): PersonV1 = new { def score: Int = s }
         case class PersonV2(score: String)
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
           .changeFieldType(_.score, literal("0"))
           .build
 
-        assertTrue(migration.size == 1)
+        assertTrue(migration(makePersonV1(42)) == Right(PersonV2("0")))
       }
     ),
     suite("Case Class → Structural")(
       test("addField works with structural target selectors") {
         case class PersonV1(name: String)
-        given Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
 
         type PersonV2 = { def name: String; def age: Int }
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
@@ -123,10 +127,10 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
       },
       test("renameField works with structural target selectors") {
         case class PersonV1(firstName: String)
-        given Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
 
         type PersonV2 = { def fullName: String }
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
@@ -139,29 +143,29 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
         case class PersonV1(name: String, age: Int)
         type PersonV2 = { def name: String }
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
           .dropField(_.age, literal(0))
           .buildPartial
 
-        assertTrue(migration.size == 1)
+        assertTrue(migration.dynamicMigration(Schema[PersonV1].toDynamicValue(PersonV1("Alice", 30))).isRight)
       },
       test("changeFieldType works with structural target selectors") {
         case class PersonV1(score: Int)
         type PersonV2 = { def score: String }
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
           .changeFieldType(_.score, literal("0"))
           .build
 
-        assertTrue(migration.size == 1)
+        assertTrue(migration(PersonV1(42)).isRight)
       }
     ),
     suite("Structural → Structural")(
@@ -171,8 +175,8 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
 
         def makePersonV1(name: String): PersonV1 = new { def firstName: String = name }
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
@@ -187,7 +191,7 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
           def name: String = n
           def age: Int     = a
         }
-        given Schema[PersonV0] = Schema.derived[PersonV0]
+        implicit val personV0Schema: Schema[PersonV0] = Schema.derived[PersonV0]
 
         val migration = Migration.newBuilder[PersonV0, PersonV0].build
 
@@ -196,61 +200,48 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
       test("dropField works with structural selectors on both sides") {
         type PersonV1 = { def name: String; def age: Int }
         type PersonV2 = { def name: String }
+        def makePersonV1(n: String, a: Int): PersonV1 = new {
+          def name: String = n
+          def age: Int     = a
+        }
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
           .dropField(_.age, literal(0))
           .buildPartial
 
-        assertTrue(migration.size == 1)
+        assertTrue(migration.dynamicMigration(Schema[PersonV1].toDynamicValue(makePersonV1("Alice", 30))).isRight)
       },
       test("changeFieldType works with structural selectors on both sides") {
         type PersonV1 = { def score: Int }
         type PersonV2 = { def score: String }
+        def makePersonV1(s: Int): PersonV1 = new { def score: Int = s }
 
-        given Schema[PersonV1] = Schema.derived[PersonV1]
-        given Schema[PersonV2] = Schema.derived[PersonV2]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val personV2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
 
         val migration = Migration
           .newBuilder[PersonV1, PersonV2]
           .changeFieldType(_.score, literal("0"))
           .build
 
-        assertTrue(migration.size == 1)
+        assertTrue(migration(makePersonV1(42)).isRight)
       }
     ),
     suite("Structural selector validation")(
-      test("build fails to compile when structural target field is missing") {
-        typeCheck {
-          """
-          import scala.language.reflectiveCalls
-          import scala.reflect.Selectable.reflectiveSelectable
-          import zio.blocks.schema.Schema
-          import zio.blocks.schema.migration.Migration
-
-          type PersonV1 = { def name: String }
-          type PersonV2 = { def name: String; def age: Int }
-
-          given Schema[PersonV1] = Schema.derived[PersonV1]
-          given Schema[PersonV2] = Schema.derived[PersonV2]
-
-          Migration.newBuilder[PersonV1, PersonV2].build
-          """
-        }.map(result => assertTrue(result.isLeft))
-      },
       test("build succeeds for nested structural fields without structural selectors") {
         case class Address(street: String, city: String)
         case class PersonV1(name: String, address: Address)
-        given Schema[Address]  = Schema.derived[Address]
-        given Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val addressSchema: Schema[Address]   = Schema.derived[Address]
+        implicit val personV1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
 
         type AddressV2 = { def street: String; def city: String }
         type PersonV2  = { def name: String; def address: AddressV2; def age: Int }
-        given Schema[AddressV2] = Schema.derived[AddressV2]
-        given Schema[PersonV2]  = Schema.derived[PersonV2]
+        implicit val addressV2Schema: Schema[AddressV2] = Schema.derived[AddressV2]
+        implicit val personV2Schema: Schema[PersonV2]   = Schema.derived[PersonV2]
 
         val addressMigration = Migration
           .newBuilder[Address, AddressV2]
@@ -266,6 +257,89 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
           .build
 
         assertTrue(migration(PersonV1("Leo", Address("123 Main St", "NYC"))).isRight)
+      },
+      test("deep nested structural renameField via migrateField") {
+        type Inner  = { def firstName: String }
+        type Outer  = { def data: Inner }
+        type Inner2 = { def fullName: String }
+        type Outer2 = { def data: Inner2 }
+
+        def makeInner(n: String): Inner = new { def firstName: String = n }
+        def makeOuter(d: Inner): Outer  = new { def data: Inner = d }
+
+        implicit val innerSchema: Schema[Inner]   = Schema.derived[Inner]
+        implicit val outerSchema: Schema[Outer]   = Schema.derived[Outer]
+        implicit val inner2Schema: Schema[Inner2] = Schema.derived[Inner2]
+        implicit val outer2Schema: Schema[Outer2] = Schema.derived[Outer2]
+
+        val innerMigration = Migration
+          .newBuilder[Inner, Inner2]
+          .renameField(_.firstName, _.fullName)
+          .build
+
+        val migration = Migration
+          .newBuilder[Outer, Outer2]
+          .migrateField(_.data, innerMigration)
+          .build
+
+        assertTrue(migration(makeOuter(makeInner("Alice"))).isRight)
+      },
+      test("deep nested structural dropField via migrateField") {
+        type Inner  = { def name: String; def age: Int }
+        type Outer  = { def data: Inner }
+        type Inner2 = { def name: String }
+        type Outer2 = { def data: Inner2 }
+
+        def makeInner(n: String, a: Int): Inner = new {
+          def name: String = n
+          def age: Int     = a
+        }
+        def makeOuter(d: Inner): Outer = new { def data: Inner = d }
+
+        implicit val innerSchema: Schema[Inner]   = Schema.derived[Inner]
+        implicit val outerSchema: Schema[Outer]   = Schema.derived[Outer]
+        implicit val inner2Schema: Schema[Inner2] = Schema.derived[Inner2]
+        implicit val outer2Schema: Schema[Outer2] = Schema.derived[Outer2]
+
+        val innerMigration = Migration
+          .newBuilder[Inner, Inner2]
+          .dropField(_.age, literal(0))
+          .buildPartial
+
+        val outerMigration = Migration
+          .newBuilder[Outer, Outer2]
+          .migrateField(_.data, innerMigration)
+          .buildPartial
+
+        assertTrue(
+          outerMigration.dynamicMigration(Schema[Outer].toDynamicValue(makeOuter(makeInner("Bob", 25)))).isRight
+        )
+      },
+      test("deep nested structural changeFieldType via migrateField") {
+        type Inner  = { def score: Int }
+        type Outer  = { def data: Inner }
+        type Inner2 = { def score: String }
+        type Outer2 = { def data: Inner2 }
+
+        def makeInner(s: Int): Inner   = new { def score: Int = s }
+        def makeOuter(d: Inner): Outer = new { def data: Inner = d }
+
+        implicit val innerSchema: Schema[Inner]   = Schema.derived[Inner]
+        implicit val outerSchema: Schema[Outer]   = Schema.derived[Outer]
+        implicit val inner2Schema: Schema[Inner2] = Schema.derived[Inner2]
+        implicit val outer2Schema: Schema[Outer2] = Schema.derived[Outer2]
+
+        val innerMigration = Migration
+          .newBuilder[Inner, Inner2]
+          .changeFieldType(_.score, literal("0"))
+          .build
+
+        val migration = Migration
+          .newBuilder[Outer, Outer2]
+          .migrateField(_.data, innerMigration)
+          .build
+
+        assertTrue(migration(makeOuter(makeInner(42))).isRight)
       },
       test("nested structural migrateField tracks deep structural fields") {
         type StreetV1  = { def name: String }
@@ -286,12 +360,12 @@ object StructuralMigrationSpec extends ZIOSpecDefault {
           def address: AddressV1 = addressValue
         }
 
-        given Schema[StreetV1]  = Schema.derived[StreetV1]
-        given Schema[AddressV1] = Schema.derived[AddressV1]
-        given Schema[PersonV1]  = Schema.derived[PersonV1]
-        given Schema[StreetV2]  = Schema.derived[StreetV2]
-        given Schema[AddressV2] = Schema.derived[AddressV2]
-        given Schema[PersonV2]  = Schema.derived[PersonV2]
+        implicit val streetV1Schema: Schema[StreetV1]   = Schema.derived[StreetV1]
+        implicit val addressV1Schema: Schema[AddressV1] = Schema.derived[AddressV1]
+        implicit val personV1Schema: Schema[PersonV1]   = Schema.derived[PersonV1]
+        implicit val streetV2Schema: Schema[StreetV2]   = Schema.derived[StreetV2]
+        implicit val addressV2Schema: Schema[AddressV2] = Schema.derived[AddressV2]
+        implicit val personV2Schema: Schema[PersonV2]   = Schema.derived[PersonV2]
 
         val streetMigration = Migration
           .newBuilder[StreetV1, StreetV2]

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -197,9 +197,10 @@ final class MigrationBuilder[A, B, Changeset](
     caseSourceSchema: Schema[CaseA],
     caseTargetSchema: Schema[CaseB]
   ): MigrationBuilder[A, B, Changeset] = {
-    val innerBuilder = new MigrationBuilder[CaseA, CaseB, Any](caseSourceSchema, caseTargetSchema, Chunk.empty)
-    val builtInner   = caseMigration(innerBuilder)
-    appendAction(MigrationAction.TransformCase(DynamicOptic.root.caseOf(caseName), builtInner.actions))
+    val innerBuilder   = new MigrationBuilder[CaseA, CaseB, Any](caseSourceSchema, caseTargetSchema, Chunk.empty)
+    val builtInner     = caseMigration(innerBuilder)
+    val targetCaseName = caseTargetSchema.reflect.typeId.name
+    appendAction(MigrationAction.TransformCase(DynamicOptic.root.caseOf(caseName), targetCaseName, builtInner.actions))
   }
 
   // ----- Collections -----
@@ -255,7 +256,9 @@ final class MigrationBuilder[A, B, Changeset](
     new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
 
   /**
-   * Build migration without full validation.
+   * Builds a [[Migration]] without changeset completeness validation. Intended
+   * for internal testing and partial migration construction. Prefer [[build]]
+   * for all production migrations.
    */
   private[migration] def buildPartial: Migration[A, B] =
     new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
@@ -346,8 +346,7 @@ object MigrationBuilderMacros {
         ${c.prefix}.targetSchema,
         ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.ChangeFieldType(
           sourcePath,
-          $converter.toDynamic,
-          _root_.scala.Some(targetPath)
+          $converter.toDynamic
         )
       )
     }"""

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
@@ -230,7 +230,8 @@ object MigrationBuilderMacros {
         ${c.prefix}.targetSchema,
         ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.TransformField(
           fromPath,
-          $transform.toDynamic
+          $transform.toDynamic,
+          _root_.scala.Some(toPath)
         )
       )
     }"""
@@ -271,7 +272,8 @@ object MigrationBuilderMacros {
         ${c.prefix}.targetSchema,
         ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.MandateField(
           sourcePath,
-          $default.toDynamic
+          $default.toDynamic,
+          _root_.scala.Some(targetPath)
         )
       )
     }"""
@@ -311,7 +313,10 @@ object MigrationBuilderMacros {
       new _root_.zio.blocks.schema.migration.MigrationBuilder[$aType, $bType, $newCSType](
         ${c.prefix}.sourceSchema,
         ${c.prefix}.targetSchema,
-        ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.OptionalizeField(sourcePath)
+        ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.OptionalizeField(
+          sourcePath,
+          _root_.scala.Some(targetPath)
+        )
       )
     }"""
   }
@@ -341,7 +346,8 @@ object MigrationBuilderMacros {
         ${c.prefix}.targetSchema,
         ${c.prefix}.actions :+ _root_.zio.blocks.schema.migration.MigrationAction.ChangeFieldType(
           sourcePath,
-          $converter.toDynamic
+          $converter.toDynamic,
+          _root_.scala.Some(targetPath)
         )
       )
     }"""

--- a/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
+++ b/schema/shared/src/main/scala-2/zio/blocks/schema/migration/MigrationBuilderSyntax.scala
@@ -206,8 +206,15 @@ object MigrationBuilderMacros {
     val bType  = weakTypeOf[B]
     val csType = weakTypeOf[CS]
 
-    val fromFieldName      = extractFieldPathFromSelector(c)(from.tree)
-    val toFieldName        = extractFieldPathFromSelector(c)(to.tree)
+    val fromFieldName = extractFieldPathFromSelector(c)(from.tree)
+    val toFieldName   = extractFieldPathFromSelector(c)(to.tree)
+    if (fromFieldName != toFieldName)
+      c.abort(
+        c.enclosingPosition,
+        s"transformField requires the same field name in source and target, " +
+          s"got '$fromFieldName' and '$toFieldName'. " +
+          s"Use renameField followed by transformField for rename-and-transform."
+      )
     val transformFieldType = createTransformFieldType(c)(fromFieldName, toFieldName)
     val newCSType          = addToChangeset(c)(csType, transformFieldType)
 
@@ -240,8 +247,15 @@ object MigrationBuilderMacros {
     val bType  = weakTypeOf[B]
     val csType = weakTypeOf[CS]
 
-    val sourceFieldName  = extractFieldPathFromSelector(c)(source.tree)
-    val targetFieldName  = extractFieldPathFromSelector(c)(target.tree)
+    val sourceFieldName = extractFieldPathFromSelector(c)(source.tree)
+    val targetFieldName = extractFieldPathFromSelector(c)(target.tree)
+    if (sourceFieldName != targetFieldName)
+      c.abort(
+        c.enclosingPosition,
+        s"mandateField requires the same field name in source and target, " +
+          s"got '$sourceFieldName' and '$targetFieldName'. " +
+          s"Use renameField followed by mandateField for rename-and-mandate."
+      )
     val mandateFieldType = createMandateFieldType(c)(sourceFieldName, targetFieldName)
     val newCSType        = addToChangeset(c)(csType, mandateFieldType)
 
@@ -275,8 +289,15 @@ object MigrationBuilderMacros {
     val bType  = weakTypeOf[B]
     val csType = weakTypeOf[CS]
 
-    val sourceFieldName      = extractFieldPathFromSelector(c)(source.tree)
-    val targetFieldName      = extractFieldPathFromSelector(c)(target.tree)
+    val sourceFieldName = extractFieldPathFromSelector(c)(source.tree)
+    val targetFieldName = extractFieldPathFromSelector(c)(target.tree)
+    if (sourceFieldName != targetFieldName)
+      c.abort(
+        c.enclosingPosition,
+        s"optionalizeField requires the same field name in source and target, " +
+          s"got '$sourceFieldName' and '$targetFieldName'. " +
+          s"Use renameField followed by optionalizeField for rename-and-optionalize."
+      )
     val optionalizeFieldType = createOptionalizeFieldType(c)(sourceFieldName, targetFieldName)
     val newCSType            = addToChangeset(c)(csType, optionalizeFieldType)
 

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilder.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilder.scala
@@ -112,11 +112,12 @@ final class MigrationBuilder[A, B, Changeset](
       caseTargetSchema,
       Chunk.empty
     )
-    val builtInner = caseMigration(innerBuilder)
+    val builtInner     = caseMigration(innerBuilder)
+    val targetCaseName = caseTargetSchema.reflect.typeId.name
     new MigrationBuilder(
       sourceSchema,
       targetSchema,
-      actions :+ MigrationAction.TransformCase(DynamicOptic.root.caseOf(caseName), builtInner.actions)
+      actions :+ MigrationAction.TransformCase(DynamicOptic.root.caseOf(caseName), targetCaseName, builtInner.actions)
     )
   }
 
@@ -183,6 +184,11 @@ final class MigrationBuilder[A, B, Changeset](
   ): Migration[A, B] =
     new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
 
+  /**
+   * Builds a [[Migration]] without changeset completeness validation. Intended
+   * for internal testing and partial migration construction. Prefer [[build]]
+   * for all production migrations.
+   */
   private[migration] def buildPartial: Migration[A, B] =
     new Migration(sourceSchema, targetSchema, new DynamicMigration(actions))
 }

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
@@ -134,8 +134,14 @@ object MigrationBuilderMacros {
   )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] = {
     import q.reflect.*
 
-    val fromFieldPath      = extractFieldPathFromTerm(from.asTerm)
-    val toFieldPath        = extractFieldPathFromTerm(to.asTerm)
+    val fromFieldPath = extractFieldPathFromTerm(from.asTerm)
+    val toFieldPath   = extractFieldPathFromTerm(to.asTerm)
+    if (fromFieldPath != toFieldPath)
+      report.errorAndAbort(
+        s"transformField requires the same field name in source and target, " +
+          s"got '$fromFieldPath' and '$toFieldPath'. " +
+          s"Use renameField followed by transformField for rename-and-transform."
+      )
     val fromFieldType      = ConstantType(StringConstant(fromFieldPath))
     val toFieldType        = ConstantType(StringConstant(toFieldPath))
     val transformedWrapped = TypeRepr.of[Changeset.TransformField].appliedTo(List(fromFieldType, toFieldType))
@@ -164,6 +170,12 @@ object MigrationBuilderMacros {
 
     val sourceFieldPath = extractFieldPathFromTerm(source.asTerm)
     val targetFieldPath = extractFieldPathFromTerm(target.asTerm)
+    if (sourceFieldPath != targetFieldPath)
+      report.errorAndAbort(
+        s"mandateField requires the same field name in source and target, " +
+          s"got '$sourceFieldPath' and '$targetFieldPath'. " +
+          s"Use renameField followed by mandateField for rename-and-mandate."
+      )
     val sourceFieldType = ConstantType(StringConstant(sourceFieldPath))
     val targetFieldType = ConstantType(StringConstant(targetFieldPath))
     val mandatedWrapped = TypeRepr.of[Changeset.MandateField].appliedTo(List(sourceFieldType, targetFieldType))
@@ -189,8 +201,14 @@ object MigrationBuilderMacros {
   )(using q: Quotes): Expr[MigrationBuilder[A, B, ?]] = {
     import q.reflect.*
 
-    val sourceFieldPath     = extractFieldPathFromTerm(source.asTerm)
-    val targetFieldPath     = extractFieldPathFromTerm(target.asTerm)
+    val sourceFieldPath = extractFieldPathFromTerm(source.asTerm)
+    val targetFieldPath = extractFieldPathFromTerm(target.asTerm)
+    if (sourceFieldPath != targetFieldPath)
+      report.errorAndAbort(
+        s"optionalizeField requires the same field name in source and target, " +
+          s"got '$sourceFieldPath' and '$targetFieldPath'. " +
+          s"Use renameField followed by optionalizeField for rename-and-optionalize."
+      )
     val sourceFieldType     = ConstantType(StringConstant(sourceFieldPath))
     val targetFieldType     = ConstantType(StringConstant(targetFieldPath))
     val optionalizedWrapped = TypeRepr.of[Changeset.OptionalizeField].appliedTo(List(sourceFieldType, targetFieldType))
@@ -301,20 +319,7 @@ object MigrationBuilderMacros {
   private def extractFieldPathFromTerm(term: Any)(using q: Quotes): String = {
     import q.reflect.*
 
-    def structuralFieldAccess(t: Term): Option[(Term, String)] = t match {
-      case TypeApply(
-            Select(
-              Apply(
-                Select(Apply(Ident("reflectiveSelectable"), List(parent)), "selectDynamic"),
-                List(Literal(StringConstant(fieldName)))
-              ),
-              "$asInstanceOf$"
-            ),
-            _
-          ) =>
-        Some((parent, fieldName))
-      case _ => None
-    }
+    def structuralFieldAccess(t: Term): Option[(Term, String)] = SelectorMacros.extractSelectDynamic(t)
 
     @tailrec
     def toPathBody(t: Term): Term = t match {
@@ -343,20 +348,7 @@ object MigrationBuilderMacros {
   private def extractLeafFieldName(term: Any)(using q: Quotes): String = {
     import q.reflect.*
 
-    def structuralFieldAccess(t: Term): Option[(Term, String)] = t match {
-      case TypeApply(
-            Select(
-              Apply(
-                Select(Apply(Ident("reflectiveSelectable"), List(parent)), "selectDynamic"),
-                List(Literal(StringConstant(fieldName)))
-              ),
-              "$asInstanceOf$"
-            ),
-            _
-          ) =>
-        Some((parent, fieldName))
-      case _ => None
-    }
+    def structuralFieldAccess(t: Term): Option[(Term, String)] = SelectorMacros.extractSelectDynamic(t)
 
     @tailrec
     def toPathBody(t: Term): Term = t match {

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
@@ -246,11 +246,10 @@ object MigrationBuilderMacros {
       case '[newCs] =>
         '{
           val sourcePath = SelectorMacros.toPath[A, Any]($source)
-          val targetPath = SelectorMacros.toPath[B, Any]($target)
           new MigrationBuilder[A, B, newCs](
             $builder.sourceSchema,
             $builder.targetSchema,
-            $builder.actions :+ MigrationAction.ChangeFieldType(sourcePath, $converter.toDynamic, Some(targetPath))
+            $builder.actions :+ MigrationAction.ChangeFieldType(sourcePath, $converter.toDynamic)
           )
         }
     }

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/MigrationBuilderMacros.scala
@@ -151,10 +151,11 @@ object MigrationBuilderMacros {
       case '[newCs] =>
         '{
           val fromPath = SelectorMacros.toPath[A, Any]($from)
+          val toPath   = SelectorMacros.toPath[B, Any]($to)
           new MigrationBuilder[A, B, newCs](
             $builder.sourceSchema,
             $builder.targetSchema,
-            $builder.actions :+ MigrationAction.TransformField(fromPath, $transform.toDynamic)
+            $builder.actions :+ MigrationAction.TransformField(fromPath, $transform.toDynamic, Some(toPath))
           )
         }
     }
@@ -185,10 +186,11 @@ object MigrationBuilderMacros {
       case '[newCs] =>
         '{
           val sourcePath = SelectorMacros.toPath[A, Option[?]]($source)
+          val targetPath = SelectorMacros.toPath[B, Any]($target)
           new MigrationBuilder[A, B, newCs](
             $builder.sourceSchema,
             $builder.targetSchema,
-            $builder.actions :+ MigrationAction.MandateField(sourcePath, $default.toDynamic)
+            $builder.actions :+ MigrationAction.MandateField(sourcePath, $default.toDynamic, Some(targetPath))
           )
         }
     }
@@ -218,10 +220,11 @@ object MigrationBuilderMacros {
       case '[newCs] =>
         '{
           val sourcePath = SelectorMacros.toPath[A, Any]($source)
+          val targetPath = SelectorMacros.toPath[B, Option[?]]($target)
           new MigrationBuilder[A, B, newCs](
             $builder.sourceSchema,
             $builder.targetSchema,
-            $builder.actions :+ MigrationAction.OptionalizeField(sourcePath)
+            $builder.actions :+ MigrationAction.OptionalizeField(sourcePath, Some(targetPath))
           )
         }
     }
@@ -243,10 +246,11 @@ object MigrationBuilderMacros {
       case '[newCs] =>
         '{
           val sourcePath = SelectorMacros.toPath[A, Any]($source)
+          val targetPath = SelectorMacros.toPath[B, Any]($target)
           new MigrationBuilder[A, B, newCs](
             $builder.sourceSchema,
             $builder.targetSchema,
-            $builder.actions :+ MigrationAction.ChangeFieldType(sourcePath, $converter.toDynamic)
+            $builder.actions :+ MigrationAction.ChangeFieldType(sourcePath, $converter.toDynamic, Some(targetPath))
           )
         }
     }

--- a/schema/shared/src/main/scala-3/zio/blocks/schema/migration/SelectorMacros.scala
+++ b/schema/shared/src/main/scala-3/zio/blocks/schema/migration/SelectorMacros.scala
@@ -37,23 +37,53 @@ object SelectorMacros {
   inline def extractFieldName[S, A](inline selector: S => A): String =
     ${ extractFieldNameImpl[S, A]('selector) }
 
-  def extractFieldNameImpl[S: Type, A: Type](selector: Expr[S => A])(using q: Quotes): Expr[String] = {
+  private[migration] def isReflectiveSelectable(name: String): Boolean =
+    name == "reflectiveSelectable" || name == "reflectiveSelectableFromLangReflectiveCalls"
+
+  private[migration] def extractSelectDynamic(using
+    q: Quotes
+  )(term: q.reflect.Term): Option[(q.reflect.Term, String)] = {
     import q.reflect.*
 
-    def structuralFieldAccess(term: Term): Option[(Term, String)] = term match {
+    def extractSelectableParent(t: Term): Option[Term] = t match {
+      case Apply(selectableRef, List(parent)) if isSelectableRef(selectableRef) =>
+        Some(parent)
+      case Apply(Apply(selectableRef, List(parent)), _) if isSelectableRef(selectableRef) =>
+        Some(parent)
+      case Apply(inner, _) =>
+        extractSelectableParent(inner)
+      case _ => None
+    }
+
+    term match {
       case TypeApply(
             Select(
               Apply(
-                Select(Apply(Ident("reflectiveSelectable"), List(parent)), "selectDynamic"),
+                Select(selectableApp, "selectDynamic"),
                 List(Literal(StringConstant(fieldName)))
               ),
               "$asInstanceOf$"
             ),
             _
           ) =>
-        Some((parent, fieldName))
+        extractSelectableParent(selectableApp).map(parent => (parent, fieldName))
       case _ => None
     }
+  }
+
+  private def isSelectableRef(using q: Quotes)(term: q.reflect.Term): Boolean = {
+    import q.reflect.*
+    term match {
+      case Ident(name)     => isReflectiveSelectable(name)
+      case Select(_, name) => isReflectiveSelectable(name)
+      case _               => false
+    }
+  }
+
+  def extractFieldNameImpl[S: Type, A: Type](selector: Expr[S => A])(using q: Quotes): Expr[String] = {
+    import q.reflect.*
+
+    def structuralFieldAccess(term: Term): Option[(Term, String)] = extractSelectDynamic(term)
 
     @scala.annotation.tailrec
     def toPathBody(term: Term): Term = term match {
@@ -99,20 +129,7 @@ object SelectorMacros {
         case other       => other.show
       }
 
-    def structuralFieldAccess(term: Term): Option[(Term, String)] = term match {
-      case TypeApply(
-            Select(
-              Apply(
-                Select(Apply(Ident("reflectiveSelectable"), List(parent)), "selectDynamic"),
-                List(Literal(StringConstant(fieldName)))
-              ),
-              "$asInstanceOf$"
-            ),
-            _
-          ) =>
-        Some((parent, fieldName))
-      case _ => None
-    }
+    def structuralFieldAccess(term: Term): Option[(Term, String)] = extractSelectDynamic(term)
 
     def toDynamicOptic(term: Term): Expr[DynamicOptic] = term match {
       // Identity - just the parameter reference

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaError.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaError.scala
@@ -200,23 +200,23 @@ object SchemaError {
   case class MigrationError(source: DynamicOptic, kind: MigrationErrorKind) extends Single {
     override def message: String = kind match {
       case MigrationErrorKind.PathNotFound =>
-        s"Path not found: $source"
+        s"Path not found: ${source.toScalaString}"
       case MigrationErrorKind.TypeMismatch(expected, actual) =>
-        s"Type mismatch at $source: expected $expected, got $actual"
+        s"Type mismatch at ${source.toScalaString}: expected $expected, got $actual"
       case MigrationErrorKind.MissingDefault(fieldName) =>
-        s"Missing default value for field '$fieldName' at $source"
+        s"Missing default value for field '$fieldName' at ${source.toScalaString}"
       case MigrationErrorKind.TransformFailed(reason) =>
-        s"Transform failed at $source: $reason"
+        s"Transform failed at ${source.toScalaString}: $reason"
       case MigrationErrorKind.FieldNotFound(fieldName) =>
-        s"Field '$fieldName' not found at $source"
+        s"Field '$fieldName' not found at ${source.toScalaString}"
       case MigrationErrorKind.FieldAlreadyExists(fieldName) =>
-        s"Field '$fieldName' already exists at $source"
+        s"Field '$fieldName' already exists at ${source.toScalaString}"
       case MigrationErrorKind.CaseNotFound(caseName) =>
-        s"Case '$caseName' not found at $source"
+        s"Case '$caseName' not found at ${source.toScalaString}"
       case MigrationErrorKind.InvalidValue(reason) =>
-        s"Invalid value at $source: $reason"
+        s"Invalid value at ${source.toScalaString}: $reason"
       case MigrationErrorKind.MandateFailed(reason) =>
-        s"Mandate failed at $source: $reason"
+        s"Mandate failed at ${source.toScalaString}: $reason"
     }
   }
 

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -18,6 +18,7 @@ package zio.blocks.schema.migration
 
 import zio.blocks.chunk.Chunk
 import zio.blocks.schema.{DynamicValue, DynamicSchemaExpr, SchemaError}
+import scala.util.control.NonFatal
 
 /**
  * A pure, serializable migration that operates on `DynamicValue`. This is the
@@ -75,7 +76,7 @@ final case class DynamicMigration(actions: Chunk[MigrationAction]) {
    * field without capturing its value).
    */
   def reverse: DynamicMigration =
-    new DynamicMigration(Chunk.fromIterable(actions.reverseIterator.map(_.reverse).toSeq))
+    new DynamicMigration(Chunk.fromIterator(actions.reverseIterator.map(_.reverse)))
 
   /**
    * Returns true if this migration has no actions (identity migration).
@@ -120,7 +121,18 @@ object DynamicMigration {
     val len                   = actions.length
 
     while (idx < len) {
-      ActionExecutor.execute(actions(idx), current) match {
+      val result =
+        try ActionExecutor.execute(actions(idx), current)
+        catch {
+          case NonFatal(ex) =>
+            Left(
+              SchemaError.transformFailed(
+                actions(idx).at,
+                s"Unexpected error during migration: ${ex.getClass.getSimpleName}: ${ex.getMessage}"
+              )
+            )
+        }
+      result match {
         case Right(newValue) =>
           current = newValue
           idx += 1
@@ -178,8 +190,8 @@ private[migration] object ActionExecutor {
       case RenameCase(at, from, to) =>
         executeRenameCase(at, from, to, value)
 
-      case TransformCase(at, actions) =>
-        executeTransformCase(at, actions, value)
+      case TransformCase(at, targetCaseName, actions) =>
+        executeTransformCase(at, targetCaseName, actions, value)
 
       case MigrateField(at, migration) =>
         executeApplyMigration(at, migration, value)
@@ -324,9 +336,10 @@ private[migration] object ActionExecutor {
   ): Either[SchemaError, DynamicValue] =
     modifyAt(at, value) {
       case DynamicValue.Sequence(elements) =>
-        val transformed = elements.foldLeft[Either[SchemaError, Chunk[DynamicValue]]](Right(Chunk.empty)) {
-          case (Right(acc), element) =>
-            evalExpr(transform, element, at).map(acc :+ _)
+        val transformed = elements.zipWithIndex.foldLeft[Either[SchemaError, Chunk[DynamicValue]]](Right(Chunk.empty)) {
+          case (Right(acc), (element, idx)) =>
+            val elemPath = zio.blocks.schema.DynamicOptic(at.nodes :+ zio.blocks.schema.DynamicOptic.Node.AtIndex(idx))
+            evalExpr(transform, element, elemPath).map(acc :+ _)
           case (left, _) =>
             left
         }
@@ -345,7 +358,9 @@ private[migration] object ActionExecutor {
         val transformed =
           entries.foldLeft[Either[SchemaError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
             case (Right(acc), (key, currentValue)) =>
-              evalExpr(transform, key, at).map(newKey => acc :+ (newKey -> currentValue))
+              val keyPath =
+                zio.blocks.schema.DynamicOptic(at.nodes :+ zio.blocks.schema.DynamicOptic.Node.AtMapKey(key))
+              evalExpr(transform, key, keyPath).map(newKey => acc :+ (newKey -> currentValue))
             case (left, _) =>
               left
           }
@@ -364,7 +379,9 @@ private[migration] object ActionExecutor {
         val transformed =
           entries.foldLeft[Either[SchemaError, Chunk[(DynamicValue, DynamicValue)]]](Right(Chunk.empty)) {
             case (Right(acc), (key, currentValue)) =>
-              evalExpr(transform, currentValue, at).map(newValue => acc :+ (key -> newValue))
+              val valuePath =
+                zio.blocks.schema.DynamicOptic(at.nodes :+ zio.blocks.schema.DynamicOptic.Node.AtMapKey(key))
+              evalExpr(transform, currentValue, valuePath).map(newValue => acc :+ (key -> newValue))
             case (left, _) =>
               left
           }
@@ -405,7 +422,11 @@ private[migration] object ActionExecutor {
     from: String,
     to: String,
     value: DynamicValue
-  ): Either[SchemaError, DynamicValue] =
+  ): Either[SchemaError, DynamicValue] = {
+    if (from.isEmpty || to.isEmpty)
+      return Left(
+        SchemaError.transformFailed(at, s"renameCase requires non-empty case names, got from='$from', to='$to'")
+      )
     modifyAt(at, value) {
       case DynamicValue.Variant(caseName, inner) if caseName == from =>
         Right(DynamicValue.Variant(to, inner))
@@ -415,18 +436,30 @@ private[migration] object ActionExecutor {
       case other =>
         Left(SchemaError.typeMismatch(at, "Variant", other.getClass.getSimpleName))
     }
+  }
 
   private def executeTransformCase(
     at: zio.blocks.schema.DynamicOptic,
+    targetCaseName: String,
     actions: Chunk[MigrationAction],
     value: DynamicValue
-  ): Either[SchemaError, DynamicValue] =
-    modifyAt(at, value) {
-      case DynamicValue.Variant(name, inner) =>
-        DynamicMigration.execute(actions, inner).map(DynamicValue.Variant(name, _))
+  ): Either[SchemaError, DynamicValue] = {
+    val sourceCaseName = at.nodes.lastOption.collect { case zio.blocks.schema.DynamicOptic.Node.Case(name) => name }
+      .getOrElse(targetCaseName)
+    val parentPath = zio.blocks.schema.DynamicOptic(at.nodes.dropRight(1).filter {
+      case _: zio.blocks.schema.DynamicOptic.Node.Case => false
+      case _                                           => true
+    })
+
+    modifyAt(parentPath, value) {
+      case DynamicValue.Variant(name, inner) if name == sourceCaseName =>
+        DynamicMigration.execute(actions, inner).map(DynamicValue.Variant(targetCaseName, _))
+      case v: DynamicValue.Variant =>
+        Right(v) // non-matching case, pass through unchanged
       case other =>
         Left(SchemaError.typeMismatch(at, "Variant", other.getClass.getSimpleName))
     }
+  }
 
   private def executeApplyMigration(
     at: zio.blocks.schema.DynamicOptic,
@@ -585,8 +618,15 @@ private[migration] object ActionExecutor {
           // For wrapper types, just continue to the inner value
           modifyAtPath(nodes, idx + 1, value, fullPath)(f)
 
-        case _ =>
-          Left(SchemaError.transformFailed(fullPath, s"Unsupported path node: ${nodes(idx)}"))
+        case Node.AtIndices(_) | Node.AtMapKeys(_) =>
+          Left(
+            SchemaError.transformFailed(
+              fullPath,
+              s"Batch path nodes (AtIndices/AtMapKeys) are not supported in migration paths"
+            )
+          )
+        case Node.TypeSearch(_) | Node.SchemaSearch(_) =>
+          Left(SchemaError.transformFailed(fullPath, s"Type/Schema search nodes are not supported in migration paths"))
       }
     }
   }

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -17,7 +17,7 @@
 package zio.blocks.schema.migration
 
 import zio.blocks.chunk.Chunk
-import zio.blocks.schema.{DynamicValue, DynamicSchemaExpr, SchemaError}
+import zio.blocks.schema.{DynamicOptic, DynamicSchemaExpr, DynamicValue, SchemaError}
 import scala.util.control.NonFatal
 
 /**
@@ -173,19 +173,19 @@ private[migration] object ActionExecutor {
       case RenameField(at, to) =>
         executeRename(at, to, value)
 
-      case TransformField(at, transform) =>
-        executeTransformField(at, transform, value)
+      case TransformField(at, transform, to) =>
+        executeTransformField(at, to.getOrElse(at), transform, value)
 
-      case MandateField(at, default) =>
+      case MandateField(at, default, to) =>
         evalExpr(default, value, at).flatMap { defaultValue =>
-          executeMandate(at, defaultValue, value)
+          executeMandate(at, to.getOrElse(at), defaultValue, value)
         }
 
-      case OptionalizeField(at) =>
-        executeOptionalize(at, value)
+      case OptionalizeField(at, to) =>
+        executeOptionalize(at, to.getOrElse(at), value)
 
-      case ChangeFieldType(at, converter) =>
-        executeChangeFieldType(at, converter, value)
+      case ChangeFieldType(at, converter, to) =>
+        executeChangeFieldType(at, to.getOrElse(at), converter, value)
 
       case RenameCase(at, from, to) =>
         executeRenameCase(at, from, to, value)
@@ -217,7 +217,7 @@ private[migration] object ActionExecutor {
   private def evalExpr(
     expr: DynamicSchemaExpr,
     input: DynamicValue,
-    at: zio.blocks.schema.DynamicOptic
+    at: DynamicOptic
   ): Either[SchemaError, DynamicValue] =
     expr.eval(input).flatMap { results =>
       results match {
@@ -310,27 +310,25 @@ private[migration] object ActionExecutor {
   }
 
   private def executeTransformField(
-    at: zio.blocks.schema.DynamicOptic,
+    at: DynamicOptic,
+    to: DynamicOptic,
     transform: DynamicSchemaExpr,
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
-    modifyAt(at, value) { currentValue =>
-      evalExpr(transform, currentValue, at)
-    }
+    transformInto(at, to, value)(evalExpr(transform, _, at))
 
   private def executeChangeFieldType(
-    at: zio.blocks.schema.DynamicOptic,
+    at: DynamicOptic,
+    to: DynamicOptic,
     converter: DynamicSchemaExpr,
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
-    modifyAt(at, value) { currentValue =>
-      evalExpr(converter, currentValue, at)
-    }
+    transformInto(at, to, value)(evalExpr(converter, _, at))
 
   // ==================== Collection/Map Action Execution ====================
 
   private def executeTransformElements(
-    at: zio.blocks.schema.DynamicOptic,
+    at: DynamicOptic,
     transform: DynamicSchemaExpr,
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
@@ -349,7 +347,7 @@ private[migration] object ActionExecutor {
     }
 
   private def executeTransformKeys(
-    at: zio.blocks.schema.DynamicOptic,
+    at: DynamicOptic,
     transform: DynamicSchemaExpr,
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
@@ -370,7 +368,7 @@ private[migration] object ActionExecutor {
     }
 
   private def executeTransformValues(
-    at: zio.blocks.schema.DynamicOptic,
+    at: DynamicOptic,
     transform: DynamicSchemaExpr,
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
@@ -391,14 +389,18 @@ private[migration] object ActionExecutor {
     }
 
   private def executeMandate(
-    at: zio.blocks.schema.DynamicOptic,
+    at: DynamicOptic,
+    to: DynamicOptic,
     default: DynamicValue,
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
-    modifyAt(at, value) {
+    transformInto(at, to, value) {
       // Option is represented as a Variant with cases "None" and "Some"
       case DynamicValue.Variant("None", _) =>
         Right(default)
+      case DynamicValue.Variant("Some", DynamicValue.Record(fields))
+          if fields.length == 1 && fields.head._1 == "value" =>
+        Right(fields.head._2)
       case DynamicValue.Variant("Some", inner) =>
         Right(inner)
       case other =>
@@ -407,12 +409,13 @@ private[migration] object ActionExecutor {
     }
 
   private def executeOptionalize(
-    at: zio.blocks.schema.DynamicOptic,
+    at: DynamicOptic,
+    to: DynamicOptic,
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] =
-    modifyAt(at, value) { v =>
+    transformInto(at, to, value) { v =>
       // Wrap the value in Some
-      Right(DynamicValue.Variant("Some", v))
+      Right(DynamicValue.Variant("Some", DynamicValue.Record("value" -> v)))
     }
 
   // ==================== Enum Action Execution ====================
@@ -477,7 +480,7 @@ private[migration] object ActionExecutor {
    * (root), apply directly to the value.
    */
   private def modifyAt(
-    path: zio.blocks.schema.DynamicOptic,
+    path: DynamicOptic,
     value: DynamicValue
   )(f: DynamicValue => Either[SchemaError, DynamicValue]): Either[SchemaError, DynamicValue] = {
     val nodes = path.nodes
@@ -488,13 +491,221 @@ private[migration] object ActionExecutor {
     }
   }
 
-  private def modifyAtPath(
-    nodes: IndexedSeq[zio.blocks.schema.DynamicOptic.Node],
+  private def transformInto(
+    sourcePath: DynamicOptic,
+    targetPath: DynamicOptic,
+    value: DynamicValue
+  )(f: DynamicValue => Either[SchemaError, DynamicValue]): Either[SchemaError, DynamicValue] =
+    if (sourcePath == targetPath) {
+      modifyAt(sourcePath, value)(f)
+    } else {
+      for {
+        sourceValue <- getAt(sourcePath, value)
+        targetValue <- f(sourceValue)
+        migrated    <- setAt(targetPath, targetValue, value)
+      } yield migrated
+    }
+
+  private def getAt(path: DynamicOptic, value: DynamicValue): Either[SchemaError, DynamicValue] =
+    getAtPath(path.nodes, 0, value, path)
+
+  private def getAtPath(
+    nodes: IndexedSeq[DynamicOptic.Node],
     idx: Int,
     value: DynamicValue,
-    fullPath: zio.blocks.schema.DynamicOptic
+    fullPath: DynamicOptic
+  ): Either[SchemaError, DynamicValue] = {
+    import DynamicOptic.Node
+
+    if (idx >= nodes.length) {
+      Right(value)
+    } else if (idx >= MaxPathDepth) {
+      Left(SchemaError.transformFailed(fullPath, s"Maximum path depth ($MaxPathDepth) exceeded"))
+    } else {
+      nodes(idx) match {
+        case Node.Field(name) =>
+          value match {
+            case DynamicValue.Record(fields) =>
+              fields.find(_._1 == name) match {
+                case Some((_, fieldValue)) => getAtPath(nodes, idx + 1, fieldValue, fullPath)
+                case None                  => Left(SchemaError.fieldNotFound(fullPath, name))
+              }
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Record", other.getClass.getSimpleName))
+          }
+
+        case Node.Case(caseName) =>
+          value match {
+            case DynamicValue.Variant(name, inner) if name == caseName =>
+              getAtPath(nodes, idx + 1, inner, fullPath)
+            case DynamicValue.Variant(_, _) =>
+              Left(SchemaError.caseNotFound(fullPath, caseName))
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Variant", other.getClass.getSimpleName))
+          }
+
+        case Node.Elements =>
+          value match {
+            case DynamicValue.Sequence(elements) =>
+              val results = elements.foldLeft[Either[SchemaError, Chunk[DynamicValue]]](Right(Chunk.empty)) {
+                case (Right(acc), elem) =>
+                  getAtPath(nodes, idx + 1, elem, fullPath).map(acc :+ _)
+                case (left, _) => left
+              }
+              results.map(DynamicValue.Sequence(_))
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Sequence", other.getClass.getSimpleName))
+          }
+
+        case Node.MapKeys =>
+          value match {
+            case DynamicValue.Map(entries) =>
+              val keys = entries.map(_._1)
+              Right(DynamicValue.Sequence(keys))
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Map", other.getClass.getSimpleName))
+          }
+
+        case Node.MapValues =>
+          value match {
+            case DynamicValue.Map(entries) =>
+              val results = entries.foldLeft[Either[SchemaError, Chunk[DynamicValue]]](Right(Chunk.empty)) {
+                case (Right(acc), (_, v)) =>
+                  getAtPath(nodes, idx + 1, v, fullPath).map(acc :+ _)
+                case (left, _) => left
+              }
+              results.map(DynamicValue.Sequence(_))
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Map", other.getClass.getSimpleName))
+          }
+
+        case Node.AtIndex(index) =>
+          value match {
+            case DynamicValue.Sequence(elements) =>
+              if (index < 0 || index >= elements.length) Left(SchemaError.pathNotFound(fullPath))
+              else getAtPath(nodes, idx + 1, elements(index), fullPath)
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Sequence", other.getClass.getSimpleName))
+          }
+
+        case Node.AtMapKey(key) =>
+          value match {
+            case DynamicValue.Map(entries) =>
+              entries.find(_._1 == key) match {
+                case Some((_, mapValue)) => getAtPath(nodes, idx + 1, mapValue, fullPath)
+                case None                => Left(SchemaError.pathNotFound(fullPath))
+              }
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Map", other.getClass.getSimpleName))
+          }
+
+        case Node.Wrapped =>
+          getAtPath(nodes, idx + 1, value, fullPath)
+
+        case _ =>
+          Left(SchemaError.transformFailed(fullPath, s"Unsupported path node: ${nodes(idx)}"))
+      }
+    }
+  }
+
+  private def setAt(
+    path: DynamicOptic,
+    newValue: DynamicValue,
+    value: DynamicValue
+  ): Either[SchemaError, DynamicValue] =
+    if (path.nodes.isEmpty) Right(newValue)
+    else setAtPath(path.nodes, 0, value, path, newValue)
+
+  private def setAtPath(
+    nodes: IndexedSeq[DynamicOptic.Node],
+    idx: Int,
+    value: DynamicValue,
+    fullPath: DynamicOptic,
+    newValue: DynamicValue
+  ): Either[SchemaError, DynamicValue] = {
+    import DynamicOptic.Node
+
+    if (idx >= nodes.length) {
+      Right(newValue)
+    } else if (idx >= MaxPathDepth) {
+      Left(SchemaError.transformFailed(fullPath, s"Maximum path depth ($MaxPathDepth) exceeded"))
+    } else {
+      nodes(idx) match {
+        case Node.Field(name) =>
+          value match {
+            case DynamicValue.Record(fields) =>
+              val fieldIdx = fields.indexWhere(_._1 == name)
+              if (idx == nodes.length - 1) {
+                if (fieldIdx < 0) Right(DynamicValue.Record(fields :+ (name -> newValue)))
+                else Right(DynamicValue.Record(fields.updated(fieldIdx, (name, newValue))))
+              } else if (fieldIdx < 0) {
+                Left(SchemaError.fieldNotFound(fullPath, name))
+              } else {
+                val (fieldName, fieldValue) = fields(fieldIdx)
+                setAtPath(nodes, idx + 1, fieldValue, fullPath, newValue).map { updated =>
+                  DynamicValue.Record(fields.updated(fieldIdx, (fieldName, updated)))
+                }
+              }
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Record", other.getClass.getSimpleName))
+          }
+
+        case Node.Case(caseName) =>
+          value match {
+            case DynamicValue.Variant(name, inner) if name == caseName =>
+              setAtPath(nodes, idx + 1, inner, fullPath, newValue).map(DynamicValue.Variant(name, _))
+            case DynamicValue.Variant(_, _) =>
+              Left(SchemaError.caseNotFound(fullPath, caseName))
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Variant", other.getClass.getSimpleName))
+          }
+
+        case Node.AtIndex(index) =>
+          value match {
+            case DynamicValue.Sequence(elements) =>
+              if (index < 0 || index >= elements.length) {
+                Left(SchemaError.pathNotFound(fullPath))
+              } else {
+                setAtPath(nodes, idx + 1, elements(index), fullPath, newValue).map { updated =>
+                  DynamicValue.Sequence(elements.updated(index, updated))
+                }
+              }
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Sequence", other.getClass.getSimpleName))
+          }
+
+        case Node.AtMapKey(key) =>
+          value match {
+            case DynamicValue.Map(entries) =>
+              val entryIdx = entries.indexWhere(_._1 == key)
+              if (entryIdx < 0) {
+                Left(SchemaError.pathNotFound(fullPath))
+              } else {
+                val (k, v) = entries(entryIdx)
+                setAtPath(nodes, idx + 1, v, fullPath, newValue).map { updated =>
+                  DynamicValue.Map(entries.updated(entryIdx, (k, updated)))
+                }
+              }
+            case other =>
+              Left(SchemaError.typeMismatch(fullPath, "Map", other.getClass.getSimpleName))
+          }
+
+        case Node.Wrapped =>
+          setAtPath(nodes, idx + 1, value, fullPath, newValue)
+
+        case _ =>
+          Left(SchemaError.transformFailed(fullPath, s"Unsupported target path node: ${nodes(idx)}"))
+      }
+    }
+  }
+
+  private def modifyAtPath(
+    nodes: IndexedSeq[DynamicOptic.Node],
+    idx: Int,
+    value: DynamicValue,
+    fullPath: DynamicOptic
   )(f: DynamicValue => Either[SchemaError, DynamicValue]): Either[SchemaError, DynamicValue] = {
-    import zio.blocks.schema.DynamicOptic.Node
+    import DynamicOptic.Node
 
     if (idx >= nodes.length) {
       f(value)

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -560,8 +560,12 @@ private[migration] object ActionExecutor {
         case Node.MapKeys =>
           value match {
             case DynamicValue.Map(entries) =>
-              val keys = entries.map(_._1)
-              Right(DynamicValue.Sequence(keys))
+              val results = entries.foldLeft[Either[SchemaError, Chunk[DynamicValue]]](Right(Chunk.empty)) {
+                case (Right(acc), (k, _)) =>
+                  getAtPath(nodes, idx + 1, k, fullPath).map(acc :+ _)
+                case (left, _) => left
+              }
+              results.map(DynamicValue.Sequence(_))
             case other =>
               Left(SchemaError.typeMismatch(fullPath, "Map", other.getClass.getSimpleName))
           }

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/DynamicMigration.scala
@@ -447,12 +447,12 @@ private[migration] object ActionExecutor {
     actions: Chunk[MigrationAction],
     value: DynamicValue
   ): Either[SchemaError, DynamicValue] = {
-    val sourceCaseName = at.nodes.lastOption.collect { case zio.blocks.schema.DynamicOptic.Node.Case(name) => name }
-      .getOrElse(targetCaseName)
-    val parentPath = zio.blocks.schema.DynamicOptic(at.nodes.dropRight(1).filter {
-      case _: zio.blocks.schema.DynamicOptic.Node.Case => false
-      case _                                           => true
-    })
+    val sourceCaseName =
+      at.nodes.lastOption.collect { case DynamicOptic.Node.Case(name) => name }.getOrElse(targetCaseName)
+    val parentPath = at.nodes.lastOption match {
+      case Some(_: DynamicOptic.Node.Case) => DynamicOptic(at.nodes.dropRight(1))
+      case _                               => at
+    }
 
     modifyAt(parentPath, value) {
       case DynamicValue.Variant(name, inner) if name == sourceCaseName =>

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
@@ -104,7 +104,7 @@ object MigrationAction {
       val parentPath = DynamicOptic(at.nodes.dropRight(1))
       from match {
         case Some(oldName) => RenameField(parentPath.field(to), oldName)
-        case None          => Irreversible(at, "RenameField")
+        case None          => Irreversible(parentPath, "RenameField")
       }
     }
 
@@ -202,10 +202,18 @@ object MigrationAction {
    */
   final case class TransformCase(
     at: DynamicOptic,
+    targetCaseName: String,
     actions: Chunk[MigrationAction]
   ) extends MigrationAction {
-    override def reverse: MigrationAction =
-      TransformCase(at, actions.reverse.map(_.reverse))
+    override def reverse: MigrationAction = {
+      val sourceCaseName =
+        at.nodes.lastOption.collect { case DynamicOptic.Node.Case(name) => name }.getOrElse(targetCaseName)
+      TransformCase(
+        DynamicOptic(at.nodes.dropRight(1) :+ DynamicOptic.Node.Case(targetCaseName)),
+        sourceCaseName,
+        actions.reverse.map(_.reverse)
+      )
+    }
   }
 
   /**
@@ -281,7 +289,7 @@ object MigrationAction {
    * Sentinel action representing a non-invertible operation. Executing this
    * action always fails with a descriptive error. This is returned by
    * `.reverse` on actions that cannot be structurally reversed (e.g.,
-   * `TransformValue`, `ChangeType`).
+   * `TransformField`, `ChangeFieldType`, `OptionalizeField`).
    *
    * @param at
    *   The path where the original action operated
@@ -292,6 +300,11 @@ object MigrationAction {
     at: DynamicOptic,
     originalAction: String
   ) extends MigrationAction {
+
+    /**
+     * Reversing an irreversible action returns itself — it always fails at
+     * runtime.
+     */
     override def reverse: MigrationAction = this
   }
 }

--- a/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/migration/MigrationAction.scala
@@ -125,9 +125,10 @@ object MigrationAction {
    */
   final case class TransformField(
     at: DynamicOptic,
-    transform: DynamicSchemaExpr
+    transform: DynamicSchemaExpr,
+    to: Option[DynamicOptic] = None
   ) extends MigrationAction {
-    override def reverse: MigrationAction = Irreversible(at, "TransformField")
+    override def reverse: MigrationAction = Irreversible(to.getOrElse(at), "TransformField")
   }
 
   /**
@@ -140,9 +141,10 @@ object MigrationAction {
    */
   final case class MandateField(
     at: DynamicOptic,
-    default: DynamicSchemaExpr
+    default: DynamicSchemaExpr,
+    to: Option[DynamicOptic] = None
   ) extends MigrationAction {
-    override def reverse: MigrationAction = OptionalizeField(at)
+    override def reverse: MigrationAction = OptionalizeField(to.getOrElse(at), Some(at))
   }
 
   /**
@@ -152,9 +154,10 @@ object MigrationAction {
    *   The path to the required value
    */
   final case class OptionalizeField(
-    at: DynamicOptic
+    at: DynamicOptic,
+    to: Option[DynamicOptic] = None
   ) extends MigrationAction {
-    override def reverse: MigrationAction = Irreversible(at, "OptionalizeField")
+    override def reverse: MigrationAction = Irreversible(to.getOrElse(at), "OptionalizeField")
   }
 
   /**
@@ -167,9 +170,10 @@ object MigrationAction {
    */
   final case class ChangeFieldType(
     at: DynamicOptic,
-    converter: DynamicSchemaExpr
+    converter: DynamicSchemaExpr,
+    to: Option[DynamicOptic] = None
   ) extends MigrationAction {
-    override def reverse: MigrationAction = Irreversible(at, "ChangeFieldType")
+    override def reverse: MigrationAction = Irreversible(to.getOrElse(at), "ChangeFieldType")
   }
 
   // ==================== Enum Actions ====================

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
@@ -252,6 +252,78 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
         val variant = result.toOption.get.asInstanceOf[DynamicValue.Variant]
         assertTrue(result.isRight && variant.caseNameValue == "User")
       },
+      test("applies actions to matching case selector") {
+        val input = DynamicValue.Variant(
+          "User",
+          DynamicValue.Record("name" -> DynamicValue.Primitive(PrimitiveValue.String("Bob")))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformCase(
+            root.caseOf("User"),
+            "User",
+            zio.blocks.chunk.Chunk(
+              MigrationAction.AddField(DynamicOptic.root.field("age"), dynamicLiteral(30))
+            )
+          )
+        )
+        assertTrue(
+          migration(input) == Right(
+            DynamicValue.Variant(
+              "User",
+              DynamicValue.Record(
+                "name" -> DynamicValue.Primitive(PrimitiveValue.String("Bob")),
+                "age"  -> DynamicValue.Primitive(PrimitiveValue.Int(30))
+              )
+            )
+          )
+        )
+      },
+      test("leaves non-matching case selector unchanged") {
+        val input = DynamicValue.Variant(
+          "System",
+          DynamicValue.Record("code" -> DynamicValue.Primitive(PrimitiveValue.Int(7)))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformCase(
+            root.caseOf("User"),
+            "User",
+            zio.blocks.chunk.Chunk(
+              MigrationAction.AddField(DynamicOptic.root.field("age"), dynamicLiteral(30))
+            )
+          )
+        )
+        assertTrue(migration(input) == Right(input))
+      },
+      test("applies actions to nested matching case selector") {
+        val input = DynamicValue.Record(
+          "event" -> DynamicValue.Variant(
+            "User",
+            DynamicValue.Record("name" -> DynamicValue.Primitive(PrimitiveValue.String("Bob")))
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformCase(
+            root.field("event").caseOf("User"),
+            "User",
+            zio.blocks.chunk.Chunk(
+              MigrationAction.AddField(DynamicOptic.root.field("age"), dynamicLiteral(30))
+            )
+          )
+        )
+        assertTrue(
+          migration(input) == Right(
+            DynamicValue.Record(
+              "event" -> DynamicValue.Variant(
+                "User",
+                DynamicValue.Record(
+                  "name" -> DynamicValue.Primitive(PrimitiveValue.String("Bob")),
+                  "age"  -> DynamicValue.Primitive(PrimitiveValue.Int(30))
+                )
+              )
+            )
+          )
+        )
+      },
       test("fails on non-Variant value") {
         val migration = DynamicMigration.single(
           MigrationAction.TransformCase(root, "User", zio.blocks.chunk.Chunk.empty)

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
@@ -209,6 +209,46 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
             )
           )
         )
+      },
+      test("reads nested map key paths when writing to a distinct target field") {
+        val keyA  = DynamicValue.Record("code" -> DynamicValue.Primitive(PrimitiveValue.String("a")))
+        val keyB  = DynamicValue.Record("code" -> DynamicValue.Primitive(PrimitiveValue.String("b")))
+        val input = DynamicValue.Record(
+          "byCode" -> DynamicValue.Map(
+            zio.blocks.chunk.Chunk(
+              keyA -> DynamicValue.Primitive(PrimitiveValue.Int(1)),
+              keyB -> DynamicValue.Primitive(PrimitiveValue.Int(2))
+            )
+          )
+        )
+        val sourcePath = DynamicOptic(
+          IndexedSeq(
+            DynamicOptic.Node.Field("byCode"),
+            DynamicOptic.Node.MapKeys,
+            DynamicOptic.Node.Field("code")
+          )
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(sourcePath, DynamicSchemaExpr.Select(root), Some(root.field("codes")))
+        )
+        assertTrue(
+          migration(input) == Right(
+            DynamicValue.Record(
+              "byCode" -> DynamicValue.Map(
+                zio.blocks.chunk.Chunk(
+                  keyA -> DynamicValue.Primitive(PrimitiveValue.Int(1)),
+                  keyB -> DynamicValue.Primitive(PrimitiveValue.Int(2))
+                )
+              ),
+              "codes" -> DynamicValue.Sequence(
+                zio.blocks.chunk.Chunk(
+                  DynamicValue.Primitive(PrimitiveValue.String("a")),
+                  DynamicValue.Primitive(PrimitiveValue.String("b"))
+                )
+              )
+            )
+          )
+        )
       }
     ),
     suite("executeRenameCase")(

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
@@ -170,6 +170,7 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
         val migration = DynamicMigration.single(
           MigrationAction.TransformCase(
             root,
+            "User",
             zio.blocks.chunk.Chunk(
               MigrationAction.AddField(DynamicOptic.root.field("age"), dynamicLiteral(0))
             )
@@ -181,7 +182,7 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
       },
       test("fails on non-Variant value") {
         val migration = DynamicMigration.single(
-          MigrationAction.TransformCase(root, zio.blocks.chunk.Chunk.empty)
+          MigrationAction.TransformCase(root, "User", zio.blocks.chunk.Chunk.empty)
         )
         assertTrue(migration(DynamicValue.Primitive(PrimitiveValue.Int(1))).isLeft)
       }
@@ -622,6 +623,7 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
       test("TransformCase reverse reverses inner actions") {
         val action = MigrationAction.TransformCase(
           root,
+          "TestCase",
           zio.blocks.chunk.Chunk(
             MigrationAction.AddField(root.field("a"), dynamicLiteral(1)),
             MigrationAction.RenameField(root.field("b"), "c")

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/DynamicMigrationSpec.scala
@@ -72,6 +72,22 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
             DynamicValue.Record("status" -> DynamicValue.Primitive(PrimitiveValue.Int(10)))
           )
         )
+      },
+      test("writes mandated value to a distinct target field") {
+        val input = DynamicValue.Record(
+          "maybeAge" -> DynamicValue.Variant("Some", DynamicValue.Primitive(PrimitiveValue.Int(42)))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.MandateField(root.field("maybeAge"), dynamicLiteral(0), Some(root.field("age")))
+        )
+        assertTrue(
+          migration(input) == Right(
+            DynamicValue.Record(
+              "maybeAge" -> DynamicValue.Variant("Some", DynamicValue.Primitive(PrimitiveValue.Int(42))),
+              "age"      -> DynamicValue.Primitive(PrimitiveValue.Int(42))
+            )
+          )
+        )
       }
     ),
     suite("executeOptionalize")(
@@ -85,7 +101,29 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
         assertTrue(
           migration(input) == Right(
             DynamicValue.Record(
-              "age" -> DynamicValue.Variant("Some", DynamicValue.Primitive(PrimitiveValue.Int(25)))
+              "age" -> DynamicValue.Variant(
+                "Some",
+                DynamicValue.Record("value" -> DynamicValue.Primitive(PrimitiveValue.Int(25)))
+              )
+            )
+          )
+        )
+      },
+      test("writes optionalized value to a distinct target field") {
+        val input = DynamicValue.Record(
+          "age" -> DynamicValue.Primitive(PrimitiveValue.Int(25))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.OptionalizeField(root.field("age"), Some(root.field("maybeAge")))
+        )
+        assertTrue(
+          migration(input) == Right(
+            DynamicValue.Record(
+              "age"      -> DynamicValue.Primitive(PrimitiveValue.Int(25)),
+              "maybeAge" -> DynamicValue.Variant(
+                "Some",
+                DynamicValue.Record("value" -> DynamicValue.Primitive(PrimitiveValue.Int(25)))
+              )
             )
           )
         )
@@ -135,6 +173,40 @@ object DynamicMigrationSpec extends ZIOSpecDefault {
         assertTrue(
           migration(input) == Right(
             DynamicValue.Record("score" -> DynamicValue.Primitive(PrimitiveValue.String("42")))
+          )
+        )
+      },
+      test("writes changed value to a distinct target field") {
+        val input = DynamicValue.Record(
+          "score" -> DynamicValue.Primitive(PrimitiveValue.Int(42))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.ChangeFieldType(root.field("score"), dynamicLiteral("42"), Some(root.field("scoreText")))
+        )
+        assertTrue(
+          migration(input) == Right(
+            DynamicValue.Record(
+              "score"     -> DynamicValue.Primitive(PrimitiveValue.Int(42)),
+              "scoreText" -> DynamicValue.Primitive(PrimitiveValue.String("42"))
+            )
+          )
+        )
+      }
+    ),
+    suite("executeTransformField")(
+      test("writes transformed value to a distinct target field") {
+        val input = DynamicValue.Record(
+          "name" -> DynamicValue.Primitive(PrimitiveValue.String("Alice"))
+        )
+        val migration = DynamicMigration.single(
+          MigrationAction.TransformField(root.field("name"), dynamicLiteral("ALICE"), Some(root.field("fullName")))
+        )
+        assertTrue(
+          migration(input) == Right(
+            DynamicValue.Record(
+              "name"     -> DynamicValue.Primitive(PrimitiveValue.String("Alice")),
+              "fullName" -> DynamicValue.Primitive(PrimitiveValue.String("ALICE"))
+            )
           )
         )
       }

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -203,21 +203,6 @@ object MigrationSpec extends ZIOSpecDefault {
         assertTrue(result == Right(PersonV2(30L)))
       },
 
-      test("transformField writes to distinct target selector") {
-        case class PersonV1(name: String)
-        case class PersonV2(fullName: String)
-
-        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
-        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration
-          .newBuilder[PersonV1, PersonV2]
-          .transformField(_.name, _.fullName, literal("Alice Smith"))
-          .build
-
-        assertTrue(migration(PersonV1("Alice")) == Right(PersonV2("Alice Smith")))
-      },
-
       test("changeFieldType selector syntax") {
         case class PersonV1(score: Int)
         case class PersonV2(score: String)
@@ -234,21 +219,6 @@ object MigrationSpec extends ZIOSpecDefault {
         val result = migration(input)
 
         assertTrue(result == Right(PersonV2("42")))
-      },
-
-      test("changeFieldType writes to distinct target selector") {
-        case class PersonV1(score: Int)
-        case class PersonV2(scoreText: String)
-
-        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
-        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration
-          .newBuilder[PersonV1, PersonV2]
-          .changeFieldType(_.score, _.scoreText, literal("42"))
-          .build
-
-        assertTrue(migration(PersonV1(42)) == Right(PersonV2("42")))
       },
 
       test("mandateField builder records mandate action") {
@@ -268,25 +238,6 @@ object MigrationSpec extends ZIOSpecDefault {
         )
       },
 
-      test("mandateField writes to distinct target selector") {
-        case class PersonV1(maybeAge: Option[Int])
-        case class PersonV2(age: Int)
-
-        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
-        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration
-          .newBuilder[PersonV1, PersonV2]
-          .mandateField(_.maybeAge, _.age, literal(0))
-          .build
-
-        assertTrue(
-          migration(PersonV1(Some(42))) == Right(PersonV2(42)),
-          migration(PersonV1(None)) == Right(PersonV2(0)),
-          migration.reverse(PersonV2(42)) == Right(PersonV1(Some(42)))
-        )
-      },
-
       test("optionalizeField builder records optionalize action") {
         case class PersonV1(age: Int)
         case class PersonV2(age: Option[Int])
@@ -302,21 +253,6 @@ object MigrationSpec extends ZIOSpecDefault {
           builder.actions.length == 1,
           builder.actions.head.isInstanceOf[MigrationAction.OptionalizeField]
         )
-      },
-
-      test("optionalizeField writes to distinct target selector") {
-        case class PersonV1(age: Int)
-        case class PersonV2(maybeAge: Option[Int])
-
-        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
-        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
-
-        val migration = Migration
-          .newBuilder[PersonV1, PersonV2]
-          .optionalizeField(_.age, _.maybeAge)
-          .build
-
-        assertTrue(migration(PersonV1(42)) == Right(PersonV2(Some(42))))
       },
 
       test("transformElements evaluates per element") {

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -43,10 +43,12 @@ object MigrationSpec extends ZIOSpecDefault {
     final case class UserV2(fullName: String, age: Int) extends EventV2
     final case class SystemV2(code: Int)                extends EventV2
 
-    implicit val userV1Schema: Schema[UserV1]   = Schema.derived[UserV1]
-    implicit val userV2Schema: Schema[UserV2]   = Schema.derived[UserV2]
-    implicit val eventV1Schema: Schema[EventV1] = Schema.derived[EventV1]
-    implicit val eventV2Schema: Schema[EventV2] = Schema.derived[EventV2]
+    implicit val userV1Schema: Schema[UserV1]     = Schema.derived[UserV1]
+    implicit val userV2Schema: Schema[UserV2]     = Schema.derived[UserV2]
+    implicit val systemV1Schema: Schema[SystemV1] = Schema.derived[SystemV1]
+    implicit val systemV2Schema: Schema[SystemV2] = Schema.derived[SystemV2]
+    implicit val eventV1Schema: Schema[EventV1]   = Schema.derived[EventV1]
+    implicit val eventV2Schema: Schema[EventV2]   = Schema.derived[EventV2]
   }
 
   private def dynamicLiteral[A: Schema](value: A): DynamicSchemaExpr =
@@ -324,12 +326,11 @@ object MigrationSpec extends ZIOSpecDefault {
         val migration = Migration
           .newBuilder[StatusV1, StatusV2]
           .renameCase("Pending", "Enabled")
-          .buildPartial
+          .build
 
-        val input  = statusV1Schema.toDynamicValue(Pending: StatusV1)
-        val result = migration.dynamicMigration(input)
+        val result = migration(Pending: StatusV1)
 
-        assertTrue(result == Right(statusV2Schema.toDynamicValue(Enabled: StatusV2)))
+        assertTrue(result == Right(Enabled: StatusV2))
       },
       test("renameCase does not affect other cases") {
         import RenameCaseFixtures._
@@ -337,27 +338,29 @@ object MigrationSpec extends ZIOSpecDefault {
         val migration = Migration
           .newBuilder[StatusV1, StatusV2]
           .renameCase("Pending", "Enabled")
-          .buildPartial
+          .renameCase("Active", "ActiveV2")
+          .build
 
-        val input  = statusV1Schema.toDynamicValue(Active: StatusV1)
-        val result = migration.dynamicMigration(input)
+        val result = migration(Active: StatusV1)
 
-        assertTrue(result.isRight)
+        assertTrue(result == Right(ActiveV2: StatusV2))
       },
-      test("transformCase inner migration has correct actions") {
+      test("transformCase executes nested migration on matching case") {
         import TransformCaseFixtures._
 
-        val builder = Migration
+        val migration = Migration
           .newBuilder[EventV1, EventV2]
           .transformCase[UserV1, UserV2]("UserV1")(
             _.renameField(_.name, _.fullName).addField(_.age, literal(0))
           )
+          .transformCase[SystemV1, SystemV2]("SystemV1")(
+            _.transformField(_.code, _.code, identityExpr[Int])
+          )
+          .build
 
-        val action = builder.actions.head.asInstanceOf[MigrationAction.TransformCase]
-        assertTrue(
-          builder.actions.length == 1,
-          action.actions.length == 2
-        )
+        val result = migration(UserV1("Alice"): EventV1)
+
+        assertTrue(result == Right(UserV2("Alice", 0): EventV2))
       }
     ),
 

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -422,9 +422,12 @@ object MigrationSpec extends ZIOSpecDefault {
           )
           .build
 
-        val result = migration(UserV1("Alice"): EventV1)
-
-        assertTrue(result == Right(UserV2("Alice", 0): EventV2))
+        assertTrue(
+          migration(UserV1("Alice"): EventV1) == Right(UserV2("Alice", 0): EventV2),
+          migration(SystemV1(7): EventV1) == Right(SystemV2(7): EventV2),
+          migration.reverse(UserV2("Alice", 0): EventV2) == Right(UserV1("Alice"): EventV1),
+          migration.reverse(SystemV2(7): EventV2).isLeft
+        )
       }
     ),
 

--- a/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/migration/MigrationSpec.scala
@@ -203,6 +203,21 @@ object MigrationSpec extends ZIOSpecDefault {
         assertTrue(result == Right(PersonV2(30L)))
       },
 
+      test("transformField writes to distinct target selector") {
+        case class PersonV1(name: String)
+        case class PersonV2(fullName: String)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .transformField(_.name, _.fullName, literal("Alice Smith"))
+          .build
+
+        assertTrue(migration(PersonV1("Alice")) == Right(PersonV2("Alice Smith")))
+      },
+
       test("changeFieldType selector syntax") {
         case class PersonV1(score: Int)
         case class PersonV2(score: String)
@@ -219,6 +234,21 @@ object MigrationSpec extends ZIOSpecDefault {
         val result = migration(input)
 
         assertTrue(result == Right(PersonV2("42")))
+      },
+
+      test("changeFieldType writes to distinct target selector") {
+        case class PersonV1(score: Int)
+        case class PersonV2(scoreText: String)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .changeFieldType(_.score, _.scoreText, literal("42"))
+          .build
+
+        assertTrue(migration(PersonV1(42)) == Right(PersonV2("42")))
       },
 
       test("mandateField builder records mandate action") {
@@ -238,6 +268,25 @@ object MigrationSpec extends ZIOSpecDefault {
         )
       },
 
+      test("mandateField writes to distinct target selector") {
+        case class PersonV1(maybeAge: Option[Int])
+        case class PersonV2(age: Int)
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .mandateField(_.maybeAge, _.age, literal(0))
+          .build
+
+        assertTrue(
+          migration(PersonV1(Some(42))) == Right(PersonV2(42)),
+          migration(PersonV1(None)) == Right(PersonV2(0)),
+          migration.reverse(PersonV2(42)) == Right(PersonV1(Some(42)))
+        )
+      },
+
       test("optionalizeField builder records optionalize action") {
         case class PersonV1(age: Int)
         case class PersonV2(age: Option[Int])
@@ -253,6 +302,21 @@ object MigrationSpec extends ZIOSpecDefault {
           builder.actions.length == 1,
           builder.actions.head.isInstanceOf[MigrationAction.OptionalizeField]
         )
+      },
+
+      test("optionalizeField writes to distinct target selector") {
+        case class PersonV1(age: Int)
+        case class PersonV2(maybeAge: Option[Int])
+
+        implicit val v1Schema: Schema[PersonV1] = Schema.derived[PersonV1]
+        implicit val v2Schema: Schema[PersonV2] = Schema.derived[PersonV2]
+
+        val migration = Migration
+          .newBuilder[PersonV1, PersonV2]
+          .optionalizeField(_.age, _.maybeAge)
+          .build
+
+        assertTrue(migration(PersonV1(42)) == Right(PersonV2(Some(42))))
       },
 
       test("transformElements evaluates per element") {


### PR DESCRIPTION
## Summary

Focused support patch for the schema migration work in #966 / #519.

- capture target selector paths in the Scala 2 and Scala 3 builder macros for transformField, mandateField, optionalizeField, and changeFieldType
- execute those actions by reading from the source path and writing to the captured target path when they differ
- traverse nested MapKeys source selectors when a migration reads from map keys and writes to a distinct target path
- align Option Some payloads with schema DynamicValue encoding
- execute TransformCase correctly when the action path is a case selector such as root.caseOf(caseName)
- leave non-matching enum cases unchanged while applying case-specific inner actions to the matching payload
- add dynamic and typed regression coverage for distinct target selectors, nested map-key selectors, TransformCase selectors, nested case selectors, and reverse behavior
- keep the docs workflow's setup-sbt cache key generation from inheriting workflow-level JDK_JAVA_OPTIONS output

## Why

The current branch validates both source and target selectors, but the runtime action data only carried the source path. Distinct target selectors could compile while the interpreter still mutated the source field, leaving the target schema without the field it expects.

Target-path writes also use the dynamic runtime to read the source selector before writing the target selector. That source read stopped at MapKeys instead of continuing through the remaining optic nodes, so a selector such as byCode.mapKeys.code would pass whole key records to the transform instead of the selected key fields. This patch makes dynamic migration source reads recurse through MapKeys the same way MapValues and DynamicSchemaExpr.Select already do.

There was also a TransformCase execution gap: the builder records transformCase(caseName) as a case-specific optic, but the interpreter treated that optic as if it still pointed at a Variant. That makes real typed enum migrations fail for matching cases and reject unrelated cases that should be left alone. This patch executes those actions at the enum parent path, applies the inner migration only for the selected case, and preserves the existing root-path behavior for manually constructed dynamic migrations.

The docs job failed before running project code because setup-sbt builds a cache key from `java -version`, and workflow-level `JDK_JAVA_OPTIONS` caused Java to prepend a note containing a comma. The setup-sbt steps now clear only that variable for the action itself; the normal sbt/doc/test steps still inherit the workflow JVM options.

## Validation

- `sbt -Dsbt.color=false '++3.8.3; schemaJVM/testOnly zio.blocks.schema.migration.DynamicMigrationSpec'` - 148 tests passed
- `sbt -Dsbt.color=false '++2.13.18; schemaJVM/testOnly zio.blocks.schema.migration.DynamicMigrationSpec'` - 148 tests passed
- `sbt -Dsbt.color=false '++3.8.3; fmtDirty'`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'workflow yaml ok'"`
- `git diff --check`

## Payment

Algora platform payout to GitHub user @jamilahmadzai if maintainers consider this support PR bounty-eligible. No off-platform PayPal or Solana details are required for Algora.
