### PR TITLE
Remove zio-sbt-gh-query sbt plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-lazy val zioSbtVersion  = "0.5.2"
-addSbtPlugin("dev.zio" % "zio-sbt-website"  % zioSbtVersion)
+lazy val zioSbtVersion = "0.5.2"
+addSbtPlugin("dev.zio" % "zio-sbt-website" % zioSbtVersion)
 
 addSbtPlugin("com.timushev.sbt"   % "sbt-updates"              % "0.6.4")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                  % "0.4.8")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 lazy val zioSbtVersion  = "0.5.2"
 addSbtPlugin("dev.zio" % "zio-sbt-website"  % zioSbtVersion)
-addSbtPlugin("dev.zio" % "zio-sbt-gh-query" % zioSbtVersion)
 
 addSbtPlugin("com.timushev.sbt"   % "sbt-updates"              % "0.6.4")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                  % "0.4.8")


### PR DESCRIPTION
## Summary
Remove the `zio-sbt-gh-query` sbt plugin from the project dependencies. This plugin is no longer needed.

## Changes
- Removed `zio-sbt-gh-query` plugin from `project/plugins.sbt`
- Kept `zio-sbt-website` plugin and `zioSbtVersion` variable which are still in use

🤖 Generated with [Claude Code](https://claude.com/claude-code)