### PR TITLE
Ensure npm is available in release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,9 +262,10 @@ jobs:
       - name: Cache Dependencies
         uses: coursier/cache-action@v8
       - name: Setup NodeJs
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24.12.0
           registry-url: https://registry.npmjs.org
+          cache: 'npm'
       - name: Publish Docs to NPM Registry
         run: sbt docs/publishToNpm


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration by specifying an exact version for the Node.js setup action and enabling npm caching to improve build efficiency.

- CI/CD workflow improvements:
  * Updated `actions/setup-node` to use version `v6.4.0` and enabled npm caching by setting the `cache` input to `'npm'` in `.github/workflows/ci.yml`.