### PR TITLE
feat(combinators): Concat picks meaningful LUB on Scala 2 sibling types

### DIFF
--- a/combinators/shared/src/main/scala-2/zio/blocks/combinators/ConcatCompanionPlatform.scala
+++ b/combinators/shared/src/main/scala-2/zio/blocks/combinators/ConcatCompanionPlatform.scala
@@ -29,6 +29,23 @@ private[combinators] trait ConcatCompanionPlatform extends LowerPriorityConcat {
 
 private[combinators] object ConcatMacros {
 
+  /**
+   * Symbols that, when they appear as the (only) parent of a LUB, do not carry
+   * user-meaningful information. When the meaningful-LUB heuristic filters
+   * parents of a `RefinedType` LUB, parents whose symbol matches any of these
+   * are dropped.
+   */
+  private val NoiseSymbolFullNames: Set[String] = Set(
+    "scala.Any",
+    "scala.AnyRef",
+    "scala.AnyVal",
+    "java.lang.Object",
+    "scala.Product",
+    "scala.Serializable",
+    "java.io.Serializable",
+    "java.lang.Comparable"
+  )
+
   def disjointImpl[L: c.WeakTypeTag, R: c.WeakTypeTag](c: whitebox.Context): c.Tree = {
     import c.universe._
 
@@ -37,6 +54,16 @@ private[combinators] object ConcatMacros {
 
     if (lType =:= rType || lType <:< rType || rType <:< lType)
       c.abort(c.enclosingPosition, s"Concat.disjoint requires disjoint types but $lType and $rType are related")
+
+    // Also reject whenever the higher-priority `derive` can produce an
+    // identity-like Concat via a meaningful common supertype (e.g. Dog & Cat
+    // sharing sealed Animal). Otherwise both implicits would type-check and
+    // implicit search would report an ambiguity instead of preferring derive.
+    if (meaningfulLub(c)(lType, rType).isDefined)
+      c.abort(
+        c.enclosingPosition,
+        s"Concat.disjoint requires disjoint types but $lType and $rType share a meaningful common supertype"
+      )
 
     val outType = appliedType(typeOf[Either[_, _]].typeConstructor, List(lType, rType))
 
@@ -56,35 +83,87 @@ private[combinators] object ConcatMacros {
     val lType = weakTypeOf[L].dealias
     val rType = weakTypeOf[R].dealias
 
-    if (lType =:= rType) {
+    def identityInstance(outType: Type): Tree =
       q"""
         new _root_.zio.blocks.combinators.Concat[$lType, $rType] {
-          type Out = $lType
+          type Out = $outType
           def isIdentityLike: _root_.scala.Boolean = true
-          def left(l: $lType): $lType = l
-          def right(r: $rType): $lType = r
+          def left(l: $lType): $outType  = l: $outType
+          def right(r: $rType): $outType = r: $outType
         }
       """
-    } else if (lType <:< rType) {
-      q"""
-        new _root_.zio.blocks.combinators.Concat[$lType, $rType] {
-          type Out = $rType
-          def isIdentityLike: _root_.scala.Boolean = true
-          def left(l: $lType): $rType = l: $rType
-          def right(r: $rType): $rType = r
-        }
-      """
-    } else if (rType <:< lType) {
-      q"""
-        new _root_.zio.blocks.combinators.Concat[$lType, $rType] {
-          type Out = $lType
-          def isIdentityLike: _root_.scala.Boolean = true
-          def left(l: $lType): $lType = l
-          def right(r: $rType): $lType = r: $lType
-        }
-      """
-    } else {
-      c.abort(c.enclosingPosition, s"Cannot derive Concat for disjoint types $lType and $rType; use Concat.disjoint")
+
+    if (lType =:= rType) identityInstance(lType)
+    else if (lType <:< rType) identityInstance(rType)
+    else if (rType <:< lType) identityInstance(lType)
+    else
+      meaningfulLub(c)(lType, rType) match {
+        case Some(outType) => identityInstance(outType)
+        case None          =>
+          // Aborting rejects this candidate during implicit search so the
+          // lower-priority `disjoint` implicit can be considered. Whether
+          // search ultimately succeeds depends on the caller's expected type.
+          c.abort(
+            c.enclosingPosition,
+            s"No unique meaningful common supertype for $lType and $rType; cannot derive identity-like Concat"
+          )
+      }
+  }
+
+  /**
+   * Returns the meaningful common supertype of `lType` and `rType`, if any.
+   *
+   * Scala 2's `lub` often returns refinements such as `Animal with Product with
+   * Serializable` for two case classes sharing a sealed parent. This helper
+   * strips out "noise" parents (see [[NoiseSymbolFullNames]]) and:
+   *
+   *   - returns `Some(t)` when exactly one meaningful parent remains;
+   *   - returns `None` when zero or multiple meaningful parents remain, leaving
+   *     the disambiguation to the caller (which falls back to `Either[L, R]`
+   *     via the lower-priority `disjoint` implicit).
+   *
+   * Returning `None` for the multiple-parent case is intentional: emitting an
+   * intersection type like `Animal with Mammal` would not satisfy an explicit
+   * request such as `Concat.WithOut[Dog, Cat, Animal]` anyway, so falling
+   * through to `Either` keeps the behavior predictable.
+   */
+  private def meaningfulLub(c: whitebox.Context)(lType: c.Type, rType: c.Type): Option[c.Type] = {
+    import c.universe._
+
+    def normalize(t: Type): Type = t.dealias.widen
+
+    def flattenRefinement(t: Type): List[Type] = normalize(t) match {
+      case RefinedType(parents, _)      => parents.flatMap(flattenRefinement)
+      case AnnotatedType(_, underlying) => flattenRefinement(underlying)
+      case other                        => List(other)
+    }
+
+    def isNoise(t: Type): Boolean = {
+      val sym = normalize(t).typeSymbol
+      sym != NoSymbol && NoiseSymbolFullNames.contains(sym.fullName)
+    }
+
+    def distinctTypes(types: List[Type]): List[Type] =
+      types.foldLeft(List.empty[Type]) { (acc, t) =>
+        if (acc.exists(_ =:= t)) acc else acc :+ t
+      }
+
+    val rawLub = normalize(lub(List(lType, rType)))
+
+    val candidates = distinctTypes(
+      flattenRefinement(rawLub)
+        .map(normalize)
+        .filterNot(isNoise)
+        .filter(t => lType <:< t && rType <:< t)
+    )
+
+    val mostSpecific = candidates.filterNot { t =>
+      candidates.exists(u => !(u =:= t) && u <:< t)
+    }
+
+    mostSpecific match {
+      case one :: Nil => Some(one)
+      case _          => None
     }
   }
 

--- a/combinators/shared/src/main/scala/zio/blocks/combinators/Concat.scala
+++ b/combinators/shared/src/main/scala/zio/blocks/combinators/Concat.scala
@@ -25,7 +25,9 @@ package zio.blocks.combinators
  *   - same type: keep that type;
  *   - subtype + supertype: keep the supertype;
  *   - siblings sharing a unique meaningful common supertype (e.g. `Dog` and
- *     `Cat` extending sealed `Animal`): keep that supertype;
+ *     `Cat` extending sealed `Animal`): keep that supertype (a supertype is
+ *     ''meaningful'' when it is not a noise type such as `Any`, `AnyRef`,
+ *     `AnyVal`, `Object`, `Product`, or `Serializable`);
  *   - otherwise: widen disjoint values into `Either[L, R]` on Scala 2 (or
  *     produce the native union `L | R` on Scala 3).
  *

--- a/combinators/shared/src/main/scala/zio/blocks/combinators/Concat.scala
+++ b/combinators/shared/src/main/scala/zio/blocks/combinators/Concat.scala
@@ -20,8 +20,15 @@ package zio.blocks.combinators
  * Typeclass describing the element type produced by sequential concatenation of
  * values of type `L` and `R`.
  *
- * Same-type and subtype relationships collapse to the wider existing type,
- * while disjoint concatenation is provided by platform-specific derivation.
+ * The derivation rules — implemented per platform — are:
+ *
+ *   - same type: keep that type;
+ *   - subtype + supertype: keep the supertype;
+ *   - siblings sharing a unique meaningful common supertype (e.g. `Dog` and
+ *     `Cat` extending sealed `Animal`): keep that supertype;
+ *   - otherwise: widen disjoint values into `Either[L, R]` on Scala 2 (or
+ *     produce the native union `L | R` on Scala 3).
+ *
  * `Stream.concat` uses [[isIdentityLike]] to decide whether it can reuse
  * elements as-is or must wrap/project them through [[left]] and [[right]].
  *

--- a/combinators/shared/src/test/scala-2/zio/blocks/combinators/ConcatSpec.scala
+++ b/combinators/shared/src/test/scala-2/zio/blocks/combinators/ConcatSpec.scala
@@ -68,15 +68,53 @@ object ConcatSpec extends ZIOSpecDefault {
         assertTrue(left == "hello")
       }
     ),
+    suite("meaningful common supertype (siblings)")(
+      test("Concat[Dog, Cat] resolves Out = Animal (shared sealed parent) and is identity-like") {
+        def leftValue[O](d: Dog)(implicit c: Concat.WithOut[Dog, Cat, O]): O   = c.left(d)
+        def rightValue[O](k: Cat)(implicit c: Concat.WithOut[Dog, Cat, O]): O  = c.right(k)
+        def isIdentityFor[O](implicit c: Concat.WithOut[Dog, Cat, O]): Boolean = c.isIdentityLike
+
+        val d             = Dog("Rex")
+        val k             = Cat("Misty")
+        val left: Animal  = leftValue(d)
+        val right: Animal = rightValue(k)
+
+        // Identity-like means concat reuses values bare (no Either wrapping).
+        assertTrue(
+          isIdentityFor,
+          left.asInstanceOf[AnyRef] eq d,
+          right.asInstanceOf[AnyRef] eq k
+        )
+      },
+      test("Concat[Cat, Dog] resolves Out = Animal symmetrically") {
+        def leftValue[O](k: Cat)(implicit c: Concat.WithOut[Cat, Dog, O]): O   = c.left(k)
+        def rightValue[O](d: Dog)(implicit c: Concat.WithOut[Cat, Dog, O]): O  = c.right(d)
+        def isIdentityFor[O](implicit c: Concat.WithOut[Cat, Dog, O]): Boolean = c.isIdentityLike
+
+        val k             = Cat("Misty")
+        val d             = Dog("Rex")
+        val left: Animal  = leftValue(k)
+        val right: Animal = rightValue(d)
+
+        // Reference equality (eq) proves no wrapping/copy occurred.
+        assertTrue(
+          isIdentityFor,
+          left.asInstanceOf[AnyRef] eq k,
+          right.asInstanceOf[AnyRef] eq d
+        )
+      }
+    ),
     suite("unrelated types")(
-      test("Concat[String, Int] resolves Out = Either[String, Int]") {
-        def leftValue[O](implicit c: Concat.WithOut[String, Int, O]): O  = c.left("hello")
-        def rightValue[O](implicit c: Concat.WithOut[String, Int, O]): O = c.right(42)
+      test("Concat[String, Int] resolves Out = Either[String, Int] and wraps values") {
+        def leftValue[O](implicit c: Concat.WithOut[String, Int, O]): O           = c.left("hello")
+        def rightValue[O](implicit c: Concat.WithOut[String, Int, O]): O          = c.right(42)
+        def isIdentityFor[O](implicit c: Concat.WithOut[String, Int, O]): Boolean = c.isIdentityLike
 
         val left: Either[String, Int]  = leftValue
         val right: Either[String, Int] = rightValue
 
-        assertTrue(left == Left("hello"), right == Right(42))
+        // Genuinely disjoint types must wrap via Either; identityLike is false.
+        assertTrue(!isIdentityFor, left == Left("hello"), right == Right(42))
       }
     ),
     suite("two-implicit feasibility gate")(

--- a/docs/reference/combinators.md
+++ b/docs/reference/combinators.md
@@ -120,15 +120,19 @@ Its rules are:
 
 - same type => keep that type
 - subtype + supertype => keep the supertype
-- unrelated types => widen to `Either[L, R]` (the Scala 2 encoding of `L | R`)
+- siblings with a unique meaningful common supertype => keep that supertype (e.g. `Dog` and `Cat` under sealed `Animal` collapse to `Animal`)
+- otherwise (no shared meaningful supertype) => widen to `Either[L, R]` (the Scala 2 encoding of `L | R`)
 
 For example, Scala 2 infers witnesses equivalent to these shapes:
 
 ```scala
 Concat.Concat.WithOut[Int, Int, Int]
 Concat.Concat.WithOut[Dog, Animal, Animal]
+Concat.Concat.WithOut[Dog, Cat, Animal]
 Concat.Concat.WithOut[String, Int, Either[String, Int]]
 ```
+
+A common supertype is "meaningful" when it is something other than the noise types Scala 2's LUB inference produces by default (`Any`, `AnyRef`, `AnyVal`, `Object`, `Product`, `Serializable`, `java.io.Serializable`, `Comparable`). If filtering those parents leaves exactly one candidate, it becomes the result type — and the witness is identity-like, so callers such as `Stream.concat` reuse values bare without wrapping. Zero or multiple meaningful parents fall through to `Either`.
 
 Unlike `Choices`, `Concat` is not usually called directly at runtime. It exists mainly so shared Scala-2 APIs can infer the same public result types that Scala 3 expresses with native unions.
 

--- a/docs/reference/streams/stream.md
+++ b/docs/reference/streams/stream.md
@@ -876,9 +876,10 @@ The result type follows the same widening rules as Scala 3 unions:
 
 - identical types stay unchanged (`A ++ A => A`)
 - subtypes widen to the supertype (`Dog ++ Animal => Animal`)
-- unrelated types remain disjoint (`String ++ Int => String | Int`)
+- siblings with a common meaningful supertype widen to that supertype (`Dog ++ Cat => Animal`, when both extend a sealed `Animal`)
+- otherwise the result is a disjoint union (`String ++ Int => String | Int`)
 
-On Scala 3, disjoint concat results are native unions. On Scala 2, the same disjoint concat results are represented as `Either`, while same/subtype cases still collapse to the wider existing type.
+On Scala 3, disjoint concat results are native unions. On Scala 2, the same/subtype and sibling cases collapse to the wider existing type (zero-cost, values are reused as-is); only types without a shared meaningful supertype fall back to `Either[L, R]`.
 
 Evaluation is sequential: the second stream only starts when the first completes:
 


### PR DESCRIPTION
## Motivation

On Scala 3, `Concat[L, R]` derives `L | R` directly, and union types widen to their nearest common supertype at use sites. On Scala 2 the macro only emitted an identity-like `Concat` when one side was a subtype of the other; every other pair fell through to `Concat.disjoint`, which wraps values in `Either[L, R]`.

The asymmetry shows up most visibly in `Stream.concat`:

```scala
sealed trait Animal
case class Dog(name: String) extends Animal
case class Cat(name: String) extends Animal

Stream.succeed(Dog("Rex")) ++ Stream.succeed(Cat("Misty"))
// Scala 3:          Stream[Nothing, Dog | Cat]           — widens to Animal at use sites, no wrapping
// Scala 2 (before): Stream[Nothing, Either[Dog, Cat]]    — values wrapped in Left/Right
// Scala 2 (after):  Stream[Nothing, Animal]              — zero-cost, matches Scala 3
```

Genuinely disjoint types like `String ++ Int` keep the old `Either` behavior on Scala 2, preserving type safety where there is no real common supertype.

## What changed

In `combinators/shared/src/main/scala-2/zio/blocks/combinators/ConcatCompanionPlatform.scala` (Scala 2 only):

1. New private `meaningfulLub` helper. Calls `c.universe.lub(L, R)`, flattens any `RefinedType` parents, filters out noise symbols (`Any`, `AnyRef`, `AnyVal`, `Object`, `Product`, `Serializable`, `java.io.Serializable`, `Comparable`), keeps only true supertypes of both operands, and picks the most-specific candidate. Returns `Some(t)` only when **exactly one** meaningful parent remains; `None` for zero or multiple — predictability over cleverness (no auto-generated `A with B` intersections that would not satisfy explicit `WithOut[L, R, A]` requests anyway).
2. `concatImpl` (the `derive` macro) now tries `meaningfulLub` after the three subtype branches. On hit: emits identity-like `Concat[L, R] { type Out = t }`. On miss: `c.abort` so implicit search falls through to `disjoint` (same fallback mechanism as before).
3. `disjointImpl` also aborts when `meaningfulLub` is defined. Without this, both `derive` (high priority) and `disjoint` (low priority) would type-check for sibling case classes and the compiler would report an ambiguity instead of preferring `derive`.

Scala 3 `Concat` is untouched.

## User-visible effect on Scala 2

| Operands | Before | After |
|---|---|---|
| `Concat[Dog, Cat]` (siblings under sealed `Animal`) | `Either[Dog, Cat]`, wrapped | `Animal`, identity-like |
| `Concat[Dog, Animal]` (subtype) | `Animal`, identity-like | `Animal`, identity-like (unchanged) |
| `Concat[String, Int]` (disjoint) | `Either[String, Int]`, wrapped | `Either[String, Int]`, wrapped (unchanged) |

## Tests

New `"meaningful common supertype (siblings)"` suite in `combinators/shared/src/test/scala-2/zio/blocks/combinators/ConcatSpec.scala` covers both sibling-LUB directions and asserts bare-value passthrough via `eq`/`==`. The existing `"unrelated types"` test was extended to assert `!isIdentityLike` for the disjoint `Either` case.

## Verification

- Scala 2.13.18: `combinatorsJVM/test` 78 passed, `combinatorsJS/test` 60 passed, `streamsJVM/test` 1036 passed.
- Scala 3.8.3: `combinatorsJVM/test` 144 passed, `combinatorsJS/test` 144 passed, `streamsJVM/test` 1036 passed.

Downstream sweep: only `streams` consumes `Concat` (`Stream.concat` / `++`); both Scala versions of `streamsJVM` pass with no test changes needed.

Two unrelated Scala 3 test files (`TypeInferenceSpec`, `UnionsSpec`) had unused `scala.compiletime.testing.typeCheckErrors` imports removed by `fmtDirty`.
