### PR TITLE
feat(streams,ringbuffer): concurrent stream operators (mapPar / mergeAll / flatMapPar) + primitive SPSC ring buffers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -506,7 +506,7 @@ lazy val schema = crossProject(JSPlatform, JVMPlatform)
 
 lazy val streams = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Full)
-  .dependsOn(scope, chunk, combinators)
+  .dependsOn(scope, chunk, combinators, ringbuffer)
   .settings(stdSettings("zio-blocks-streams", Seq(Scala3, Scala33, Scala213)))
   .settings(crossProjectSettings)
   .settings(buildInfoSettings("zio.blocks.streams"))
@@ -516,6 +516,10 @@ lazy val streams = crossProject(JSPlatform, JVMPlatform)
   )
   .jvmSettings(
     mimaSettings(failOnProblem = false),
+    // Stream tests create concurrent producer threads; run specs sequentially
+    // to avoid CPU starvation across specs (parallelExecution := true is the
+    // default from stdSettings).
+    Test / parallelExecution := false,
     // Streams requires JDK 21+ (Project Loom virtual threads).
     // Override the default -release flag so Thread.ofVirtual() is available.
     // Only set -release 21 when running on JDK 21+; on JDK 17 CI, skip
@@ -1296,8 +1300,8 @@ lazy val `streams-benchmark` = project
       // Apache Pekko Streams (Apache-2.0 fork of Akka Streams)
       "org.apache.pekko" %% "pekko-stream" % "1.5.0",
       // Kyo — algebraic effect streams (Scala 3 only)
-      "io.getkyo" %% "kyo-prelude" % "0.19.0",
-      "io.getkyo" %% "kyo-core"    % "0.19.0",
+      "io.getkyo" %% "kyo-prelude" % "1.0-RC1",
+      "io.getkyo" %% "kyo-core"    % "1.0-RC1",
       // Ox — direct-style streaming (SoftwareMill, Scala 3 only)
       "com.softwaremill.ox" %% "core" % "1.0.4"
     ),

--- a/docs/reference/ringbuffer/spsc.mdx
+++ b/docs/reference/ringbuffer/spsc.mdx
@@ -268,6 +268,47 @@ val filled = rb4.fill(() => { counter.incrementAndGet(); s"item-${counter.get()}
 println(s"Filled $filled items")
 ```
 
+## Primitive variants
+
+The generic `SpscRingBuffer[A]` stores `AnyRef` slots, which boxes Java primitives on the producer side. For SPSC workloads handing off `Int`, `Long`, `Float`, or `Double` values between two threads, four zero-boxing companions are provided:
+
+| Type | Class | Slot encoding |
+|---|---|---|
+| `Int`    | `IntSpscRingBuffer`    | one `Long` per slot: high 32 bits hold an occupancy tag (`0` = empty, `1` = data, `2` = DONE sentinel), low 32 bits hold the `Int` payload. The whole 64-bit word is `0L` when empty, so any tagged value is non-zero regardless of the payload bits. |
+| `Long`   | `LongSpscRingBuffer`   | one `Long` per slot. `Long.MinValue` is reserved as the empty marker and `Long.MinValue + 1L` as the in-band DONE sentinel; offering either value throws `IllegalArgumentException`. All other `Long` values pass through unchanged. |
+| `Float`  | `FloatSpscRingBuffer`  | one `Long` per slot: high 32 bits tag (`0` = empty, `1` = data, `2` = DONE), low 32 bits hold `floatToRawIntBits(value)`. The whole word is `0L` when empty. Every `Float` (including `0.0f`, `NaN`, `±Inf`) is representable. |
+| `Double` | `DoubleSpscRingBuffer` | one `Long` per slot. `doubleToRawLongBits(value)` is stored directly; two reserved non-canonical `NaN` bit patterns mark empty (`0xFFF8_0000_0000_0001L`) and DONE (`0xFFF8_0000_0000_0002L`). Any `NaN` payload is canonicalized to `Double.NaN` on offer so it can never collide with the reserved markers. |
+
+All four use the same FastFlow algorithm as the generic version — single backing `Array[Long]`, padded indices, look-ahead cache — and expose the same core operations (`offer`, `take`, `peek`, `isEmpty`, `isFull`, `size`, `capacity`). The only API difference is that `take` returns a primitive instead of `AnyRef`, so callers should check `peek()` first to know whether the next read will be a real value or just the empty marker. (The generic `drain`/`fill` batch helpers are not provided on the primitive variants; loop `peek`/`take` directly.)
+
+In addition, each primitive variant exposes two methods for **in-band end-of-stream signalling**, used by the concurrent stream operators to propagate "no more data" through a primitive queue without needing a separate side channel:
+
+- `offerDone(): Boolean` — write the DONE sentinel into the next free slot, returning `true` on success or `false` if the queue is full. Once `offerDone()` succeeds the producer should not offer any further values.
+- `pollPacked(): Long` — atomically poll the next slot and return its packed encoding: `EMPTY_PACKED`/`EMPTY` / `EMPTY_BITS` when empty (consumer index NOT advanced), `DONE_PACKED`/`DONE` / `DONE_BITS` for the DONE sentinel (index advanced), or a non-sentinel encoded value otherwise (index advanced). The exact constant names live on each companion object (`IntSpscRingBuffer.DONE_PACKED`, `LongSpscRingBuffer.DONE`, `FloatSpscRingBuffer.DONE_PACKED`, `DoubleSpscRingBuffer.DONE_BITS`).
+
+`pollPacked` is intended for advanced consumers that want a single atomic operation distinguishing empty / data / DONE. Most application code that simply needs primitive throughput is fine using the higher-level concurrent stream operators below.
+
+```scala mdoc:silent:reset
+import zio.blocks.ringbuffer.{IntSpscRingBuffer, LongSpscRingBuffer, DoubleSpscRingBuffer}
+
+val ints = new IntSpscRingBuffer(16)
+ints.offer(42)
+if (ints.peek()) {
+  val v: Int = ints.take()     // 42
+}
+
+val longs = new LongSpscRingBuffer(16)
+longs.offer(Long.MaxValue)
+if (longs.peek()) {
+  val w: Long = longs.take()   // Long.MaxValue
+}
+
+val doubles = new DoubleSpscRingBuffer(16)
+doubles.offer(Double.NaN)      // canonicalized to Double.NaN's bit pattern on offer
+```
+
+These variants underpin the primitive-specialized concurrent stream operators (`mapPar`, `mergeAll`, `flatMapPar`) so primitive streams do not box during cross-thread handoff.
+
 ## Examples
 
 ### SPSC: Producer-Consumer Ping-Pong

--- a/docs/reference/streams/concurrent-operators.md
+++ b/docs/reference/streams/concurrent-operators.md
@@ -1,0 +1,106 @@
+---
+id: concurrent-operators
+title: "Concurrent Operators"
+---
+
+ZIO Blocks Streams ships **three** concurrent operators that fan work across virtual threads while preserving the typed-error, synchronous, pull-based programming model. The calling thread still receives `Either[E, Z]` — no effect system is required.
+
+| Operator | Purpose |
+|---|---|
+| `Stream#mapPar(n)(f)` | Apply `f` to each element on up to `n` worker threads. Output is **unordered** (arrival order, not input order). |
+| `Stream.mergeAll(n)(streams)` | Drain up to `n` inner streams concurrently; interleave their elements as they arrive. |
+| `Stream#flatMapPar(n)(f)` | Per element, produce a sub-stream via `f`; drain up to `n` sub-streams concurrently. |
+
+All three operators are **JVM-only**. On Scala.js they degrade to sequential equivalents (`map`, `flatten`, `flatMap`).
+
+## Semantics
+
+**Output order.** Concurrent output is **unordered** with respect to input position. Elements arrive as workers complete, not in input order. If you need input order, use sequential `map` / `flatMap`.
+
+**Error propagation.** The first typed error from any worker or inner stream terminates all concurrent work and surfaces as `Left(e)` from the terminal operation. Defects (unexpected exceptions) propagate as thrown exceptions, same as sequential operators.
+
+**Resource safety.** All worker threads and ring-buffer queues are cleaned up deterministically when the consumer closes the reader, the stream errors, or the scope finalizes.
+
+**Primitive specialization.** Readers produced by concurrent operators preserve primitive specialization — `Int`, `Long`, `Float`, and `Double` streams use specialized lock-free queues internally, avoiding boxing in the concurrent handoff between threads.
+
+## Buffer sizing
+
+Concurrent operators use internal ring-buffer queues (default size **64**). Override with `Stream.bufferSize(n) { ... }` where `n` is a positive power of two:
+
+```
+Stream.bufferSize(256) {
+  Stream.range(0, 1_000_000).mapPar(8)(heavyComputation)
+}.runCollect
+```
+
+Larger buffers help when producers are bursty; smaller buffers reduce memory when many concurrent streams are active. The default is fine for most workloads.
+
+`Pipeline.buffer(n)` inserts a buffer of `n` elements between upstream and downstream (async handoff on JVM, sync on JS).
+
+## Examples
+
+### `mapPar`
+
+```
+// Apply an expensive function using 8 virtual threads.
+// Output order varies between runs.
+val result = Stream.range(0, 1000)
+  .mapPar(8)(n => { Thread.sleep(1); n * 2 })
+  .runCollect
+// result: Right(Chunk(...)) -- all 1000 elements, but not in 0,2,4,... order
+```
+
+### `mergeAll`
+
+```
+// Drain 10 streams concurrently, up to 4 at a time.
+val streams = Stream.fromIterable(
+  (0 until 10).map(i => Stream.range(i * 100, (i + 1) * 100))
+)
+val merged = Stream.mergeAll(4)(streams).runFold(0L)(_ + _)
+// merged: Right(499500) -- all elements consumed, order interleaved
+```
+
+### `flatMapPar`
+
+```
+// Each element spawns a sub-stream; up to 8 drained concurrently.
+val flat = Stream.range(0, 50)
+  .flatMapPar(8)(i => Stream.range(i * 20, (i + 1) * 20))
+  .runFold(0L)(_ + _)
+// flat: Right(499500)
+```
+
+### Error behaviour
+
+```
+// Typed error in a worker terminates all workers
+val err1 = Stream.range(0, 1000)
+  .flatMap(n => if (n == 500) Stream.fail("bad element") else Stream.succeed(n))
+  .mapPar(4)(identity)
+  .runCollect
+// err1: Left("bad element")
+
+// Error in one inner stream terminates mergeAll
+val err2 = Stream.mergeAll(4)(Stream.fromIterable(
+  List(Stream.range(0, 100), Stream.fail("inner error"), Stream.range(200, 300))
+)).runCollect
+// err2: Left("inner error")
+```
+
+## Guidelines
+
+- **Use `mapPar(n)(f)` for expensive per-element work** — network calls, CPU-bound computation, blocking I/O. Do not use it for trivially cheap functions (e.g. `_ + 1`); the thread-handoff overhead exceeds the parallelism benefit.
+- **Use `mergeAll(n)(streams)` for concurrent fan-in** — draining multiple independent sources (files, connections, partitions) simultaneously. Use `flatMapPar(n)(f)` when each input element produces a sub-stream to drain concurrently.
+- **Concurrent output is unordered.** If you need sorted results, apply `.runCollect.map(_.sorted)` or accumulate into a structure that handles ordering. If you need input-order preservation, use sequential `map` / `flatMap`.
+- **`mapPar`, `mergeAll`, and `flatMapPar` are JVM-only.** On JS they degrade to sequential equivalents.
+
+## Comparison with other libraries
+
+| Feature | ZB Streams | fs2 | Kyo | Ox | Pekko |
+|---|---|---|---|---|---|
+| Concurrent operators | `mapPar`, `mergeAll`, `flatMapPar` | `parEvalMap` | `mapParUnordered`* | `mapPar` | `mapAsync`, `flatMapMerge` |
+| Effect system required | No | Yes (cats-effect) | Yes (Kyo) | No (virtual threads) | Yes (Akka) |
+| Typed errors | `Either[E, Z]` | ApplicativeError | Kyo effects | Exceptions | No |
+
+\* Kyo's `mapParUnordered` forks a fiber per element (very slow for large streams). Kyo's `collectAll` merges streams but does not parallelize pure computation within them.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -211,6 +211,7 @@ const sidebars = {
              "reference/streams/sink",
              "reference/streams/reader",
              "reference/streams/writer",
+             "reference/streams/concurrent-operators",
              "reference/streams/zero-boxing",
            ]
          },

--- a/ringbuffer-benchmarks/src/main/scala/zio/blocks/ringbuffer/benchmarks/PrimitiveSpscThroughputBenchmark.scala
+++ b/ringbuffer-benchmarks/src/main/scala/zio/blocks/ringbuffer/benchmarks/PrimitiveSpscThroughputBenchmark.scala
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.ringbuffer.benchmarks
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.{Blackhole, Control}
+
+import java.util.concurrent.{ArrayBlockingQueue, TimeUnit}
+import scala.compiletime.uninitialized
+import org.jctools.queues.SpscArrayQueue
+import zio.blocks.ringbuffer.{
+  DoubleSpscRingBuffer,
+  FloatSpscRingBuffer,
+  IntSpscRingBuffer,
+  LongSpscRingBuffer,
+  SpscRingBuffer
+}
+
+/**
+ * SPSC throughput benchmarks for the primitive-specialized ring buffers.
+ *
+ * Each `*Benchmark` class compares the primitive variant against three boxing
+ * baselines using the same element type:
+ *   - ZIO generic `SpscRingBuffer[BoxedType]` (boxing reference)
+ *   - JDK `ArrayBlockingQueue[BoxedType]` (lock-based)
+ *   - JCTools `SpscArrayQueue[BoxedType]` (speed-of-light reference)
+ *
+ * The point is to make the zero-boxing win visible: primitive variants skip the
+ * auto-box per element on the producer and the auto-unbox per element on the
+ * consumer, and store data in a primitive `int[]` / `long[]` / `float[]` /
+ * `double[]` array, so each element costs 4-8 bytes instead of the 16-byte
+ * boxed object + 4-byte pointer.
+ *
+ * Uses 1 producer thread and 1 consumer thread via JMH @Group.
+ */
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G", "-XX:+AlwaysPreTouch"))
+@State(Scope.Group)
+class IntPrimitiveSpscBenchmark {
+
+  @Param(Array("ZIO_INT_PRIM", "ZIO_OBJECT", "ABQ", "JCTOOLS_SPSC"))
+  var impl: String = uninitialized
+
+  @Param(Array("1024"))
+  var capacity: Int = uninitialized
+
+  private var prim: IntSpscRingBuffer                    = uninitialized
+  private var rb: SpscRingBuffer[java.lang.Integer]      = uninitialized
+  private var abq: ArrayBlockingQueue[java.lang.Integer] = uninitialized
+  private var jcq: SpscArrayQueue[java.lang.Integer]     = uninitialized
+
+  private val ITEM_INT: Int               = 42
+  private val ITEM_BOX: java.lang.Integer = java.lang.Integer.valueOf(42)
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    prim = null; rb = null; abq = null; jcq = null
+    impl match {
+      case "ZIO_INT_PRIM" => prim = new IntSpscRingBuffer(capacity)
+      case "ZIO_OBJECT"   => rb = new SpscRingBuffer[java.lang.Integer](capacity)
+      case "ABQ"          => abq = new ArrayBlockingQueue[java.lang.Integer](capacity)
+      case "JCTOOLS_SPSC" => jcq = new SpscArrayQueue[java.lang.Integer](capacity)
+    }
+  }
+
+  @Benchmark
+  @Group("spsc_int")
+  @GroupThreads(1)
+  def produce(control: Control): Unit = impl match {
+    case "ZIO_INT_PRIM" =>
+      while (!control.stopMeasurement && !prim.offer(ITEM_INT)) Thread.onSpinWait()
+    case "ZIO_OBJECT" =>
+      while (!control.stopMeasurement && !rb.offer(ITEM_BOX)) Thread.onSpinWait()
+    case "ABQ" =>
+      while (!control.stopMeasurement && !abq.offer(ITEM_BOX)) Thread.onSpinWait()
+    case "JCTOOLS_SPSC" =>
+      while (!control.stopMeasurement && !jcq.offer(ITEM_BOX)) Thread.onSpinWait()
+  }
+
+  @Benchmark
+  @Group("spsc_int")
+  @GroupThreads(1)
+  def consume(control: Control, bh: Blackhole): Unit = impl match {
+    case "ZIO_INT_PRIM" =>
+      while (!control.stopMeasurement && !prim.peek()) Thread.onSpinWait()
+      if (prim.peek()) bh.consume(prim.take())
+    case "ZIO_OBJECT" =>
+      var v = rb.take()
+      while (!control.stopMeasurement && (v eq null)) { Thread.onSpinWait(); v = rb.take() }
+      if (v ne null) bh.consume(v)
+    case "ABQ" =>
+      var v = abq.poll()
+      while (!control.stopMeasurement && (v eq null)) { Thread.onSpinWait(); v = abq.poll() }
+      if (v ne null) bh.consume(v)
+    case "JCTOOLS_SPSC" =>
+      var v = jcq.poll()
+      while (!control.stopMeasurement && (v eq null)) { Thread.onSpinWait(); v = jcq.poll() }
+      if (v ne null) bh.consume(v)
+  }
+}
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G", "-XX:+AlwaysPreTouch"))
+@State(Scope.Group)
+class LongPrimitiveSpscBenchmark {
+
+  @Param(Array("ZIO_LONG_PRIM", "ZIO_OBJECT", "ABQ", "JCTOOLS_SPSC"))
+  var impl: String = uninitialized
+
+  @Param(Array("1024"))
+  var capacity: Int = uninitialized
+
+  private var prim: LongSpscRingBuffer                = uninitialized
+  private var rb: SpscRingBuffer[java.lang.Long]      = uninitialized
+  private var abq: ArrayBlockingQueue[java.lang.Long] = uninitialized
+  private var jcq: SpscArrayQueue[java.lang.Long]     = uninitialized
+
+  private val ITEM_LONG: Long          = 42L
+  private val ITEM_BOX: java.lang.Long = java.lang.Long.valueOf(42L)
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    prim = null; rb = null; abq = null; jcq = null
+    impl match {
+      case "ZIO_LONG_PRIM" => prim = new LongSpscRingBuffer(capacity)
+      case "ZIO_OBJECT"    => rb = new SpscRingBuffer[java.lang.Long](capacity)
+      case "ABQ"           => abq = new ArrayBlockingQueue[java.lang.Long](capacity)
+      case "JCTOOLS_SPSC"  => jcq = new SpscArrayQueue[java.lang.Long](capacity)
+    }
+  }
+
+  @Benchmark
+  @Group("spsc_long")
+  @GroupThreads(1)
+  def produce(control: Control): Unit = impl match {
+    case "ZIO_LONG_PRIM" =>
+      while (!control.stopMeasurement && !prim.offer(ITEM_LONG)) Thread.onSpinWait()
+    case "ZIO_OBJECT" =>
+      while (!control.stopMeasurement && !rb.offer(ITEM_BOX)) Thread.onSpinWait()
+    case "ABQ" =>
+      while (!control.stopMeasurement && !abq.offer(ITEM_BOX)) Thread.onSpinWait()
+    case "JCTOOLS_SPSC" =>
+      while (!control.stopMeasurement && !jcq.offer(ITEM_BOX)) Thread.onSpinWait()
+  }
+
+  @Benchmark
+  @Group("spsc_long")
+  @GroupThreads(1)
+  def consume(control: Control, bh: Blackhole): Unit = impl match {
+    case "ZIO_LONG_PRIM" =>
+      while (!control.stopMeasurement && !prim.peek()) Thread.onSpinWait()
+      if (prim.peek()) bh.consume(prim.take())
+    case "ZIO_OBJECT" =>
+      var v = rb.take()
+      while (!control.stopMeasurement && (v eq null)) { Thread.onSpinWait(); v = rb.take() }
+      if (v ne null) bh.consume(v)
+    case "ABQ" =>
+      var v = abq.poll()
+      while (!control.stopMeasurement && (v eq null)) { Thread.onSpinWait(); v = abq.poll() }
+      if (v ne null) bh.consume(v)
+    case "JCTOOLS_SPSC" =>
+      var v = jcq.poll()
+      while (!control.stopMeasurement && (v eq null)) { Thread.onSpinWait(); v = jcq.poll() }
+      if (v ne null) bh.consume(v)
+  }
+}
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G", "-XX:+AlwaysPreTouch"))
+@State(Scope.Group)
+class FloatPrimitiveSpscBenchmark {
+
+  @Param(Array("ZIO_FLOAT_PRIM", "ZIO_OBJECT", "ABQ", "JCTOOLS_SPSC"))
+  var impl: String = uninitialized
+
+  @Param(Array("1024"))
+  var capacity: Int = uninitialized
+
+  private var prim: FloatSpscRingBuffer                = uninitialized
+  private var rb: SpscRingBuffer[java.lang.Float]      = uninitialized
+  private var abq: ArrayBlockingQueue[java.lang.Float] = uninitialized
+  private var jcq: SpscArrayQueue[java.lang.Float]     = uninitialized
+
+  private val ITEM_FLOAT: Float         = 42.0f
+  private val ITEM_BOX: java.lang.Float = java.lang.Float.valueOf(42.0f)
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    prim = null; rb = null; abq = null; jcq = null
+    impl match {
+      case "ZIO_FLOAT_PRIM" => prim = new FloatSpscRingBuffer(capacity)
+      case "ZIO_OBJECT"     => rb = new SpscRingBuffer[java.lang.Float](capacity)
+      case "ABQ"            => abq = new ArrayBlockingQueue[java.lang.Float](capacity)
+      case "JCTOOLS_SPSC"   => jcq = new SpscArrayQueue[java.lang.Float](capacity)
+    }
+  }
+
+  @Benchmark
+  @Group("spsc_float")
+  @GroupThreads(1)
+  def produce(control: Control): Unit = impl match {
+    case "ZIO_FLOAT_PRIM" =>
+      while (!control.stopMeasurement && !prim.offer(ITEM_FLOAT)) Thread.onSpinWait()
+    case "ZIO_OBJECT" =>
+      while (!control.stopMeasurement && !rb.offer(ITEM_BOX)) Thread.onSpinWait()
+    case "ABQ" =>
+      while (!control.stopMeasurement && !abq.offer(ITEM_BOX)) Thread.onSpinWait()
+    case "JCTOOLS_SPSC" =>
+      while (!control.stopMeasurement && !jcq.offer(ITEM_BOX)) Thread.onSpinWait()
+  }
+
+  @Benchmark
+  @Group("spsc_float")
+  @GroupThreads(1)
+  def consume(control: Control, bh: Blackhole): Unit = impl match {
+    case "ZIO_FLOAT_PRIM" =>
+      while (!control.stopMeasurement && !prim.peek()) Thread.onSpinWait()
+      if (prim.peek()) bh.consume(prim.take())
+    case "ZIO_OBJECT" =>
+      var v = rb.take()
+      while (!control.stopMeasurement && (v eq null)) { Thread.onSpinWait(); v = rb.take() }
+      if (v ne null) bh.consume(v)
+    case "ABQ" =>
+      var v = abq.poll()
+      while (!control.stopMeasurement && (v eq null)) { Thread.onSpinWait(); v = abq.poll() }
+      if (v ne null) bh.consume(v)
+    case "JCTOOLS_SPSC" =>
+      var v = jcq.poll()
+      while (!control.stopMeasurement && (v eq null)) { Thread.onSpinWait(); v = jcq.poll() }
+      if (v ne null) bh.consume(v)
+  }
+}
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G", "-XX:+AlwaysPreTouch"))
+@State(Scope.Group)
+class DoublePrimitiveSpscBenchmark {
+
+  @Param(Array("ZIO_DOUBLE_PRIM", "ZIO_OBJECT", "ABQ", "JCTOOLS_SPSC"))
+  var impl: String = uninitialized
+
+  @Param(Array("1024"))
+  var capacity: Int = uninitialized
+
+  private var prim: DoubleSpscRingBuffer                = uninitialized
+  private var rb: SpscRingBuffer[java.lang.Double]      = uninitialized
+  private var abq: ArrayBlockingQueue[java.lang.Double] = uninitialized
+  private var jcq: SpscArrayQueue[java.lang.Double]     = uninitialized
+
+  private val ITEM_DOUBLE: Double        = 42.0
+  private val ITEM_BOX: java.lang.Double = java.lang.Double.valueOf(42.0)
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    prim = null; rb = null; abq = null; jcq = null
+    impl match {
+      case "ZIO_DOUBLE_PRIM" => prim = new DoubleSpscRingBuffer(capacity)
+      case "ZIO_OBJECT"      => rb = new SpscRingBuffer[java.lang.Double](capacity)
+      case "ABQ"             => abq = new ArrayBlockingQueue[java.lang.Double](capacity)
+      case "JCTOOLS_SPSC"    => jcq = new SpscArrayQueue[java.lang.Double](capacity)
+    }
+  }
+
+  @Benchmark
+  @Group("spsc_double")
+  @GroupThreads(1)
+  def produce(control: Control): Unit = impl match {
+    case "ZIO_DOUBLE_PRIM" =>
+      while (!control.stopMeasurement && !prim.offer(ITEM_DOUBLE)) Thread.onSpinWait()
+    case "ZIO_OBJECT" =>
+      while (!control.stopMeasurement && !rb.offer(ITEM_BOX)) Thread.onSpinWait()
+    case "ABQ" =>
+      while (!control.stopMeasurement && !abq.offer(ITEM_BOX)) Thread.onSpinWait()
+    case "JCTOOLS_SPSC" =>
+      while (!control.stopMeasurement && !jcq.offer(ITEM_BOX)) Thread.onSpinWait()
+  }
+
+  @Benchmark
+  @Group("spsc_double")
+  @GroupThreads(1)
+  def consume(control: Control, bh: Blackhole): Unit = impl match {
+    case "ZIO_DOUBLE_PRIM" =>
+      while (!control.stopMeasurement && !prim.peek()) Thread.onSpinWait()
+      if (prim.peek()) bh.consume(prim.take())
+    case "ZIO_OBJECT" =>
+      var v = rb.take()
+      while (!control.stopMeasurement && (v eq null)) { Thread.onSpinWait(); v = rb.take() }
+      if (v ne null) bh.consume(v)
+    case "ABQ" =>
+      var v = abq.poll()
+      while (!control.stopMeasurement && (v eq null)) { Thread.onSpinWait(); v = abq.poll() }
+      if (v ne null) bh.consume(v)
+    case "JCTOOLS_SPSC" =>
+      var v = jcq.poll()
+      while (!control.stopMeasurement && (v eq null)) { Thread.onSpinWait(); v = jcq.poll() }
+      if (v ne null) bh.consume(v)
+  }
+}

--- a/ringbuffer/jvm/src/main/scala/zio/blocks/ringbuffer/DoubleSpscRingBuffer.scala
+++ b/ringbuffer/jvm/src/main/scala/zio/blocks/ringbuffer/DoubleSpscRingBuffer.scala
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.ringbuffer
+
+import java.lang.invoke.{MethodHandles, VarHandle}
+
+private[ringbuffer] class DoubleSpscPad0 {
+  var p00, p01, p02, p03, p04, p05, p06, p07, p08, p09, p0a, p0b, p0c, p0d, p0e, p0f: Long = 0L
+}
+
+private[ringbuffer] class DoubleSpscProducerFields extends DoubleSpscPad0 {
+  var producerIndex: Long = 0L
+  var producerLimit: Long = 0L
+}
+
+private[ringbuffer] class DoubleSpscPad1 extends DoubleSpscProducerFields {
+  var p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p1a, p1b, p1c, p1d, p1e, p1f: Long = 0L
+}
+
+private[ringbuffer] class DoubleSpscConsumerFields extends DoubleSpscPad1 {
+  var consumerIndex: Long = 0L
+}
+
+private[ringbuffer] class DoubleSpscPad2 extends DoubleSpscConsumerFields {
+  var p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p2a, p2b, p2c, p2d, p2e, p2f: Long = 0L
+}
+
+/**
+ * High-performance non-blocking SPSC ring buffer specialized for `Double`.
+ *
+ * Layout: a single `Array[Long]` storing raw `doubleToRawLongBits`. The
+ * FastFlow signal uses two reserved NaN bit patterns: `EMPTY_BITS`
+ * (`0xFFF8_0000_0000_0001L`) is the empty marker, `DONE_BITS`
+ * (`0xFFF8_0000_0000_0002L`) is the in-band end-of-stream marker. If the user
+ * offers a `Double` whose raw bits happen to equal either reserved pattern, it
+ * is canonicalized to `Double.NaN`'s standard bit pattern
+ * (`0x7FF8_0000_0000_0000L`) on insertion.
+ *
+ * **This canonicalization is unobservable**: IEEE 754 guarantees `NaN != NaN`,
+ * all NaNs compare equal under reference NaN semantics, and there is no
+ * portable Scala/Java way to round-trip a specific NaN payload through
+ * arithmetic. The remapping only affects two specific raw bit patterns, which
+ * the user could not have meaningfully produced through normal floating-point
+ * operations.
+ *
+ * In-band "done" sentinel: producers can call `offerDone()` to insert the
+ * end-of-stream marker after the last data value. Consumers reading via
+ * `pollPacked()` receive `EMPTY_BITS` for empty, `DONE_BITS` for the sentinel,
+ * or the raw `doubleToRawLongBits` value for data. This removes the need for a
+ * separate control queue alongside the data queue.
+ *
+ * One memory-ordered op per insert/remove, one cache line per slot.
+ *
+ * SPSC: one producer thread, one consumer thread.
+ *
+ * @param capacity
+ *   must be a positive power of two
+ */
+final class DoubleSpscRingBuffer(val capacity: Int) extends DoubleSpscPad2 {
+  require(capacity > 0 && (capacity & (capacity - 1)) == 0, s"capacity must be a positive power of 2, got: $capacity")
+
+  import DoubleSpscRingBuffer._
+
+  private val mask: Long        = (capacity - 1).toLong
+  private val data: Array[Long] = {
+    val a = new Array[Long](capacity)
+    java.util.Arrays.fill(a, EMPTY_BITS)
+    a
+  }
+  private val lookAheadStep: Long = Math.max(1, Math.min(capacity / 4, 4096)).toLong
+
+  def offer(a: Double): Boolean = {
+    val pIdx = producerIndex
+    if (pIdx >= producerLimit) {
+      if (!offerSlowPath(pIdx)) return false
+    }
+    val offset  = (pIdx & mask).toInt
+    val rawBits = java.lang.Double.doubleToRawLongBits(a)
+    val toStore = if (rawBits == EMPTY_BITS || rawBits == DONE_BITS) CANONICAL_NAN_BITS else rawBits
+    LONG_HANDLE.setRelease(data, offset, toStore)
+    PRODUCER_INDEX.setOpaque(this, pIdx + 1L)
+    true
+  }
+
+  /**
+   * Insert the in-band done sentinel. Returns `false` if the buffer is full;
+   * the caller is expected to retry until it succeeds.
+   */
+  def offerDone(): Boolean = {
+    val pIdx = producerIndex
+    if (pIdx >= producerLimit) {
+      if (!offerSlowPath(pIdx)) return false
+    }
+    val offset = (pIdx & mask).toInt
+    LONG_HANDLE.setRelease(data, offset, DONE_BITS)
+    PRODUCER_INDEX.setOpaque(this, pIdx + 1L)
+    true
+  }
+
+  def peek(): Boolean = {
+    val offset = (consumerIndex & mask).toInt
+    (LONG_HANDLE.getAcquire(data, offset): Long) != EMPTY_BITS
+  }
+
+  def take(): Double = {
+    val cIdx   = consumerIndex
+    val offset = (cIdx & mask).toInt
+    val bits   = (LONG_HANDLE.getAcquire(data, offset): Long)
+    if (bits == EMPTY_BITS) return java.lang.Double.longBitsToDouble(EMPTY_BITS)
+    LONG_HANDLE.setRelease(data, offset, EMPTY_BITS)
+    CONSUMER_INDEX.setOpaque(this, cIdx + 1L)
+    java.lang.Double.longBitsToDouble(bits)
+  }
+
+  /**
+   * Atomically polls the next slot and returns the raw bits:
+   *   - `EMPTY_BITS` — slot is empty; consumer index is NOT advanced.
+   *   - `DONE_BITS` — in-band done sentinel; consumer index advanced.
+   *   - any other value — `doubleToRawLongBits(value)` for the payload;
+   *     consumer index advanced. Decode with `Double.longBitsToDouble`.
+   */
+  def pollPacked(): Long = {
+    val cIdx   = consumerIndex
+    val offset = (cIdx & mask).toInt
+    val bits   = (LONG_HANDLE.getAcquire(data, offset): Long)
+    if (bits == EMPTY_BITS) return EMPTY_BITS
+    LONG_HANDLE.setRelease(data, offset, EMPTY_BITS)
+    CONSUMER_INDEX.setOpaque(this, cIdx + 1L)
+    bits
+  }
+
+  def isEmpty: Boolean = {
+    val cIdx = CONSUMER_INDEX.getAcquire(this).asInstanceOf[Long]
+    val pIdx = PRODUCER_INDEX.getAcquire(this).asInstanceOf[Long]
+    pIdx == cIdx
+  }
+
+  def isFull: Boolean = {
+    val cIdx = CONSUMER_INDEX.getAcquire(this).asInstanceOf[Long]
+    val pIdx = PRODUCER_INDEX.getAcquire(this).asInstanceOf[Long]
+    (pIdx - cIdx).toInt == capacity
+  }
+
+  def size: Int = {
+    val cIdx = CONSUMER_INDEX.getAcquire(this).asInstanceOf[Long]
+    val pIdx = PRODUCER_INDEX.getAcquire(this).asInstanceOf[Long]
+    (pIdx - cIdx).toInt
+  }
+
+  private def offerSlowPath(pIdx: Long): Boolean = {
+    val lookAheadOffset = ((pIdx + lookAheadStep) & mask).toInt
+    if ((LONG_HANDLE.getAcquire(data, lookAheadOffset): Long) == EMPTY_BITS) {
+      producerLimit = pIdx + lookAheadStep
+      true
+    } else {
+      val currentOffset = (pIdx & mask).toInt
+      if ((LONG_HANDLE.getAcquire(data, currentOffset): Long) != EMPTY_BITS) {
+        false
+      } else {
+        producerLimit = pIdx + 1L
+        true
+      }
+    }
+  }
+}
+
+object DoubleSpscRingBuffer {
+
+  /** Reserved NaN bit pattern used as the empty-slot marker. */
+  final val EMPTY_BITS: Long = 0xfff8000000000001L
+
+  /** Reserved NaN bit pattern used as the in-band done sentinel. */
+  final val DONE_BITS: Long = 0xfff8000000000002L
+
+  // Canonical NaN bit pattern (matches `Double.NaN`).
+  private final val CANONICAL_NAN_BITS: Long = 0x7ff8000000000000L
+
+  private val PRODUCER_INDEX: VarHandle =
+    MethodHandles
+      .privateLookupIn(classOf[DoubleSpscProducerFields], MethodHandles.lookup())
+      .findVarHandle(classOf[DoubleSpscProducerFields], "producerIndex", classOf[Long])
+
+  private val CONSUMER_INDEX: VarHandle =
+    MethodHandles
+      .privateLookupIn(classOf[DoubleSpscConsumerFields], MethodHandles.lookup())
+      .findVarHandle(classOf[DoubleSpscConsumerFields], "consumerIndex", classOf[Long])
+
+  private val LONG_HANDLE: VarHandle = MethodHandles.arrayElementVarHandle(classOf[Array[Long]])
+
+  def apply(capacity: Int): DoubleSpscRingBuffer = new DoubleSpscRingBuffer(capacity)
+}

--- a/ringbuffer/jvm/src/main/scala/zio/blocks/ringbuffer/FloatSpscRingBuffer.scala
+++ b/ringbuffer/jvm/src/main/scala/zio/blocks/ringbuffer/FloatSpscRingBuffer.scala
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.ringbuffer
+
+import java.lang.invoke.{MethodHandles, VarHandle}
+
+private[ringbuffer] class FloatSpscPad0 {
+  var p00, p01, p02, p03, p04, p05, p06, p07, p08, p09, p0a, p0b, p0c, p0d, p0e, p0f: Long = 0L
+}
+
+private[ringbuffer] class FloatSpscProducerFields extends FloatSpscPad0 {
+  var producerIndex: Long = 0L
+  var producerLimit: Long = 0L
+}
+
+private[ringbuffer] class FloatSpscPad1 extends FloatSpscProducerFields {
+  var p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p1a, p1b, p1c, p1d, p1e, p1f: Long = 0L
+}
+
+private[ringbuffer] class FloatSpscConsumerFields extends FloatSpscPad1 {
+  var consumerIndex: Long = 0L
+}
+
+private[ringbuffer] class FloatSpscPad2 extends FloatSpscConsumerFields {
+  var p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p2a, p2b, p2c, p2d, p2e, p2f: Long = 0L
+}
+
+/**
+ * High-performance non-blocking SPSC ring buffer specialized for `Float`.
+ *
+ * Layout: a single `Array[Long]`. Each slot packs both the data and the
+ * occupancy/control signal into one 64-bit word:
+ *   - bits 32..63: tag (`0` = empty, `1` = data, `2` = done)
+ *   - bits 0..31: `Float.floatToRawIntBits(value)` (only meaningful when tag ==
+ *     1)
+ *
+ * The packed slot itself is the FastFlow signal; one memory-ordered op per
+ * insert/remove, one cache line per slot. All `Float` values are representable
+ * (including `0.0f`, `NaN`, `+/-Inf`); the non-zero tag guarantees a stored
+ * slot is never zero.
+ *
+ * In-band "done" sentinel: producers can call `offerDone()` to insert an
+ * end-of-stream marker after the last data value. Consumers reading via
+ * `pollPacked()` receive `EMPTY_PACKED` for empty, `DONE_PACKED` for the
+ * sentinel, or a `TAG_FULL | float bits` value for data. This removes the need
+ * for a separate control queue alongside the data queue.
+ *
+ * SPSC: one producer thread, one consumer thread.
+ *
+ * @param capacity
+ *   must be a positive power of two
+ */
+final class FloatSpscRingBuffer(val capacity: Int) extends FloatSpscPad2 {
+  require(capacity > 0 && (capacity & (capacity - 1)) == 0, s"capacity must be a positive power of 2, got: $capacity")
+
+  import FloatSpscRingBuffer._
+
+  private val mask: Long          = (capacity - 1).toLong
+  private val data: Array[Long]   = new Array[Long](capacity)
+  private val lookAheadStep: Long = Math.max(1, Math.min(capacity / 4, 4096)).toLong
+
+  def offer(a: Float): Boolean = {
+    val pIdx = producerIndex
+    if (pIdx >= producerLimit) {
+      if (!offerSlowPath(pIdx)) return false
+    }
+    val offset = (pIdx & mask).toInt
+    val packed = TAG_FULL | (java.lang.Float.floatToRawIntBits(a).toLong & LOW32_MASK)
+    LONG_HANDLE.setRelease(data, offset, packed)
+    PRODUCER_INDEX.setOpaque(this, pIdx + 1L)
+    true
+  }
+
+  /**
+   * Insert the in-band done sentinel. Returns `false` if the buffer is full;
+   * the caller is expected to retry until it succeeds.
+   */
+  def offerDone(): Boolean = {
+    val pIdx = producerIndex
+    if (pIdx >= producerLimit) {
+      if (!offerSlowPath(pIdx)) return false
+    }
+    val offset = (pIdx & mask).toInt
+    LONG_HANDLE.setRelease(data, offset, DONE_PACKED)
+    PRODUCER_INDEX.setOpaque(this, pIdx + 1L)
+    true
+  }
+
+  def peek(): Boolean = {
+    val offset = (consumerIndex & mask).toInt
+    (LONG_HANDLE.getAcquire(data, offset): Long) != 0L
+  }
+
+  def take(): Float = {
+    val cIdx   = consumerIndex
+    val offset = (cIdx & mask).toInt
+    val packed = (LONG_HANDLE.getAcquire(data, offset): Long)
+    if (packed == 0L) return 0.0f
+    LONG_HANDLE.setRelease(data, offset, 0L)
+    CONSUMER_INDEX.setOpaque(this, cIdx + 1L)
+    java.lang.Float.intBitsToFloat(packed.toInt)
+  }
+
+  /**
+   * Atomically polls the next slot and returns the raw packed value:
+   *   - `EMPTY_PACKED` (`0L`) — slot is empty; consumer index is NOT advanced.
+   *   - `DONE_PACKED` — in-band done sentinel; consumer index advanced.
+   *   - any other value — packed data (`TAG_FULL | floatToRawIntBits`);
+   *     consumer index advanced. The payload is
+   *     `Float.intBitsToFloat(packed.toInt)`.
+   */
+  def pollPacked(): Long = {
+    val cIdx   = consumerIndex
+    val offset = (cIdx & mask).toInt
+    val packed = (LONG_HANDLE.getAcquire(data, offset): Long)
+    if (packed == 0L) return 0L
+    LONG_HANDLE.setRelease(data, offset, 0L)
+    CONSUMER_INDEX.setOpaque(this, cIdx + 1L)
+    packed
+  }
+
+  def isEmpty: Boolean = {
+    val cIdx = CONSUMER_INDEX.getAcquire(this).asInstanceOf[Long]
+    val pIdx = PRODUCER_INDEX.getAcquire(this).asInstanceOf[Long]
+    pIdx == cIdx
+  }
+
+  def isFull: Boolean = {
+    val cIdx = CONSUMER_INDEX.getAcquire(this).asInstanceOf[Long]
+    val pIdx = PRODUCER_INDEX.getAcquire(this).asInstanceOf[Long]
+    (pIdx - cIdx).toInt == capacity
+  }
+
+  def size: Int = {
+    val cIdx = CONSUMER_INDEX.getAcquire(this).asInstanceOf[Long]
+    val pIdx = PRODUCER_INDEX.getAcquire(this).asInstanceOf[Long]
+    (pIdx - cIdx).toInt
+  }
+
+  private def offerSlowPath(pIdx: Long): Boolean = {
+    val lookAheadOffset = ((pIdx + lookAheadStep) & mask).toInt
+    if ((LONG_HANDLE.getAcquire(data, lookAheadOffset): Long) == 0L) {
+      producerLimit = pIdx + lookAheadStep
+      true
+    } else {
+      val currentOffset = (pIdx & mask).toInt
+      if ((LONG_HANDLE.getAcquire(data, currentOffset): Long) != 0L) {
+        false
+      } else {
+        producerLimit = pIdx + 1L
+        true
+      }
+    }
+  }
+}
+
+object FloatSpscRingBuffer {
+
+  /** Packed value returned by `pollPacked()` when the next slot is empty. */
+  final val EMPTY_PACKED: Long = 0L
+
+  /** Packed value returned by `pollPacked()` for the in-band done sentinel. */
+  final val DONE_PACKED: Long = 2L << 32
+
+  private final val TAG_FULL: Long   = 1L << 32
+  private final val LOW32_MASK: Long = 0xffffffffL
+
+  private val PRODUCER_INDEX: VarHandle =
+    MethodHandles
+      .privateLookupIn(classOf[FloatSpscProducerFields], MethodHandles.lookup())
+      .findVarHandle(classOf[FloatSpscProducerFields], "producerIndex", classOf[Long])
+
+  private val CONSUMER_INDEX: VarHandle =
+    MethodHandles
+      .privateLookupIn(classOf[FloatSpscConsumerFields], MethodHandles.lookup())
+      .findVarHandle(classOf[FloatSpscConsumerFields], "consumerIndex", classOf[Long])
+
+  private val LONG_HANDLE: VarHandle = MethodHandles.arrayElementVarHandle(classOf[Array[Long]])
+
+  def apply(capacity: Int): FloatSpscRingBuffer = new FloatSpscRingBuffer(capacity)
+}

--- a/ringbuffer/jvm/src/main/scala/zio/blocks/ringbuffer/IntSpscRingBuffer.scala
+++ b/ringbuffer/jvm/src/main/scala/zio/blocks/ringbuffer/IntSpscRingBuffer.scala
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.ringbuffer
+
+import java.lang.invoke.{MethodHandles, VarHandle}
+
+private[ringbuffer] class IntSpscPad0 {
+  var p00, p01, p02, p03, p04, p05, p06, p07, p08, p09, p0a, p0b, p0c, p0d, p0e, p0f: Long = 0L
+}
+
+private[ringbuffer] class IntSpscProducerFields extends IntSpscPad0 {
+  var producerIndex: Long = 0L
+  var producerLimit: Long = 0L
+}
+
+private[ringbuffer] class IntSpscPad1 extends IntSpscProducerFields {
+  var p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p1a, p1b, p1c, p1d, p1e, p1f: Long = 0L
+}
+
+private[ringbuffer] class IntSpscConsumerFields extends IntSpscPad1 {
+  var consumerIndex: Long = 0L
+}
+
+private[ringbuffer] class IntSpscPad2 extends IntSpscConsumerFields {
+  var p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p2a, p2b, p2c, p2d, p2e, p2f: Long = 0L
+}
+
+/**
+ * High-performance non-blocking SPSC ring buffer specialized for `Int`.
+ *
+ * Layout: a single `Array[Long]`. Each slot packs both the data and the
+ * occupancy/control signal into one 64-bit word:
+ *   - bits 32..63: tag (`0` = empty, `1` = data, `2` = done)
+ *   - bits 0..31: the user's `Int` value (only meaningful when tag == 1)
+ *
+ * This makes the slot's own value act as the FastFlow signal: every
+ * insert/remove is a single memory-ordered op on a single cache line. Zero is
+ * the empty marker because the array is zero-initialized; a stored value with a
+ * non-zero tag is always non-zero regardless of the `Int` payload (including
+ * `0`, `Int.MinValue`, `Int.MaxValue`, etc.).
+ *
+ * In-band "done" sentinel: producers can call `offerDone()` to insert an
+ * end-of-stream marker after the last data value. Consumers reading via
+ * `pollPacked()` receive `EMPTY_PACKED` for empty, `DONE_PACKED` for the
+ * sentinel, or a `TAG_FULL | Int payload` value for data. This removes the need
+ * for a separate control queue alongside the data queue.
+ *
+ * SPSC: one producer thread, one consumer thread.
+ *
+ * @param capacity
+ *   must be a positive power of two
+ */
+final class IntSpscRingBuffer(val capacity: Int) extends IntSpscPad2 {
+  require(capacity > 0 && (capacity & (capacity - 1)) == 0, s"capacity must be a positive power of 2, got: $capacity")
+
+  import IntSpscRingBuffer._
+
+  private val mask: Long          = (capacity - 1).toLong
+  private val data: Array[Long]   = new Array[Long](capacity)
+  private val lookAheadStep: Long = Math.max(1, Math.min(capacity / 4, 4096)).toLong
+
+  def offer(a: Int): Boolean = {
+    val pIdx = producerIndex
+    if (pIdx >= producerLimit) {
+      if (!offerSlowPath(pIdx)) return false
+    }
+    val offset = (pIdx & mask).toInt
+    val packed = TAG_FULL | (a.toLong & LOW32_MASK)
+    LONG_HANDLE.setRelease(data, offset, packed)
+    PRODUCER_INDEX.setOpaque(this, pIdx + 1L)
+    true
+  }
+
+  /**
+   * Insert the in-band done sentinel. Returns `false` if the buffer is full;
+   * the caller is expected to retry until it succeeds.
+   */
+  def offerDone(): Boolean = {
+    val pIdx = producerIndex
+    if (pIdx >= producerLimit) {
+      if (!offerSlowPath(pIdx)) return false
+    }
+    val offset = (pIdx & mask).toInt
+    LONG_HANDLE.setRelease(data, offset, DONE_PACKED)
+    PRODUCER_INDEX.setOpaque(this, pIdx + 1L)
+    true
+  }
+
+  def peek(): Boolean = {
+    val offset = (consumerIndex & mask).toInt
+    (LONG_HANDLE.getAcquire(data, offset): Long) != 0L
+  }
+
+  def take(): Int = {
+    val cIdx   = consumerIndex
+    val offset = (cIdx & mask).toInt
+    val packed = (LONG_HANDLE.getAcquire(data, offset): Long)
+    if (packed == 0L) return 0
+    LONG_HANDLE.setRelease(data, offset, 0L)
+    CONSUMER_INDEX.setOpaque(this, cIdx + 1L)
+    packed.toInt
+  }
+
+  /**
+   * Atomically polls the next slot and returns the raw packed value:
+   *   - `EMPTY_PACKED` (`0L`) — slot is empty; consumer index is NOT advanced.
+   *   - `DONE_PACKED` — in-band done sentinel; consumer index advanced.
+   *   - any other value — packed data (`TAG_FULL | (a & LOW32_MASK)`); consumer
+   *     index advanced. The payload is `packed.toInt`.
+   */
+  def pollPacked(): Long = {
+    val cIdx   = consumerIndex
+    val offset = (cIdx & mask).toInt
+    val packed = (LONG_HANDLE.getAcquire(data, offset): Long)
+    if (packed == 0L) return 0L
+    LONG_HANDLE.setRelease(data, offset, 0L)
+    CONSUMER_INDEX.setOpaque(this, cIdx + 1L)
+    packed
+  }
+
+  def isEmpty: Boolean = {
+    val cIdx = CONSUMER_INDEX.getAcquire(this).asInstanceOf[Long]
+    val pIdx = PRODUCER_INDEX.getAcquire(this).asInstanceOf[Long]
+    pIdx == cIdx
+  }
+
+  def isFull: Boolean = {
+    val cIdx = CONSUMER_INDEX.getAcquire(this).asInstanceOf[Long]
+    val pIdx = PRODUCER_INDEX.getAcquire(this).asInstanceOf[Long]
+    (pIdx - cIdx).toInt == capacity
+  }
+
+  def size: Int = {
+    val cIdx = CONSUMER_INDEX.getAcquire(this).asInstanceOf[Long]
+    val pIdx = PRODUCER_INDEX.getAcquire(this).asInstanceOf[Long]
+    (pIdx - cIdx).toInt
+  }
+
+  private def offerSlowPath(pIdx: Long): Boolean = {
+    val lookAheadOffset = ((pIdx + lookAheadStep) & mask).toInt
+    if ((LONG_HANDLE.getAcquire(data, lookAheadOffset): Long) == 0L) {
+      producerLimit = pIdx + lookAheadStep
+      true
+    } else {
+      val currentOffset = (pIdx & mask).toInt
+      if ((LONG_HANDLE.getAcquire(data, currentOffset): Long) != 0L) {
+        false
+      } else {
+        producerLimit = pIdx + 1L
+        true
+      }
+    }
+  }
+}
+
+object IntSpscRingBuffer {
+
+  /** Packed value returned by `pollPacked()` when the next slot is empty. */
+  final val EMPTY_PACKED: Long = 0L
+
+  /** Packed value returned by `pollPacked()` for the in-band done sentinel. */
+  final val DONE_PACKED: Long = 2L << 32
+
+  private final val TAG_FULL: Long   = 1L << 32
+  private final val LOW32_MASK: Long = 0xffffffffL
+
+  private val PRODUCER_INDEX: VarHandle =
+    MethodHandles
+      .privateLookupIn(classOf[IntSpscProducerFields], MethodHandles.lookup())
+      .findVarHandle(classOf[IntSpscProducerFields], "producerIndex", classOf[Long])
+
+  private val CONSUMER_INDEX: VarHandle =
+    MethodHandles
+      .privateLookupIn(classOf[IntSpscConsumerFields], MethodHandles.lookup())
+      .findVarHandle(classOf[IntSpscConsumerFields], "consumerIndex", classOf[Long])
+
+  private val LONG_HANDLE: VarHandle = MethodHandles.arrayElementVarHandle(classOf[Array[Long]])
+
+  def apply(capacity: Int): IntSpscRingBuffer = new IntSpscRingBuffer(capacity)
+}

--- a/ringbuffer/jvm/src/main/scala/zio/blocks/ringbuffer/LongSpscRingBuffer.scala
+++ b/ringbuffer/jvm/src/main/scala/zio/blocks/ringbuffer/LongSpscRingBuffer.scala
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.ringbuffer
+
+import java.lang.invoke.{MethodHandles, VarHandle}
+
+private[ringbuffer] class LongSpscPad0 {
+  var p00, p01, p02, p03, p04, p05, p06, p07, p08, p09, p0a, p0b, p0c, p0d, p0e, p0f: Long = 0L
+}
+
+private[ringbuffer] class LongSpscProducerFields extends LongSpscPad0 {
+  var producerIndex: Long = 0L
+  var producerLimit: Long = 0L
+}
+
+private[ringbuffer] class LongSpscPad1 extends LongSpscProducerFields {
+  var p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p1a, p1b, p1c, p1d, p1e, p1f: Long = 0L
+}
+
+private[ringbuffer] class LongSpscConsumerFields extends LongSpscPad1 {
+  var consumerIndex: Long = 0L
+}
+
+private[ringbuffer] class LongSpscPad2 extends LongSpscConsumerFields {
+  var p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p2a, p2b, p2c, p2d, p2e, p2f: Long = 0L
+}
+
+/**
+ * High-performance non-blocking SPSC ring buffer specialized for `Long`.
+ *
+ * Layout: a single `Array[Long]`. Since every 64-bit pattern is a legal `Long`,
+ * the FastFlow signal requires reserving sentinel values: `EMPTY`
+ * (`Long.MinValue`) means "slot empty" and `DONE` (`Long.MinValue + 1L`) is the
+ * in-band end-of-stream marker. The array is pre-filled with `EMPTY` at
+ * construction.
+ *
+ * **`offer(EMPTY)` and `offer(DONE)` throw `IllegalArgumentException`** (the
+ * same shape of contract as `SpscRingBuffer.offer(null)`). This costs two bit
+ * patterns out of 2^64 in exchange for a single memory-ordered op per
+ * insert/remove on a single cache line per slot, and removes the need for a
+ * separate control queue.
+ *
+ * In-band "done" sentinel: producers can call `offerDone()` to insert the
+ * end-of-stream marker after the last data value. Consumers reading via
+ * `pollPacked()` receive `EMPTY` for empty, `DONE` for the sentinel, or the raw
+ * `Long` payload for data.
+ *
+ * SPSC: one producer thread, one consumer thread.
+ *
+ * @param capacity
+ *   must be a positive power of two
+ */
+final class LongSpscRingBuffer(val capacity: Int) extends LongSpscPad2 {
+  require(capacity > 0 && (capacity & (capacity - 1)) == 0, s"capacity must be a positive power of 2, got: $capacity")
+
+  import LongSpscRingBuffer._
+
+  private val mask: Long        = (capacity - 1).toLong
+  private val data: Array[Long] = {
+    val a = new Array[Long](capacity)
+    java.util.Arrays.fill(a, EMPTY)
+    a
+  }
+  private val lookAheadStep: Long = Math.max(1, Math.min(capacity / 4, 4096)).toLong
+
+  def offer(a: Long): Boolean = {
+    if (a == EMPTY || a == DONE)
+      throw new IllegalArgumentException(
+        s"offer($a) is not permitted: Long.MinValue and Long.MinValue + 1L are reserved sentinels"
+      )
+    val pIdx = producerIndex
+    if (pIdx >= producerLimit) {
+      if (!offerSlowPath(pIdx)) return false
+    }
+    val offset = (pIdx & mask).toInt
+    LONG_HANDLE.setRelease(data, offset, a)
+    PRODUCER_INDEX.setOpaque(this, pIdx + 1L)
+    true
+  }
+
+  /**
+   * Insert the in-band done sentinel. Returns `false` if the buffer is full;
+   * the caller is expected to retry until it succeeds.
+   */
+  def offerDone(): Boolean = {
+    val pIdx = producerIndex
+    if (pIdx >= producerLimit) {
+      if (!offerSlowPath(pIdx)) return false
+    }
+    val offset = (pIdx & mask).toInt
+    LONG_HANDLE.setRelease(data, offset, DONE)
+    PRODUCER_INDEX.setOpaque(this, pIdx + 1L)
+    true
+  }
+
+  def peek(): Boolean = {
+    val offset = (consumerIndex & mask).toInt
+    (LONG_HANDLE.getAcquire(data, offset): Long) != EMPTY
+  }
+
+  def take(): Long = {
+    val cIdx   = consumerIndex
+    val offset = (cIdx & mask).toInt
+    val e      = (LONG_HANDLE.getAcquire(data, offset): Long)
+    if (e == EMPTY) return EMPTY
+    LONG_HANDLE.setRelease(data, offset, EMPTY)
+    CONSUMER_INDEX.setOpaque(this, cIdx + 1L)
+    e
+  }
+
+  /**
+   * Atomically polls the next slot:
+   *   - `EMPTY` (`Long.MinValue`) — slot is empty; consumer index NOT advanced.
+   *   - `DONE` (`Long.MinValue + 1L`) — in-band done sentinel; consumer index
+   *     advanced.
+   *   - any other value — the user-visible data; consumer index advanced.
+   */
+  def pollPacked(): Long = {
+    val cIdx   = consumerIndex
+    val offset = (cIdx & mask).toInt
+    val e      = (LONG_HANDLE.getAcquire(data, offset): Long)
+    if (e == EMPTY) return EMPTY
+    LONG_HANDLE.setRelease(data, offset, EMPTY)
+    CONSUMER_INDEX.setOpaque(this, cIdx + 1L)
+    e
+  }
+
+  def isEmpty: Boolean = {
+    val cIdx = CONSUMER_INDEX.getAcquire(this).asInstanceOf[Long]
+    val pIdx = PRODUCER_INDEX.getAcquire(this).asInstanceOf[Long]
+    pIdx == cIdx
+  }
+
+  def isFull: Boolean = {
+    val cIdx = CONSUMER_INDEX.getAcquire(this).asInstanceOf[Long]
+    val pIdx = PRODUCER_INDEX.getAcquire(this).asInstanceOf[Long]
+    (pIdx - cIdx).toInt == capacity
+  }
+
+  def size: Int = {
+    val cIdx = CONSUMER_INDEX.getAcquire(this).asInstanceOf[Long]
+    val pIdx = PRODUCER_INDEX.getAcquire(this).asInstanceOf[Long]
+    (pIdx - cIdx).toInt
+  }
+
+  private def offerSlowPath(pIdx: Long): Boolean = {
+    val lookAheadOffset = ((pIdx + lookAheadStep) & mask).toInt
+    if ((LONG_HANDLE.getAcquire(data, lookAheadOffset): Long) == EMPTY) {
+      producerLimit = pIdx + lookAheadStep
+      true
+    } else {
+      val currentOffset = (pIdx & mask).toInt
+      if ((LONG_HANDLE.getAcquire(data, currentOffset): Long) != EMPTY) {
+        false
+      } else {
+        producerLimit = pIdx + 1L
+        true
+      }
+    }
+  }
+}
+
+object LongSpscRingBuffer {
+
+  /** Reserved sentinel: slot is empty. */
+  final val EMPTY: Long = Long.MinValue
+
+  /** Reserved sentinel: in-band end-of-stream marker. */
+  final val DONE: Long = Long.MinValue + 1L
+
+  private val PRODUCER_INDEX: VarHandle =
+    MethodHandles
+      .privateLookupIn(classOf[LongSpscProducerFields], MethodHandles.lookup())
+      .findVarHandle(classOf[LongSpscProducerFields], "producerIndex", classOf[Long])
+
+  private val CONSUMER_INDEX: VarHandle =
+    MethodHandles
+      .privateLookupIn(classOf[LongSpscConsumerFields], MethodHandles.lookup())
+      .findVarHandle(classOf[LongSpscConsumerFields], "consumerIndex", classOf[Long])
+
+  private val LONG_HANDLE: VarHandle = MethodHandles.arrayElementVarHandle(classOf[Array[Long]])
+
+  def apply(capacity: Int): LongSpscRingBuffer = new LongSpscRingBuffer(capacity)
+}

--- a/ringbuffer/jvm/src/main/scala/zio/blocks/ringbuffer/SpscRingBuffer.scala
+++ b/ringbuffer/jvm/src/main/scala/zio/blocks/ringbuffer/SpscRingBuffer.scala
@@ -94,7 +94,7 @@ final class SpscRingBuffer[A <: AnyRef](val capacity: Int) extends SpscPad2 {
 
     val offset = (pIdx & m).toInt
     ARRAY_HANDLE.setRelease(buf, offset, a.asInstanceOf[AnyRef])
-    PRODUCER_INDEX.setRelease(this, pIdx + 1L)
+    PRODUCER_INDEX.setOpaque(this, pIdx + 1L)
     true
   }
 
@@ -117,7 +117,7 @@ final class SpscRingBuffer[A <: AnyRef](val capacity: Int) extends SpscPad2 {
     if (e eq null) return null.asInstanceOf[A]
 
     ARRAY_HANDLE.setRelease(buf, offset, null.asInstanceOf[AnyRef])
-    CONSUMER_INDEX.setRelease(this, cIdx + 1L)
+    CONSUMER_INDEX.setOpaque(this, cIdx + 1L)
     e
   }
 
@@ -181,7 +181,7 @@ final class SpscRingBuffer[A <: AnyRef](val capacity: Int) extends SpscPad2 {
       if (e eq null) return count
       ARRAY_HANDLE.setRelease(buf, offset, null.asInstanceOf[AnyRef])
       cIdx += 1L
-      CONSUMER_INDEX.setRelease(this, cIdx)
+      CONSUMER_INDEX.setOpaque(this, cIdx)
       count += 1
       consumer(e)
     }
@@ -236,7 +236,7 @@ final class SpscRingBuffer[A <: AnyRef](val capacity: Int) extends SpscPad2 {
       val offset = (pIdx & m).toInt
       ARRAY_HANDLE.setRelease(buf, offset, a.asInstanceOf[AnyRef])
       pIdx += 1L
-      PRODUCER_INDEX.setRelease(this, pIdx)
+      PRODUCER_INDEX.setOpaque(this, pIdx)
       count += 1
     }
     producerLimit = pLim
@@ -253,6 +253,7 @@ final class SpscRingBuffer[A <: AnyRef](val capacity: Int) extends SpscPad2 {
       if ((ARRAY_HANDLE.getAcquire(buf, currentOffset): AnyRef) ne null) {
         false
       } else {
+        producerLimit = pIdx + 1
         true
       }
     }

--- a/ringbuffer/jvm/src/test/scala/zio/blocks/ringbuffer/PrimitiveSpscRingBufferSpec.scala
+++ b/ringbuffer/jvm/src/test/scala/zio/blocks/ringbuffer/PrimitiveSpscRingBufferSpec.scala
@@ -1,0 +1,695 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.ringbuffer
+
+import zio._
+import zio.test._
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
+
+object PrimitiveSpscRingBufferSpec extends ZIOSpecDefault {
+  def spec = suite("PrimitiveSpscRingBufferSpec")(
+    intSuite,
+    longSuite,
+    doubleSuite,
+    floatSuite,
+    inBandDoneSuite
+  )
+
+  private val inBandDoneSuite = suite("in-band DONE sentinel")(
+    test("IntSpscRingBuffer: offerDone + pollPacked produces DONE_PACKED") {
+      val rb = IntSpscRingBuffer(4)
+      rb.offer(42)
+      rb.offerDone()
+      val p1 = rb.pollPacked()
+      val p2 = rb.pollPacked()
+      val p3 = rb.pollPacked()
+      assertTrue(
+        p1 != IntSpscRingBuffer.EMPTY_PACKED,
+        p1 != IntSpscRingBuffer.DONE_PACKED,
+        p1.toInt == 42,
+        p2 == IntSpscRingBuffer.DONE_PACKED,
+        p3 == IntSpscRingBuffer.EMPTY_PACKED
+      )
+    },
+    test("LongSpscRingBuffer: offerDone + pollPacked produces DONE") {
+      val rb = LongSpscRingBuffer(4)
+      rb.offer(123L)
+      rb.offerDone()
+      val p1 = rb.pollPacked()
+      val p2 = rb.pollPacked()
+      val p3 = rb.pollPacked()
+      assertTrue(
+        p1 == 123L,
+        p2 == LongSpscRingBuffer.DONE,
+        p3 == LongSpscRingBuffer.EMPTY
+      )
+    },
+    test("FloatSpscRingBuffer: offerDone + pollPacked produces DONE_PACKED") {
+      val rb = FloatSpscRingBuffer(4)
+      rb.offer(3.14f)
+      rb.offerDone()
+      val p1: Long  = rb.pollPacked()
+      val p2: Long  = rb.pollPacked()
+      val p3: Long  = rb.pollPacked()
+      val f1: Float = java.lang.Float.intBitsToFloat(p1.toInt)
+      assertTrue(
+        p1 != FloatSpscRingBuffer.EMPTY_PACKED,
+        p1 != FloatSpscRingBuffer.DONE_PACKED,
+        f1 == 3.14f,
+        p2 == FloatSpscRingBuffer.DONE_PACKED,
+        p3 == FloatSpscRingBuffer.EMPTY_PACKED
+      )
+    },
+    test("DoubleSpscRingBuffer: offerDone + pollPacked produces DONE_BITS") {
+      val rb = DoubleSpscRingBuffer(4)
+      rb.offer(2.71)
+      rb.offerDone()
+      val p1: Long   = rb.pollPacked()
+      val p2: Long   = rb.pollPacked()
+      val p3: Long   = rb.pollPacked()
+      val d1: Double = java.lang.Double.longBitsToDouble(p1)
+      assertTrue(
+        d1 == 2.71,
+        p2 == DoubleSpscRingBuffer.DONE_BITS,
+        p3 == DoubleSpscRingBuffer.EMPTY_BITS
+      )
+    },
+    test("DONE is ordered after data in same Long queue") {
+      val rb = LongSpscRingBuffer(16)
+      var i  = 0L
+      while (i < 8L) {
+        rb.offer(i + 1)
+        i += 1L
+      }
+      rb.offerDone()
+      var sum = 0L
+      var p   = rb.pollPacked()
+      while (p != LongSpscRingBuffer.DONE && p != LongSpscRingBuffer.EMPTY) {
+        sum += p
+        p = rb.pollPacked()
+      }
+      assertTrue(p == LongSpscRingBuffer.DONE, sum == (1L + 2 + 3 + 4 + 5 + 6 + 7 + 8))
+    }
+  )
+
+  private val intSuite = suite("IntSpscRingBuffer")(
+    test("offer then peek then take") {
+      val rb = IntSpscRingBuffer(4)
+      assertTrue(rb.offer(42), rb.peek(), rb.take() == 42)
+    },
+    test("FIFO ordering") {
+      val rb = IntSpscRingBuffer(8)
+      rb.offer(1)
+      rb.offer(2)
+      rb.offer(3)
+      assertTrue(rb.peek(), rb.take() == 1, rb.peek(), rb.take() == 2, rb.peek(), rb.take() == 3)
+    },
+    test("full buffer rejects offer") {
+      val rb = IntSpscRingBuffer(2)
+      assertTrue(rb.offer(1), rb.offer(2), !rb.offer(3))
+    },
+    test("empty buffer reports no data") {
+      val rb = IntSpscRingBuffer(2)
+      assertTrue(!rb.peek())
+    },
+    test("isEmpty / isFull / size track occupancy") {
+      val rb = IntSpscRingBuffer(2)
+      val e0 = rb.isEmpty
+      val f0 = rb.isFull
+      val s0 = rb.size
+      rb.offer(1)
+      val e1 = rb.isEmpty
+      val f1 = rb.isFull
+      val s1 = rb.size
+      rb.offer(2)
+      val e2 = rb.isEmpty
+      val f2 = rb.isFull
+      val s2 = rb.size
+      rb.take()
+      val e3 = rb.isEmpty
+      val f3 = rb.isFull
+      val s3 = rb.size
+      assertTrue(
+        e0,
+        !f0,
+        s0 == 0,
+        !e1,
+        !f1,
+        s1 == 1,
+        !e2,
+        f2,
+        s2 == 2,
+        !e3,
+        !f3,
+        s3 == 1
+      )
+    },
+    test("capacity must be a positive power of two") {
+      val cases   = List(0, -1, 3, 5, 6, 7)
+      val results = cases.map { c =>
+        try { IntSpscRingBuffer(c); false }
+        catch { case _: IllegalArgumentException => true }
+      }
+      assertTrue(results.forall(identity))
+    },
+    test("capacity=1 boundary") {
+      val rb = IntSpscRingBuffer(1)
+      assertTrue(rb.offer(7), rb.peek(), rb.take() == 7, !rb.peek())
+    },
+    test("boundary values") {
+      val rb     = IntSpscRingBuffer(8)
+      val values = List(Int.MinValue, Int.MaxValue, 0, -1)
+      values.foreach(rb.offer)
+      val read = values.forall { expected =>
+        rb.peek() && rb.take() == expected
+      }
+      assertTrue(read, !rb.peek())
+    },
+    test("wrap-around fill drain refill") {
+      val rb = IntSpscRingBuffer(4)
+      assertTrue(rb.offer(1), rb.offer(2), rb.offer(3), rb.offer(4)) &&
+      assertTrue(
+        rb.peek(),
+        rb.take() == 1,
+        rb.peek(),
+        rb.take() == 2,
+        rb.peek(),
+        rb.take() == 3,
+        rb.peek(),
+        rb.take() == 4
+      ) &&
+      assertTrue(
+        rb.offer(5),
+        rb.offer(6),
+        rb.offer(7),
+        rb.offer(8),
+        rb.peek(),
+        rb.take() == 5,
+        rb.peek(),
+        rb.take() == 6,
+        rb.peek(),
+        rb.take() == 7,
+        rb.peek(),
+        rb.take() == 8
+      )
+    },
+    test("simple 1p1c stress 100k") {
+      ZIO.attemptBlocking {
+        val count       = 100_000
+        val expectedSum = count.toLong * (count - 1) / 2
+        val rb          = IntSpscRingBuffer(1024)
+
+        val producerDone = new CountDownLatch(1)
+        val consumerDone = new CountDownLatch(1)
+        val orderError   = new AtomicBoolean(false)
+        val actualSum    = new AtomicLong(0L)
+
+        val producer = new Thread(() => {
+          var i = 0
+          while (i < count) {
+            if (rb.offer(i)) i += 1
+            else Thread.onSpinWait()
+          }
+          producerDone.countDown()
+        })
+
+        val consumer = new Thread(() => {
+          var expected = 0
+          var received = 0
+          while (received < count) {
+            if (rb.peek()) {
+              val v = rb.take()
+              if (v != expected) orderError.set(true)
+              actualSum.addAndGet(v.toLong)
+              expected += 1
+              received += 1
+            } else Thread.onSpinWait()
+          }
+          consumerDone.countDown()
+        })
+
+        producer.start()
+        consumer.start()
+        producerDone.await()
+        consumerDone.await()
+
+        assertTrue(!orderError.get(), actualSum.get() == expectedSum, rb.isEmpty)
+      }
+    } @@ TestAspect.timeout(60.seconds)
+  )
+
+  private val longSuite = suite("LongSpscRingBuffer")(
+    test("offer then peek then take") {
+      val rb = LongSpscRingBuffer(4)
+      assertTrue(rb.offer(42L), rb.peek(), rb.take() == 42L)
+    },
+    test("FIFO ordering") {
+      val rb = LongSpscRingBuffer(8)
+      rb.offer(1L)
+      rb.offer(2L)
+      rb.offer(3L)
+      assertTrue(rb.peek(), rb.take() == 1L, rb.peek(), rb.take() == 2L, rb.peek(), rb.take() == 3L)
+    },
+    test("full buffer rejects offer") {
+      val rb = LongSpscRingBuffer(2)
+      assertTrue(rb.offer(1L), rb.offer(2L), !rb.offer(3L))
+    },
+    test("empty buffer reports no data") {
+      val rb = LongSpscRingBuffer(2)
+      assertTrue(!rb.peek())
+    },
+    test("isEmpty / isFull / size track occupancy") {
+      val rb = LongSpscRingBuffer(2)
+      val s0 = (rb.isEmpty, rb.isFull, rb.size)
+      rb.offer(1L)
+      val s1 = (rb.isEmpty, rb.isFull, rb.size)
+      rb.offer(2L)
+      val s2 = (rb.isEmpty, rb.isFull, rb.size)
+      rb.take()
+      val s3 = (rb.isEmpty, rb.isFull, rb.size)
+      assertTrue(
+        s0 == ((true, false, 0)),
+        s1 == ((false, false, 1)),
+        s2 == ((false, true, 2)),
+        s3 == ((false, false, 1))
+      )
+    },
+    test("capacity must be a positive power of two") {
+      val cases   = List(0, -1, 3, 5, 6, 7)
+      val results = cases.map { c =>
+        try { LongSpscRingBuffer(c); false }
+        catch { case _: IllegalArgumentException => true }
+      }
+      assertTrue(results.forall(identity))
+    },
+    test("capacity=1 boundary") {
+      val rb = LongSpscRingBuffer(1)
+      assertTrue(rb.offer(7L), rb.peek(), rb.take() == 7L, !rb.peek())
+    },
+    test("boundary values") {
+      val rb = LongSpscRingBuffer(8)
+      // Long.MinValue is the empty-slot sentinel and Long.MinValue + 1L is the
+      // in-band DONE sentinel; both are rejected on offer.
+      val values = List(Long.MinValue + 2L, Long.MaxValue, 0L, -1L)
+      values.foreach(rb.offer)
+      val read = values.forall { expected =>
+        rb.peek() && rb.take() == expected
+      }
+      assertTrue(read, !rb.peek())
+    },
+    test("offer(Long.MinValue) is rejected") {
+      val rb     = LongSpscRingBuffer(2)
+      val thrown =
+        try { rb.offer(Long.MinValue); false }
+        catch { case _: IllegalArgumentException => true }
+      assertTrue(thrown, !rb.peek())
+    },
+    test("offer(Long.MinValue + 1L) is rejected (in-band DONE sentinel)") {
+      val rb     = LongSpscRingBuffer(2)
+      val thrown =
+        try { rb.offer(Long.MinValue + 1L); false }
+        catch { case _: IllegalArgumentException => true }
+      assertTrue(thrown, !rb.peek())
+    },
+    test("wrap-around fill drain refill") {
+      val rb = LongSpscRingBuffer(4)
+      assertTrue(rb.offer(1L), rb.offer(2L), rb.offer(3L), rb.offer(4L)) &&
+      assertTrue(
+        rb.peek(),
+        rb.take() == 1L,
+        rb.peek(),
+        rb.take() == 2L,
+        rb.peek(),
+        rb.take() == 3L,
+        rb.peek(),
+        rb.take() == 4L
+      ) &&
+      assertTrue(
+        rb.offer(5L),
+        rb.offer(6L),
+        rb.offer(7L),
+        rb.offer(8L),
+        rb.peek(),
+        rb.take() == 5L,
+        rb.peek(),
+        rb.take() == 6L,
+        rb.peek(),
+        rb.take() == 7L,
+        rb.peek(),
+        rb.take() == 8L
+      )
+    },
+    test("simple 1p1c stress 100k") {
+      ZIO.attemptBlocking {
+        val count       = 100_000
+        val expectedSum = count.toLong * (count - 1) / 2
+        val rb          = LongSpscRingBuffer(1024)
+
+        val producerDone = new CountDownLatch(1)
+        val consumerDone = new CountDownLatch(1)
+        val orderError   = new AtomicBoolean(false)
+        val actualSum    = new AtomicLong(0L)
+
+        val producer = new Thread(() => {
+          var i = 0L
+          while (i < count.toLong) {
+            if (rb.offer(i)) i += 1L
+            else Thread.onSpinWait()
+          }
+          producerDone.countDown()
+        })
+
+        val consumer = new Thread(() => {
+          var expected = 0L
+          var received = 0
+          while (received < count) {
+            if (rb.peek()) {
+              val v = rb.take()
+              if (v != expected) orderError.set(true)
+              actualSum.addAndGet(v)
+              expected += 1L
+              received += 1
+            } else Thread.onSpinWait()
+          }
+          consumerDone.countDown()
+        })
+
+        producer.start()
+        consumer.start()
+        producerDone.await()
+        consumerDone.await()
+
+        assertTrue(!orderError.get(), actualSum.get() == expectedSum, rb.isEmpty)
+      }
+    } @@ TestAspect.timeout(60.seconds)
+  )
+
+  private val doubleSuite = suite("DoubleSpscRingBuffer")(
+    test("offer then peek then take") {
+      val rb = DoubleSpscRingBuffer(4)
+      assertTrue(rb.offer(42.5), rb.peek(), rb.take() == 42.5)
+    },
+    test("FIFO ordering") {
+      val rb = DoubleSpscRingBuffer(8)
+      rb.offer(1.0)
+      rb.offer(2.0)
+      rb.offer(3.0)
+      assertTrue(rb.peek(), rb.take() == 1.0, rb.peek(), rb.take() == 2.0, rb.peek(), rb.take() == 3.0)
+    },
+    test("full buffer rejects offer") {
+      val rb = DoubleSpscRingBuffer(2)
+      assertTrue(rb.offer(1.0), rb.offer(2.0), !rb.offer(3.0))
+    },
+    test("empty buffer reports no data") {
+      val rb = DoubleSpscRingBuffer(2)
+      assertTrue(!rb.peek())
+    },
+    test("isEmpty / isFull / size track occupancy") {
+      val rb = DoubleSpscRingBuffer(2)
+      val s0 = (rb.isEmpty, rb.isFull, rb.size)
+      rb.offer(1.0)
+      val s1 = (rb.isEmpty, rb.isFull, rb.size)
+      rb.offer(2.0)
+      val s2 = (rb.isEmpty, rb.isFull, rb.size)
+      rb.take()
+      val s3 = (rb.isEmpty, rb.isFull, rb.size)
+      assertTrue(
+        s0 == ((true, false, 0)),
+        s1 == ((false, false, 1)),
+        s2 == ((false, true, 2)),
+        s3 == ((false, false, 1))
+      )
+    },
+    test("capacity must be a positive power of two") {
+      val cases   = List(0, -1, 3, 5, 6, 7)
+      val results = cases.map { c =>
+        try { DoubleSpscRingBuffer(c); false }
+        catch { case _: IllegalArgumentException => true }
+      }
+      assertTrue(results.forall(identity))
+    },
+    test("capacity=1 boundary") {
+      val rb = DoubleSpscRingBuffer(1)
+      assertTrue(rb.offer(7.25), rb.peek(), rb.take() == 7.25, !rb.peek())
+    },
+    test("boundary values") {
+      val rb     = DoubleSpscRingBuffer(8)
+      val values = List(Double.MinValue, Double.MaxValue, 0.0, -1.0)
+      values.foreach(rb.offer)
+      val read = values.forall { expected =>
+        rb.peek() && rb.take() == expected
+      }
+      assertTrue(read, !rb.peek())
+    },
+    test("NaN round-trips as NaN") {
+      val rb = DoubleSpscRingBuffer(2)
+      rb.offer(Double.NaN)
+      val nonEmpty = rb.peek()
+      val taken    = rb.take()
+      assertTrue(nonEmpty, taken.isNaN)
+    },
+    test("sentinel-bit NaN is canonicalized but still observed as NaN") {
+      // The reserved empty marker bit pattern: if the user manages to
+      // construct a Double with this exact raw layout, offer must canonicalize
+      // it to Double.NaN's bit pattern so the slot is still observed as full.
+      val rb            = DoubleSpscRingBuffer(2)
+      val sentinelAsDbl = java.lang.Double.longBitsToDouble(0xfff8000000000001L)
+      val offered       = rb.offer(sentinelAsDbl)
+      val nonEmpty      = rb.peek()
+      val taken         = rb.take()
+      assertTrue(offered, nonEmpty, taken.isNaN)
+    },
+    test("+/- Inf round-trip") {
+      val rb = DoubleSpscRingBuffer(4)
+      rb.offer(Double.PositiveInfinity)
+      rb.offer(Double.NegativeInfinity)
+      assertTrue(
+        rb.peek(),
+        rb.take() == Double.PositiveInfinity,
+        rb.peek(),
+        rb.take() == Double.NegativeInfinity
+      )
+    },
+    test("wrap-around fill drain refill") {
+      val rb = DoubleSpscRingBuffer(4)
+      assertTrue(rb.offer(1.0), rb.offer(2.0), rb.offer(3.0), rb.offer(4.0)) &&
+      assertTrue(
+        rb.peek(),
+        rb.take() == 1.0,
+        rb.peek(),
+        rb.take() == 2.0,
+        rb.peek(),
+        rb.take() == 3.0,
+        rb.peek(),
+        rb.take() == 4.0
+      ) &&
+      assertTrue(
+        rb.offer(5.0),
+        rb.offer(6.0),
+        rb.offer(7.0),
+        rb.offer(8.0),
+        rb.peek(),
+        rb.take() == 5.0,
+        rb.peek(),
+        rb.take() == 6.0,
+        rb.peek(),
+        rb.take() == 7.0,
+        rb.peek(),
+        rb.take() == 8.0
+      )
+    },
+    test("simple 1p1c stress 100k") {
+      ZIO.attemptBlocking {
+        val count       = 100_000
+        val expectedSum = count.toLong * (count - 1) / 2
+        val rb          = DoubleSpscRingBuffer(1024)
+
+        val producerDone = new CountDownLatch(1)
+        val consumerDone = new CountDownLatch(1)
+        val orderError   = new AtomicBoolean(false)
+        val actualSum    = new AtomicReference[Double](0.0)
+
+        val producer = new Thread(() => {
+          var i = 0
+          while (i < count) {
+            if (rb.offer(i.toDouble)) i += 1
+            else Thread.onSpinWait()
+          }
+          producerDone.countDown()
+        })
+
+        val consumer = new Thread(() => {
+          var expected = 0
+          var received = 0
+          var sum      = 0.0
+          while (received < count) {
+            if (rb.peek()) {
+              val v = rb.take()
+              if (v != expected.toDouble) orderError.set(true)
+              sum += v
+              expected += 1
+              received += 1
+            } else Thread.onSpinWait()
+          }
+          actualSum.set(sum)
+          consumerDone.countDown()
+        })
+
+        producer.start()
+        consumer.start()
+        producerDone.await()
+        consumerDone.await()
+
+        assertTrue(!orderError.get(), actualSum.get() == expectedSum.toDouble, rb.isEmpty)
+      }
+    } @@ TestAspect.timeout(60.seconds)
+  )
+
+  private val floatSuite = suite("FloatSpscRingBuffer")(
+    test("offer then peek then take") {
+      val rb = FloatSpscRingBuffer(4)
+      assertTrue(rb.offer(42.5f), rb.peek(), rb.take() == 42.5f)
+    },
+    test("FIFO ordering") {
+      val rb = FloatSpscRingBuffer(8)
+      rb.offer(1.0f)
+      rb.offer(2.0f)
+      rb.offer(3.0f)
+      assertTrue(rb.peek(), rb.take() == 1.0f, rb.peek(), rb.take() == 2.0f, rb.peek(), rb.take() == 3.0f)
+    },
+    test("full buffer rejects offer") {
+      val rb = FloatSpscRingBuffer(2)
+      assertTrue(rb.offer(1.0f), rb.offer(2.0f), !rb.offer(3.0f))
+    },
+    test("empty buffer reports no data") {
+      val rb = FloatSpscRingBuffer(2)
+      assertTrue(!rb.peek())
+    },
+    test("isEmpty / isFull / size track occupancy") {
+      val rb = FloatSpscRingBuffer(2)
+      val s0 = (rb.isEmpty, rb.isFull, rb.size)
+      rb.offer(1.0f)
+      val s1 = (rb.isEmpty, rb.isFull, rb.size)
+      rb.offer(2.0f)
+      val s2 = (rb.isEmpty, rb.isFull, rb.size)
+      rb.take()
+      val s3 = (rb.isEmpty, rb.isFull, rb.size)
+      assertTrue(
+        s0 == ((true, false, 0)),
+        s1 == ((false, false, 1)),
+        s2 == ((false, true, 2)),
+        s3 == ((false, false, 1))
+      )
+    },
+    test("capacity must be a positive power of two") {
+      val cases   = List(0, -1, 3, 5, 6, 7)
+      val results = cases.map { c =>
+        try { FloatSpscRingBuffer(c); false }
+        catch { case _: IllegalArgumentException => true }
+      }
+      assertTrue(results.forall(identity))
+    },
+    test("capacity=1 boundary") {
+      val rb = FloatSpscRingBuffer(1)
+      assertTrue(rb.offer(7.25f), rb.peek(), rb.take() == 7.25f, !rb.peek())
+    },
+    test("boundary values") {
+      val rb     = FloatSpscRingBuffer(8)
+      val values = List(Float.MinValue, Float.MaxValue, 0.0f, -1.0f)
+      values.foreach(rb.offer)
+      val read = values.forall { expected =>
+        rb.peek() && rb.take() == expected
+      }
+      assertTrue(read, !rb.peek())
+    },
+    test("wrap-around fill drain refill") {
+      val rb = FloatSpscRingBuffer(4)
+      assertTrue(rb.offer(1.0f), rb.offer(2.0f), rb.offer(3.0f), rb.offer(4.0f)) &&
+      assertTrue(
+        rb.peek(),
+        rb.take() == 1.0f,
+        rb.peek(),
+        rb.take() == 2.0f,
+        rb.peek(),
+        rb.take() == 3.0f,
+        rb.peek(),
+        rb.take() == 4.0f
+      ) &&
+      assertTrue(
+        rb.offer(5.0f),
+        rb.offer(6.0f),
+        rb.offer(7.0f),
+        rb.offer(8.0f),
+        rb.peek(),
+        rb.take() == 5.0f,
+        rb.peek(),
+        rb.take() == 6.0f,
+        rb.peek(),
+        rb.take() == 7.0f,
+        rb.peek(),
+        rb.take() == 8.0f
+      )
+    },
+    test("simple 1p1c stress 100k") {
+      ZIO.attemptBlocking {
+        val count       = 100_000
+        val expectedSum = count.toLong * (count - 1) / 2
+        val rb          = FloatSpscRingBuffer(1024)
+
+        val producerDone = new CountDownLatch(1)
+        val consumerDone = new CountDownLatch(1)
+        val orderError   = new AtomicBoolean(false)
+        val actualSum    = new AtomicReference[Double](0.0)
+
+        val producer = new Thread(() => {
+          var i = 0
+          while (i < count) {
+            if (rb.offer(i.toFloat)) i += 1
+            else Thread.onSpinWait()
+          }
+          producerDone.countDown()
+        })
+
+        val consumer = new Thread(() => {
+          var expected = 0
+          var received = 0
+          var sum      = 0.0
+          while (received < count) {
+            if (rb.peek()) {
+              val v = rb.take()
+              if (v != expected.toFloat) orderError.set(true)
+              sum += v.toDouble
+              expected += 1
+              received += 1
+            } else Thread.onSpinWait()
+          }
+          actualSum.set(sum)
+          consumerDone.countDown()
+        })
+
+        producer.start()
+        consumer.start()
+        producerDone.await()
+        consumerDone.await()
+
+        assertTrue(!orderError.get(), actualSum.get() == expectedSum.toDouble, rb.isEmpty)
+      }
+    } @@ TestAspect.timeout(60.seconds)
+  )
+}

--- a/streams-benchmark/src/main/scala/zio/blocks/streams/bench/StreamConcurrentBench.scala
+++ b/streams-benchmark/src/main/scala/zio/blocks/streams/bench/StreamConcurrentBench.scala
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.bench
+
+import org.openjdk.jmh.annotations._
+import zio.blocks.streams.{Stream => ZbStream}
+import java.util.concurrent.TimeUnit
+import scala.compiletime.uninitialized
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import fs2.{Stream => Fs2Stream}
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.{Sink => PekkaSink, Source}
+import org.apache.pekko.stream.{Materializer, SystemMaterializer}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.Duration as ScalaDuration
+
+import ox.channels.BufferCapacity
+import ox.flow.Flow
+
+/**
+ * Benchmark: Concurrent stream operator throughput — mapPar, mergeAll,
+ * flatMapPar.
+ *
+ * ==Purpose==
+ * Measures sustained throughput for parallel stream operations across four
+ * streaming libraries: ZIO Blocks (zb), fs2, Apache Pekko Streams (pekko), and
+ * Ox. Each operator uses the library's idiomatic API for unordered parallelism.
+ *
+ * ==Why Unordered?==
+ * All benchmarks use unordered parallel variants (`mapParUnordered`,
+ * `parEvalMapUnordered`, `mapAsyncUnordered`, `flatMapMerge`/`flattenPar`) for
+ * a fair comparison. Ordered variants require buffering to reconstruct input
+ * order, adding overhead not intrinsic to parallelism.
+ *
+ * ==Kyo==
+ * Kyo 1.0-RC1 is included for mapPar using `mapParUnordered` which forks a
+ * fiber per element via Channel + Fiber + Semaphore. Kyo is excluded from
+ * mergeAll and flatMapPar because `Stream.collectAll` with pure `.map(fn)`
+ * inner streams runs all work on a single scheduler thread (verified
+ * empirically: fibers never yield during synchronous computation).
+ *
+ * ==Operators==
+ *   - `mapPar` — transform each element independently in parallel (1M elements)
+ *   - `mergeAll` — fan-in 100 inner streams × 10K elements each (1M total)
+ *     concurrently
+ *   - `flatMapPar` — map each element to an inner stream and merge (100K × 10 =
+ *     1M total)
+ *
+ * ==Workloads (`workload` param)==
+ *   - `light` — `x + 1` (trivial; isolates infrastructure overhead)
+ *   - `heavy` — 100-iteration arithmetic loop (measures parallelism scaling)
+ *
+ * ==Parallelism (`parallelism` param)==
+ * `1`, `8`, `16` — sequential baseline, typical CPU count, oversubscribed.
+ *
+ * ==Effect Wrappers==
+ * fs2 `parEvalMapUnordered` requires `A => IO[B]`; Pekko `mapAsyncUnordered`
+ * requires `A => Future[B]`. ZIO Blocks, Ox, and the underlying work function
+ * are pure.
+ */
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+  value = 1,
+  jvmArgsPrepend = Array(
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
+  )
+)
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+class StreamConcurrentBench {
+
+  @Param(Array("1", "8", "16"))
+  var parallelism: Int = uninitialized
+
+  @Param(Array("light", "heavy"))
+  var workload: String = uninitialized
+
+  private val N         = 1_000_000
+  private val outerN    = 100
+  private val innerN    = 10_000
+  private val fmpOuterN = 1_000
+  private val fmpInnerN = 1_000
+
+  private var workFn: Int => Int = uninitialized
+
+  implicit private var pekkoSystem: ActorSystem = uninitialized
+  implicit private var pekkoMat: Materializer   = uninitialized
+  implicit private var ec: ExecutionContext     = uninitialized
+
+  private given BufferCapacity = BufferCapacity.default
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    workFn = workload match {
+      case "heavy" => { x =>
+        var s = x.toLong
+        var i = 0
+        while (i < 100) { s = (s * 31 + 17) ^ (s >>> 3); i += 1 }
+        s.toInt
+      }
+      case _ => x => x + 1
+    }
+
+    pekkoSystem = ActorSystem("concurrent-bench")
+    pekkoMat = SystemMaterializer(pekkoSystem).materializer
+    ec = pekkoSystem.dispatcher
+  }
+
+  @TearDown(Level.Trial)
+  def teardown(): Unit =
+    if (pekkoSystem != null)
+      Await.result(pekkoSystem.terminate(), ScalaDuration(30, "s"))
+
+  private def zbFold(s: ZbStream[Nothing, Int]): Long =
+    s.runFold(0L)((acc, i) => acc + i) match {
+      case Right(v) => v
+      case Left(_)  => 0L
+    }
+
+  private def fs2Fold(s: Fs2Stream[IO, Int]): Long =
+    s.compile.fold(0L)(_ + _).unsafeRunSync()
+
+  private def pekkoFold(src: Source[Int, ?]): Long =
+    Await.result(src.runWith(PekkaSink.fold(0L)(_ + _)), ScalaDuration.Inf)
+
+  private def oxFold(f: Flow[Int]): Long =
+    f.runFold(0L)((acc, i) => acc + i)
+
+  // kyo_mapPar removed: mapParUnordered forks 1M fibers (1 per element),
+  // consuming 1-10GB of memory per iteration and causing OOM on the host.
+  // Measured at 0.004 ops/s before removal.
+
+  @Benchmark
+  def zb_mapPar(): Long =
+    zbFold(ZbStream.range(0, N).mapPar(parallelism)(workFn))
+
+  @Benchmark
+  def fs2_mapPar(): Long =
+    fs2Fold(
+      Fs2Stream
+        .range(0, N)
+        .covary[IO]
+        .parEvalMapUnordered(parallelism)(a => IO(workFn(a)))
+    )
+
+  @Benchmark
+  def pekko_mapPar(): Long =
+    pekkoFold(
+      Source(0 until N).mapAsyncUnordered(parallelism)(a => Future(workFn(a)))
+    )
+
+  @Benchmark
+  def ox_mapPar(): Long =
+    oxFold(
+      Flow.fromIterable(0 until N).mapParUnordered(parallelism)(workFn)
+    )
+
+  @Benchmark
+  def zb_mergeAll(): Long = {
+    val fn      = workFn
+    val streams = ZbStream.range(0, outerN).map(i => ZbStream.range(i * innerN, (i + 1) * innerN).map(fn))
+    zbFold(ZbStream.mergeAll(parallelism)(streams))
+  }
+
+  @Benchmark
+  def fs2_mergeAll(): Long = {
+    val fn                                         = workFn
+    val streams: Fs2Stream[IO, Fs2Stream[IO, Int]] =
+      Fs2Stream
+        .range(0, outerN)
+        .covary[IO]
+        .map(i => Fs2Stream.range(i * innerN, (i + 1) * innerN).covary[IO].map(fn))
+    fs2Fold(streams.parJoin(parallelism))
+  }
+
+  @Benchmark
+  def pekko_mergeAll(): Long = {
+    val fn = workFn
+    pekkoFold(
+      Source(0 until outerN)
+        .flatMapMerge(parallelism, i => Source(i * innerN until (i + 1) * innerN).map(fn))
+    )
+  }
+
+  @Benchmark
+  def ox_mergeAll(): Long = {
+    val fn                     = workFn
+    val flows: Flow[Flow[Int]] =
+      Flow
+        .fromIterable(0 until outerN)
+        .map(i => Flow.fromIterable(i * innerN until (i + 1) * innerN).map(fn))
+    oxFold(flows.flattenPar(parallelism))
+  }
+
+  @Benchmark
+  def zb_flatMapPar(): Long = {
+    val fn = workFn
+    zbFold(
+      ZbStream
+        .range(0, fmpOuterN)
+        .flatMapPar(parallelism)(i => ZbStream.range(0, fmpInnerN).map(j => fn(i * fmpInnerN + j)))
+    )
+  }
+
+  @Benchmark
+  def fs2_flatMapPar(): Long = {
+    val fn = workFn
+    fs2Fold(
+      Fs2Stream
+        .range(0, fmpOuterN)
+        .covary[IO]
+        .map(i => Fs2Stream.range(0, fmpInnerN).covary[IO].map(j => fn(i * fmpInnerN + j)))
+        .parJoin(parallelism)
+    )
+  }
+
+  @Benchmark
+  def pekko_flatMapPar(): Long = {
+    val fn = workFn
+    pekkoFold(
+      Source(0 until fmpOuterN)
+        .flatMapMerge(parallelism, i => Source(0 until fmpInnerN).map(j => fn(i * fmpInnerN + j)))
+    )
+  }
+
+  @Benchmark
+  def ox_flatMapPar(): Long = {
+    val fn = workFn
+    oxFold(
+      Flow
+        .fromIterable(0 until fmpOuterN)
+        .map(i => Flow.fromIterable(0 until fmpInnerN).map(j => fn(i * fmpInnerN + j)))
+        .flattenPar(parallelism)
+    )
+  }
+
+}

--- a/streams-benchmark/src/main/scala/zio/blocks/streams/bench/StreamEvalBench.scala
+++ b/streams-benchmark/src/main/scala/zio/blocks/streams/bench/StreamEvalBench.scala
@@ -35,7 +35,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration as ScalaDuration
 
 // ---- Kyo ----
-import kyo.{Stream => KyoStream, *}
+import kyo.{Scope as _, Stream => KyoStream, *}
 
 // ---- Ox ----
 import ox.flow.Flow

--- a/streams-benchmark/src/main/scala/zio/blocks/streams/bench/StreamPipelineBench.scala
+++ b/streams-benchmark/src/main/scala/zio/blocks/streams/bench/StreamPipelineBench.scala
@@ -35,7 +35,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration as ScalaDuration
 
 // ---- Kyo ----
-import kyo.{Stream => KyoStream, *}
+import kyo.{Scope as _, Stream => KyoStream, *}
 
 /**
  * Benchmark: Stream pipeline throughput.

--- a/streams-benchmark/src/main/scala/zio/blocks/streams/bench/StreamSetupBench.scala
+++ b/streams-benchmark/src/main/scala/zio/blocks/streams/bench/StreamSetupBench.scala
@@ -34,7 +34,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration as ScalaDuration
 
 // ---- Kyo ----
-import kyo.{Stream => KyoStream, *}
+import kyo.{Scope as _, Stream => KyoStream, *}
 
 /**
  * Benchmark: Stream pipeline construction cost — no evaluation.

--- a/streams/js/src/main/scala/zio/blocks/streams/PlatformSpecific.scala
+++ b/streams/js/src/main/scala/zio/blocks/streams/PlatformSpecific.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.blocks.streams.io.Reader
+import zio.blocks.streams.internal.EndOfStream
+
+/**
+ * JavaScript-specific platform implementation.
+ *
+ * Scala.js is single-threaded; true concurrency is not supported. Virtual
+ * threads are not available. [[createBufferedReader]] uses
+ * [[internal.SyncBufferedReader]] to synchronously prefetch elements.
+ *
+ * [[createMergeReader]] and [[createMapParReader]] degrade to sequential
+ * implementations (flatMap and map, respectively).
+ */
+trait PlatformSpecific extends Platform {
+  override val supportsConcurrency: Boolean = false
+
+  override def startVirtualThread(name: String, task: Runnable): Thread =
+    throw new UnsupportedOperationException(
+      "Virtual threads are not supported on Scala.js. Use supportsConcurrency to guard calls."
+    )
+
+  override def createBufferedReader[A](upstream: Reader[A], bufferSize: Int): Reader[A] =
+    new internal.SyncBufferedReader(upstream, bufferSize)
+
+  override def createMergeReader[A](
+    outerReader: Reader[?],
+    maxOpen: Int,
+    bufferSize: Int,
+    elemType: JvmType
+  ): Reader[A] =
+    new Reader[A] {
+      private val outer            = outerReader.asInstanceOf[Reader[Stream[Any, A]]]
+      private var inner: Reader[A] = null
+      private var outerDone        = false
+
+      def isClosed: Boolean = outerDone && (inner == null || inner.isClosed)
+
+      def read[A1 >: A](sentinel: A1): A1 = {
+        while (true) {
+          if (inner != null) {
+            val v = inner.read[Any](EndOfStream)
+            if (v.asInstanceOf[AnyRef] ne EndOfStream) {
+              return v.asInstanceOf[A1]
+            }
+            // Inner stream exhausted, close it and get next
+            try inner.close()
+            catch { case _: Throwable => () }
+            inner = null
+          }
+          // Try to get next inner stream from outer
+          val nextInner = outer.read[Any](EndOfStream)
+          if (nextInner.asInstanceOf[AnyRef] eq EndOfStream) {
+            outerDone = true
+            return sentinel
+          }
+          inner = nextInner.asInstanceOf[Stream[Any, A]].compile(0, bufferSize)
+        }
+        sentinel
+      }
+
+      def close(): Unit = {
+        if (inner != null) {
+          try inner.close()
+          catch { case _: Throwable => () }
+          inner = null
+        }
+        outer.close()
+        outerDone = true
+      }
+    }
+
+  override def createMapParReader[A, B](
+    upstream: Reader[A],
+    n: Int,
+    f: A => B,
+    bufferSize: Int,
+    inType: JvmType,
+    outType: JvmType
+  ): Reader[B] =
+    new Reader[B] {
+      override def jvmType: JvmType = outType
+      def isClosed: Boolean         = upstream.isClosed
+
+      def read[B1 >: B](sentinel: B1): B1 = {
+        val v = upstream.read[Any](EndOfStream)
+        if (v.asInstanceOf[AnyRef] eq EndOfStream) {
+          sentinel
+        } else {
+          val a = v.asInstanceOf[A]
+          f(a).asInstanceOf[B1]
+        }
+      }
+
+      def close(): Unit = upstream.close()
+    }
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/PlatformSpecific.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/PlatformSpecific.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.blocks.streams.JvmType
+import zio.blocks.streams.io.Reader
+
+import java.lang.invoke.MethodHandles
+import scala.util.control.NonFatal
+
+/**
+ * JVM implementation of the cross-platform [[Platform]] capabilities.
+ *
+ * Mixed into the package-level `Platform` object on JVM, so call sites use the
+ * same `Platform.*` surface regardless of platform.
+ *
+ *   - `supportsConcurrency` is `true`.
+ *   - `startVirtualThread` uses `Thread.ofVirtual().start(...)` reflectively
+ *     when running on JDK 21+, falling back to a daemon `Thread` otherwise.
+ *   - `createBufferedReader`, `createMergeReader`, and `createMapParReader`
+ *     return primitive-specialized readers (Int / Long / Float / Double) when
+ *     the upstream's `JvmType` allows it, and the generic AnyRef variants
+ *     otherwise.
+ */
+trait PlatformSpecific extends Platform {
+  override val supportsConcurrency: Boolean = true
+
+  override def startVirtualThread(name: String, task: Runnable): Thread =
+    VirtualThreadSupport.startVirtual match {
+      case Some(startVirtual) =>
+        try startVirtual(name, task)
+        catch {
+          case err if NonFatal(err) => fallbackThread(name, task)
+        }
+      case None => fallbackThread(name, task)
+    }
+
+  override def createBufferedReader[A](upstream: Reader[A], bufferSize: Int): Reader[A] =
+    new internal.ConcurrentBufferedReader(upstream, bufferSize)
+
+  override def createMergeReader[A](
+    outerReader: Reader[?],
+    maxOpen: Int,
+    bufferSize: Int,
+    elemType: JvmType
+  ): Reader[A] =
+    elemType match {
+      case JvmType.Int =>
+        new internal.IntConcurrentMergeReader(outerReader, maxOpen, bufferSize).asInstanceOf[Reader[A]]
+      case JvmType.Long =>
+        new internal.LongConcurrentMergeReader(outerReader, maxOpen, bufferSize).asInstanceOf[Reader[A]]
+      case JvmType.Double =>
+        new internal.DoubleConcurrentMergeReader(outerReader, maxOpen, bufferSize).asInstanceOf[Reader[A]]
+      case JvmType.Float =>
+        new internal.FloatConcurrentMergeReader(outerReader, maxOpen, bufferSize).asInstanceOf[Reader[A]]
+      case _ =>
+        new internal.ConcurrentMergeReader[A](outerReader, maxOpen, bufferSize)
+    }
+
+  override def createMapParReader[A, B](
+    upstream: Reader[A],
+    n: Int,
+    f: A => B,
+    bufferSize: Int,
+    inType: JvmType,
+    outType: JvmType
+  ): Reader[B] =
+    inType match {
+      case JvmType.Int =>
+        new internal.IntConcurrentMapParReader[B](
+          upstream.asInstanceOf[Reader[Int]],
+          n,
+          f.asInstanceOf[Int => B],
+          bufferSize,
+          outType
+        ).asInstanceOf[Reader[B]]
+      case JvmType.Long =>
+        new internal.LongConcurrentMapParReader[B](
+          upstream.asInstanceOf[Reader[Long]],
+          n,
+          f.asInstanceOf[Long => B],
+          bufferSize,
+          outType
+        ).asInstanceOf[Reader[B]]
+      case JvmType.Double =>
+        new internal.DoubleConcurrentMapParReader[B](
+          upstream.asInstanceOf[Reader[Double]],
+          n,
+          f.asInstanceOf[Double => B],
+          bufferSize,
+          outType
+        ).asInstanceOf[Reader[B]]
+      case JvmType.Float =>
+        new internal.FloatConcurrentMapParReader[B](
+          upstream.asInstanceOf[Reader[Float]],
+          n,
+          f.asInstanceOf[Float => B],
+          bufferSize,
+          outType
+        ).asInstanceOf[Reader[B]]
+      case _ =>
+        new internal.ConcurrentMapParReader[A, B](upstream, n, f, bufferSize)
+    }
+
+  private def fallbackThread(name: String, task: Runnable): Thread = {
+    val thread = new Thread(task)
+    thread.setName(name)
+    thread.setDaemon(true)
+    thread.start()
+    thread
+  }
+}
+
+private object VirtualThreadSupport {
+  val startVirtual: Option[(String, Runnable) => Thread] =
+    try {
+      val lookup          = MethodHandles.lookup()
+      val threadClass     = Class.forName("java.lang.Thread").asInstanceOf[Class[Thread]]
+      val ofVirtualMethod = threadClass.getMethod("ofVirtual")
+      val ofVirtualHandle = lookup.unreflect(ofVirtualMethod)
+      val builderClass    = ofVirtualMethod.getReturnType
+      val nameHandle      = lookup.unreflect(builderClass.getMethod("name", classOf[String], java.lang.Long.TYPE))
+      val startHandle     = lookup.unreflect(builderClass.getMethod("start", classOf[Runnable]))
+
+      Some { (name: String, task: Runnable) =>
+        val builder      = ofVirtualHandle.invoke().asInstanceOf[AnyRef]
+        val namedBuilder = nameHandle.invoke(builder, name, Long.box(0L)).asInstanceOf[AnyRef]
+        startHandle.invoke(namedBuilder, task).asInstanceOf[Thread]
+      }
+    } catch {
+      // Any reflective/initialization failure (e.g. NoSuchMethodException,
+      // ClassNotFoundException, SecurityException, IllegalAccessException,
+      // InvocationTargetException, InaccessibleObjectException, LinkageError)
+      // must fall back to a platform thread rather than crash class init.
+      case scala.util.control.NonFatal(_) => None
+    }
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/ByteBufferReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/ByteBufferReader.scala
@@ -18,6 +18,7 @@ package zio.blocks.streams.internal
 
 import zio.blocks.streams.JvmType
 import zio.blocks.streams.io.Reader
+import zio.blocks.chunk.{Chunk, ChunkBuilder}
 
 import java.nio.ByteBuffer
 
@@ -47,6 +48,25 @@ private[streams] final class ByteBufferReader(buffer: ByteBuffer) extends Reader
     if (b >= 0) Byte.box(b.toByte).asInstanceOf[A1] else sentinel
   }
 
+  override def readN[A1 >: Byte](n: Int): Chunk[A1] = {
+    if (n <= 0 || done) return Chunk.empty
+    val count = math.min(n, buffer.remaining())
+    if (count == 0) { done = true; return Chunk.empty }
+    val arr = new Array[Byte](count)
+    buffer.get(arr, 0, count)
+    if (buffer.remaining() == 0) done = true
+    Chunk.fromArray(arr).asInstanceOf[Chunk[A1]]
+  }
+
+  override def readUpToN[A1 >: Byte](n: Int): Chunk[A1] = {
+    if (n <= 0) return Chunk.empty
+    val arr  = new Array[Byte](n)
+    val read = readBytes(arr, 0, n)(unsafeEvidence)
+    if (read <= 0) Chunk.empty
+    else if (read == n) Chunk.fromArray(arr).asInstanceOf[Chunk[A1]]
+    else Chunk.fromArray(java.util.Arrays.copyOf(arr, read)).asInstanceOf[Chunk[A1]]
+  }
+
   override def readable(): Boolean = !done && buffer.hasRemaining
 
   override def readByte(): Int =
@@ -54,7 +74,7 @@ private[streams] final class ByteBufferReader(buffer: ByteBuffer) extends Reader
     else if (buffer.hasRemaining) (buffer.get() & 0xff)
     else { done = true; -1 }
 
-  override def readBytes(buf: Array[Byte], offset: Int, len: Int): Int =
+  override def readBytes(buf: Array[Byte], offset: Int, len: Int)(implicit ev: Byte <:< Byte): Int =
     if (len == 0) 0
     else if (done) -1
     else {
@@ -121,6 +141,34 @@ private[streams] final class ByteBufferIntReader(buffer: ByteBuffer) extends Rea
     if (done) sentinel
     else if (buffer.remaining() >= 4) Int.box(buffer.getInt()).asInstanceOf[A1]
     else { done = true; sentinel }
+
+  override def readN[A1 >: Int](n: Int): Chunk[A1] = {
+    if (n <= 0 || done) return Chunk.empty
+    val count = math.min(n, buffer.remaining() / 4)
+    if (count == 0) { done = true; return Chunk.empty }
+    val arr = new Array[Int](count)
+    var i   = 0
+    while (i < count) {
+      arr(i) = buffer.getInt()
+      i += 1
+    }
+    if (buffer.remaining() < 4) done = true
+    Chunk.fromArray(arr).asInstanceOf[Chunk[A1]]
+  }
+
+  override def readUpToN[A1 >: Int](n: Int): Chunk[A1] = {
+    if (n <= 0) return Chunk.empty
+    val b = new ChunkBuilder.Int(); b.sizeHint(math.min(n, 64))
+    val s = Long.MinValue
+    var v = readInt(s)(unsafeEvidence)
+    if (v == s) return Chunk.empty
+    var i = 0
+    while (v != s && i < n) {
+      b.addOne(v.toInt); i += 1
+      if (i < n) v = readInt(s)(unsafeEvidence)
+    }
+    b.result().asInstanceOf[Chunk[A1]]
+  }
 
   override def readable(): Boolean = !done && buffer.remaining() >= 4
 
@@ -192,6 +240,34 @@ private[streams] final class ByteBufferLongReader(buffer: ByteBuffer) extends Re
     else if (buffer.remaining() >= 8) Long.box(buffer.getLong()).asInstanceOf[A1]
     else { done = true; sentinel }
 
+  override def readN[A1 >: Long](n: Int): Chunk[A1] = {
+    if (n <= 0 || done) return Chunk.empty
+    val count = math.min(n, buffer.remaining() / 8)
+    if (count == 0) { done = true; return Chunk.empty }
+    val arr = new Array[Long](count)
+    var i   = 0
+    while (i < count) {
+      arr(i) = buffer.getLong()
+      i += 1
+    }
+    if (buffer.remaining() < 8) done = true
+    Chunk.fromArray(arr).asInstanceOf[Chunk[A1]]
+  }
+
+  override def readUpToN[A1 >: Long](n: Int): Chunk[A1] = {
+    if (n <= 0) return Chunk.empty
+    val b = new ChunkBuilder.Long(); b.sizeHint(math.min(n, 64))
+    val s = Long.MaxValue
+    var v = readLong(s)(unsafeEvidence)
+    if (v == s) return Chunk.empty
+    var i = 0
+    while (v != s && i < n) {
+      b.addOne(v); i += 1
+      if (i < n) v = readLong(s)(unsafeEvidence)
+    }
+    b.result().asInstanceOf[Chunk[A1]]
+  }
+
   override def readable(): Boolean = !done && buffer.remaining() >= 8
 
   override def readByte(): Int =
@@ -262,6 +338,34 @@ private[streams] final class ByteBufferDoubleReader(buffer: ByteBuffer) extends 
     else if (buffer.remaining() >= 8) Double.box(buffer.getDouble()).asInstanceOf[A1]
     else { done = true; sentinel }
 
+  override def readN[A1 >: Double](n: Int): Chunk[A1] = {
+    if (n <= 0 || done) return Chunk.empty
+    val count = math.min(n, buffer.remaining() / 8)
+    if (count == 0) { done = true; return Chunk.empty }
+    val arr = new Array[Double](count)
+    var i   = 0
+    while (i < count) {
+      arr(i) = buffer.getDouble()
+      i += 1
+    }
+    if (buffer.remaining() < 8) done = true
+    Chunk.fromArray(arr).asInstanceOf[Chunk[A1]]
+  }
+
+  override def readUpToN[A1 >: Double](n: Int): Chunk[A1] = {
+    if (n <= 0) return Chunk.empty
+    val b = new ChunkBuilder.Double(); b.sizeHint(math.min(n, 64))
+    val s = Double.MaxValue
+    var v = readDouble(s)(unsafeEvidence)
+    if (v == s) return Chunk.empty
+    var i = 0
+    while (v != s && i < n) {
+      b.addOne(v); i += 1
+      if (i < n) v = readDouble(s)(unsafeEvidence)
+    }
+    b.result().asInstanceOf[Chunk[A1]]
+  }
+
   override def readable(): Boolean = !done && buffer.remaining() >= 8
 
   override def readByte(): Int =
@@ -331,6 +435,34 @@ private[streams] final class ByteBufferFloatReader(buffer: ByteBuffer) extends R
     if (done) sentinel
     else if (buffer.remaining() >= 4) Float.box(buffer.getFloat()).asInstanceOf[A1]
     else { done = true; sentinel }
+
+  override def readN[A1 >: Float](n: Int): Chunk[A1] = {
+    if (n <= 0 || done) return Chunk.empty
+    val count = math.min(n, buffer.remaining() / 4)
+    if (count == 0) { done = true; return Chunk.empty }
+    val arr = new Array[Float](count)
+    var i   = 0
+    while (i < count) {
+      arr(i) = buffer.getFloat()
+      i += 1
+    }
+    if (buffer.remaining() < 4) done = true
+    Chunk.fromArray(arr).asInstanceOf[Chunk[A1]]
+  }
+
+  override def readUpToN[A1 >: Float](n: Int): Chunk[A1] = {
+    if (n <= 0) return Chunk.empty
+    val b = new ChunkBuilder.Float(); b.sizeHint(math.min(n, 64))
+    val s = Double.MaxValue
+    var v = readFloat(s)(unsafeEvidence)
+    if (v == s) return Chunk.empty
+    var i = 0
+    while (v != s && i < n) {
+      b.addOne(v.toFloat); i += 1
+      if (i < n) v = readFloat(s)(unsafeEvidence)
+    }
+    b.result().asInstanceOf[Chunk[A1]]
+  }
 
   override def readable(): Boolean = !done && buffer.remaining() >= 4
 

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/ChannelReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/ChannelReader.scala
@@ -16,6 +16,7 @@
 
 package zio.blocks.streams.internal
 
+import zio.blocks.chunk.{Chunk, ChunkBuilder}
 import zio.blocks.streams.JvmType
 import zio.blocks.streams.io.Reader
 
@@ -55,7 +56,7 @@ private[streams] final class ChannelReader(ch: ReadableByteChannel, bufSize: Int
     else if (fill() && buf.hasRemaining) (buf.get() & 0xff)
     else -1
 
-  override def readBytes(arr: Array[Byte], offset: Int, len: Int): Int =
+  override def readBytes(arr: Array[Byte], offset: Int, len: Int)(implicit ev: Byte <:< Byte): Int =
     if (len == 0) 0
     else if (st != 0) -1
     else if (buf.hasRemaining) {
@@ -67,6 +68,43 @@ private[streams] final class ChannelReader(ch: ReadableByteChannel, bufSize: Int
       buf.get(arr, offset, n)
       n
     } else -1
+
+  override def readN[A1 >: Byte](n: Int): Chunk[A1] = {
+    if (n <= 0 || isClosed) return Chunk.empty
+    if (n <= 8192) {
+      val arr     = new Array[Byte](n)
+      var total   = 0
+      var stopped = false
+      while (total < n && !isClosed && !stopped) {
+        val read = readBytes(arr, total, n - total)
+        if (read > 0) total += read
+        else stopped = true // EOF, error, or non-blocking channel with no available data
+      }
+      if (total == 0) Chunk.empty
+      else if (total == n) Chunk.fromArray(arr).asInstanceOf[Chunk[A1]]
+      else Chunk.fromArray(java.util.Arrays.copyOf(arr, total)).asInstanceOf[Chunk[A1]]
+    } else {
+      val b       = new ChunkBuilder.Byte()
+      val buf     = new Array[Byte](8192)
+      var rem     = n
+      var stopped = false
+      while (rem > 0 && !isClosed && !stopped) {
+        val read = readBytes(buf, 0, math.min(rem, 8192))
+        if (read > 0) { var k = 0; while (k < read) { b.addOne(buf(k)); k += 1 }; rem -= read }
+        else stopped = true
+      }
+      b.result().asInstanceOf[Chunk[A1]]
+    }
+  }
+
+  override def readUpToN[A1 >: Byte](n: Int): Chunk[A1] = {
+    if (n <= 0 || isClosed) return Chunk.empty
+    val arr  = new Array[Byte](n)
+    val read = readBytes(arr, 0, n)(unsafeEvidence)
+    if (read <= 0) Chunk.empty
+    else if (read == n) Chunk.fromArray(arr).asInstanceOf[Chunk[A1]]
+    else Chunk.fromArray(java.util.Arrays.copyOf(arr, read)).asInstanceOf[Chunk[A1]]
+  }
 
   override def skip(n: Long): Unit = {
     var r = n; while (r > 0) { val b = readByte(); if (b < 0) r = 0 else r -= 1 }

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/ConcurrentBufferedReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/ConcurrentBufferedReader.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.internal
+
+import zio.blocks.chunk.{Chunk, ChunkBuilder}
+import zio.blocks.streams.Platform
+import zio.blocks.streams.io.Reader
+import zio.blocks.streams.queues.BlockingSpscQueue
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * A concurrent buffered reader. The producer runs on a separate virtual thread
+ * (or daemon thread) and feeds elements into a [[BlockingSpscQueue]]; the
+ * consumer pulls from the queue.
+ *
+ * Null elements from upstream are transparently encoded as [[NullSentinel]] to
+ * distinguish them from the queue's null-means-closed signal and the
+ * [[EndOfStream]] completion sentinel.
+ *
+ * Thread ownership: the producer thread exclusively owns `upstream`. The
+ * consumer (this reader) never calls `upstream.read()` or `upstream.close()`.
+ */
+private[streams] final class ConcurrentBufferedReader[A](upstream: Reader[A], bufferSize: Int) extends Reader[A] {
+  import ConcurrentBufferedReader._
+
+  private val queue: BlockingSpscQueue[AnyRef]   = new BlockingSpscQueue[AnyRef](bufferSize)
+  @volatile private var producerError: Throwable = null
+  @volatile private var consumerClosed: Boolean  = false
+  @volatile private var producerDone: Boolean    = false
+  private var upstreamClosedByProducer: Boolean  = false
+
+  private val producerTask: Runnable = new Runnable {
+    def run(): Unit =
+      try {
+        var running = true
+        while (running && !consumerClosed && !queue.isClosed && !Thread.currentThread().isInterrupted) {
+          val v = upstream.read[Any](EndOfStream)
+          if (v.asInstanceOf[AnyRef] eq EndOfStream) {
+            queue.offer(EndOfStream)
+            running = false
+          } else {
+            val wrapped = if (v == null) NullSentinel else v.asInstanceOf[AnyRef]
+            if (!queue.offer(wrapped)) {
+              running = false
+            }
+          }
+        }
+      } catch {
+        case t: Throwable =>
+          producerError = t
+          queue.offer(EndOfStream)
+      } finally {
+        queue.close()
+        if (!upstreamClosedByProducer) {
+          upstreamClosedByProducer = true
+          try upstream.close()
+          catch { case _: Throwable => () }
+        }
+        producerDone = true
+      }
+  }
+
+  private val producerThread: Thread = Platform.startVirtualThread(
+    s"zio-blocks-buffer-${ConcurrentBufferedReader.counter.getAndIncrement()}",
+    producerTask
+  )
+
+  def isClosed: Boolean = producerDone && queue.isEmpty
+
+  def read[A1 >: A](sentinel: A1): A1 = {
+    val result = queue.take()
+    result match {
+      case null =>
+        val err = producerError
+        if (err ne null) rethrow(err)
+        sentinel
+      case r if r eq EndOfStream =>
+        val err = producerError
+        if (err ne null) rethrow(err)
+        sentinel
+      case r if r eq NullSentinel =>
+        null.asInstanceOf[A1]
+      case r =>
+        r.asInstanceOf[A1]
+    }
+  }
+
+  override def readUpToN[A1 >: A](n: Int): Chunk[A1] = {
+    if (n <= 0) return Chunk.empty
+    val first = queue.take()
+    first match {
+      case null =>
+        val err = producerError
+        if (err ne null) rethrow(err)
+        Chunk.empty
+      case r if r eq EndOfStream =>
+        val err = producerError
+        if (err ne null) rethrow(err)
+        Chunk.empty
+      case r if r eq NullSentinel =>
+        if (n == 1) Chunk.single(null.asInstanceOf[A1])
+        else {
+          val b = ChunkBuilder.make[A1](math.min(n, 16))
+          b += null.asInstanceOf[A1]
+          drainQueue(b, n - 1)
+          b.result()
+        }
+      case r =>
+        if (n == 1) Chunk.single(r.asInstanceOf[A1])
+        else {
+          val b = ChunkBuilder.make[A1](math.min(n, 16))
+          b += r.asInstanceOf[A1]
+          drainQueue(b, n - 1)
+          b.result()
+        }
+    }
+  }
+
+  private def drainQueue[A1 >: A](b: ChunkBuilder[A1], limit: Int): Unit = {
+    var i = 0
+    while (i < limit) {
+      val v = queue.poll()
+      v match {
+        case null                   => return
+        case r if r eq EndOfStream  => return
+        case r if r eq NullSentinel => b += null.asInstanceOf[A1]; i += 1
+        case r                      => b += r.asInstanceOf[A1]; i += 1
+      }
+    }
+  }
+
+  def close(): Unit = {
+    consumerClosed = true
+    queue.close()
+    producerThread.interrupt()
+    producerThread.join(5000)
+  }
+
+  private def rethrow(t: Throwable): Nothing = t match {
+    case se: StreamError => throw se
+    case _               => throw t
+  }
+}
+
+private object ConcurrentBufferedReader {
+  val counter: AtomicLong  = new AtomicLong(0L)
+  val NullSentinel: AnyRef = new AnyRef
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/ConcurrentMapParReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/ConcurrentMapParReader.scala
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.internal
+
+import zio.blocks.streams.Platform
+import zio.blocks.streams.io.Reader
+import zio.blocks.ringbuffer.SpscRingBuffer
+
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong, AtomicReference, AtomicReferenceArray}
+import java.util.concurrent.locks.LockSupport
+
+private[streams] final class ConcurrentMapParReader[A, B](
+  upstream: Reader[A],
+  n: Int,
+  f: A => B,
+  bufferSize: Int
+) extends Reader[B] {
+  import ConcurrentMapParReader._
+
+  require(n >= 1, s"ConcurrentMapParReader requires n >= 1, got $n")
+
+  private val outputQueues: Array[SpscRingBuffer[AnyRef]] =
+    Array.tabulate(n)(_ => new SpscRingBuffer[AnyRef](bufferSize))
+  @volatile private var consumerWaiter: Thread = null
+
+  private val inputQueues: Array[SpscRingBuffer[AnyRef]] =
+    Array.tabulate(n)(_ => new SpscRingBuffer[AnyRef](bufferSize))
+  private val workerWaiters  = new AtomicReferenceArray[Thread](n)
+  private val workerThreads  = new AtomicReferenceArray[Thread](n)
+  private val workersRunning = new AtomicInteger(n)
+
+  private val errorRef                            = new AtomicReference[Throwable](null)
+  @volatile private var consumerClosed: Boolean   = false
+  @volatile private var coordinatorThread: Thread = null.asInstanceOf[Thread]
+
+  private val workerTasks: Array[Runnable] = Array.tabulate(n) { idx =>
+    new Runnable {
+      def run(): Unit = workerLoop(idx)
+    }
+  }
+
+  Array.tabulate(n) { idx =>
+    Platform.startVirtualThread(
+      s"zio-blocks-mappar-worker-${counter.getAndIncrement()}-$idx",
+      workerTasks(idx)
+    )
+  }
+
+  private val coordinatorTask: Runnable = new Runnable {
+    def run(): Unit =
+      try {
+        var scanIdx = 0
+        var running = true
+
+        while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+          val batch = upstream.readUpToN[Any](bufferSize)
+          if (batch.isEmpty) {
+            running = false
+          } else {
+            var j = 0
+            while (j < batch.length && running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+              val v          = batch(j)
+              val wrapped    = if (v == null) NullWorkSentinel else v.asInstanceOf[AnyRef]
+              var dispatched = false
+              while (!dispatched && !consumerClosed && !Thread.currentThread().isInterrupted) {
+                var i = 0
+                while (i < n && !dispatched) {
+                  val qIdx = (scanIdx + i) % n
+                  if (inputQueues(qIdx).offer(wrapped)) {
+                    val ww = workerWaiters.get(qIdx)
+                    if (ww ne null) LockSupport.unpark(ww)
+                    scanIdx = (qIdx + 1) % n
+                    dispatched = true
+                  }
+                  i += 1
+                }
+                if (!dispatched) {
+                  LockSupport.parkNanos(this, 1000L)
+                }
+              }
+              if (!dispatched) running = false
+              j += 1
+            }
+          }
+        }
+      } catch {
+        case t: Throwable =>
+          recordError(t)
+      } finally {
+        signalWorkersToStop()
+        try upstream.close()
+        catch { case _: Throwable => () }
+      }
+  }
+
+  coordinatorThread = Platform.startVirtualThread(
+    s"zio-blocks-mappar-coordinator-${counter.getAndIncrement()}",
+    coordinatorTask
+  )
+
+  private def allOutputQueuesEmpty(): Boolean = {
+    var i = 0
+    while (i < n) {
+      if (!outputQueues(i).isEmpty) return false
+      i += 1
+    }
+    true
+  }
+
+  def isClosed: Boolean = eofReturned || consumerClosed
+
+  private var scanStart: Int          = 0
+  private var doneSignalSeen: Boolean = false
+  private var eofReturned: Boolean    = false
+
+  def read[B1 >: B](sentinel: B1): B1 = {
+    while (true) {
+      var i      = 0
+      var sawAny = false
+      while (i < n) {
+        val qIdx = (scanStart + i) % n
+        val item = outputQueues(qIdx).take()
+        if (item ne null) {
+          sawAny = true
+          scanStart = (qIdx + 1) % n
+          val err = errorRef.get()
+          if (err ne null) rethrow(err)
+          if (item eq NullSentinel) return null.asInstanceOf[B1]
+          if (item eq AllWorkersDone) doneSignalSeen = true
+          else return item.asInstanceOf[B1]
+        }
+        i += 1
+      }
+
+      val err = errorRef.get()
+      if (err ne null) rethrow(err)
+      if (doneSignalSeen && !sawAny) { eofReturned = true; return sentinel }
+
+      consumerWaiter = Thread.currentThread()
+      if (!doneSignalSeen && allOutputQueuesEmpty() && errorRef.get() == null) {
+        LockSupport.park(this)
+      }
+      consumerWaiter = null
+    }
+    sentinel
+  }
+
+  def close(): Unit = {
+    consumerClosed = true
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+    var i = 0
+    while (i < n) {
+      val ww = workerWaiters.get(i)
+      if (ww ne null) LockSupport.unpark(ww)
+      i += 1
+    }
+
+    val ct = coordinatorThread
+    if (ct ne null) {
+      ct.interrupt()
+      ct.join(5000)
+    }
+
+    i = 0
+    while (i < n) {
+      val t = workerThreads.get(i)
+      if (t ne null) {
+        t.interrupt()
+        t.join(5000)
+      }
+      i += 1
+    }
+  }
+
+  private def workerLoop(idx: Int): Unit = {
+    val self = Thread.currentThread()
+    workerThreads.set(idx, self)
+
+    var keepRunning = true
+    while (keepRunning && !consumerClosed && !self.isInterrupted) {
+      var input: AnyRef = null
+      while ((input eq null) && keepRunning && !consumerClosed && !self.isInterrupted) {
+        input = inputQueues(idx).take()
+        if (input eq null) {
+          workerWaiters.set(idx, self)
+          input = inputQueues(idx).take()
+          if (input eq null) {
+            if (!consumerClosed && !self.isInterrupted) {
+              LockSupport.park(this)
+            }
+          }
+          workerWaiters.set(idx, null)
+        }
+      }
+
+      if ((input eq null) || (input eq DoneSentinel) || consumerClosed || self.isInterrupted) {
+        keepRunning = false
+      } else {
+        try {
+          val element     = if (input eq NullWorkSentinel) null.asInstanceOf[A] else input.asInstanceOf[A]
+          val result      = f(element)
+          val wrapped     = if (result == null) NullSentinel else result.asInstanceOf[AnyRef]
+          var spscOffered = false
+          while (!spscOffered) {
+            if (consumerClosed || self.isInterrupted) {
+              keepRunning = false
+              spscOffered = true
+            } else if (outputQueues(idx).offer(wrapped)) {
+              spscOffered = true
+              val cw = consumerWaiter
+              if (cw ne null) LockSupport.unpark(cw)
+            } else {
+              LockSupport.parkNanos(this, 1000L)
+            }
+          }
+        } catch {
+          case t: Throwable =>
+            recordError(t)
+            keepRunning = false
+        }
+      }
+    }
+
+    if (workersRunning.decrementAndGet() == 0) {
+      var done = false
+      while (!done) {
+        if (consumerClosed || Thread.currentThread().isInterrupted) {
+          done = true
+        } else if (outputQueues(idx).offer(AllWorkersDone)) {
+          done = true
+          val cw = consumerWaiter
+          if (cw ne null) LockSupport.unpark(cw)
+        } else {
+          LockSupport.parkNanos(this, 1000L)
+        }
+      }
+    }
+  }
+
+  private def signalWorkersToStop(): Unit = {
+    var i = 0
+    while (i < n) {
+      while (!inputQueues(i).offer(DoneSentinel) && !consumerClosed && !Thread.currentThread().isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+      val ww = workerWaiters.get(i)
+      if (ww ne null) LockSupport.unpark(ww)
+      i += 1
+    }
+  }
+
+  private def recordError(t: Throwable): Unit =
+    if (errorRef.compareAndSet(null, t)) {
+      consumerClosed = true
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      var i = 0
+      while (i < n) {
+        val ww = workerWaiters.get(i)
+        if (ww ne null) LockSupport.unpark(ww)
+        i += 1
+      }
+
+      val ct = coordinatorThread
+      if (ct ne null) ct.interrupt()
+
+      i = 0
+      while (i < n) {
+        val wt = workerThreads.get(i)
+        if (wt ne null) wt.interrupt()
+        i += 1
+      }
+    }
+
+  private def rethrow(t: Throwable): Nothing = t match {
+    case se: StreamError => throw se
+    case _               => throw t
+  }
+}
+
+private[internal] object ConcurrentMapParReader {
+  val counter: AtomicLong       = new AtomicLong(0L)
+  val inputQueueCapacity: Int   = zio.blocks.streams.Stream.DefaultBufferSize
+  val outputQueueCapacity: Int  = zio.blocks.streams.Stream.DefaultBufferSize
+  val coordinatorBatchSize: Int = zio.blocks.streams.Stream.DefaultBufferSize
+  val NullSentinel: AnyRef      = new AnyRef
+  val NullWorkSentinel: AnyRef  = new AnyRef
+  val AllWorkersDone: AnyRef    = new AnyRef
+  val DoneSentinel: AnyRef      = new AnyRef
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/ConcurrentMergeReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/ConcurrentMergeReader.scala
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.internal
+
+import zio.blocks.chunk.{Chunk, ChunkBuilder}
+import zio.blocks.streams.Platform
+import zio.blocks.streams.Stream
+import zio.blocks.streams.io.Reader
+import zio.blocks.ringbuffer.SpscRingBuffer
+import zio.blocks.streams.queues.BlockingMpmcQueue
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference, AtomicReferenceArray}
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * Concurrent fan-in reader for `Stream[Any, Stream[Any, A]]`.
+ *
+ * A single coordinator thread reads inner stream descriptions from
+ * `outerReader` and hands them to an eagerly-started pool of drainer threads
+ * (up to `maxOpen`). Drainers compile and drain inner streams into per-drainer
+ * SPSC queues consumed by this reader.
+ */
+private[streams] final class ConcurrentMergeReader[A](outerReader: Reader[?], maxOpen: Int, bufferSize: Int)
+    extends Reader[A] {
+  import ConcurrentMergeReader._
+
+  require(maxOpen >= 1, s"ConcurrentMergeReader requires maxOpen >= 1, got $maxOpen")
+
+  private val outer: Reader[Any]                          = outerReader.asInstanceOf[Reader[Any]]
+  private val outputQueues: Array[SpscRingBuffer[AnyRef]] =
+    Array.tabulate(maxOpen)(_ => new SpscRingBuffer[AnyRef](bufferSize))
+  @volatile private var consumerWaiter: Thread = null
+
+  private val errorRef                          = new AtomicReference[Throwable](null)
+  @volatile private var consumerClosed: Boolean = false
+
+  private var completedCount: Int = 0
+
+  @volatile private var totalStarted: Int        = 0
+  @volatile private var coordinatorDone: Boolean = false
+
+  private val workQueue      = new BlockingMpmcQueue[AnyRef](Math.max(maxOpen, 16))
+  private val drainerLatch   = new CountDownLatch(maxOpen)
+  private val drainerThreads = new AtomicReferenceArray[Thread](maxOpen)
+
+  @volatile private var coordinatorThread: Thread = null.asInstanceOf[Thread]
+
+  Array.tabulate(maxOpen) { idx =>
+    Platform.startVirtualThread(
+      s"zio-blocks-merge-drainer-${counter.getAndIncrement()}-$idx",
+      new Runnable { def run(): Unit = drainerLoop(idx) }
+    )
+  }
+
+  private val coordinatorTask: Runnable = new Runnable {
+    def run(): Unit =
+      try {
+        var running = true
+        while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+          val v = outer.read[Any](EndOfStream)
+          if (v.asInstanceOf[AnyRef] eq EndOfStream) {
+            running = false
+          } else if (workQueue.offer(v.asInstanceOf[AnyRef])) {
+            totalStarted += 1
+          } else {
+            running = false
+          }
+        }
+      } catch {
+        case t: Throwable =>
+          recordError(t)
+      } finally {
+        try {
+          var i = 0
+          while (i < maxOpen) {
+            workQueue.offer(DoneSentinel)
+            i += 1
+          }
+          try drainerLatch.await()
+          catch { case _: InterruptedException => () }
+        } catch {
+          case t: Throwable => recordError(t)
+        } finally {
+          // Publish completion via a volatile flag rather than an AllDone enqueue.
+          // The SPSC queues are owned by a single drainer at a time; sending
+          // AllDone from a different thread would violate that contract.
+          coordinatorDone = true
+          val cw = consumerWaiter
+          if (cw ne null) LockSupport.unpark(cw)
+          try outer.close()
+          catch { case _: Throwable => () }
+        }
+      }
+  }
+
+  coordinatorThread = Platform.startVirtualThread(
+    s"zio-blocks-merge-coordinator-${counter.getAndIncrement()}",
+    coordinatorTask
+  )
+
+  private def allOutputQueuesEmpty(): Boolean = {
+    var i = 0
+    while (i < maxOpen) {
+      if (!outputQueues(i).isEmpty) return false
+      i += 1
+    }
+    true
+  }
+
+  def isClosed: Boolean = coordinatorDone && completedCount >= totalStarted && allOutputQueuesEmpty()
+
+  private var scanStart: Int = 0
+
+  private def terminal: Boolean = coordinatorDone && completedCount >= totalStarted
+
+  def read[A1 >: A](sentinel: A1): A1 = {
+    while (true) {
+      var i = 0
+      while (i < maxOpen) {
+        val qIdx = (scanStart + i) % maxOpen
+        val item = outputQueues(qIdx).take()
+        if (item ne null) {
+          scanStart = (qIdx + 1) % maxOpen
+          val err = errorRef.get()
+          if (err ne null) rethrow(err)
+          if (item eq NullSentinel) return null.asInstanceOf[A1]
+          else if (item eq InnerDone) completedCount += 1
+          else return item.asInstanceOf[A1]
+        }
+        i += 1
+      }
+
+      val err = errorRef.get()
+      if (err ne null) rethrow(err)
+
+      if (terminal) {
+        // Re-scan after observing terminal state: items may have been written
+        // between the scan above and the visibility of coordinatorDone.
+        if (allOutputQueuesEmpty()) return sentinel
+        // else loop again to drain whatever became visible
+      } else {
+        consumerWaiter = Thread.currentThread()
+        try {
+          if (!terminal && allOutputQueuesEmpty() && errorRef.get() == null) {
+            LockSupport.park(this)
+          }
+        } finally {
+          consumerWaiter = null
+        }
+      }
+    }
+    sentinel
+  }
+
+  override def readUpToN[A1 >: A](n: Int): Chunk[A1] = {
+    if (n <= 0) return Chunk.empty
+    val first = read[Any](EndOfStream)
+    if (first.asInstanceOf[AnyRef] eq EndOfStream) return Chunk.empty
+    if (n == 1) return Chunk.single(first.asInstanceOf[A1])
+
+    val b = ChunkBuilder.make[A1](math.min(n, 16))
+    b += first.asInstanceOf[A1]
+    var i = 1
+    while (i < n) {
+      var foundData = false
+      var q         = 0
+      while (q < maxOpen) {
+        val qIdx = (scanStart + q) % maxOpen
+        val item = outputQueues(qIdx).take()
+        if (item ne null) {
+          scanStart = (qIdx + 1) % maxOpen
+          val err = errorRef.get()
+          if (err ne null) rethrow(err)
+          if (item eq NullSentinel) {
+            b += null.asInstanceOf[A1]
+            i += 1; foundData = true
+          } else if (item eq InnerDone) {
+            completedCount += 1
+          } else {
+            b += item.asInstanceOf[A1]
+            i += 1; foundData = true
+          }
+          if (i >= n) return b.result()
+        }
+        q += 1
+      }
+      if (!foundData) {
+        return b.result()
+      }
+    }
+    b.result()
+  }
+
+  def close(): Unit = {
+    consumerClosed = true
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+    workQueue.close()
+
+    coordinatorThread.interrupt()
+    coordinatorThread.join(5000)
+
+    var i = 0
+    while (i < maxOpen) {
+      val t = drainerThreads.get(i)
+      if (t ne null) {
+        t.interrupt()
+        t.join(5000)
+      }
+      i += 1
+    }
+  }
+
+  private def drainerLoop(idx: Int): Unit = {
+    val self = Thread.currentThread()
+    drainerThreads.set(idx, self)
+    try {
+      var keepRunning = true
+      while (keepRunning && !consumerClosed && !self.isInterrupted) {
+        val work = workQueue.take()
+        if ((work eq null) || (work eq DoneSentinel) || consumerClosed || self.isInterrupted) {
+          keepRunning = false
+        } else {
+          drainInner(work.asInstanceOf[Stream[Any, A]], idx)
+        }
+      }
+    } finally {
+      drainerLatch.countDown()
+    }
+  }
+
+  private def drainInner(innerStream: Stream[Any, A], drainerIdx: Int): Unit = {
+    var innerReader: Reader[A] = null
+    try {
+      innerReader = innerStream.compile(0, bufferSize)
+      var running = true
+      while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+        val v = innerReader.read[Any](EndOfStream)
+        if (v.asInstanceOf[AnyRef] eq EndOfStream) {
+          running = false
+        } else {
+          val wrapped = if (v == null) NullSentinel else v.asInstanceOf[AnyRef]
+          var offered = false
+          while (!offered && !consumerClosed && !Thread.currentThread().isInterrupted) {
+            if (outputQueues(drainerIdx).offer(wrapped)) {
+              offered = true
+              val cw = consumerWaiter
+              if (cw ne null) LockSupport.unpark(cw)
+            } else {
+              LockSupport.parkNanos(this, 1000L)
+            }
+          }
+          if (!offered) {
+            running = false
+          }
+        }
+      }
+
+    } catch {
+      case t: Throwable =>
+        recordError(t)
+    } finally {
+      var doneOffered = false
+      while (!doneOffered) {
+        if (outputQueues(drainerIdx).offer(InnerDone)) {
+          doneOffered = true
+          val cw = consumerWaiter
+          if (cw ne null) LockSupport.unpark(cw)
+        } else {
+          LockSupport.parkNanos(this, 1000L)
+        }
+      }
+      if (innerReader ne null) {
+        try innerReader.close()
+        catch { case _: Throwable => () }
+      }
+    }
+  }
+
+  private def recordError(t: Throwable): Unit =
+    if (errorRef.compareAndSet(null, t)) {
+      consumerClosed = true
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      workQueue.close()
+      val ct = coordinatorThread
+      if (ct ne null) ct.interrupt()
+      var i = 0
+      while (i < maxOpen) {
+        val dt = drainerThreads.get(i)
+        if (dt ne null) dt.interrupt()
+        i += 1
+      }
+    }
+
+  private def rethrow(t: Throwable): Nothing = t match {
+    case se: StreamError => throw se
+    case _               => throw t
+  }
+}
+
+private[internal] object ConcurrentMergeReader {
+  val counter: AtomicLong      = new AtomicLong(0L)
+  val outputQueueCapacity: Int = zio.blocks.streams.Stream.DefaultBufferSize
+
+  val NullSentinel: AnyRef         = new AnyRef
+  val InnerDone: AnyRef            = new AnyRef
+  val AllDone: AnyRef              = new AnyRef
+  private val DoneSentinel: AnyRef = new AnyRef
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/DoubleConcurrentMapParReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/DoubleConcurrentMapParReader.scala
@@ -1,0 +1,613 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.internal
+
+import zio.blocks.ringbuffer.{
+  DoubleSpscRingBuffer,
+  FloatSpscRingBuffer,
+  IntSpscRingBuffer,
+  LongSpscRingBuffer,
+  SpscRingBuffer
+}
+import zio.blocks.streams.{JvmType, Platform}
+import zio.blocks.streams.io.Reader
+
+import java.util.concurrent.atomic.{AtomicReference, AtomicReferenceArray}
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * `Double`-specialized concurrent `mapPar` reader.
+ *
+ * The per-worker input queue is `DoubleSpscRingBuffer`, which reserves the bit
+ * patterns `EMPTY_BITS = 0xfff8000000000001L` and `DONE_BITS =
+ * 0xfff8000000000002L` (both `NaN`) as in-band sentinels; any input value
+ * encoding to those exact bit patterns is rejected by the input queue and
+ * surfaced as a stream error.
+ *
+ * The per-worker output queue is selected at construction time from `outType`:
+ *   - `JvmType.Int` → `IntSpscRingBuffer`
+ *   - `JvmType.Long` → `LongSpscRingBuffer`
+ *   - `JvmType.Float` → `FloatSpscRingBuffer`
+ *   - `JvmType.Double` → `DoubleSpscRingBuffer`
+ *   - everything else → `SpscRingBuffer[AnyRef]` (boxed fallback)
+ *
+ * When the output queue is primitive there is **zero allocation** on the
+ * worker-to-consumer hot path.
+ */
+private[streams] final class DoubleConcurrentMapParReader[B](
+  upstream: Reader[Double],
+  n: Int,
+  f: Double => B,
+  bufferSize: Int,
+  outType: JvmType
+) extends Reader[B] {
+  import ConcurrentMapParReader._
+
+  require(n >= 1, s"DoubleConcurrentMapParReader requires n >= 1, got $n")
+
+  private val doubleToIntFn: (Double => Int) =
+    if (outType eq JvmType.Int) f.asInstanceOf[Double => Int] else null
+  private val doubleToLongFn: (Double => Long) =
+    if (outType eq JvmType.Long) f.asInstanceOf[Double => Long] else null
+  private val doubleToDoubleFn: (Double => Double) =
+    if (outType eq JvmType.Double) f.asInstanceOf[Double => Double] else null
+  private val doubleToFloatFn: (Double => Float) =
+    if (outType eq JvmType.Float) f.asInstanceOf[Double => Float] else null
+
+  private val outIntQs: Array[IntSpscRingBuffer] =
+    if (outType eq JvmType.Int) Array.tabulate(n)(_ => new IntSpscRingBuffer(bufferSize)) else null
+  private val outLongQs: Array[LongSpscRingBuffer] =
+    if (outType eq JvmType.Long) Array.tabulate(n)(_ => new LongSpscRingBuffer(bufferSize)) else null
+  private val outFloatQs: Array[FloatSpscRingBuffer] =
+    if (outType eq JvmType.Float) Array.tabulate(n)(_ => new FloatSpscRingBuffer(bufferSize)) else null
+  private val outDoubleQs: Array[DoubleSpscRingBuffer] =
+    if (outType eq JvmType.Double) Array.tabulate(n)(_ => new DoubleSpscRingBuffer(bufferSize)) else null
+  private val outRefQs: Array[SpscRingBuffer[AnyRef]] =
+    if ((outIntQs eq null) && (outLongQs eq null) && (outFloatQs eq null) && (outDoubleQs eq null))
+      Array.tabulate(n)(_ => new SpscRingBuffer[AnyRef](bufferSize))
+    else null
+
+  @volatile private var consumerWaiter: Thread = null
+
+  private val inputQueues: Array[DoubleSpscRingBuffer] =
+    Array.tabulate(n)(_ => new DoubleSpscRingBuffer(bufferSize))
+  private val workerWaiters = new AtomicReferenceArray[Thread](n)
+  private val workerThreads = new AtomicReferenceArray[Thread](n)
+
+  private val errorRef                            = new AtomicReference[Throwable](null)
+  @volatile private var consumerClosed: Boolean   = false
+  @volatile private var coordinatorThread: Thread = null.asInstanceOf[Thread]
+
+  private val workerTasks: Array[Runnable] = Array.tabulate(n) { idx =>
+    new Runnable {
+      def run(): Unit = workerLoop(idx)
+    }
+  }
+
+  Array.tabulate(n) { idx =>
+    Platform.startVirtualThread(
+      s"zio-blocks-mappar-worker-${counter.getAndIncrement()}-$idx",
+      workerTasks(idx)
+    )
+  }
+
+  private val coordinatorTask: Runnable = new Runnable {
+    def run(): Unit =
+      try {
+        val coordBuf = new Array[Double](bufferSize)
+        var scanIdx  = 0
+        var running  = true
+
+        while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+          val count = upstream.readDoubles(coordBuf, 0, bufferSize)(unsafeEvidence)
+          if (count <= 0) {
+            running = false
+          } else {
+            var j = 0
+            while (j < count && running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+              val v          = coordBuf(j)
+              var dispatched = false
+              while (!dispatched && !consumerClosed && !Thread.currentThread().isInterrupted) {
+                var i = 0
+                while (i < n && !dispatched) {
+                  val qIdx = (scanIdx + i) % n
+                  if (inputQueues(qIdx).offer(v)) {
+                    val ww = workerWaiters.get(qIdx)
+                    if (ww ne null) LockSupport.unpark(ww)
+                    scanIdx = (qIdx + 1) % n
+                    dispatched = true
+                  }
+                  i += 1
+                }
+                if (!dispatched) {
+                  LockSupport.parkNanos(this, 1000L)
+                }
+              }
+              if (!dispatched) running = false
+              j += 1
+            }
+          }
+        }
+      } catch {
+        case t: Throwable =>
+          recordError(t)
+      } finally {
+        signalWorkersToStop()
+        try upstream.close()
+        catch { case _: Throwable => () }
+      }
+  }
+
+  coordinatorThread = Platform.startVirtualThread(
+    s"zio-blocks-mappar-coordinator-${counter.getAndIncrement()}",
+    coordinatorTask
+  )
+
+  def isClosed: Boolean = eofReturned || consumerClosed
+
+  private var scanStart: Int        = 0
+  private var workersDoneCount: Int = 0
+  private var eofReturned: Boolean  = false
+
+  override def jvmType: JvmType = outType
+
+  def read[B1 >: B](sentinel: B1): B1 =
+    if (outIntQs ne null) {
+      val v = pollIntOnce(IntSpscRingBuffer.EMPTY_PACKED)
+      if (v == IntSpscRingBuffer.EMPTY_PACKED) sentinel
+      else Int.box(v.toInt).asInstanceOf[B1]
+    } else if (outLongQs ne null) {
+      val v = pollLongOnce(LongSpscRingBuffer.EMPTY)
+      if (v == LongSpscRingBuffer.EMPTY) sentinel
+      else Long.box(v).asInstanceOf[B1]
+    } else if (outFloatQs ne null) {
+      val packed = pollFloatPacked()
+      if (packed == FloatSpscRingBuffer.EMPTY_PACKED) sentinel
+      else Float.box(java.lang.Float.intBitsToFloat(packed.toInt)).asInstanceOf[B1]
+    } else if (outDoubleQs ne null) {
+      val packed = pollDoublePacked()
+      if (packed == DoubleSpscRingBuffer.EMPTY_BITS) sentinel
+      else Double.box(java.lang.Double.longBitsToDouble(packed)).asInstanceOf[B1]
+    } else {
+      readRef(sentinel)
+    }
+
+  override def readInt(sentinel: Long)(implicit ev: B <:< Int): Long =
+    if (outIntQs ne null) {
+      val v = pollIntOnce(IntSpscRingBuffer.EMPTY_PACKED)
+      if (v == IntSpscRingBuffer.EMPTY_PACKED) sentinel
+      else v.toInt.toLong
+    } else readIntFromRef(sentinel)
+
+  override def readLong(sentinel: Long)(implicit ev: B <:< Long): Long =
+    if (outLongQs ne null) {
+      val v = pollLongOnce(LongSpscRingBuffer.EMPTY)
+      if (v == LongSpscRingBuffer.EMPTY) sentinel else v
+    } else readLongFromRef(sentinel)
+
+  override def readFloat(sentinel: Double)(implicit ev: B <:< Float): Double =
+    if (outFloatQs ne null) {
+      val packed = pollFloatPacked()
+      if (packed == FloatSpscRingBuffer.EMPTY_PACKED) sentinel
+      else java.lang.Float.intBitsToFloat(packed.toInt).toDouble
+    } else readFloatFromRef(sentinel)
+
+  override def readDouble(sentinel: Double)(implicit ev: B <:< Double): Double =
+    if (outDoubleQs ne null) {
+      val packed = pollDoublePacked()
+      if (packed == DoubleSpscRingBuffer.EMPTY_BITS) sentinel
+      else java.lang.Double.longBitsToDouble(packed)
+    } else readDoubleFromRef(sentinel)
+
+  private def pollIntOnce(emptyMarker: Long): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outIntQs(qIdx).pollPacked()
+          if (packed == IntSpscRingBuffer.DONE_PACKED) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != IntSpscRingBuffer.EMPTY_PACKED) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return emptyMarker }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    emptyMarker
+  }
+
+  private def pollLongOnce(emptyMarker: Long): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outLongQs(qIdx).pollPacked()
+          if (packed == LongSpscRingBuffer.DONE) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != LongSpscRingBuffer.EMPTY) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return emptyMarker }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    emptyMarker
+  }
+
+  private def pollFloatPacked(): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outFloatQs(qIdx).pollPacked()
+          if (packed == FloatSpscRingBuffer.DONE_PACKED) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != FloatSpscRingBuffer.EMPTY_PACKED) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return FloatSpscRingBuffer.EMPTY_PACKED }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    FloatSpscRingBuffer.EMPTY_PACKED
+  }
+
+  private def pollDoublePacked(): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outDoubleQs(qIdx).pollPacked()
+          if (packed == DoubleSpscRingBuffer.DONE_BITS) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != DoubleSpscRingBuffer.EMPTY_BITS) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return DoubleSpscRingBuffer.EMPTY_BITS }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    DoubleSpscRingBuffer.EMPTY_BITS
+  }
+
+  private def readRef[B1 >: B](sentinel: B1): B1 = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx = (scanStart + i) % n
+          val item = outRefQs(qIdx).take()
+          if (item ne null) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            if (item eq NullSentinel) return null.asInstanceOf[B1]
+            if (item eq AllWorkersDone) workersDoneCount += 1
+            else return item.asInstanceOf[B1]
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return sentinel }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    sentinel
+  }
+
+  private def readIntFromRef(sentinel: Long): Long = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].intValue().toLong
+  }
+  private def readLongFromRef(sentinel: Long): Long = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].longValue()
+  }
+  private def readFloatFromRef(sentinel: Double): Double = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].floatValue().toDouble
+  }
+  private def readDoubleFromRef(sentinel: Double): Double = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].doubleValue()
+  }
+
+  def close(): Unit = {
+    consumerClosed = true
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+    var i = 0
+    while (i < n) {
+      val ww = workerWaiters.get(i)
+      if (ww ne null) LockSupport.unpark(ww)
+      i += 1
+    }
+
+    val ct = coordinatorThread
+    if (ct ne null) {
+      ct.interrupt()
+      ct.join(5000)
+    }
+
+    i = 0
+    while (i < n) {
+      val t = workerThreads.get(i)
+      if (t ne null) {
+        t.interrupt()
+        t.join(5000)
+      }
+      i += 1
+    }
+  }
+
+  private def workerLoop(idx: Int): Unit = {
+    val self = Thread.currentThread()
+    workerThreads.set(idx, self)
+
+    var keepRunning = true
+
+    while (keepRunning && !consumerClosed && !self.isInterrupted) {
+      var packed = inputQueues(idx).pollPacked()
+      if (packed == DoubleSpscRingBuffer.EMPTY_BITS) {
+        workerWaiters.set(idx, self)
+        packed = inputQueues(idx).pollPacked()
+        if (packed == DoubleSpscRingBuffer.EMPTY_BITS) {
+          if (!consumerClosed && !self.isInterrupted) LockSupport.park(this)
+        }
+        workerWaiters.set(idx, null)
+      }
+      if (packed == DoubleSpscRingBuffer.DONE_BITS) {
+        keepRunning = false
+      } else if (packed != DoubleSpscRingBuffer.EMPTY_BITS) {
+        val input: Double = java.lang.Double.longBitsToDouble(packed)
+        try {
+          if (doubleToIntFn ne null) {
+            val out = doubleToIntFn(input)
+            offerToIntOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else if (doubleToLongFn ne null) {
+            val out = doubleToLongFn(input)
+            offerToLongOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else if (doubleToDoubleFn ne null) {
+            val out = doubleToDoubleFn(input)
+            offerToDoubleOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else if (doubleToFloatFn ne null) {
+            val out = doubleToFloatFn(input)
+            offerToFloatOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else {
+            val result          = f(input)
+            val wrapped: AnyRef = if (result == null) NullSentinel else result.asInstanceOf[AnyRef]
+            offerToRefOutput(idx, wrapped, self) || { keepRunning = false; true }; ()
+          }
+        } catch {
+          case t: Throwable =>
+            recordError(t)
+            keepRunning = false
+        }
+      }
+    }
+
+    signalWorkerDone(idx, self)
+  }
+
+  private def offerToIntOutput(idx: Int, value: Int, self: Thread): Boolean = {
+    val q = outIntQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToLongOutput(idx: Int, value: Long, self: Thread): Boolean = {
+    val q = outLongQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToFloatOutput(idx: Int, value: Float, self: Thread): Boolean = {
+    val q = outFloatQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToDoubleOutput(idx: Int, value: Double, self: Thread): Boolean = {
+    val q = outDoubleQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToRefOutput(idx: Int, wrapped: AnyRef, self: Thread): Boolean = {
+    val q = outRefQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(wrapped)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def signalWorkerDone(idx: Int, self: Thread): Unit = {
+    if (outIntQs ne null) {
+      while (!outIntQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else if (outLongQs ne null) {
+      while (!outLongQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else if (outFloatQs ne null) {
+      while (!outFloatQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else if (outDoubleQs ne null) {
+      while (!outDoubleQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else {
+      while (!outRefQs(idx).offer(AllWorkersDone) && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    }
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+  }
+
+  private def signalWorkersToStop(): Unit = {
+    var i = 0
+    while (i < n) {
+      while (!inputQueues(i).offerDone() && !consumerClosed && !Thread.currentThread().isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+      val ww = workerWaiters.get(i)
+      if (ww ne null) LockSupport.unpark(ww)
+      i += 1
+    }
+  }
+
+  private def recordError(t: Throwable): Unit =
+    if (errorRef.compareAndSet(null, t)) {
+      consumerClosed = true
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      var i = 0
+      while (i < n) {
+        val ww = workerWaiters.get(i)
+        if (ww ne null) LockSupport.unpark(ww)
+        i += 1
+      }
+
+      val ct = coordinatorThread
+      if (ct ne null) ct.interrupt()
+
+      i = 0
+      while (i < n) {
+        val wt = workerThreads.get(i)
+        if (wt ne null) wt.interrupt()
+        i += 1
+      }
+    }
+
+  private def rethrow(t: Throwable): Nothing = t match {
+    case se: StreamError => throw se
+    case _               => throw t
+  }
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/DoubleConcurrentMergeReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/DoubleConcurrentMergeReader.scala
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.internal
+
+import zio.blocks.chunk.{Chunk, ChunkBuilder}
+import zio.blocks.ringbuffer.DoubleSpscRingBuffer
+import zio.blocks.streams.{JvmType, Platform, Stream}
+import zio.blocks.streams.io.Reader
+import zio.blocks.streams.queues.BlockingMpmcQueue
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.{AtomicReference, AtomicReferenceArray}
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * `Double`-specialized concurrent merge reader (used by `mergeAll` /
+ * `flatMapPar`).
+ *
+ * Uses `DoubleSpscRingBuffer` for the per-drainer data channel, which reserves
+ * two NaN bit patterns: `EMPTY_BITS` (`0xFFF8_0000_0000_0001L`) is the
+ * empty-slot marker and `DONE_BITS` (`0xFFF8_0000_0000_0002L`) is the in-band
+ * end-of-stream sentinel. Any other 64-bit pattern decodes to a real `Double`
+ * via `java.lang.Double.longBitsToDouble`.
+ *
+ * Each drainer writes one in-band DONE to its data queue when it has finished
+ * all assigned inner streams. The consumer counts DONE sentinels and terminates
+ * once it has seen `maxOpen` of them — no separate `coordinatorDone` volatile
+ * flag is needed on the hot path.
+ */
+private[streams] final class DoubleConcurrentMergeReader(outerReader: Reader[?], maxOpen: Int, bufferSize: Int)
+    extends Reader[Double] {
+  import ConcurrentMergeReader._
+  import DoubleConcurrentMergeReader._
+
+  require(maxOpen >= 1, s"DoubleConcurrentMergeReader requires maxOpen >= 1, got $maxOpen")
+
+  private val outer: Reader[Any] = outerReader.asInstanceOf[Reader[Any]]
+
+  private val dataQueues: Array[DoubleSpscRingBuffer] =
+    Array.tabulate(maxOpen)(_ => new DoubleSpscRingBuffer(bufferSize))
+  @volatile private var consumerWaiter: Thread = null
+
+  private val errorRef                          = new AtomicReference[Throwable](null)
+  @volatile private var consumerClosed: Boolean = false
+
+  private val workQueue      = new BlockingMpmcQueue[AnyRef](Math.max(maxOpen, 16))
+  private val drainerLatch   = new CountDownLatch(maxOpen)
+  private val drainerThreads = new AtomicReferenceArray[Thread](maxOpen)
+
+  @volatile private var coordinatorThread: Thread = null.asInstanceOf[Thread]
+
+  Array.tabulate(maxOpen) { idx =>
+    Platform.startVirtualThread(
+      s"zio-blocks-merge-drainer-${counter.getAndIncrement()}-$idx",
+      new Runnable { def run(): Unit = drainerLoop(idx) }
+    )
+  }
+
+  private val coordinatorTask: Runnable = new Runnable {
+    def run(): Unit =
+      try {
+        var running = true
+        while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+          val v = outer.read[Any](EndOfStream)
+          if (v.asInstanceOf[AnyRef] eq EndOfStream) {
+            running = false
+          } else {
+            if (!workQueue.offer(v.asInstanceOf[AnyRef])) running = false
+          }
+        }
+      } catch {
+        case t: Throwable =>
+          recordError(t)
+      } finally {
+        try {
+          var i = 0
+          while (i < maxOpen) {
+            workQueue.offer(DoneSentinel)
+            i += 1
+          }
+          try drainerLatch.await()
+          catch { case _: InterruptedException => () }
+        } catch {
+          case t: Throwable => recordError(t)
+        } finally {
+          try outer.close()
+          catch { case _: Throwable => () }
+        }
+      }
+  }
+
+  coordinatorThread = Platform.startVirtualThread(
+    s"zio-blocks-merge-coordinator-${counter.getAndIncrement()}",
+    coordinatorTask
+  )
+
+  override def jvmType: JvmType = JvmType.Double
+
+  def isClosed: Boolean = eofReturned || consumerClosed
+
+  // Consumer-thread-private state: scanStart, drainersDone, eofReturned are
+  // mutated only from the consumer side and therefore need no atomics.
+  private var scanStart: Int       = 0
+  private var drainersDone: Int    = 0
+  private var eofReturned: Boolean = false
+
+  override def readDouble(sentinel: Double)(implicit ev: Double <:< Double): Double = {
+    while (true) {
+      var i = 0
+      while (i < maxOpen) {
+        val qIdx   = (scanStart + i) % maxOpen
+        val packed = dataQueues(qIdx).pollPacked()
+        if (packed == DoubleSpscRingBuffer.DONE_BITS) {
+          drainersDone += 1
+        } else if (packed != DoubleSpscRingBuffer.EMPTY_BITS) {
+          scanStart = (qIdx + 1) % maxOpen
+          val err = errorRef.get()
+          if (err ne null) rethrow(err)
+          return java.lang.Double.longBitsToDouble(packed)
+        }
+        i += 1
+      }
+
+      val err = errorRef.get()
+      if (err ne null) rethrow(err)
+
+      if (drainersDone >= maxOpen) {
+        eofReturned = true
+        return sentinel
+      }
+
+      consumerWaiter = Thread.currentThread()
+      try {
+        // Re-poll after registering as waiter (avoid lost wakeup).
+        var k     = 0
+        var found = false
+        var datum = 0.0d
+        while (k < maxOpen && !found) {
+          val qIdx2   = (scanStart + k) % maxOpen
+          val packed2 = dataQueues(qIdx2).pollPacked()
+          if (packed2 == DoubleSpscRingBuffer.DONE_BITS) {
+            drainersDone += 1
+          } else if (packed2 != DoubleSpscRingBuffer.EMPTY_BITS) {
+            scanStart = (qIdx2 + 1) % maxOpen
+            datum = java.lang.Double.longBitsToDouble(packed2)
+            found = true
+          }
+          k += 1
+        }
+        if (found) {
+          consumerWaiter = null
+          val err2 = errorRef.get()
+          if (err2 ne null) rethrow(err2)
+          return datum
+        }
+        if (drainersDone < maxOpen && errorRef.get() == null && !consumerClosed) {
+          LockSupport.park(this)
+        }
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    sentinel
+  }
+
+  def read[A1 >: Double](sentinel: A1): A1 = {
+    val v = readDouble(Double.MaxValue)(unsafeEvidence)
+    if (v == Double.MaxValue) sentinel
+    else Double.box(v).asInstanceOf[A1]
+  }
+
+  override def readUpToN[A1 >: Double](n: Int): Chunk[A1] = {
+    if (n <= 0) return Chunk.empty
+    val first = readDouble(Double.MaxValue)(unsafeEvidence)
+    if (first == Double.MaxValue) return Chunk.empty
+    if (n == 1) return Chunk.single(first.asInstanceOf[A1])
+
+    val b = new ChunkBuilder.Double()
+    b.addOne(first)
+    var i = 1
+    while (i < n) {
+      var found = false
+      var q     = 0
+      while (q < maxOpen && !found) {
+        val qIdx   = (scanStart + q) % maxOpen
+        val packed = dataQueues(qIdx).pollPacked()
+        if (packed == DoubleSpscRingBuffer.DONE_BITS) {
+          drainersDone += 1
+        } else if (packed != DoubleSpscRingBuffer.EMPTY_BITS) {
+          found = true
+          scanStart = (qIdx + 1) % maxOpen
+          val err = errorRef.get()
+          if (err ne null) rethrow(err)
+          b.addOne(java.lang.Double.longBitsToDouble(packed))
+          i += 1
+        }
+        q += 1
+      }
+      if (!found) return b.result().asInstanceOf[Chunk[A1]]
+    }
+    b.result().asInstanceOf[Chunk[A1]]
+  }
+
+  def close(): Unit = {
+    consumerClosed = true
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+    workQueue.close()
+
+    coordinatorThread.interrupt()
+    coordinatorThread.join(5000)
+
+    var i = 0
+    while (i < maxOpen) {
+      val t = drainerThreads.get(i)
+      if (t ne null) {
+        t.interrupt()
+        t.join(5000)
+      }
+      i += 1
+    }
+  }
+
+  private def drainerLoop(idx: Int): Unit = {
+    val self = Thread.currentThread()
+    drainerThreads.set(idx, self)
+    try {
+      var keepRunning = true
+      while (keepRunning && !consumerClosed && !self.isInterrupted) {
+        val work = workQueue.take()
+        if ((work eq null) || (work eq DoneSentinel) || consumerClosed || self.isInterrupted) {
+          keepRunning = false
+        } else {
+          drainInner(work.asInstanceOf[Stream[Any, Double]], idx)
+        }
+      }
+    } finally {
+      // In-band: write DONE into this drainer's data queue. This is ordered
+      // after every prior `offer` and tells the consumer that no more data
+      // will ever come from this drainer. Once the consumer has seen `maxOpen`
+      // DONE sentinels, the stream is terminated.
+      while (!dataQueues(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      drainerLatch.countDown()
+    }
+  }
+
+  private def drainInner(innerStream: Stream[Any, Double], drainerIdx: Int): Unit = {
+    var innerReader: Reader[Double] = null
+    try {
+      innerReader = innerStream.compile(0, bufferSize)
+      var running = true
+      while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+        val v = innerReader.readDouble(Double.MaxValue)(unsafeEvidence)
+        if (v == Double.MaxValue) {
+          running = false
+        } else {
+          var offered = false
+          while (!offered && !consumerClosed && !Thread.currentThread().isInterrupted) {
+            if (dataQueues(drainerIdx).offer(v)) {
+              offered = true
+              val cw = consumerWaiter
+              if (cw ne null) LockSupport.unpark(cw)
+            } else {
+              LockSupport.parkNanos(this, 1000L)
+            }
+          }
+          if (!offered) {
+            running = false
+          }
+        }
+      }
+
+    } catch {
+      case t: Throwable =>
+        recordError(t)
+    } finally {
+      if (innerReader ne null) {
+        try innerReader.close()
+        catch { case _: Throwable => () }
+      }
+    }
+  }
+
+  private def recordError(t: Throwable): Unit =
+    if (errorRef.compareAndSet(null, t)) {
+      consumerClosed = true
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      workQueue.close()
+      val ct = coordinatorThread
+      if (ct ne null) ct.interrupt()
+      var i = 0
+      while (i < maxOpen) {
+        val dt = drainerThreads.get(i)
+        if (dt ne null) dt.interrupt()
+        i += 1
+      }
+    }
+
+  private def rethrow(t: Throwable): Nothing = t match {
+    case se: StreamError => throw se
+    case _               => throw t
+  }
+}
+
+private[internal] object DoubleConcurrentMergeReader {
+  private val DoneSentinel: AnyRef = new AnyRef
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/FloatConcurrentMapParReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/FloatConcurrentMapParReader.scala
@@ -1,0 +1,610 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.internal
+
+import zio.blocks.ringbuffer.{
+  DoubleSpscRingBuffer,
+  FloatSpscRingBuffer,
+  IntSpscRingBuffer,
+  LongSpscRingBuffer,
+  SpscRingBuffer
+}
+import zio.blocks.streams.{JvmType, Platform}
+import zio.blocks.streams.io.Reader
+
+import java.util.concurrent.atomic.{AtomicReference, AtomicReferenceArray}
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * `Float`-specialized concurrent `mapPar` reader.
+ *
+ * The per-worker input queue is `FloatSpscRingBuffer`; the worker reads
+ * primitive `Float` values without boxing.
+ *
+ * The per-worker output queue is selected at construction time from `outType`:
+ *   - `JvmType.Int` → `IntSpscRingBuffer`
+ *   - `JvmType.Long` → `LongSpscRingBuffer`
+ *   - `JvmType.Float` → `FloatSpscRingBuffer`
+ *   - `JvmType.Double` → `DoubleSpscRingBuffer`
+ *   - everything else → `SpscRingBuffer[AnyRef]` (boxed fallback)
+ *
+ * When the output queue is primitive there is **zero allocation** on the
+ * worker-to-consumer hot path.
+ */
+private[streams] final class FloatConcurrentMapParReader[B](
+  upstream: Reader[Float],
+  n: Int,
+  f: Float => B,
+  bufferSize: Int,
+  outType: JvmType
+) extends Reader[B] {
+  import ConcurrentMapParReader._
+
+  require(n >= 1, s"FloatConcurrentMapParReader requires n >= 1, got $n")
+
+  private val floatToIntFn: (Float => Int) =
+    if (outType eq JvmType.Int) f.asInstanceOf[Float => Int] else null
+  private val floatToLongFn: (Float => Long) =
+    if (outType eq JvmType.Long) f.asInstanceOf[Float => Long] else null
+  private val floatToDoubleFn: (Float => Double) =
+    if (outType eq JvmType.Double) f.asInstanceOf[Float => Double] else null
+  private val floatToFloatFn: (Float => Float) =
+    if (outType eq JvmType.Float) f.asInstanceOf[Float => Float] else null
+
+  private val outIntQs: Array[IntSpscRingBuffer] =
+    if (outType eq JvmType.Int) Array.tabulate(n)(_ => new IntSpscRingBuffer(bufferSize)) else null
+  private val outLongQs: Array[LongSpscRingBuffer] =
+    if (outType eq JvmType.Long) Array.tabulate(n)(_ => new LongSpscRingBuffer(bufferSize)) else null
+  private val outFloatQs: Array[FloatSpscRingBuffer] =
+    if (outType eq JvmType.Float) Array.tabulate(n)(_ => new FloatSpscRingBuffer(bufferSize)) else null
+  private val outDoubleQs: Array[DoubleSpscRingBuffer] =
+    if (outType eq JvmType.Double) Array.tabulate(n)(_ => new DoubleSpscRingBuffer(bufferSize)) else null
+  private val outRefQs: Array[SpscRingBuffer[AnyRef]] =
+    if ((outIntQs eq null) && (outLongQs eq null) && (outFloatQs eq null) && (outDoubleQs eq null))
+      Array.tabulate(n)(_ => new SpscRingBuffer[AnyRef](bufferSize))
+    else null
+
+  @volatile private var consumerWaiter: Thread = null
+
+  private val inputQueues: Array[FloatSpscRingBuffer] =
+    Array.tabulate(n)(_ => new FloatSpscRingBuffer(bufferSize))
+  private val workerWaiters = new AtomicReferenceArray[Thread](n)
+  private val workerThreads = new AtomicReferenceArray[Thread](n)
+
+  private val errorRef                            = new AtomicReference[Throwable](null)
+  @volatile private var consumerClosed: Boolean   = false
+  @volatile private var coordinatorThread: Thread = null.asInstanceOf[Thread]
+
+  private val workerTasks: Array[Runnable] = Array.tabulate(n) { idx =>
+    new Runnable {
+      def run(): Unit = workerLoop(idx)
+    }
+  }
+
+  Array.tabulate(n) { idx =>
+    Platform.startVirtualThread(
+      s"zio-blocks-mappar-worker-${counter.getAndIncrement()}-$idx",
+      workerTasks(idx)
+    )
+  }
+
+  private val coordinatorTask: Runnable = new Runnable {
+    def run(): Unit =
+      try {
+        val coordBuf = new Array[Float](bufferSize)
+        var scanIdx  = 0
+        var running  = true
+
+        while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+          val count = upstream.readFloats(coordBuf, 0, bufferSize)(unsafeEvidence)
+          if (count <= 0) {
+            running = false
+          } else {
+            var j = 0
+            while (j < count && running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+              val v          = coordBuf(j)
+              var dispatched = false
+              while (!dispatched && !consumerClosed && !Thread.currentThread().isInterrupted) {
+                var i = 0
+                while (i < n && !dispatched) {
+                  val qIdx = (scanIdx + i) % n
+                  if (inputQueues(qIdx).offer(v)) {
+                    val ww = workerWaiters.get(qIdx)
+                    if (ww ne null) LockSupport.unpark(ww)
+                    scanIdx = (qIdx + 1) % n
+                    dispatched = true
+                  }
+                  i += 1
+                }
+                if (!dispatched) {
+                  LockSupport.parkNanos(this, 1000L)
+                }
+              }
+              if (!dispatched) running = false
+              j += 1
+            }
+          }
+        }
+      } catch {
+        case t: Throwable =>
+          recordError(t)
+      } finally {
+        signalWorkersToStop()
+        try upstream.close()
+        catch { case _: Throwable => () }
+      }
+  }
+
+  coordinatorThread = Platform.startVirtualThread(
+    s"zio-blocks-mappar-coordinator-${counter.getAndIncrement()}",
+    coordinatorTask
+  )
+
+  def isClosed: Boolean = eofReturned || consumerClosed
+
+  private var scanStart: Int        = 0
+  private var workersDoneCount: Int = 0
+  private var eofReturned: Boolean  = false
+
+  override def jvmType: JvmType = outType
+
+  def read[B1 >: B](sentinel: B1): B1 =
+    if (outIntQs ne null) {
+      val v = pollIntOnce(IntSpscRingBuffer.EMPTY_PACKED)
+      if (v == IntSpscRingBuffer.EMPTY_PACKED) sentinel
+      else Int.box(v.toInt).asInstanceOf[B1]
+    } else if (outLongQs ne null) {
+      val v = pollLongOnce(LongSpscRingBuffer.EMPTY)
+      if (v == LongSpscRingBuffer.EMPTY) sentinel
+      else Long.box(v).asInstanceOf[B1]
+    } else if (outFloatQs ne null) {
+      val packed = pollFloatPacked()
+      if (packed == FloatSpscRingBuffer.EMPTY_PACKED) sentinel
+      else Float.box(java.lang.Float.intBitsToFloat(packed.toInt)).asInstanceOf[B1]
+    } else if (outDoubleQs ne null) {
+      val packed = pollDoublePacked()
+      if (packed == DoubleSpscRingBuffer.EMPTY_BITS) sentinel
+      else Double.box(java.lang.Double.longBitsToDouble(packed)).asInstanceOf[B1]
+    } else {
+      readRef(sentinel)
+    }
+
+  override def readInt(sentinel: Long)(implicit ev: B <:< Int): Long =
+    if (outIntQs ne null) {
+      val v = pollIntOnce(IntSpscRingBuffer.EMPTY_PACKED)
+      if (v == IntSpscRingBuffer.EMPTY_PACKED) sentinel
+      else v.toInt.toLong
+    } else readIntFromRef(sentinel)
+
+  override def readLong(sentinel: Long)(implicit ev: B <:< Long): Long =
+    if (outLongQs ne null) {
+      val v = pollLongOnce(LongSpscRingBuffer.EMPTY)
+      if (v == LongSpscRingBuffer.EMPTY) sentinel else v
+    } else readLongFromRef(sentinel)
+
+  override def readFloat(sentinel: Double)(implicit ev: B <:< Float): Double =
+    if (outFloatQs ne null) {
+      val packed = pollFloatPacked()
+      if (packed == FloatSpscRingBuffer.EMPTY_PACKED) sentinel
+      else java.lang.Float.intBitsToFloat(packed.toInt).toDouble
+    } else readFloatFromRef(sentinel)
+
+  override def readDouble(sentinel: Double)(implicit ev: B <:< Double): Double =
+    if (outDoubleQs ne null) {
+      val packed = pollDoublePacked()
+      if (packed == DoubleSpscRingBuffer.EMPTY_BITS) sentinel
+      else java.lang.Double.longBitsToDouble(packed)
+    } else readDoubleFromRef(sentinel)
+
+  private def pollIntOnce(emptyMarker: Long): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outIntQs(qIdx).pollPacked()
+          if (packed == IntSpscRingBuffer.DONE_PACKED) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != IntSpscRingBuffer.EMPTY_PACKED) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return emptyMarker }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    emptyMarker
+  }
+
+  private def pollLongOnce(emptyMarker: Long): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outLongQs(qIdx).pollPacked()
+          if (packed == LongSpscRingBuffer.DONE) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != LongSpscRingBuffer.EMPTY) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return emptyMarker }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    emptyMarker
+  }
+
+  private def pollFloatPacked(): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outFloatQs(qIdx).pollPacked()
+          if (packed == FloatSpscRingBuffer.DONE_PACKED) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != FloatSpscRingBuffer.EMPTY_PACKED) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return FloatSpscRingBuffer.EMPTY_PACKED }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    FloatSpscRingBuffer.EMPTY_PACKED
+  }
+
+  private def pollDoublePacked(): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outDoubleQs(qIdx).pollPacked()
+          if (packed == DoubleSpscRingBuffer.DONE_BITS) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != DoubleSpscRingBuffer.EMPTY_BITS) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return DoubleSpscRingBuffer.EMPTY_BITS }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    DoubleSpscRingBuffer.EMPTY_BITS
+  }
+
+  private def readRef[B1 >: B](sentinel: B1): B1 = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx = (scanStart + i) % n
+          val item = outRefQs(qIdx).take()
+          if (item ne null) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            if (item eq NullSentinel) return null.asInstanceOf[B1]
+            if (item eq AllWorkersDone) workersDoneCount += 1
+            else return item.asInstanceOf[B1]
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return sentinel }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    sentinel
+  }
+
+  private def readIntFromRef(sentinel: Long): Long = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].intValue().toLong
+  }
+  private def readLongFromRef(sentinel: Long): Long = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].longValue()
+  }
+  private def readFloatFromRef(sentinel: Double): Double = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].floatValue().toDouble
+  }
+  private def readDoubleFromRef(sentinel: Double): Double = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].doubleValue()
+  }
+
+  def close(): Unit = {
+    consumerClosed = true
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+    var i = 0
+    while (i < n) {
+      val ww = workerWaiters.get(i)
+      if (ww ne null) LockSupport.unpark(ww)
+      i += 1
+    }
+
+    val ct = coordinatorThread
+    if (ct ne null) {
+      ct.interrupt()
+      ct.join(5000)
+    }
+
+    i = 0
+    while (i < n) {
+      val t = workerThreads.get(i)
+      if (t ne null) {
+        t.interrupt()
+        t.join(5000)
+      }
+      i += 1
+    }
+  }
+
+  private def workerLoop(idx: Int): Unit = {
+    val self = Thread.currentThread()
+    workerThreads.set(idx, self)
+
+    var keepRunning = true
+
+    while (keepRunning && !consumerClosed && !self.isInterrupted) {
+      var packed = inputQueues(idx).pollPacked()
+      if (packed == FloatSpscRingBuffer.EMPTY_PACKED) {
+        workerWaiters.set(idx, self)
+        packed = inputQueues(idx).pollPacked()
+        if (packed == FloatSpscRingBuffer.EMPTY_PACKED) {
+          if (!consumerClosed && !self.isInterrupted) LockSupport.park(this)
+        }
+        workerWaiters.set(idx, null)
+      }
+      if (packed == FloatSpscRingBuffer.DONE_PACKED) {
+        keepRunning = false
+      } else if (packed != FloatSpscRingBuffer.EMPTY_PACKED) {
+        val input: Float = java.lang.Float.intBitsToFloat(packed.toInt)
+        try {
+          if (floatToIntFn ne null) {
+            val out = floatToIntFn(input)
+            offerToIntOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else if (floatToLongFn ne null) {
+            val out = floatToLongFn(input)
+            offerToLongOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else if (floatToDoubleFn ne null) {
+            val out = floatToDoubleFn(input)
+            offerToDoubleOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else if (floatToFloatFn ne null) {
+            val out = floatToFloatFn(input)
+            offerToFloatOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else {
+            val result          = f(input)
+            val wrapped: AnyRef = if (result == null) NullSentinel else result.asInstanceOf[AnyRef]
+            offerToRefOutput(idx, wrapped, self) || { keepRunning = false; true }; ()
+          }
+        } catch {
+          case t: Throwable =>
+            recordError(t)
+            keepRunning = false
+        }
+      }
+    }
+
+    signalWorkerDone(idx, self)
+  }
+
+  private def offerToIntOutput(idx: Int, value: Int, self: Thread): Boolean = {
+    val q = outIntQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToLongOutput(idx: Int, value: Long, self: Thread): Boolean = {
+    val q = outLongQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToFloatOutput(idx: Int, value: Float, self: Thread): Boolean = {
+    val q = outFloatQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToDoubleOutput(idx: Int, value: Double, self: Thread): Boolean = {
+    val q = outDoubleQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToRefOutput(idx: Int, wrapped: AnyRef, self: Thread): Boolean = {
+    val q = outRefQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(wrapped)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def signalWorkerDone(idx: Int, self: Thread): Unit = {
+    if (outIntQs ne null) {
+      while (!outIntQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else if (outLongQs ne null) {
+      while (!outLongQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else if (outFloatQs ne null) {
+      while (!outFloatQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else if (outDoubleQs ne null) {
+      while (!outDoubleQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else {
+      while (!outRefQs(idx).offer(AllWorkersDone) && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    }
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+  }
+
+  private def signalWorkersToStop(): Unit = {
+    var i = 0
+    while (i < n) {
+      while (!inputQueues(i).offerDone() && !consumerClosed && !Thread.currentThread().isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+      val ww = workerWaiters.get(i)
+      if (ww ne null) LockSupport.unpark(ww)
+      i += 1
+    }
+  }
+
+  private def recordError(t: Throwable): Unit =
+    if (errorRef.compareAndSet(null, t)) {
+      consumerClosed = true
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      var i = 0
+      while (i < n) {
+        val ww = workerWaiters.get(i)
+        if (ww ne null) LockSupport.unpark(ww)
+        i += 1
+      }
+
+      val ct = coordinatorThread
+      if (ct ne null) ct.interrupt()
+
+      i = 0
+      while (i < n) {
+        val wt = workerThreads.get(i)
+        if (wt ne null) wt.interrupt()
+        i += 1
+      }
+    }
+
+  private def rethrow(t: Throwable): Nothing = t match {
+    case se: StreamError => throw se
+    case _               => throw t
+  }
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/FloatConcurrentMergeReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/FloatConcurrentMergeReader.scala
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.internal
+
+import zio.blocks.chunk.{Chunk, ChunkBuilder}
+import zio.blocks.ringbuffer.FloatSpscRingBuffer
+import zio.blocks.streams.{JvmType, Platform, Stream}
+import zio.blocks.streams.io.Reader
+import zio.blocks.streams.queues.BlockingMpmcQueue
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.{AtomicReference, AtomicReferenceArray}
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * `Float`-specialized concurrent merge reader (used by `mergeAll` /
+ * `flatMapPar`).
+ *
+ * Uses `FloatSpscRingBuffer` for the per-drainer data channel, which packs each
+ * `Float`'s raw bits alongside a non-zero tag in a `Long` slot: `EMPTY_PACKED`
+ * (`0L`) signals an empty slot and `DONE_PACKED` (`2L << 32`) is the in-band
+ * end-of-stream sentinel. Any other value is real data whose payload is
+ * `java.lang.Float.intBitsToFloat(packed.toInt)`.
+ *
+ * Each drainer writes one in-band DONE to its data queue when it has finished
+ * all assigned inner streams. The consumer counts DONE sentinels and terminates
+ * once it has seen `maxOpen` of them — no separate `coordinatorDone` volatile
+ * flag is needed on the hot path.
+ */
+private[streams] final class FloatConcurrentMergeReader(outerReader: Reader[?], maxOpen: Int, bufferSize: Int)
+    extends Reader[Float] {
+  import ConcurrentMergeReader._
+  import FloatConcurrentMergeReader._
+
+  require(maxOpen >= 1, s"FloatConcurrentMergeReader requires maxOpen >= 1, got $maxOpen")
+
+  private val outer: Reader[Any] = outerReader.asInstanceOf[Reader[Any]]
+
+  private val dataQueues: Array[FloatSpscRingBuffer] =
+    Array.tabulate(maxOpen)(_ => new FloatSpscRingBuffer(bufferSize))
+  @volatile private var consumerWaiter: Thread = null
+
+  private val errorRef                          = new AtomicReference[Throwable](null)
+  @volatile private var consumerClosed: Boolean = false
+
+  private val workQueue      = new BlockingMpmcQueue[AnyRef](Math.max(maxOpen, 16))
+  private val drainerLatch   = new CountDownLatch(maxOpen)
+  private val drainerThreads = new AtomicReferenceArray[Thread](maxOpen)
+
+  @volatile private var coordinatorThread: Thread = null.asInstanceOf[Thread]
+
+  Array.tabulate(maxOpen) { idx =>
+    Platform.startVirtualThread(
+      s"zio-blocks-merge-drainer-${counter.getAndIncrement()}-$idx",
+      new Runnable { def run(): Unit = drainerLoop(idx) }
+    )
+  }
+
+  private val coordinatorTask: Runnable = new Runnable {
+    def run(): Unit =
+      try {
+        var running = true
+        while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+          val v = outer.read[Any](EndOfStream)
+          if (v.asInstanceOf[AnyRef] eq EndOfStream) {
+            running = false
+          } else {
+            if (!workQueue.offer(v.asInstanceOf[AnyRef])) running = false
+          }
+        }
+      } catch {
+        case t: Throwable =>
+          recordError(t)
+      } finally {
+        try {
+          var i = 0
+          while (i < maxOpen) {
+            workQueue.offer(DoneSentinel)
+            i += 1
+          }
+          try drainerLatch.await()
+          catch { case _: InterruptedException => () }
+        } catch {
+          case t: Throwable => recordError(t)
+        } finally {
+          try outer.close()
+          catch { case _: Throwable => () }
+        }
+      }
+  }
+
+  coordinatorThread = Platform.startVirtualThread(
+    s"zio-blocks-merge-coordinator-${counter.getAndIncrement()}",
+    coordinatorTask
+  )
+
+  override def jvmType: JvmType = JvmType.Float
+
+  def isClosed: Boolean = eofReturned || consumerClosed
+
+  // Consumer-thread-private state: scanStart, drainersDone, eofReturned are
+  // mutated only from the consumer side and therefore need no atomics.
+  private var scanStart: Int       = 0
+  private var drainersDone: Int    = 0
+  private var eofReturned: Boolean = false
+
+  override def readFloat(sentinel: Double)(implicit ev: Float <:< Float): Double = {
+    while (true) {
+      var i = 0
+      while (i < maxOpen) {
+        val qIdx   = (scanStart + i) % maxOpen
+        val packed = dataQueues(qIdx).pollPacked()
+        if (packed == FloatSpscRingBuffer.DONE_PACKED) {
+          drainersDone += 1
+        } else if (packed != FloatSpscRingBuffer.EMPTY_PACKED) {
+          scanStart = (qIdx + 1) % maxOpen
+          val err = errorRef.get()
+          if (err ne null) rethrow(err)
+          return java.lang.Float.intBitsToFloat(packed.toInt).toDouble
+        }
+        i += 1
+      }
+
+      val err = errorRef.get()
+      if (err ne null) rethrow(err)
+
+      if (drainersDone >= maxOpen) {
+        eofReturned = true
+        return sentinel
+      }
+
+      consumerWaiter = Thread.currentThread()
+      try {
+        // Re-poll after registering as waiter (avoid lost wakeup).
+        var k     = 0
+        var found = false
+        var datum = 0.0f
+        while (k < maxOpen && !found) {
+          val qIdx2   = (scanStart + k) % maxOpen
+          val packed2 = dataQueues(qIdx2).pollPacked()
+          if (packed2 == FloatSpscRingBuffer.DONE_PACKED) {
+            drainersDone += 1
+          } else if (packed2 != FloatSpscRingBuffer.EMPTY_PACKED) {
+            scanStart = (qIdx2 + 1) % maxOpen
+            datum = java.lang.Float.intBitsToFloat(packed2.toInt)
+            found = true
+          }
+          k += 1
+        }
+        if (found) {
+          consumerWaiter = null
+          val err2 = errorRef.get()
+          if (err2 ne null) rethrow(err2)
+          return datum.toDouble
+        }
+        if (drainersDone < maxOpen && errorRef.get() == null && !consumerClosed) {
+          LockSupport.park(this)
+        }
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    sentinel
+  }
+
+  def read[A1 >: Float](sentinel: A1): A1 = {
+    val v = readFloat(Double.MaxValue)(unsafeEvidence)
+    if (v == Double.MaxValue) sentinel
+    else Float.box(v.toFloat).asInstanceOf[A1]
+  }
+
+  override def readUpToN[A1 >: Float](n: Int): Chunk[A1] = {
+    if (n <= 0) return Chunk.empty
+    val first = readFloat(Double.MaxValue)(unsafeEvidence)
+    if (first == Double.MaxValue) return Chunk.empty
+    if (n == 1) return Chunk.single(first.toFloat.asInstanceOf[A1])
+
+    val b = new ChunkBuilder.Float()
+    b.addOne(first.toFloat)
+    var i = 1
+    while (i < n) {
+      var found = false
+      var q     = 0
+      while (q < maxOpen && !found) {
+        val qIdx   = (scanStart + q) % maxOpen
+        val packed = dataQueues(qIdx).pollPacked()
+        if (packed == FloatSpscRingBuffer.DONE_PACKED) {
+          drainersDone += 1
+        } else if (packed != FloatSpscRingBuffer.EMPTY_PACKED) {
+          found = true
+          scanStart = (qIdx + 1) % maxOpen
+          val err = errorRef.get()
+          if (err ne null) rethrow(err)
+          b.addOne(java.lang.Float.intBitsToFloat(packed.toInt))
+          i += 1
+        }
+        q += 1
+      }
+      if (!found) return b.result().asInstanceOf[Chunk[A1]]
+    }
+    b.result().asInstanceOf[Chunk[A1]]
+  }
+
+  def close(): Unit = {
+    consumerClosed = true
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+    workQueue.close()
+
+    coordinatorThread.interrupt()
+    coordinatorThread.join(5000)
+
+    var i = 0
+    while (i < maxOpen) {
+      val t = drainerThreads.get(i)
+      if (t ne null) {
+        t.interrupt()
+        t.join(5000)
+      }
+      i += 1
+    }
+  }
+
+  private def drainerLoop(idx: Int): Unit = {
+    val self = Thread.currentThread()
+    drainerThreads.set(idx, self)
+    try {
+      var keepRunning = true
+      while (keepRunning && !consumerClosed && !self.isInterrupted) {
+        val work = workQueue.take()
+        if ((work eq null) || (work eq DoneSentinel) || consumerClosed || self.isInterrupted) {
+          keepRunning = false
+        } else {
+          drainInner(work.asInstanceOf[Stream[Any, Float]], idx)
+        }
+      }
+    } finally {
+      // In-band: write DONE into this drainer's data queue. This is ordered
+      // after every prior `offer` and tells the consumer that no more data
+      // will ever come from this drainer. Once the consumer has seen `maxOpen`
+      // DONE sentinels, the stream is terminated.
+      while (!dataQueues(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      drainerLatch.countDown()
+    }
+  }
+
+  private def drainInner(innerStream: Stream[Any, Float], drainerIdx: Int): Unit = {
+    var innerReader: Reader[Float] = null
+    try {
+      innerReader = innerStream.compile(0, bufferSize)
+      var running = true
+      while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+        val v = innerReader.readFloat(Double.MaxValue)(unsafeEvidence)
+        if (v == Double.MaxValue) {
+          running = false
+        } else {
+          var offered = false
+          while (!offered && !consumerClosed && !Thread.currentThread().isInterrupted) {
+            if (dataQueues(drainerIdx).offer(v.toFloat)) {
+              offered = true
+              val cw = consumerWaiter
+              if (cw ne null) LockSupport.unpark(cw)
+            } else {
+              LockSupport.parkNanos(this, 1000L)
+            }
+          }
+          if (!offered) {
+            running = false
+          }
+        }
+      }
+
+    } catch {
+      case t: Throwable =>
+        recordError(t)
+    } finally {
+      if (innerReader ne null) {
+        try innerReader.close()
+        catch { case _: Throwable => () }
+      }
+    }
+  }
+
+  private def recordError(t: Throwable): Unit =
+    if (errorRef.compareAndSet(null, t)) {
+      consumerClosed = true
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      workQueue.close()
+      val ct = coordinatorThread
+      if (ct ne null) ct.interrupt()
+      var i = 0
+      while (i < maxOpen) {
+        val dt = drainerThreads.get(i)
+        if (dt ne null) dt.interrupt()
+        i += 1
+      }
+    }
+
+  private def rethrow(t: Throwable): Nothing = t match {
+    case se: StreamError => throw se
+    case _               => throw t
+  }
+}
+
+private[internal] object FloatConcurrentMergeReader {
+  private val DoneSentinel: AnyRef = new AnyRef
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/IntConcurrentMapParReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/IntConcurrentMapParReader.scala
@@ -1,0 +1,654 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.internal
+
+import zio.blocks.ringbuffer.{
+  DoubleSpscRingBuffer,
+  FloatSpscRingBuffer,
+  IntSpscRingBuffer,
+  LongSpscRingBuffer,
+  SpscRingBuffer
+}
+import zio.blocks.streams.{JvmType, Platform}
+import zio.blocks.streams.io.Reader
+
+import java.util.concurrent.atomic.{AtomicReference, AtomicReferenceArray}
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * `Int`-specialized concurrent `mapPar` reader.
+ *
+ * The per-worker input queue is `IntSpscRingBuffer`; the worker reads primitive
+ * `Int` values directly without boxing.
+ *
+ * The per-worker output queue is selected at construction time based on
+ * `outType`:
+ *   - `JvmType.Int` → `IntSpscRingBuffer`
+ *   - `JvmType.Long` → `LongSpscRingBuffer`
+ *   - `JvmType.Float` → `FloatSpscRingBuffer`
+ *   - `JvmType.Double` → `DoubleSpscRingBuffer`
+ *   - everything else → `SpscRingBuffer[AnyRef]` (boxed fallback for reference
+ *     types and unspecialized primitives like `Byte`/`Short`/etc.)
+ *
+ * When the output queue is primitive there is **zero allocation** on the
+ * worker-to-consumer hot path. End-of-stream is signalled with the in-band DONE
+ * sentinel of each output queue; the consumer counts DONE markers and
+ * terminates once all `n` workers have signalled.
+ *
+ * For the `Long` output specialization, `Long.MinValue` (EMPTY) and
+ * `Long.MinValue + 1L` (DONE) are reserved sentinels; a mapping function
+ * returning either value will trigger `IllegalArgumentException` and surface as
+ * a stream error.
+ */
+private[streams] final class IntConcurrentMapParReader[B](
+  upstream: Reader[Int],
+  n: Int,
+  f: Int => B,
+  bufferSize: Int,
+  outType: JvmType
+) extends Reader[B] {
+  import ConcurrentMapParReader._
+
+  require(n >= 1, s"IntConcurrentMapParReader requires n >= 1, got $n")
+
+  // Concrete primitive function types let the JVM use `Function1` specialization
+  // (e.g. `apply$mcII$sp`) on the worker hot path.
+  private val intToIntFn: (Int => Int) =
+    if (outType eq JvmType.Int) f.asInstanceOf[Int => Int] else null
+  private val intToLongFn: (Int => Long) =
+    if (outType eq JvmType.Long) f.asInstanceOf[Int => Long] else null
+  private val intToDoubleFn: (Int => Double) =
+    if (outType eq JvmType.Double) f.asInstanceOf[Int => Double] else null
+  private val intToFloatFn: (Int => Float) =
+    if (outType eq JvmType.Float) f.asInstanceOf[Int => Float] else null
+
+  // Output queues: exactly one of these is non-null per instance.
+  private val outIntQs: Array[IntSpscRingBuffer] =
+    if (outType eq JvmType.Int) Array.tabulate(n)(_ => new IntSpscRingBuffer(bufferSize)) else null
+  private val outLongQs: Array[LongSpscRingBuffer] =
+    if (outType eq JvmType.Long) Array.tabulate(n)(_ => new LongSpscRingBuffer(bufferSize)) else null
+  private val outFloatQs: Array[FloatSpscRingBuffer] =
+    if (outType eq JvmType.Float) Array.tabulate(n)(_ => new FloatSpscRingBuffer(bufferSize)) else null
+  private val outDoubleQs: Array[DoubleSpscRingBuffer] =
+    if (outType eq JvmType.Double) Array.tabulate(n)(_ => new DoubleSpscRingBuffer(bufferSize)) else null
+  private val outRefQs: Array[SpscRingBuffer[AnyRef]] =
+    if ((outIntQs eq null) && (outLongQs eq null) && (outFloatQs eq null) && (outDoubleQs eq null))
+      Array.tabulate(n)(_ => new SpscRingBuffer[AnyRef](bufferSize))
+    else null
+
+  @volatile private var consumerWaiter: Thread = null
+
+  private val inputQueues: Array[IntSpscRingBuffer] =
+    Array.tabulate(n)(_ => new IntSpscRingBuffer(bufferSize))
+  private val workerWaiters = new AtomicReferenceArray[Thread](n)
+  private val workerThreads = new AtomicReferenceArray[Thread](n)
+
+  private val errorRef                            = new AtomicReference[Throwable](null)
+  @volatile private var consumerClosed: Boolean   = false
+  @volatile private var coordinatorThread: Thread = null.asInstanceOf[Thread]
+
+  private val workerTasks: Array[Runnable] = Array.tabulate(n) { idx =>
+    new Runnable {
+      def run(): Unit = workerLoop(idx)
+    }
+  }
+
+  Array.tabulate(n) { idx =>
+    Platform.startVirtualThread(
+      s"zio-blocks-mappar-worker-${counter.getAndIncrement()}-$idx",
+      workerTasks(idx)
+    )
+  }
+
+  private val coordinatorTask: Runnable = new Runnable {
+    def run(): Unit =
+      try {
+        val coordBuf = new Array[Int](bufferSize)
+        var scanIdx  = 0
+        var running  = true
+
+        while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+          val count = upstream.readInts(coordBuf, 0, bufferSize)(unsafeEvidence)
+          if (count <= 0) {
+            running = false
+          } else {
+            var j = 0
+            while (j < count && running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+              val intVal     = coordBuf(j)
+              var dispatched = false
+              while (!dispatched && !consumerClosed && !Thread.currentThread().isInterrupted) {
+                var i = 0
+                while (i < n && !dispatched) {
+                  val qIdx = (scanIdx + i) % n
+                  if (inputQueues(qIdx).offer(intVal)) {
+                    val ww = workerWaiters.get(qIdx)
+                    if (ww ne null) LockSupport.unpark(ww)
+                    scanIdx = (qIdx + 1) % n
+                    dispatched = true
+                  }
+                  i += 1
+                }
+                if (!dispatched) {
+                  LockSupport.parkNanos(this, 1000L)
+                }
+              }
+              if (!dispatched) running = false
+              j += 1
+            }
+          }
+        }
+      } catch {
+        case t: Throwable =>
+          recordError(t)
+      } finally {
+        signalWorkersToStop()
+        try upstream.close()
+        catch { case _: Throwable => () }
+      }
+  }
+
+  coordinatorThread = Platform.startVirtualThread(
+    s"zio-blocks-mappar-coordinator-${counter.getAndIncrement()}",
+    coordinatorTask
+  )
+
+  def isClosed: Boolean = eofReturned || consumerClosed
+
+  // Consumer-private state.
+  private var scanStart: Int        = 0
+  private var workersDoneCount: Int = 0
+  private var eofReturned: Boolean  = false
+
+  override def jvmType: JvmType = outType
+
+  // ============================================================
+  //  READ DISPATCH
+  // ============================================================
+
+  def read[B1 >: B](sentinel: B1): B1 =
+    if (outIntQs ne null) {
+      val v = pollIntOnce(IntSpscRingBuffer.EMPTY_PACKED)
+      if (v == IntSpscRingBuffer.EMPTY_PACKED) sentinel
+      else Int.box(v.toInt).asInstanceOf[B1]
+    } else if (outLongQs ne null) {
+      val v = pollLongOnce(LongSpscRingBuffer.EMPTY)
+      if (v == LongSpscRingBuffer.EMPTY) sentinel
+      else Long.box(v).asInstanceOf[B1]
+    } else if (outFloatQs ne null) {
+      val packed = pollFloatPacked()
+      if (packed == FloatSpscRingBuffer.EMPTY_PACKED) sentinel
+      else Float.box(java.lang.Float.intBitsToFloat(packed.toInt)).asInstanceOf[B1]
+    } else if (outDoubleQs ne null) {
+      val packed = pollDoublePacked()
+      if (packed == DoubleSpscRingBuffer.EMPTY_BITS) sentinel
+      else Double.box(java.lang.Double.longBitsToDouble(packed)).asInstanceOf[B1]
+    } else {
+      readRef(sentinel)
+    }
+
+  override def readInt(sentinel: Long)(implicit ev: B <:< Int): Long =
+    if (outIntQs ne null) {
+      val v = pollIntOnce(IntSpscRingBuffer.EMPTY_PACKED)
+      if (v == IntSpscRingBuffer.EMPTY_PACKED) sentinel
+      else v.toInt.toLong
+    } else readIntFromRef(sentinel)
+
+  override def readLong(sentinel: Long)(implicit ev: B <:< Long): Long =
+    if (outLongQs ne null) {
+      val v = pollLongOnce(LongSpscRingBuffer.EMPTY)
+      if (v == LongSpscRingBuffer.EMPTY) sentinel else v
+    } else readLongFromRef(sentinel)
+
+  override def readFloat(sentinel: Double)(implicit ev: B <:< Float): Double =
+    if (outFloatQs ne null) {
+      val packed = pollFloatPacked()
+      if (packed == FloatSpscRingBuffer.EMPTY_PACKED) sentinel
+      else java.lang.Float.intBitsToFloat(packed.toInt).toDouble
+    } else readFloatFromRef(sentinel)
+
+  override def readDouble(sentinel: Double)(implicit ev: B <:< Double): Double =
+    if (outDoubleQs ne null) {
+      val packed = pollDoublePacked()
+      if (packed == DoubleSpscRingBuffer.EMPTY_BITS) sentinel
+      else java.lang.Double.longBitsToDouble(packed)
+    } else readDoubleFromRef(sentinel)
+
+  // ============================================================
+  //  PRIMITIVE OUTPUT POLLERS (zero-allocation hot paths)
+  // ============================================================
+
+  /**
+   * Drives the consumer loop on an `Array[IntSpscRingBuffer]`. Returns the
+   * packed `Long` data slot (always non-empty) on success, or the supplied
+   * `emptyMarker` on real EOS (after counting all `n` worker DONE sentinels).
+   *
+   * The returned packed value is `TAG_FULL | (a & LOW32_MASK)` for data, so the
+   * caller decodes via `.toInt`.
+   */
+  private def pollIntOnce(emptyMarker: Long): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outIntQs(qIdx).pollPacked()
+          if (packed == IntSpscRingBuffer.DONE_PACKED) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != IntSpscRingBuffer.EMPTY_PACKED) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return emptyMarker }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    emptyMarker
+  }
+
+  private def pollLongOnce(emptyMarker: Long): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outLongQs(qIdx).pollPacked()
+          if (packed == LongSpscRingBuffer.DONE) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != LongSpscRingBuffer.EMPTY) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return emptyMarker }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    emptyMarker
+  }
+
+  /** Returns `FloatSpscRingBuffer.EMPTY_PACKED` (0L) on real EOS. */
+  private def pollFloatPacked(): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outFloatQs(qIdx).pollPacked()
+          if (packed == FloatSpscRingBuffer.DONE_PACKED) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != FloatSpscRingBuffer.EMPTY_PACKED) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return FloatSpscRingBuffer.EMPTY_PACKED }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    FloatSpscRingBuffer.EMPTY_PACKED
+  }
+
+  /** Returns `DoubleSpscRingBuffer.EMPTY_BITS` on real EOS. */
+  private def pollDoublePacked(): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outDoubleQs(qIdx).pollPacked()
+          if (packed == DoubleSpscRingBuffer.DONE_BITS) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != DoubleSpscRingBuffer.EMPTY_BITS) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return DoubleSpscRingBuffer.EMPTY_BITS }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    DoubleSpscRingBuffer.EMPTY_BITS
+  }
+
+  // ============================================================
+  //  REFERENCE-OUTPUT POLLERS (used when output type is not Int/Long/Float/Double)
+  // ============================================================
+
+  private def readRef[B1 >: B](sentinel: B1): B1 = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx = (scanStart + i) % n
+          val item = outRefQs(qIdx).take()
+          if (item ne null) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            if (item eq NullSentinel) return null.asInstanceOf[B1]
+            if (item eq AllWorkersDone) workersDoneCount += 1
+            else return item.asInstanceOf[B1]
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return sentinel }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    sentinel
+  }
+
+  private def readIntFromRef(sentinel: Long): Long = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].intValue().toLong
+  }
+  private def readLongFromRef(sentinel: Long): Long = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].longValue()
+  }
+  private def readFloatFromRef(sentinel: Double): Double = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].floatValue().toDouble
+  }
+  private def readDoubleFromRef(sentinel: Double): Double = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].doubleValue()
+  }
+
+  // ============================================================
+  //  CLOSE / WORKER / ERROR PLUMBING
+  // ============================================================
+
+  def close(): Unit = {
+    consumerClosed = true
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+    var i = 0
+    while (i < n) {
+      val ww = workerWaiters.get(i)
+      if (ww ne null) LockSupport.unpark(ww)
+      i += 1
+    }
+
+    val ct = coordinatorThread
+    if (ct ne null) {
+      ct.interrupt()
+      ct.join(5000)
+    }
+
+    i = 0
+    while (i < n) {
+      val t = workerThreads.get(i)
+      if (t ne null) {
+        t.interrupt()
+        t.join(5000)
+      }
+      i += 1
+    }
+  }
+
+  private def workerLoop(idx: Int): Unit = {
+    val self = Thread.currentThread()
+    workerThreads.set(idx, self)
+
+    var keepRunning = true
+
+    while (keepRunning && !consumerClosed && !self.isInterrupted) {
+      var packed = inputQueues(idx).pollPacked()
+      if (packed == IntSpscRingBuffer.EMPTY_PACKED) {
+        workerWaiters.set(idx, self)
+        packed = inputQueues(idx).pollPacked()
+        if (packed == IntSpscRingBuffer.EMPTY_PACKED) {
+          if (!consumerClosed && !self.isInterrupted) LockSupport.park(this)
+        }
+        workerWaiters.set(idx, null)
+      }
+      if (packed == IntSpscRingBuffer.DONE_PACKED) {
+        keepRunning = false
+      } else if (packed != IntSpscRingBuffer.EMPTY_PACKED) {
+        val input = packed.toInt
+        try {
+          if (intToIntFn ne null) {
+            val out = intToIntFn(input)
+            offerToIntOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else if (intToLongFn ne null) {
+            val out = intToLongFn(input)
+            offerToLongOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else if (intToDoubleFn ne null) {
+            val out = intToDoubleFn(input)
+            offerToDoubleOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else if (intToFloatFn ne null) {
+            val out = intToFloatFn(input)
+            offerToFloatOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else {
+            val result          = f(input)
+            val wrapped: AnyRef = if (result == null) NullSentinel else result.asInstanceOf[AnyRef]
+            offerToRefOutput(idx, wrapped, self) || { keepRunning = false; true }; ()
+          }
+        } catch {
+          case t: Throwable =>
+            recordError(t)
+            keepRunning = false
+        }
+      }
+    }
+
+    // Per-worker EOS marker on whichever output queue is in use.
+    signalWorkerDone(idx, self)
+  }
+
+  /** Returns true on successful offer, false on consumer-closed/interrupt. */
+  private def offerToIntOutput(idx: Int, value: Int, self: Thread): Boolean = {
+    val q = outIntQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToLongOutput(idx: Int, value: Long, self: Thread): Boolean = {
+    val q = outLongQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToFloatOutput(idx: Int, value: Float, self: Thread): Boolean = {
+    val q = outFloatQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToDoubleOutput(idx: Int, value: Double, self: Thread): Boolean = {
+    val q = outDoubleQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToRefOutput(idx: Int, wrapped: AnyRef, self: Thread): Boolean = {
+    val q = outRefQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(wrapped)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  /** Per-worker DONE marker on whichever output queue is in use. */
+  private def signalWorkerDone(idx: Int, self: Thread): Unit = {
+    if (outIntQs ne null) {
+      while (!outIntQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else if (outLongQs ne null) {
+      while (!outLongQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else if (outFloatQs ne null) {
+      while (!outFloatQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else if (outDoubleQs ne null) {
+      while (!outDoubleQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else {
+      while (!outRefQs(idx).offer(AllWorkersDone) && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    }
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+  }
+
+  private def signalWorkersToStop(): Unit = {
+    var i = 0
+    while (i < n) {
+      // In-band: write the DONE sentinel directly into the worker's input queue
+      // so it is naturally ordered after every prior data offer to that queue.
+      while (!inputQueues(i).offerDone() && !consumerClosed && !Thread.currentThread().isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+      val ww = workerWaiters.get(i)
+      if (ww ne null) LockSupport.unpark(ww)
+      i += 1
+    }
+  }
+
+  private def recordError(t: Throwable): Unit =
+    if (errorRef.compareAndSet(null, t)) {
+      consumerClosed = true
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      var i = 0
+      while (i < n) {
+        val ww = workerWaiters.get(i)
+        if (ww ne null) LockSupport.unpark(ww)
+        i += 1
+      }
+
+      val ct = coordinatorThread
+      if (ct ne null) ct.interrupt()
+
+      i = 0
+      while (i < n) {
+        val wt = workerThreads.get(i)
+        if (wt ne null) wt.interrupt()
+        i += 1
+      }
+    }
+
+  private def rethrow(t: Throwable): Nothing = t match {
+    case se: StreamError => throw se
+    case _               => throw t
+  }
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/IntConcurrentMergeReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/IntConcurrentMergeReader.scala
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.internal
+
+import zio.blocks.chunk.{Chunk, ChunkBuilder}
+import zio.blocks.ringbuffer.IntSpscRingBuffer
+import zio.blocks.streams.{JvmType, Platform, Stream}
+import zio.blocks.streams.io.Reader
+import zio.blocks.streams.queues.BlockingMpmcQueue
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.{AtomicReference, AtomicReferenceArray}
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * `Int`-specialized concurrent merge reader (used by `mergeAll` /
+ * `flatMapPar`).
+ *
+ * Uses `IntSpscRingBuffer` for the per-drainer data channel, which packs each
+ * `Int` payload alongside a non-zero tag in a `Long` slot: `EMPTY_PACKED`
+ * (`0L`) signals an empty slot and `DONE_PACKED` (`2L << 32`) is the in-band
+ * end-of-stream sentinel. Any other value is real data whose payload is
+ * `packed.toInt`.
+ *
+ * Each drainer writes one in-band DONE to its data queue when it has finished
+ * all assigned inner streams. The consumer counts DONE sentinels and terminates
+ * once it has seen `maxOpen` of them — no separate `coordinatorDone` volatile
+ * flag is needed on the hot path.
+ */
+private[streams] final class IntConcurrentMergeReader(outerReader: Reader[?], maxOpen: Int, bufferSize: Int)
+    extends Reader[Int] {
+  import ConcurrentMergeReader._
+  import IntConcurrentMergeReader._
+
+  require(maxOpen >= 1, s"IntConcurrentMergeReader requires maxOpen >= 1, got $maxOpen")
+
+  private val outer: Reader[Any] = outerReader.asInstanceOf[Reader[Any]]
+
+  private val dataQueues: Array[IntSpscRingBuffer] =
+    Array.tabulate(maxOpen)(_ => new IntSpscRingBuffer(bufferSize))
+  @volatile private var consumerWaiter: Thread = null
+
+  private val errorRef                          = new AtomicReference[Throwable](null)
+  @volatile private var consumerClosed: Boolean = false
+
+  private val workQueue      = new BlockingMpmcQueue[AnyRef](Math.max(maxOpen, 16))
+  private val drainerLatch   = new CountDownLatch(maxOpen)
+  private val drainerThreads = new AtomicReferenceArray[Thread](maxOpen)
+
+  @volatile private var coordinatorThread: Thread = null.asInstanceOf[Thread]
+
+  Array.tabulate(maxOpen) { idx =>
+    Platform.startVirtualThread(
+      s"zio-blocks-merge-drainer-${counter.getAndIncrement()}-$idx",
+      new Runnable { def run(): Unit = drainerLoop(idx) }
+    )
+  }
+
+  private val coordinatorTask: Runnable = new Runnable {
+    def run(): Unit =
+      try {
+        var running = true
+        while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+          val v = outer.read[Any](EndOfStream)
+          if (v.asInstanceOf[AnyRef] eq EndOfStream) {
+            running = false
+          } else {
+            if (!workQueue.offer(v.asInstanceOf[AnyRef])) running = false
+          }
+        }
+      } catch {
+        case t: Throwable =>
+          recordError(t)
+      } finally {
+        try {
+          var i = 0
+          while (i < maxOpen) {
+            workQueue.offer(DoneSentinel)
+            i += 1
+          }
+          try drainerLatch.await()
+          catch { case _: InterruptedException => () }
+        } catch {
+          case t: Throwable => recordError(t)
+        } finally {
+          try outer.close()
+          catch { case _: Throwable => () }
+        }
+      }
+  }
+
+  coordinatorThread = Platform.startVirtualThread(
+    s"zio-blocks-merge-coordinator-${counter.getAndIncrement()}",
+    coordinatorTask
+  )
+
+  override def jvmType: JvmType = JvmType.Int
+
+  def isClosed: Boolean = eofReturned || consumerClosed
+
+  // Consumer-thread-private state: scanStart, drainersDone, eofReturned are
+  // mutated only from the consumer side and therefore need no atomics.
+  private var scanStart: Int       = 0
+  private var drainersDone: Int    = 0
+  private var eofReturned: Boolean = false
+
+  override def readInt(sentinel: Long)(implicit ev: Int <:< Int): Long = {
+    while (true) {
+      var i = 0
+      while (i < maxOpen) {
+        val qIdx   = (scanStart + i) % maxOpen
+        val packed = dataQueues(qIdx).pollPacked()
+        if (packed == IntSpscRingBuffer.DONE_PACKED) {
+          drainersDone += 1
+        } else if (packed != IntSpscRingBuffer.EMPTY_PACKED) {
+          scanStart = (qIdx + 1) % maxOpen
+          val err = errorRef.get()
+          if (err ne null) rethrow(err)
+          return packed.toInt.toLong
+        }
+        i += 1
+      }
+
+      val err = errorRef.get()
+      if (err ne null) rethrow(err)
+
+      if (drainersDone >= maxOpen) {
+        eofReturned = true
+        return sentinel
+      }
+
+      consumerWaiter = Thread.currentThread()
+      try {
+        // Re-poll after registering as waiter (avoid lost wakeup).
+        var k     = 0
+        var found = false
+        var datum = 0
+        while (k < maxOpen && !found) {
+          val qIdx2   = (scanStart + k) % maxOpen
+          val packed2 = dataQueues(qIdx2).pollPacked()
+          if (packed2 == IntSpscRingBuffer.DONE_PACKED) {
+            drainersDone += 1
+          } else if (packed2 != IntSpscRingBuffer.EMPTY_PACKED) {
+            scanStart = (qIdx2 + 1) % maxOpen
+            datum = packed2.toInt
+            found = true
+          }
+          k += 1
+        }
+        if (found) {
+          consumerWaiter = null
+          val err2 = errorRef.get()
+          if (err2 ne null) rethrow(err2)
+          return datum.toLong
+        }
+        if (drainersDone < maxOpen && errorRef.get() == null && !consumerClosed) {
+          LockSupport.park(this)
+        }
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    sentinel
+  }
+
+  def read[A1 >: Int](sentinel: A1): A1 = {
+    val v = readInt(Long.MinValue)(unsafeEvidence)
+    if (v == Long.MinValue) sentinel
+    else Int.box(v.toInt).asInstanceOf[A1]
+  }
+
+  override def readUpToN[A1 >: Int](n: Int): Chunk[A1] = {
+    if (n <= 0) return Chunk.empty
+    val first = readInt(Long.MinValue)(unsafeEvidence)
+    if (first == Long.MinValue) return Chunk.empty
+    if (n == 1) return Chunk.single(first.toInt.asInstanceOf[A1])
+
+    val b = new ChunkBuilder.Int()
+    b.addOne(first.toInt)
+    var i = 1
+    while (i < n) {
+      var found = false
+      var q     = 0
+      while (q < maxOpen && !found) {
+        val qIdx   = (scanStart + q) % maxOpen
+        val packed = dataQueues(qIdx).pollPacked()
+        if (packed == IntSpscRingBuffer.DONE_PACKED) {
+          drainersDone += 1
+        } else if (packed != IntSpscRingBuffer.EMPTY_PACKED) {
+          found = true
+          scanStart = (qIdx + 1) % maxOpen
+          val err = errorRef.get()
+          if (err ne null) rethrow(err)
+          b.addOne(packed.toInt)
+          i += 1
+        }
+        q += 1
+      }
+      if (!found) return b.result().asInstanceOf[Chunk[A1]]
+    }
+    b.result().asInstanceOf[Chunk[A1]]
+  }
+
+  def close(): Unit = {
+    consumerClosed = true
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+    workQueue.close()
+
+    coordinatorThread.interrupt()
+    coordinatorThread.join(5000)
+
+    var i = 0
+    while (i < maxOpen) {
+      val t = drainerThreads.get(i)
+      if (t ne null) {
+        t.interrupt()
+        t.join(5000)
+      }
+      i += 1
+    }
+  }
+
+  private def drainerLoop(idx: Int): Unit = {
+    val self = Thread.currentThread()
+    drainerThreads.set(idx, self)
+    try {
+      var keepRunning = true
+      while (keepRunning && !consumerClosed && !self.isInterrupted) {
+        val work = workQueue.take()
+        if ((work eq null) || (work eq DoneSentinel) || consumerClosed || self.isInterrupted) {
+          keepRunning = false
+        } else {
+          drainInner(work.asInstanceOf[Stream[Any, Int]], idx)
+        }
+      }
+    } finally {
+      // In-band: write DONE into this drainer's data queue. This is ordered
+      // after every prior `offer` and tells the consumer that no more data
+      // will ever come from this drainer. Once the consumer has seen `maxOpen`
+      // DONE sentinels, the stream is terminated.
+      while (!dataQueues(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      drainerLatch.countDown()
+    }
+  }
+
+  private def drainInner(innerStream: Stream[Any, Int], drainerIdx: Int): Unit = {
+    var innerReader: Reader[Int] = null
+    try {
+      innerReader = innerStream.compile(0, bufferSize)
+      var running = true
+      while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+        val v = innerReader.readInt(Long.MinValue)(unsafeEvidence)
+        if (v == Long.MinValue) {
+          running = false
+        } else {
+          var offered = false
+          while (!offered && !consumerClosed && !Thread.currentThread().isInterrupted) {
+            if (dataQueues(drainerIdx).offer(v.toInt)) {
+              offered = true
+              val cw = consumerWaiter
+              if (cw ne null) LockSupport.unpark(cw)
+            } else {
+              LockSupport.parkNanos(this, 1000L)
+            }
+          }
+          if (!offered) {
+            running = false
+          }
+        }
+      }
+
+    } catch {
+      case t: Throwable =>
+        recordError(t)
+    } finally {
+      if (innerReader ne null) {
+        try innerReader.close()
+        catch { case _: Throwable => () }
+      }
+    }
+  }
+
+  private def recordError(t: Throwable): Unit =
+    if (errorRef.compareAndSet(null, t)) {
+      consumerClosed = true
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      workQueue.close()
+      val ct = coordinatorThread
+      if (ct ne null) ct.interrupt()
+      var i = 0
+      while (i < maxOpen) {
+        val dt = drainerThreads.get(i)
+        if (dt ne null) dt.interrupt()
+        i += 1
+      }
+    }
+
+  private def rethrow(t: Throwable): Nothing = t match {
+    case se: StreamError => throw se
+    case _               => throw t
+  }
+}
+
+private[internal] object IntConcurrentMergeReader {
+  private val DoneSentinel: AnyRef = new AnyRef
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/LongConcurrentMapParReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/LongConcurrentMapParReader.scala
@@ -1,0 +1,631 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.internal
+
+import zio.blocks.ringbuffer.{
+  DoubleSpscRingBuffer,
+  FloatSpscRingBuffer,
+  IntSpscRingBuffer,
+  LongSpscRingBuffer,
+  SpscRingBuffer
+}
+import zio.blocks.streams.{JvmType, Platform}
+import zio.blocks.streams.io.Reader
+
+import java.util.concurrent.atomic.{AtomicReference, AtomicReferenceArray}
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * `Long`-specialized concurrent `mapPar` reader.
+ *
+ * The per-worker input queue is `LongSpscRingBuffer`, which reserves
+ * `Long.MinValue` (EMPTY) and `Long.MinValue + 1L` (DONE) as in-band sentinels;
+ * neither value can flow through the input path. Streams that may legitimately
+ * contain those values should avoid this specialized factory (e.g. by mapping
+ * through boxed `Long`).
+ *
+ * The per-worker output queue is selected at construction time from `outType`:
+ *   - `JvmType.Int` → `IntSpscRingBuffer`
+ *   - `JvmType.Long` → `LongSpscRingBuffer`
+ *   - `JvmType.Float` → `FloatSpscRingBuffer`
+ *   - `JvmType.Double` → `DoubleSpscRingBuffer`
+ *   - everything else → `SpscRingBuffer[AnyRef]` (boxed fallback)
+ *
+ * When the output queue is primitive there is **zero allocation** on the
+ * worker-to-consumer hot path. End-of-stream is signalled with the in-band DONE
+ * sentinel of each output queue; the consumer counts DONE markers and
+ * terminates once all `n` workers have signalled.
+ */
+private[streams] final class LongConcurrentMapParReader[B](
+  upstream: Reader[Long],
+  n: Int,
+  f: Long => B,
+  bufferSize: Int,
+  outType: JvmType
+) extends Reader[B] {
+  import ConcurrentMapParReader._
+
+  require(n >= 1, s"LongConcurrentMapParReader requires n >= 1, got $n")
+
+  private val longToIntFn: (Long => Int) =
+    if (outType eq JvmType.Int) f.asInstanceOf[Long => Int] else null
+  private val longToLongFn: (Long => Long) =
+    if (outType eq JvmType.Long) f.asInstanceOf[Long => Long] else null
+  private val longToDoubleFn: (Long => Double) =
+    if (outType eq JvmType.Double) f.asInstanceOf[Long => Double] else null
+  private val longToFloatFn: (Long => Float) =
+    if (outType eq JvmType.Float) f.asInstanceOf[Long => Float] else null
+
+  private val outIntQs: Array[IntSpscRingBuffer] =
+    if (outType eq JvmType.Int) Array.tabulate(n)(_ => new IntSpscRingBuffer(bufferSize)) else null
+  private val outLongQs: Array[LongSpscRingBuffer] =
+    if (outType eq JvmType.Long) Array.tabulate(n)(_ => new LongSpscRingBuffer(bufferSize)) else null
+  private val outFloatQs: Array[FloatSpscRingBuffer] =
+    if (outType eq JvmType.Float) Array.tabulate(n)(_ => new FloatSpscRingBuffer(bufferSize)) else null
+  private val outDoubleQs: Array[DoubleSpscRingBuffer] =
+    if (outType eq JvmType.Double) Array.tabulate(n)(_ => new DoubleSpscRingBuffer(bufferSize)) else null
+  private val outRefQs: Array[SpscRingBuffer[AnyRef]] =
+    if ((outIntQs eq null) && (outLongQs eq null) && (outFloatQs eq null) && (outDoubleQs eq null))
+      Array.tabulate(n)(_ => new SpscRingBuffer[AnyRef](bufferSize))
+    else null
+
+  @volatile private var consumerWaiter: Thread = null
+
+  private val inputQueues: Array[LongSpscRingBuffer] =
+    Array.tabulate(n)(_ => new LongSpscRingBuffer(bufferSize))
+  private val workerWaiters = new AtomicReferenceArray[Thread](n)
+  private val workerThreads = new AtomicReferenceArray[Thread](n)
+
+  private val errorRef                            = new AtomicReference[Throwable](null)
+  @volatile private var consumerClosed: Boolean   = false
+  @volatile private var coordinatorThread: Thread = null.asInstanceOf[Thread]
+
+  private val workerTasks: Array[Runnable] = Array.tabulate(n) { idx =>
+    new Runnable {
+      def run(): Unit = workerLoop(idx)
+    }
+  }
+
+  Array.tabulate(n) { idx =>
+    Platform.startVirtualThread(
+      s"zio-blocks-mappar-worker-${counter.getAndIncrement()}-$idx",
+      workerTasks(idx)
+    )
+  }
+
+  private val coordinatorTask: Runnable = new Runnable {
+    def run(): Unit =
+      try {
+        val coordBuf = new Array[Long](bufferSize)
+        var scanIdx  = 0
+        var running  = true
+
+        while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+          val count = upstream.readLongs(coordBuf, 0, bufferSize)(unsafeEvidence)
+          if (count <= 0) {
+            running = false
+          } else {
+            var j = 0
+            while (j < count && running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+              val v          = coordBuf(j)
+              var dispatched = false
+              while (!dispatched && !consumerClosed && !Thread.currentThread().isInterrupted) {
+                var i = 0
+                while (i < n && !dispatched) {
+                  val qIdx = (scanIdx + i) % n
+                  if (inputQueues(qIdx).offer(v)) {
+                    val ww = workerWaiters.get(qIdx)
+                    if (ww ne null) LockSupport.unpark(ww)
+                    scanIdx = (qIdx + 1) % n
+                    dispatched = true
+                  }
+                  i += 1
+                }
+                if (!dispatched) {
+                  LockSupport.parkNanos(this, 1000L)
+                }
+              }
+              if (!dispatched) running = false
+              j += 1
+            }
+          }
+        }
+      } catch {
+        case t: Throwable =>
+          recordError(t)
+      } finally {
+        signalWorkersToStop()
+        try upstream.close()
+        catch { case _: Throwable => () }
+      }
+  }
+
+  coordinatorThread = Platform.startVirtualThread(
+    s"zio-blocks-mappar-coordinator-${counter.getAndIncrement()}",
+    coordinatorTask
+  )
+
+  def isClosed: Boolean = eofReturned || consumerClosed
+
+  private var scanStart: Int        = 0
+  private var workersDoneCount: Int = 0
+  private var eofReturned: Boolean  = false
+
+  override def jvmType: JvmType = outType
+
+  // ============================================================
+  //  READ DISPATCH
+  // ============================================================
+
+  def read[B1 >: B](sentinel: B1): B1 =
+    if (outIntQs ne null) {
+      val v = pollIntOnce(IntSpscRingBuffer.EMPTY_PACKED)
+      if (v == IntSpscRingBuffer.EMPTY_PACKED) sentinel
+      else Int.box(v.toInt).asInstanceOf[B1]
+    } else if (outLongQs ne null) {
+      val v = pollLongOnce(LongSpscRingBuffer.EMPTY)
+      if (v == LongSpscRingBuffer.EMPTY) sentinel
+      else Long.box(v).asInstanceOf[B1]
+    } else if (outFloatQs ne null) {
+      val packed = pollFloatPacked()
+      if (packed == FloatSpscRingBuffer.EMPTY_PACKED) sentinel
+      else Float.box(java.lang.Float.intBitsToFloat(packed.toInt)).asInstanceOf[B1]
+    } else if (outDoubleQs ne null) {
+      val packed = pollDoublePacked()
+      if (packed == DoubleSpscRingBuffer.EMPTY_BITS) sentinel
+      else Double.box(java.lang.Double.longBitsToDouble(packed)).asInstanceOf[B1]
+    } else {
+      readRef(sentinel)
+    }
+
+  override def readInt(sentinel: Long)(implicit ev: B <:< Int): Long =
+    if (outIntQs ne null) {
+      val v = pollIntOnce(IntSpscRingBuffer.EMPTY_PACKED)
+      if (v == IntSpscRingBuffer.EMPTY_PACKED) sentinel
+      else v.toInt.toLong
+    } else readIntFromRef(sentinel)
+
+  override def readLong(sentinel: Long)(implicit ev: B <:< Long): Long =
+    if (outLongQs ne null) {
+      val v = pollLongOnce(LongSpscRingBuffer.EMPTY)
+      if (v == LongSpscRingBuffer.EMPTY) sentinel else v
+    } else readLongFromRef(sentinel)
+
+  override def readFloat(sentinel: Double)(implicit ev: B <:< Float): Double =
+    if (outFloatQs ne null) {
+      val packed = pollFloatPacked()
+      if (packed == FloatSpscRingBuffer.EMPTY_PACKED) sentinel
+      else java.lang.Float.intBitsToFloat(packed.toInt).toDouble
+    } else readFloatFromRef(sentinel)
+
+  override def readDouble(sentinel: Double)(implicit ev: B <:< Double): Double =
+    if (outDoubleQs ne null) {
+      val packed = pollDoublePacked()
+      if (packed == DoubleSpscRingBuffer.EMPTY_BITS) sentinel
+      else java.lang.Double.longBitsToDouble(packed)
+    } else readDoubleFromRef(sentinel)
+
+  // ============================================================
+  //  PRIMITIVE OUTPUT POLLERS (zero-allocation hot paths)
+  // ============================================================
+
+  private def pollIntOnce(emptyMarker: Long): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outIntQs(qIdx).pollPacked()
+          if (packed == IntSpscRingBuffer.DONE_PACKED) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != IntSpscRingBuffer.EMPTY_PACKED) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return emptyMarker }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    emptyMarker
+  }
+
+  private def pollLongOnce(emptyMarker: Long): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outLongQs(qIdx).pollPacked()
+          if (packed == LongSpscRingBuffer.DONE) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != LongSpscRingBuffer.EMPTY) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return emptyMarker }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    emptyMarker
+  }
+
+  private def pollFloatPacked(): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outFloatQs(qIdx).pollPacked()
+          if (packed == FloatSpscRingBuffer.DONE_PACKED) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != FloatSpscRingBuffer.EMPTY_PACKED) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return FloatSpscRingBuffer.EMPTY_PACKED }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    FloatSpscRingBuffer.EMPTY_PACKED
+  }
+
+  private def pollDoublePacked(): Long = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx   = (scanStart + i) % n
+          val packed = outDoubleQs(qIdx).pollPacked()
+          if (packed == DoubleSpscRingBuffer.DONE_BITS) {
+            workersDoneCount += 1
+            sawAny = true
+          } else if (packed != DoubleSpscRingBuffer.EMPTY_BITS) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            return packed
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return DoubleSpscRingBuffer.EMPTY_BITS }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    DoubleSpscRingBuffer.EMPTY_BITS
+  }
+
+  // ============================================================
+  //  REFERENCE-OUTPUT POLLERS
+  // ============================================================
+
+  private def readRef[B1 >: B](sentinel: B1): B1 = {
+    val self = Thread.currentThread()
+    while (true) {
+      consumerWaiter = self
+      try {
+        var i      = 0
+        var sawAny = false
+        while (i < n) {
+          val qIdx = (scanStart + i) % n
+          val item = outRefQs(qIdx).take()
+          if (item ne null) {
+            sawAny = true
+            scanStart = (qIdx + 1) % n
+            val err = errorRef.get()
+            if (err ne null) rethrow(err)
+            if (item eq NullSentinel) return null.asInstanceOf[B1]
+            if (item eq AllWorkersDone) workersDoneCount += 1
+            else return item.asInstanceOf[B1]
+          }
+          i += 1
+        }
+        val err = errorRef.get()
+        if (err ne null) rethrow(err)
+        if (workersDoneCount >= n) { eofReturned = true; return sentinel }
+        if (!sawAny && errorRef.get() == null) LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    sentinel
+  }
+
+  private def readIntFromRef(sentinel: Long): Long = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].intValue().toLong
+  }
+  private def readLongFromRef(sentinel: Long): Long = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].longValue()
+  }
+  private def readFloatFromRef(sentinel: Double): Double = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].floatValue().toDouble
+  }
+  private def readDoubleFromRef(sentinel: Double): Double = {
+    val v = readRef[Any](EndOfStream)
+    if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
+    else v.asInstanceOf[java.lang.Number].doubleValue()
+  }
+
+  // ============================================================
+  //  CLOSE / WORKER / ERROR PLUMBING
+  // ============================================================
+
+  def close(): Unit = {
+    consumerClosed = true
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+    var i = 0
+    while (i < n) {
+      val ww = workerWaiters.get(i)
+      if (ww ne null) LockSupport.unpark(ww)
+      i += 1
+    }
+
+    val ct = coordinatorThread
+    if (ct ne null) {
+      ct.interrupt()
+      ct.join(5000)
+    }
+
+    i = 0
+    while (i < n) {
+      val t = workerThreads.get(i)
+      if (t ne null) {
+        t.interrupt()
+        t.join(5000)
+      }
+      i += 1
+    }
+  }
+
+  private def workerLoop(idx: Int): Unit = {
+    val self = Thread.currentThread()
+    workerThreads.set(idx, self)
+
+    var keepRunning = true
+
+    while (keepRunning && !consumerClosed && !self.isInterrupted) {
+      var packed = inputQueues(idx).pollPacked()
+      if (packed == LongSpscRingBuffer.EMPTY) {
+        workerWaiters.set(idx, self)
+        packed = inputQueues(idx).pollPacked()
+        if (packed == LongSpscRingBuffer.EMPTY) {
+          if (!consumerClosed && !self.isInterrupted) LockSupport.park(this)
+        }
+        workerWaiters.set(idx, null)
+      }
+      if (packed == LongSpscRingBuffer.DONE) {
+        keepRunning = false
+      } else if (packed != LongSpscRingBuffer.EMPTY) {
+        val input: Long = packed
+        try {
+          if (longToIntFn ne null) {
+            val out = longToIntFn(input)
+            offerToIntOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else if (longToLongFn ne null) {
+            val out = longToLongFn(input)
+            offerToLongOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else if (longToDoubleFn ne null) {
+            val out = longToDoubleFn(input)
+            offerToDoubleOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else if (longToFloatFn ne null) {
+            val out = longToFloatFn(input)
+            offerToFloatOutput(idx, out, self) || { keepRunning = false; true }; ()
+          } else {
+            val result          = f(input)
+            val wrapped: AnyRef = if (result == null) NullSentinel else result.asInstanceOf[AnyRef]
+            offerToRefOutput(idx, wrapped, self) || { keepRunning = false; true }; ()
+          }
+        } catch {
+          case t: Throwable =>
+            recordError(t)
+            keepRunning = false
+        }
+      }
+    }
+
+    signalWorkerDone(idx, self)
+  }
+
+  private def offerToIntOutput(idx: Int, value: Int, self: Thread): Boolean = {
+    val q = outIntQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToLongOutput(idx: Int, value: Long, self: Thread): Boolean = {
+    val q = outLongQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToFloatOutput(idx: Int, value: Float, self: Thread): Boolean = {
+    val q = outFloatQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToDoubleOutput(idx: Int, value: Double, self: Thread): Boolean = {
+    val q = outDoubleQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(value)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def offerToRefOutput(idx: Int, wrapped: AnyRef, self: Thread): Boolean = {
+    val q = outRefQs(idx)
+    while (true) {
+      if (consumerClosed || self.isInterrupted) return false
+      if (q.offer(wrapped)) {
+        val cw = consumerWaiter
+        if (cw ne null) LockSupport.unpark(cw)
+        return true
+      }
+      LockSupport.parkNanos(this, 1000L)
+    }
+    false
+  }
+
+  private def signalWorkerDone(idx: Int, self: Thread): Unit = {
+    if (outIntQs ne null) {
+      while (!outIntQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else if (outLongQs ne null) {
+      while (!outLongQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else if (outFloatQs ne null) {
+      while (!outFloatQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else if (outDoubleQs ne null) {
+      while (!outDoubleQs(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    } else {
+      while (!outRefQs(idx).offer(AllWorkersDone) && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+    }
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+  }
+
+  private def signalWorkersToStop(): Unit = {
+    var i = 0
+    while (i < n) {
+      while (!inputQueues(i).offerDone() && !consumerClosed && !Thread.currentThread().isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+      val ww = workerWaiters.get(i)
+      if (ww ne null) LockSupport.unpark(ww)
+      i += 1
+    }
+  }
+
+  private def recordError(t: Throwable): Unit =
+    if (errorRef.compareAndSet(null, t)) {
+      consumerClosed = true
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      var i = 0
+      while (i < n) {
+        val ww = workerWaiters.get(i)
+        if (ww ne null) LockSupport.unpark(ww)
+        i += 1
+      }
+
+      val ct = coordinatorThread
+      if (ct ne null) ct.interrupt()
+
+      i = 0
+      while (i < n) {
+        val wt = workerThreads.get(i)
+        if (wt ne null) wt.interrupt()
+        i += 1
+      }
+    }
+
+  private def rethrow(t: Throwable): Nothing = t match {
+    case se: StreamError => throw se
+    case _               => throw t
+  }
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/LongConcurrentMergeReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/LongConcurrentMergeReader.scala
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.internal
+
+import zio.blocks.chunk.{Chunk, ChunkBuilder}
+import zio.blocks.ringbuffer.LongSpscRingBuffer
+import zio.blocks.streams.{JvmType, Platform, Stream}
+import zio.blocks.streams.io.Reader
+import zio.blocks.streams.queues.BlockingMpmcQueue
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.{AtomicReference, AtomicReferenceArray}
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * `Long`-specialized concurrent merge reader (used by `mergeAll` /
+ * `flatMapPar`).
+ *
+ * Uses `LongSpscRingBuffer` for the per-drainer data channel, which reserves
+ * `Long.MinValue` as an empty-slot sentinel and `Long.MinValue + 1L` as the
+ * in-band end-of-stream sentinel. Neither value can flow through this
+ * specialized path; if an inner stream emits one of them, the data queue's
+ * `offer` will throw `IllegalArgumentException` and the drainer surfaces that
+ * as a stream error rather than letting it leak.
+ *
+ * Each drainer writes one in-band DONE to its data queue when it has finished
+ * all assigned inner streams. The consumer counts DONE sentinels and terminates
+ * once it has seen `maxOpen` of them — no separate `coordinatorDone` volatile
+ * flag is needed on the hot path.
+ *
+ * Streams that may legitimately contain `Long.MinValue` or `Long.MinValue + 1L`
+ * should avoid the specialized factory in
+ * `PlatformSpecific.specializeMergeReader`.
+ */
+private[streams] final class LongConcurrentMergeReader(outerReader: Reader[?], maxOpen: Int, bufferSize: Int)
+    extends Reader[Long] {
+  import ConcurrentMergeReader._
+  import LongConcurrentMergeReader._
+
+  require(maxOpen >= 1, s"LongConcurrentMergeReader requires maxOpen >= 1, got $maxOpen")
+
+  private val outer: Reader[Any] = outerReader.asInstanceOf[Reader[Any]]
+
+  private val dataQueues: Array[LongSpscRingBuffer] =
+    Array.tabulate(maxOpen)(_ => new LongSpscRingBuffer(bufferSize))
+  @volatile private var consumerWaiter: Thread = null
+
+  private val errorRef                          = new AtomicReference[Throwable](null)
+  @volatile private var consumerClosed: Boolean = false
+
+  private val workQueue      = new BlockingMpmcQueue[AnyRef](Math.max(maxOpen, 16))
+  private val drainerLatch   = new CountDownLatch(maxOpen)
+  private val drainerThreads = new AtomicReferenceArray[Thread](maxOpen)
+
+  @volatile private var coordinatorThread: Thread = null.asInstanceOf[Thread]
+
+  Array.tabulate(maxOpen) { idx =>
+    Platform.startVirtualThread(
+      s"zio-blocks-merge-drainer-${counter.getAndIncrement()}-$idx",
+      new Runnable { def run(): Unit = drainerLoop(idx) }
+    )
+  }
+
+  private val coordinatorTask: Runnable = new Runnable {
+    def run(): Unit =
+      try {
+        var running = true
+        while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+          val v = outer.read[Any](EndOfStream)
+          if (v.asInstanceOf[AnyRef] eq EndOfStream) {
+            running = false
+          } else {
+            if (!workQueue.offer(v.asInstanceOf[AnyRef])) running = false
+          }
+        }
+      } catch {
+        case t: Throwable =>
+          recordError(t)
+      } finally {
+        try {
+          var i = 0
+          while (i < maxOpen) {
+            workQueue.offer(DoneSentinel)
+            i += 1
+          }
+          try drainerLatch.await()
+          catch { case _: InterruptedException => () }
+        } catch {
+          case t: Throwable => recordError(t)
+        } finally {
+          try outer.close()
+          catch { case _: Throwable => () }
+        }
+      }
+  }
+
+  coordinatorThread = Platform.startVirtualThread(
+    s"zio-blocks-merge-coordinator-${counter.getAndIncrement()}",
+    coordinatorTask
+  )
+
+  override def jvmType: JvmType = JvmType.Long
+
+  def isClosed: Boolean = eofReturned || consumerClosed
+
+  // Consumer-thread-private state: scanStart, drainersDone, eofReturned are
+  // mutated only from the consumer side and therefore need no atomics.
+  private var scanStart: Int       = 0
+  private var drainersDone: Int    = 0
+  private var eofReturned: Boolean = false
+
+  override def readLong(sentinel: Long)(implicit ev: Long <:< Long): Long = {
+    while (true) {
+      var i = 0
+      while (i < maxOpen) {
+        val qIdx   = (scanStart + i) % maxOpen
+        val packed = dataQueues(qIdx).pollPacked()
+        if (packed == LongSpscRingBuffer.DONE) {
+          drainersDone += 1
+        } else if (packed != LongSpscRingBuffer.EMPTY) {
+          scanStart = (qIdx + 1) % maxOpen
+          val err = errorRef.get()
+          if (err ne null) rethrow(err)
+          return packed
+        }
+        i += 1
+      }
+
+      val err = errorRef.get()
+      if (err ne null) rethrow(err)
+
+      if (drainersDone >= maxOpen) {
+        eofReturned = true
+        return sentinel
+      }
+
+      consumerWaiter = Thread.currentThread()
+      try {
+        // Re-poll after registering as waiter (avoid lost wakeup).
+        var k     = 0
+        var found = false
+        var datum = 0L
+        while (k < maxOpen && !found) {
+          val qIdx2   = (scanStart + k) % maxOpen
+          val packed2 = dataQueues(qIdx2).pollPacked()
+          if (packed2 == LongSpscRingBuffer.DONE) {
+            drainersDone += 1
+          } else if (packed2 != LongSpscRingBuffer.EMPTY) {
+            scanStart = (qIdx2 + 1) % maxOpen
+            datum = packed2
+            found = true
+          }
+          k += 1
+        }
+        if (found) {
+          consumerWaiter = null
+          val err2 = errorRef.get()
+          if (err2 ne null) rethrow(err2)
+          return datum
+        }
+        if (drainersDone < maxOpen && errorRef.get() == null && !consumerClosed) {
+          LockSupport.park(this)
+        }
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    sentinel
+  }
+
+  def read[A1 >: Long](sentinel: A1): A1 = {
+    val v = readLong(Long.MaxValue)(unsafeEvidence)
+    if (v == Long.MaxValue) sentinel
+    else Long.box(v).asInstanceOf[A1]
+  }
+
+  override def readUpToN[A1 >: Long](n: Int): Chunk[A1] = {
+    if (n <= 0) return Chunk.empty
+    val first = readLong(Long.MaxValue)(unsafeEvidence)
+    if (first == Long.MaxValue) return Chunk.empty
+    if (n == 1) return Chunk.single(first.asInstanceOf[A1])
+
+    val b = new ChunkBuilder.Long()
+    b.addOne(first)
+    var i = 1
+    while (i < n) {
+      var found = false
+      var q     = 0
+      while (q < maxOpen && !found) {
+        val qIdx   = (scanStart + q) % maxOpen
+        val packed = dataQueues(qIdx).pollPacked()
+        if (packed == LongSpscRingBuffer.DONE) {
+          drainersDone += 1
+        } else if (packed != LongSpscRingBuffer.EMPTY) {
+          found = true
+          scanStart = (qIdx + 1) % maxOpen
+          val err = errorRef.get()
+          if (err ne null) rethrow(err)
+          b.addOne(packed)
+          i += 1
+        }
+        q += 1
+      }
+      if (!found) return b.result().asInstanceOf[Chunk[A1]]
+    }
+    b.result().asInstanceOf[Chunk[A1]]
+  }
+
+  def close(): Unit = {
+    consumerClosed = true
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+    workQueue.close()
+
+    coordinatorThread.interrupt()
+    coordinatorThread.join(5000)
+
+    var i = 0
+    while (i < maxOpen) {
+      val t = drainerThreads.get(i)
+      if (t ne null) {
+        t.interrupt()
+        t.join(5000)
+      }
+      i += 1
+    }
+  }
+
+  private def drainerLoop(idx: Int): Unit = {
+    val self = Thread.currentThread()
+    drainerThreads.set(idx, self)
+    try {
+      var keepRunning = true
+      while (keepRunning && !consumerClosed && !self.isInterrupted) {
+        val work = workQueue.take()
+        if ((work eq null) || (work eq DoneSentinel) || consumerClosed || self.isInterrupted) {
+          keepRunning = false
+        } else {
+          drainInner(work.asInstanceOf[Stream[Any, Long]], idx)
+        }
+      }
+    } finally {
+      // In-band: write DONE into this drainer's data queue. This is ordered
+      // after every prior `offer` and tells the consumer that no more data
+      // will ever come from this drainer. Once the consumer has seen `maxOpen`
+      // DONE sentinels, the stream is terminated.
+      while (!dataQueues(idx).offerDone() && !consumerClosed && !self.isInterrupted) {
+        LockSupport.parkNanos(this, 1000L)
+      }
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      drainerLatch.countDown()
+    }
+  }
+
+  private def drainInner(innerStream: Stream[Any, Long], drainerIdx: Int): Unit = {
+    var innerReader: Reader[Long] = null
+    try {
+      innerReader = innerStream.compile(0, bufferSize)
+      var running = true
+      while (running && !consumerClosed && !Thread.currentThread().isInterrupted) {
+        val v = innerReader.readLong(Long.MaxValue)(unsafeEvidence)
+        if (v == Long.MaxValue) {
+          running = false
+        } else {
+          var offered = false
+          while (!offered && !consumerClosed && !Thread.currentThread().isInterrupted) {
+            if (dataQueues(drainerIdx).offer(v)) {
+              offered = true
+              val cw = consumerWaiter
+              if (cw ne null) LockSupport.unpark(cw)
+            } else {
+              LockSupport.parkNanos(this, 1000L)
+            }
+          }
+          if (!offered) {
+            running = false
+          }
+        }
+      }
+
+    } catch {
+      case t: Throwable =>
+        recordError(t)
+    } finally {
+      if (innerReader ne null) {
+        try innerReader.close()
+        catch { case _: Throwable => () }
+      }
+    }
+  }
+
+  private def recordError(t: Throwable): Unit =
+    if (errorRef.compareAndSet(null, t)) {
+      consumerClosed = true
+      val cw = consumerWaiter
+      if (cw ne null) LockSupport.unpark(cw)
+      workQueue.close()
+      val ct = coordinatorThread
+      if (ct ne null) ct.interrupt()
+      var i = 0
+      while (i < maxOpen) {
+        val dt = drainerThreads.get(i)
+        if (dt ne null) dt.interrupt()
+        i += 1
+      }
+    }
+
+  private def rethrow(t: Throwable): Nothing = t match {
+    case se: StreamError => throw se
+    case _               => throw t
+  }
+}
+
+private[internal] object LongConcurrentMergeReader {
+  private val DoneSentinel: AnyRef = new AnyRef
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/queues/BlockingMpmcQueue.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/queues/BlockingMpmcQueue.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.queues
+
+import zio.blocks.ringbuffer.MpmcRingBuffer
+
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * A blocking MPMC (multi-producer, multi-consumer) queue.
+ *
+ * Backed by [[MpmcRingBuffer]] for the fast path; uses
+ * [[LockSupport.parkNanos]] for blocking when the buffer is full or empty.
+ *
+ * Multiple threads may call [[offer]] and [[take]] concurrently.
+ *
+ * ==Single-Waiter Design==
+ *
+ * Only one producer and one consumer can be fast-path woken at a time. The
+ * queue maintains a single `producerWaiter` and `consumerWaiter` volatile slot.
+ * When a thread blocks, it registers itself in the appropriate slot and calls
+ * `LockSupport.parkNanos(this, 1000L)` (1 microsecond timeout). When the
+ * opposite side has data/space, it unparks the registered waiter. Other waiting
+ * threads wake up within 1 microsecond via the timeout and retry.
+ *
+ * This design is virtual-thread friendly: `parkNanos` does not OS-block on
+ * virtual threads, allowing bounded re-checks without risk of permanent
+ * parking.
+ *
+ * ==Happens-Before Guarantee==
+ *
+ * The pattern `producerWaiter = Thread.currentThread()` (volatile write)
+ * followed by `if (closed) return false` (volatile read) ensures that a
+ * `close()` call setting `closed = true` is always visible before the thread
+ * parks. This prevents the race where a thread parks after close() has already
+ * been called.
+ *
+ * ==close() Behavior==
+ *
+ * `close()` unparks only the registered `producerWaiter` and `consumerWaiter`.
+ * Other waiting threads wake up within 1 microsecond via `parkNanos` timeout
+ * and detect the closed flag on retry. This is intentional and documented.
+ *
+ * Null elements are not permitted.
+ *
+ * @param capacity
+ *   The logical capacity. Rounded up to the next power of two >= 2 internally.
+ */
+final class BlockingMpmcQueue[A <: AnyRef](capacity: Int) {
+  require(capacity >= 1, s"BlockingMpmcQueue requires capacity >= 1, got: $capacity")
+
+  private val ringBuffer: MpmcRingBuffer[AnyRef] =
+    new MpmcRingBuffer[AnyRef](nextPowerOfTwo(capacity))
+
+  @volatile private var consumerWaiter: Thread = null
+  @volatile private var producerWaiter: Thread = null
+  @volatile private var closed: Boolean        = false
+
+  /**
+   * Offers an element to the queue, blocking until space is available or the
+   * queue is closed. Returns `true` on success, `false` if the queue was
+   * closed.
+   */
+  def offer(a: A): Boolean = {
+    if (a == null) throw new NullPointerException("BlockingMpmcQueue.offer(null) is not permitted")
+    while (true) {
+      if (closed) return false
+      if (ringBuffer.offer(a.asInstanceOf[AnyRef])) {
+        val w = consumerWaiter
+        if (w ne null) LockSupport.unpark(w)
+        return true
+      }
+      producerWaiter = Thread.currentThread()
+      try {
+        if (closed) return false
+        if (ringBuffer.offer(a.asInstanceOf[AnyRef])) {
+          val w = consumerWaiter
+          if (w ne null) LockSupport.unpark(w)
+          return true
+        }
+        LockSupport.parkNanos(this, 1000L)
+      } finally {
+        producerWaiter = null
+      }
+    }
+    false
+  }
+
+  /**
+   * Takes an element from the queue, blocking until one is available or the
+   * queue is closed. Returns the element, or `null` if closed and empty.
+   */
+  def take(): A = {
+    while (true) {
+      val e = ringBuffer.take().asInstanceOf[A]
+      if (e ne null) {
+        val w = producerWaiter
+        if (w ne null) LockSupport.unpark(w)
+        return e
+      }
+      if (closed) return null.asInstanceOf[A]
+      consumerWaiter = Thread.currentThread()
+      try {
+        val e2 = ringBuffer.take().asInstanceOf[A]
+        if (e2 ne null) {
+          val w = producerWaiter
+          if (w ne null) LockSupport.unpark(w)
+          return e2
+        }
+        if (closed) return null.asInstanceOf[A]
+        LockSupport.parkNanos(this, 1000L)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    null.asInstanceOf[A]
+  }
+
+  /** Closes the queue, unblocking any waiting thread on either side. */
+  def close(): Unit = {
+    closed = true
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+    val pw = producerWaiter
+    if (pw ne null) LockSupport.unpark(pw)
+  }
+
+  /** Whether the queue has been closed. */
+  def isClosed: Boolean = closed
+
+  /** Whether the ring buffer contains no elements. */
+  def isEmpty: Boolean = ringBuffer.isEmpty
+
+  private def nextPowerOfTwo(n: Int): Int =
+    if (n <= 1) 2
+    else {
+      val hob = Integer.highestOneBit(n - 1) << 1
+      if (hob < 2) 2 else hob
+    }
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/queues/BlockingMpscQueue.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/queues/BlockingMpscQueue.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.queues
+
+import zio.blocks.ringbuffer.MpscRingBuffer
+
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * A blocking MPSC (multi-producer, single-consumer) queue.
+ *
+ * Backed by [[MpscRingBuffer]] for the fast path; uses [[LockSupport.park]] and
+ * [[LockSupport.unpark]] for blocking when the buffer is full or empty.
+ *
+ * Multiple threads may call [[offer]] concurrently. Only a single thread may
+ * call [[take]], [[drain]], [[isEmpty]], or [[isClosed]].
+ *
+ * Multi-producer parking: a single `producerWaiter` volatile slot is used. One
+ * producer registers and gets fast-path unpark from consumer. Others use
+ * `parkNanos(1000)` (1µs) to retry — VT-friendly, no starvation.
+ *
+ * Null elements are not permitted.
+ *
+ * @param capacity
+ *   The logical capacity. Rounded up to the next power of two internally.
+ */
+final class BlockingMpscQueue[A <: AnyRef](capacity: Int) {
+  require(capacity >= 1, s"BlockingMpscQueue requires capacity >= 1, got: $capacity")
+
+  private val ringBuffer: MpscRingBuffer[AnyRef] =
+    new MpscRingBuffer[AnyRef](nextPowerOfTwo(capacity))
+
+  @volatile private var consumerWaiter: Thread = null
+  @volatile private var producerWaiter: Thread = null
+  @volatile private var closed: Boolean        = false
+
+  /**
+   * Offers an element to the queue, blocking until space is available or the
+   * queue is closed. Returns `true` on success, `false` if the queue was
+   * closed.
+   */
+  def offer(a: A): Boolean = {
+    if (a == null) throw new NullPointerException("BlockingMpscQueue.offer(null) is not permitted")
+    while (true) {
+      if (closed) return false
+      if (ringBuffer.offer(a.asInstanceOf[AnyRef])) {
+        val w = consumerWaiter
+        if (w ne null) LockSupport.unpark(w)
+        return true
+      }
+      producerWaiter = Thread.currentThread()
+      try {
+        if (closed) return false
+        if (ringBuffer.offer(a.asInstanceOf[AnyRef])) {
+          val w = consumerWaiter
+          if (w ne null) LockSupport.unpark(w)
+          return true
+        }
+        LockSupport.parkNanos(this, 1000L)
+      } finally {
+        producerWaiter = null
+      }
+    }
+    false
+  }
+
+  /**
+   * Takes an element from the queue, blocking until one is available or the
+   * queue is closed. Returns the element, or `null` if closed and empty.
+   */
+  def take(): A = {
+    while (true) {
+      val e = ringBuffer.take().asInstanceOf[A]
+      if (e ne null) {
+        val w = producerWaiter
+        if (w ne null) LockSupport.unpark(w)
+        return e
+      }
+      if (closed) return null.asInstanceOf[A]
+      consumerWaiter = Thread.currentThread()
+      try {
+        val e2 = ringBuffer.take().asInstanceOf[A]
+        if (e2 ne null) {
+          val w = producerWaiter
+          if (w ne null) LockSupport.unpark(w)
+          return e2
+        }
+        if (closed) return null.asInstanceOf[A]
+        LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    null.asInstanceOf[A]
+  }
+
+  /** Closes the queue, unblocking any waiting thread on either side. */
+  def close(): Unit = {
+    closed = true
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+    val pw = producerWaiter
+    if (pw ne null) LockSupport.unpark(pw)
+  }
+
+  /** Whether the queue has been closed. */
+  def isClosed: Boolean = closed
+
+  /** Whether the ring buffer contains no elements. */
+  def isEmpty: Boolean = ringBuffer.isEmpty
+
+  /**
+   * Drains up to `limit` elements from the queue and passes each to `consumer`.
+   *
+   * @param consumer
+   *   callback invoked for each drained element
+   * @param limit
+   *   maximum number of elements to drain
+   * @return
+   *   number of elements drained
+   */
+  def drain(consumer: A => Unit, limit: Int): Int = {
+    val drained = ringBuffer.drain(consumer.asInstanceOf[AnyRef => Unit], limit)
+    val w       = producerWaiter
+    if (w ne null) LockSupport.unpark(w)
+    drained
+  }
+
+  private def nextPowerOfTwo(n: Int): Int =
+    if (n <= 1) 1
+    else Integer.highestOneBit(n - 1) << 1
+}

--- a/streams/jvm/src/main/scala/zio/blocks/streams/queues/BlockingSpscQueue.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/queues/BlockingSpscQueue.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.queues
+
+import zio.blocks.ringbuffer.SpscRingBuffer
+
+import java.util.concurrent.locks.LockSupport
+
+/**
+ * A blocking single-producer single-consumer queue.
+ *
+ * Backed by [[SpscRingBuffer]] for the fast path; uses [[LockSupport.park]] and
+ * [[LockSupport.unpark]] for blocking when the buffer is full or empty.
+ *
+ * Two separate waiter slots are maintained — `consumerWaiter` and
+ * `producerWaiter` — so that each side registers in its own slot without
+ * overwriting the other side's registration. A single shared slot would
+ * introduce a lost-wakeup race: the producer could overwrite the consumer's
+ * registration before the consumer parks, causing the consumer's park to return
+ * via stale permit and then clear the producer's registration, leaving the
+ * producer permanently blocked.
+ *
+ * Null elements are not permitted.
+ *
+ * @param capacity
+ *   The logical capacity. Rounded up to the next power of two internally.
+ */
+final class BlockingSpscQueue[A <: AnyRef](capacity: Int) {
+  require(capacity >= 1, s"BlockingSpscQueue requires capacity >= 1, got: $capacity")
+
+  private val spinTries = 1024
+
+  private val ringBuffer: SpscRingBuffer[AnyRef] =
+    new SpscRingBuffer[AnyRef](nextPowerOfTwo(capacity))
+
+  @volatile private var consumerWaiter: Thread = null
+  @volatile private var producerWaiter: Thread = null
+  @volatile private var closed: Boolean        = false
+
+  /**
+   * Offers an element to the queue, blocking until space is available or the
+   * queue is closed. Returns `true` on success, `false` if the queue was
+   * closed.
+   */
+  def offer(a: A): Boolean = {
+    if (a == null) throw new NullPointerException("BlockingSpscQueue.offer(null) is not permitted")
+    val element = a.asInstanceOf[AnyRef]
+    while (true) {
+      if (closed) return false
+      if (ringBuffer.offer(element)) {
+        val w = consumerWaiter
+        if (w ne null) LockSupport.unpark(w)
+        return true
+      }
+      producerWaiter = Thread.currentThread()
+      try {
+        if (closed) return false
+        if (ringBuffer.offer(element)) {
+          val w = consumerWaiter
+          if (w ne null) LockSupport.unpark(w)
+          return true
+        }
+        var spins = 0
+        while (spins < spinTries) {
+          if (closed) return false
+          if (ringBuffer.offer(element)) {
+            val w = consumerWaiter
+            if (w ne null) LockSupport.unpark(w)
+            return true
+          }
+          Thread.onSpinWait()
+          spins += 1
+        }
+        LockSupport.park(this)
+      } finally {
+        producerWaiter = null
+      }
+    }
+    false
+  }
+
+  /**
+   * Takes an element from the queue, blocking until one is available or the
+   * queue is closed. Returns the element, or `null` if closed and empty.
+   */
+  def take(): A = {
+    while (true) {
+      val e = ringBuffer.take().asInstanceOf[A]
+      if (e ne null) {
+        val w = producerWaiter
+        if (w ne null) LockSupport.unpark(w)
+        return e
+      }
+      // Drain-on-close: a producer may have offered + closed between our take()
+      // and the closed read, so re-check the ring buffer after observing closed.
+      if (closed) {
+        val drained = ringBuffer.take().asInstanceOf[A]
+        if (drained ne null) return drained
+        return null.asInstanceOf[A]
+      }
+      consumerWaiter = Thread.currentThread()
+      try {
+        val e2 = ringBuffer.take().asInstanceOf[A]
+        if (e2 ne null) {
+          val w = producerWaiter
+          if (w ne null) LockSupport.unpark(w)
+          return e2
+        }
+        if (closed) {
+          val drained = ringBuffer.take().asInstanceOf[A]
+          if (drained ne null) return drained
+          return null.asInstanceOf[A]
+        }
+        var spins = 0
+        while (spins < spinTries) {
+          val e3 = ringBuffer.take().asInstanceOf[A]
+          if (e3 ne null) {
+            val w = producerWaiter
+            if (w ne null) LockSupport.unpark(w)
+            return e3
+          }
+          if (closed) {
+            val drained = ringBuffer.take().asInstanceOf[A]
+            if (drained ne null) return drained
+            return null.asInstanceOf[A]
+          }
+          Thread.onSpinWait()
+          spins += 1
+        }
+        LockSupport.park(this)
+      } finally {
+        consumerWaiter = null
+      }
+    }
+    null.asInstanceOf[A]
+  }
+
+  private[streams] def poll(): A = {
+    val e = ringBuffer.take().asInstanceOf[A]
+    if (e ne null) {
+      val w = producerWaiter
+      if (w ne null) LockSupport.unpark(w)
+    }
+    e
+  }
+
+  /** Closes the queue, unblocking any waiting thread on either side. */
+  def close(): Unit = {
+    closed = true
+    val cw = consumerWaiter
+    if (cw ne null) LockSupport.unpark(cw)
+    val pw = producerWaiter
+    if (pw ne null) LockSupport.unpark(pw)
+  }
+
+  /** Whether the queue has been closed. */
+  def isClosed: Boolean = closed
+
+  /** Whether the ring buffer contains no elements. */
+  def isEmpty: Boolean = ringBuffer.isEmpty
+
+  private def nextPowerOfTwo(n: Int): Int =
+    if (n <= 1) 1
+    else Integer.highestOneBit(n - 1) << 1
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/BufferSizeSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/BufferSizeSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio._
+import zio.test._
+
+object BufferSizeSpec extends StreamsBaseSpec {
+  def spec = suite("Stream.bufferSize")(
+    test("mapPar with custom buffer size produces correct results") {
+      for {
+        result <- ZIO.fromEither(Stream.bufferSize(128)(Stream.range(0, 1000).mapPar(4)(identity)).runCollect)
+      } yield assertTrue(result.length == 1000)
+    },
+    test("flatMapPar with custom buffer size produces correct results") {
+      for {
+        result <- ZIO.fromEither(
+                    Stream.bufferSize(32)(Stream.range(0, 10).flatMapPar(4)(i => Stream.range(0, i))).runCollect
+                  )
+      } yield assertTrue(result.length == 45)
+    },
+    test("nested bufferSize: inner wins") {
+      for {
+        result <- ZIO.fromEither(
+                    Stream.bufferSize(128)(Stream.bufferSize(32)(Stream.range(0, 100).mapPar(2)(identity))).runCollect
+                  )
+      } yield assertTrue(result.length == 100)
+    },
+    test("invalid bufferSize throws IllegalArgumentException") {
+      assertTrue(scala.util.Try(Stream.bufferSize(3)(Stream.empty)).isFailure) &&
+      assertTrue(scala.util.Try(Stream.bufferSize(0)(Stream.empty)).isFailure)
+    }
+  )
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/BufferStressSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/BufferStressSpec.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.ZIO
+import zio.blocks.chunk.Chunk
+import zio.durationInt
+import zio.test._
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.LockSupport
+
+object BufferStressSpec extends StreamsBaseSpec {
+
+  override def aspects: zio.Chunk[TestAspectAtLeastR[TestEnvironment]] =
+    zio.Chunk(TestAspect.timed, TestAspect.sequential)
+
+  def spec: Spec[TestEnvironment, Any] = suite("BufferStress")(
+    test("1M elements through buffer(16) preserves all elements") {
+      ZIO.attemptBlocking {
+        val n      = 1_000_000
+        val seen   = new AtomicInteger(0)
+        val result = Stream
+          .range(0, n)
+          .map { i =>
+            while (i - seen.get() > 8 && !Thread.currentThread().isInterrupted) Thread.onSpinWait()
+            i
+          }
+          .buffer(16)
+          .map { i =>
+            seen.incrementAndGet()
+            i
+          }
+          .runCollect
+        assertTrue(isOrderedRange(result, n))
+      }
+    } @@ TestAspect.timeout(90.seconds),
+    test("1M elements through buffer(64) sum is correct") {
+      ZIO.attemptBlocking {
+        val n        = 1_000_000
+        val expected = n.toLong * (n - 1) / 2
+        val seen     = new AtomicInteger(0)
+        val result   = Stream
+          .range(0, n)
+          .map { i =>
+            while (i - seen.get() > 32 && !Thread.currentThread().isInterrupted) Thread.onSpinWait()
+            i
+          }
+          .buffer(64)
+          .runFold(0L) { (sum, i) =>
+            seen.incrementAndGet()
+            sum + i
+          }
+        assertTrue(result == Right(expected))
+      }
+    } @@ TestAspect.timeout(90.seconds),
+    test("100K elements through buffer(1) all arrive in order") {
+      ZIO.attemptBlocking {
+        val n      = 100_000
+        val seen   = new AtomicInteger(0)
+        val result = Stream
+          .range(0, n)
+          .map { i =>
+            while (i - seen.get() > 0 && !Thread.currentThread().isInterrupted) Thread.onSpinWait()
+            i
+          }
+          .buffer(1)
+          .map { i =>
+            seen.incrementAndGet()
+            i
+          }
+          .runCollect
+        assertTrue(isOrderedRange(result, n))
+      }
+    } @@ TestAspect.timeout(90.seconds),
+    test("100K elements through buffer(8192) all arrive in order") {
+      ZIO.attemptBlocking {
+        val n      = 100_000
+        val result = Stream.range(0, n).buffer(8192).runCollect
+        assertTrue(isOrderedRange(result, n))
+      }
+    } @@ TestAspect.timeout(60.seconds),
+    test("double buffer (buffer then buffer) works correctly") {
+      ZIO.attemptBlocking {
+        val n      = 10_000
+        val seen   = new AtomicInteger(0)
+        val result = Stream
+          .range(0, n)
+          .map { i =>
+            while (i - seen.get() > 16 && !Thread.currentThread().isInterrupted) Thread.onSpinWait()
+            i
+          }
+          .buffer(32)
+          .buffer(32)
+          .map { i =>
+            seen.incrementAndGet()
+            i
+          }
+          .runCollect
+        assertTrue(isOrderedRange(result, n))
+      }
+    } @@ TestAspect.timeout(30.seconds),
+    test("no thread leaks after buffer stream completes") {
+      ZIO.attemptBlocking {
+        val baseline = Thread.getAllStackTraces.size()
+        val result   = Stream.range(0, 10_000).buffer(8192).runCollect
+
+        val deadline = System.nanoTime() + 2.seconds.toNanos
+        var after    = Thread.getAllStackTraces.size()
+        while (after > baseline + 4 && System.nanoTime() < deadline) {
+          System.gc()
+          LockSupport.parkNanos(10.millis.toNanos)
+          after = Thread.getAllStackTraces.size()
+        }
+
+        assertTrue(result.isRight, after <= baseline + 4)
+      }
+    } @@ TestAspect.timeout(30.seconds),
+    test("defect propagates through buffer without hanging") {
+      ZIO.attemptBlocking {
+        val seen   = new AtomicInteger(0)
+        val caught = scala.util.Try {
+          Stream
+            .range(0, 1_000)
+            .map { i =>
+              while (i - seen.get() > 8 && !Thread.currentThread().isInterrupted) Thread.onSpinWait()
+              i
+            }
+            .map((i: Int) => if (i == 500) throw new RuntimeException("oops") else i)
+            .buffer(16)
+            .map { i =>
+              seen.incrementAndGet()
+              i
+            }
+            .runCollect
+        }
+        assertTrue(caught.isFailure, caught.failed.get.isInstanceOf[RuntimeException])
+      }
+    } @@ TestAspect.timeout(30.seconds)
+  ) @@ TestAspect.sequential
+
+  private def isOrderedRange(result: Either[Any, Chunk[Int]], n: Int): Boolean =
+    result match {
+      case Right(chunk) if chunk.length == n =>
+        chunk(0) == 0 && chunk(n - 1) == (n - 1)
+      case _ => false
+    }
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/ConcurrentMapParReaderSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/ConcurrentMapParReaderSpec.scala
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.ZIO
+import zio.blocks.chunk.Chunk
+import zio.blocks.streams.internal.EndOfStream
+import zio.durationInt
+import zio.test._
+
+import java.util.concurrent.locks.LockSupport
+
+object ConcurrentMapParReaderSpec extends StreamsBaseSpec {
+
+  override def aspects: zio.Chunk[TestAspectAtLeastR[TestEnvironment]] =
+    zio.Chunk(TestAspect.timeout(90.seconds), TestAspect.timed, TestAspect.sequential)
+
+  def spec: Spec[TestEnvironment, Any] = suite("ConcurrentMapParReader")(
+    test("basic correctness: mapPar doubles all elements") {
+      ZIO.attemptBlocking {
+        val result = mapParStream(Stream.range(0, 100), n = 4)(_ * 2).runCollect
+        assertTrue(
+          result match {
+            case Right(chunk) =>
+              val set = chunk.toSet
+              set.size == 100 && (0 until 100).forall(i => set.contains(i * 2))
+            case _ => false
+          }
+        )
+      }
+    },
+    test("error in f propagates and does not hang") {
+      ZIO.attemptBlocking {
+        val boom      = new RuntimeException("boom-50")
+        val attempted =
+          scala.util.Try(mapParStream(Stream.range(0, 100), n = 4)(i => if (i == 50) throw boom else i).runCollect)
+        assertTrue(
+          attempted.isFailure,
+          attempted.failed.get.isInstanceOf[RuntimeException],
+          attempted.failed.get.getMessage == "boom-50"
+        )
+      }
+    },
+    test("mapPar completes reliably under repeated runs") {
+      ZIO.attemptBlocking {
+        var i = 0
+        while (i < 10) {
+          val result   = Stream.range(0, 10000).mapPar(4)(_ + 1).runFold(0L)(_ + _.toLong)
+          val expected = (1L to 10000L).sum
+          require(result == Right(expected), s"iteration $i: $result")
+          i += 1
+        }
+        assertTrue(true)
+      }
+    } @@ TestAspect.timeout(60.seconds),
+    test("mapPar: error in f is always observed by consumer") {
+      ZIO.attemptBlocking {
+        var i = 0
+        while (i < 20) {
+          val result = scala.util.Try(
+            Stream
+              .range(0, 10000)
+              .mapPar(8) { x =>
+                if (x == 5000) throw new RuntimeException("boom")
+                x + 1
+              }
+              .runCollect
+          )
+          require(result.isFailure, s"iteration $i should fail but succeeded")
+          i += 1
+        }
+        assertTrue(true)
+      }
+    } @@ TestAspect.timeout(30.seconds),
+    test("mapPar: concurrent errors do not corrupt state or hang") {
+      ZIO.attemptBlocking {
+        var i = 0
+        while (i < 20) {
+          val result = scala.util.Try(
+            Stream
+              .range(0, 1000)
+              .mapPar(8) { x =>
+                if (x % 100 == 0) throw new RuntimeException(s"err-$x")
+                x
+              }
+              .runCollect
+          )
+          require(result.isFailure, s"iteration $i should fail but succeeded")
+          i += 1
+        }
+        assertTrue(true)
+      }
+    } @@ TestAspect.timeout(30.seconds),
+    test("identity mapping with n=4 preserves all elements") {
+      ZIO.attemptBlocking {
+        val result = mapParStream(Stream.range(0, 100), n = 4)(identity).runCollect
+        assertTrue(
+          result match {
+            case Right(chunk) =>
+              val set = chunk.toSet
+              set.size == 100 && (0 until 100).forall(set.contains)
+            case _ => false
+          }
+        )
+      }
+    },
+    test("early termination: close after 10 elements cleans up worker/coordinator threads") {
+      ZIO.attemptBlocking {
+        val baseline = Thread.getAllStackTraces.size()
+
+        val reader = Platform.createMapParReader[Int, Int](
+          Stream.range(0, 500_000).compile(0),
+          4,
+          identity,
+          Stream.DefaultBufferSize,
+          JvmType.Int,
+          JvmType.Int
+        )
+
+        var i = 0
+        while (i < 10) {
+          val v = reader.read[Any](EndOfStream)
+          assertTrue(v.asInstanceOf[AnyRef] ne EndOfStream)
+          i += 1
+        }
+
+        reader.close()
+
+        val deadline = System.nanoTime() + 2.seconds.toNanos
+        var after    = Thread.getAllStackTraces.size()
+        while (after > baseline + 4 && System.nanoTime() < deadline) {
+          System.gc()
+          LockSupport.parkNanos(10.millis.toNanos)
+          after = Thread.getAllStackTraces.size()
+        }
+
+        assertTrue(after <= baseline + 4)
+      }
+    },
+    test("n=1 behaves sequentially and emits all elements") {
+      ZIO.attemptBlocking {
+        val result = mapParStream(Stream.range(0, 100), n = 1)(identity).runCollect
+        assertTrue(
+          result match {
+            case Right(chunk) =>
+              val set = chunk.toSet
+              set.size == 100 && (0 until 100).forall(set.contains)
+            case _ => false
+          }
+        )
+      }
+    },
+    test("null element preservation: null input and null output are preserved") {
+      ZIO.attemptBlocking {
+        val upstream = Stream.fromChunk(Chunk("a", null, "b"))
+        val result   = mapParStream(upstream, n = 3)(identity).runCollect
+        assertTrue(
+          result match {
+            case Right(chunk) =>
+              val set = chunk.toSet
+              set.size == 3 && set.contains("a") && set.contains("b") && set.contains(null)
+            case _ => false
+          }
+        )
+      }
+    }
+  )
+
+  private def mapParStream[A, B](stream: Stream[Any, A], n: Int)(f: A => B): Stream[Any, B] =
+    Stream.fromReader[Any, B](
+      Platform
+        .createMapParReader[A, B](stream.compile(0), n, f, Stream.DefaultBufferSize, JvmType.AnyRef, JvmType.AnyRef)
+    )
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/ConcurrentMergeReaderSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/ConcurrentMergeReaderSpec.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.ZIO
+import zio.blocks.chunk.Chunk
+import zio.blocks.streams.internal.{ConcurrentMergeReader, EndOfStream}
+import zio.blocks.streams.io.Reader
+import zio.durationInt
+import zio.test._
+
+import java.util.concurrent.locks.LockSupport
+
+object ConcurrentMergeReaderSpec extends StreamsBaseSpec {
+
+  override def aspects: zio.Chunk[TestAspectAtLeastR[TestEnvironment]] =
+    zio.Chunk(TestAspect.timeout(90.seconds), TestAspect.timed, TestAspect.sequential)
+
+  def spec: Spec[TestEnvironment, Any] = suite("ConcurrentMergeReader")(
+    test("basic merge: all elements from all inner streams are present") {
+      ZIO.attemptBlocking {
+        val inners = Chunk(
+          Stream.range(0, 100),
+          Stream.range(100, 200),
+          Stream.range(200, 300)
+        )
+
+        val result = mergeStream(inners, maxOpen = 3).runCollect
+        assertTrue(
+          result match {
+            case Right(chunk) =>
+              val set = chunk.toSet
+              set.size == 300 && (0 until 300).forall(set.contains)
+            case _ => false
+          }
+        )
+      }
+    },
+    test("empty outer stream completes immediately") {
+      ZIO.attemptBlocking {
+        val result = mergeStream[Int](Chunk.empty, maxOpen = 4).runCollect
+        assertTrue(result == Right(Chunk.empty))
+      }
+    },
+    test("empty inner streams complete cleanly") {
+      ZIO.attemptBlocking {
+        val empty  = Stream.fromChunk(Chunk.empty[Int])
+        val inners = Chunk(empty, empty, empty)
+        val result = mergeStream(inners, maxOpen = 3).runCollect
+        assertTrue(result == Right(Chunk.empty))
+      }
+    },
+    test("fail-fast: inner defect propagates without hang") {
+      ZIO.attemptBlocking {
+        val boom   = new RuntimeException("boom")
+        val inners = Chunk(
+          Stream.range(0, 1000),
+          Stream.range(0, 1000).map(i => if (i == 500) throw boom else i),
+          Stream.range(1000, 2000)
+        )
+
+        val attempted = scala.util.Try(mergeStream(inners, maxOpen = 3).runCollect)
+        assertTrue(
+          attempted.isFailure,
+          attempted.failed.get.isInstanceOf[RuntimeException],
+          attempted.failed.get.getMessage == "boom"
+        )
+      }
+    },
+    test("early termination: closing consumer stops workers") {
+      ZIO.attemptBlocking {
+        val baseline = Thread.getAllStackTraces.size()
+        val inners   = Chunk(
+          Stream.range(0, 200_000),
+          Stream.range(200_000, 400_000),
+          Stream.range(400_000, 600_000)
+        )
+
+        val reader =
+          new ConcurrentMergeReader[Int](Reader.fromChunk(inners), maxOpen = 3, bufferSize = Stream.DefaultBufferSize)
+        var i = 0
+        while (i < 5) {
+          val v = reader.read[Any](EndOfStream)
+          assertTrue(v.asInstanceOf[AnyRef] ne EndOfStream)
+          i += 1
+        }
+        reader.close()
+
+        val deadline = System.nanoTime() + 2.seconds.toNanos
+        var after    = Thread.getAllStackTraces.size()
+        while (after > baseline + 4 && System.nanoTime() < deadline) {
+          System.gc()
+          LockSupport.parkNanos(10.millis.toNanos)
+          after = Thread.getAllStackTraces.size()
+        }
+
+        assertTrue(after <= baseline + 4)
+      }
+    },
+    test("maxOpen = 1 behaves sequentially and preserves all elements") {
+      ZIO.attemptBlocking {
+        val inners = Chunk(
+          Stream.range(0, 50),
+          Stream.range(50, 100),
+          Stream.range(100, 150)
+        )
+
+        val result = mergeStream(inners, maxOpen = 1).runCollect
+        assertTrue(
+          result match {
+            case Right(chunk) =>
+              val set = chunk.toSet
+              set.size == 150 && (0 until 150).forall(set.contains)
+            case _ => false
+          }
+        )
+      }
+    },
+    test("large merge: 100 inner streams x 1000 elements each has correct sum") {
+      ZIO.attemptBlocking {
+        val inners = Chunk.fromIterable(
+          (0 until 100).map { i =>
+            val start = i * 1000
+            Stream.range(start, start + 1000)
+          }
+        )
+
+        val expected = {
+          val n = 100_000L
+          n * (n - 1L) / 2L
+        }
+
+        val result = mergeStream(inners, maxOpen = 8).runFold(0L)(_ + _.toLong)
+        assertTrue(result == Right(expected))
+      }
+    },
+    test("mergeAll completes reliably under repeated runs") {
+      ZIO.attemptBlocking {
+        var i = 0
+        while (i < 10) {
+          val result = Stream
+            .mergeAll(8)(
+              Stream.fromIterable((0 until 16).map(j => Stream.range(j * 500, (j + 1) * 500)))
+            )
+            .runFold(0L)(_ + _.toLong)
+          require(result == Right(31996000L), s"iteration $i: $result")
+          i += 1
+        }
+        assertTrue(true)
+      }
+    } @@ TestAspect.timeout(60.seconds),
+    test("mergeAll: error in one inner stream terminates all drainers promptly") {
+      ZIO.attemptBlocking {
+        val fast: Stream[String, Int]  = Stream.fromIterable(0 until 10) ++ Stream.fail("boom")
+        val slow: Stream[Nothing, Int] = Stream.fromIterable(
+          new Iterable[Int] {
+            def iterator: Iterator[Int] = Iterator.continually { Thread.sleep(50); 42 }.take(10000)
+          }
+        )
+        val result = Stream.mergeAll(2)(Stream.fromIterable(List(fast, slow))).runCollect
+        assertTrue(result.isLeft)
+      }
+    } @@ TestAspect.timeout(10.seconds),
+    test("mergeAll: concurrent errors from multiple inners do not corrupt state") {
+      ZIO.attemptBlocking {
+        var i = 0
+        while (i < 30) {
+          val streams = Stream.fromIterable(
+            (0 until 8).map(j =>
+              if (j % 2 == 0) Stream.range(0, 100) ++ Stream.fail(s"err-$j")
+              else Stream.range(100, 200)
+            )
+          )
+          val result = Stream.mergeAll(8)(streams).runCollect
+          require(result.isLeft, s"iteration $i expected Left but got Right")
+          i += 1
+        }
+        assertTrue(true)
+      }
+    } @@ TestAspect.timeout(60.seconds)
+  )
+
+  private def mergeStream[A](inners: Chunk[Stream[Any, A]], maxOpen: Int): Stream[Any, A] =
+    Stream.fromReader[Any, A](
+      new ConcurrentMergeReader[A](Reader.fromChunk(inners), maxOpen, bufferSize = Stream.DefaultBufferSize)
+    )
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/ConcurrentStressSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/ConcurrentStressSpec.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.ZIO
+import zio.blocks.chunk.Chunk
+import zio.durationInt
+import zio.test._
+
+import java.util.concurrent.locks.LockSupport
+
+object ConcurrentStressSpec extends StreamsBaseSpec {
+
+  override def aspects: zio.Chunk[TestAspectAtLeastR[TestEnvironment]] =
+    zio.Chunk(TestAspect.timed, TestAspect.sequential)
+
+  def spec: Spec[TestEnvironment, Any] = suite("ConcurrentStress")(
+    test("mergeAll - 1M elements no data loss") {
+      ZIO.attemptBlocking {
+        val n = 1_000_000L
+
+        val streams = Stream.fromChunk(
+          Chunk.fromIterable((0 until 1000).map(i => Stream.range(i * 1000, (i + 1) * 1000)))
+        )
+
+        val expected = n * (n - 1L) / 2L
+        val result   = Stream.mergeAll(16)(streams).runFold(0L)(_ + _.toLong)
+
+        assertTrue(result == Right(expected))
+      }
+    } @@ TestAspect.timeout(180.seconds),
+    test("mapPar - 100K elements no data loss") {
+      ZIO.attemptBlocking {
+        val n        = 100_000
+        val expected = (0L until n.toLong).sum * 2L
+        val result   = Stream.range(0, n).mapPar(8)(_.toLong * 2L).runFold(0L)(_ + _)
+
+        assertTrue(result == Right(expected))
+      }
+    } @@ TestAspect.timeout(90.seconds),
+    test("mergeAll - no thread leak") {
+      ZIO.attemptBlocking {
+        val baseline = Thread.getAllStackTraces.size()
+
+        val result = Stream
+          .mergeAll(8)(
+            Stream.fromChunk(
+              Chunk.fromIterable((0 until 100).map(i => Stream.range(i * 100, (i + 1) * 100)))
+            )
+          )
+          .runDrain
+
+        val after = waitForThreadSettle(baseline)
+        assertTrue(result == Right(()), after <= baseline + 4)
+      }
+    } @@ TestAspect.timeout(60.seconds),
+    test("mapPar - no thread leak") {
+      ZIO.attemptBlocking {
+        val baseline = Thread.getAllStackTraces.size()
+
+        val result = Stream
+          .range(0, 100_000)
+          .mapPar(8)(_ + 1)
+          .runDrain
+
+        val after = waitForThreadSettle(baseline)
+        assertTrue(result == Right(()), after <= baseline + 4)
+      }
+    } @@ TestAspect.timeout(60.seconds),
+    test("mergeAll - early termination no thread leak") {
+      ZIO.attemptBlocking {
+        val baseline = Thread.getAllStackTraces.size()
+
+        val result = Stream
+          .mergeAll(8)(
+            Stream.fromChunk(
+              Chunk.fromIterable((0 until 1000).map(i => Stream.range(i * 1000, (i + 1) * 1000)))
+            )
+          )
+          .take(5)
+          .runCollect
+
+        Thread.sleep(500)
+        val after = waitForThreadSettle(baseline)
+
+        assertTrue(result.map(_.size) == Right(5), after <= baseline + 4)
+      }
+    } @@ TestAspect.timeout(60.seconds),
+    test("mergeAll + mapPar pipeline") {
+      ZIO.attemptBlocking {
+        val result = Stream
+          .mergeAll(4)(
+            Stream.fromChunk(
+              Chunk.fromIterable((0 until 16).map(i => Stream.range(i * 10, (i + 1) * 10)))
+            )
+          )
+          .buffer(16)
+          .mapPar(4)(_ + 1)
+          .runCollect
+          .map(_.toSet)
+
+        val expected = Right((1 to 160).toSet)
+        assertTrue(result == expected)
+      }
+    } @@ TestAspect.timeout(60.seconds)
+  )
+
+  private def waitForThreadSettle(baseline: Int): Int = {
+    var attempts = 0
+    var current  = Thread.getAllStackTraces.size()
+
+    while (current > baseline + 4 && attempts < 50) {
+      System.gc()
+      LockSupport.parkNanos(100.millis.toNanos)
+      current = Thread.getAllStackTraces.size()
+      attempts += 1
+    }
+
+    current
+  }
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/FloatDoubleMapParSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/FloatDoubleMapParSpec.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio._
+import zio.test._
+
+/**
+ * Coverage for the Float/Double specialized
+ * [[zio.blocks.streams.internal.FloatConcurrentMapParReader]] and
+ * [[zio.blocks.streams.internal.DoubleConcurrentMapParReader]]. These are
+ * picked by [[zio.blocks.streams.PlatformSpecific.createMapParReader]] when
+ * `inType` is `JvmType.Float` / `JvmType.Double`, which happens whenever an
+ * `Int`/`Long` stream is `map`ped to `Float`/`Double` and then `mapPar`'d.
+ */
+object FloatDoubleMapParSpec extends StreamsBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("FloatDoubleMapParSpec")(
+    suite("Float mapPar")(
+      test("Float => Float identity preserves all elements") {
+        ZIO.attemptBlocking {
+          val n        = 1_000
+          val result   = Stream.range(0, n).map(_.toFloat).mapPar(4)(identity).runFold(0.0)(_ + _)
+          val expected = (0 until n).map(_.toDouble).sum
+          assertTrue(result.exists(v => math.abs(v - expected) < 1e-3))
+        }
+      } @@ TestAspect.timeout(15.seconds),
+      test("Float => Float doubles each value") {
+        ZIO.attemptBlocking {
+          val n      = 500
+          val result = Stream.range(0, n).map(_.toFloat).mapPar(3)(_ * 2.0f).runCollect
+          assertTrue(result.map(_.toSet) == Right((0 until n).map(_.toFloat * 2.0f).toSet))
+        }
+      } @@ TestAspect.timeout(15.seconds),
+      test("Float => Long widens correctly") {
+        ZIO.attemptBlocking {
+          val n        = 500
+          val result   = Stream.range(0, n).map(_.toFloat).mapPar(2)(_.toLong).runFold(0L)(_ + _)
+          val expected = n.toLong * (n - 1) / 2
+          assertTrue(result == Right(expected))
+        }
+      } @@ TestAspect.timeout(15.seconds),
+      test("Float => String boxes through generic path") {
+        ZIO.attemptBlocking {
+          val n      = 200
+          val result = Stream.range(0, n).map(_.toFloat).mapPar(2)(_.toString).runCollect
+          assertTrue(result.map(_.size) == Right(n))
+        }
+      } @@ TestAspect.timeout(15.seconds),
+      test("Float mapPar propagates worker error") {
+        ZIO.attemptBlocking {
+          val attempted = scala.util.Try {
+            Stream
+              .range(0, 100)
+              .map(_.toFloat)
+              .mapPar(2) { f =>
+                if (f >= 50.0f) throw new RuntimeException("boom") else f
+              }
+              .runDrain
+          }
+          assertTrue(attempted.isFailure)
+        }
+      } @@ TestAspect.timeout(15.seconds)
+    ),
+    suite("Double mapPar")(
+      test("Double => Double identity preserves all elements") {
+        ZIO.attemptBlocking {
+          val n        = 1_000
+          val result   = Stream.range(0, n).map(_.toDouble).mapPar(4)(identity).runFold(0.0)(_ + _)
+          val expected = (0 until n).map(_.toDouble).sum
+          assertTrue(result == Right(expected))
+        }
+      } @@ TestAspect.timeout(15.seconds),
+      test("Double => Double scales each value") {
+        ZIO.attemptBlocking {
+          val n      = 500
+          val result = Stream.range(0, n).map(_.toDouble).mapPar(3)(_ * 0.5).runCollect
+          assertTrue(result.map(_.toSet) == Right((0 until n).map(_.toDouble * 0.5).toSet))
+        }
+      } @@ TestAspect.timeout(15.seconds),
+      test("Double => Int narrows correctly") {
+        ZIO.attemptBlocking {
+          val n        = 500
+          val result   = Stream.range(0, n).map(_.toDouble).mapPar(2)(_.toInt).runFold(0L)(_ + _.toLong)
+          val expected = n.toLong * (n - 1) / 2
+          assertTrue(result == Right(expected))
+        }
+      } @@ TestAspect.timeout(15.seconds),
+      test("Double => String boxes through generic path") {
+        ZIO.attemptBlocking {
+          val n      = 200
+          val result = Stream.range(0, n).map(_.toDouble).mapPar(2)(_.toString).runCollect
+          assertTrue(result.map(_.size) == Right(n))
+        }
+      } @@ TestAspect.timeout(15.seconds),
+      test("Double mapPar(1) preserves all elements as set") {
+        ZIO.attemptBlocking {
+          val n        = 300
+          val result   = Stream.range(0, n).map(_.toDouble).mapPar(1)(_ + 1.0).runCollect
+          val expected = (0 until n).map(_.toDouble + 1.0).toSet
+          assertTrue(result.map(_.toSet) == Right(expected))
+        }
+      } @@ TestAspect.timeout(15.seconds),
+      test("Double mapPar propagates worker error") {
+        ZIO.attemptBlocking {
+          val attempted = scala.util.Try {
+            Stream
+              .range(0, 100)
+              .map(_.toDouble)
+              .mapPar(2) { d =>
+                if (d >= 50.0) throw new RuntimeException("boom") else d
+              }
+              .runDrain
+          }
+          assertTrue(attempted.isFailure)
+        }
+      } @@ TestAspect.timeout(15.seconds),
+      test("Double mapPar empty stream completes") {
+        ZIO.attemptBlocking {
+          val result = Stream.range(0, 0).map(_.toDouble).mapPar(2)(identity).runCollect
+          assertTrue(result.map(_.toList) == Right(Nil))
+        }
+      } @@ TestAspect.timeout(15.seconds)
+    )
+  )
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/IsClosedRegressionSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/IsClosedRegressionSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio._
+import zio.test._
+
+object IsClosedRegressionSpec extends StreamsBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("IsClosedRegressionSpec")(
+    suite("mapPar isClosed must not be true while elements remain (P1-A regression)")(
+      test("Int mapPar: isClosed false until all elements consumed") {
+        ZIO.attemptBlocking {
+          val n      = 10_000
+          val reader = Stream.range(0, n).mapPar(4)(identity).compile(0, Stream.DefaultBufferSize)
+          var count  = 0
+          val s      = Long.MinValue
+          var v      = reader.readInt(s)(zio.blocks.streams.internal.unsafeEvidence)
+          while (v != s) {
+            count += 1
+            v = reader.readInt(s)(zio.blocks.streams.internal.unsafeEvidence)
+          }
+          assertTrue(count == n) && assertTrue(reader.isClosed)
+        }
+      } @@ TestAspect.timeout(15.seconds),
+
+      test("Long mapPar: isClosed false until all elements consumed") {
+        ZIO.attemptBlocking {
+          val n        = 10_000
+          val result   = Stream.range(0, n).map(_.toLong).mapPar(4)(identity).runFold(0L)(_ + _)
+          val expected = n.toLong * (n - 1) / 2
+          assertTrue(result == Right(expected))
+        }
+      } @@ TestAspect.timeout(15.seconds),
+
+      test("mapPar: readable() is consistent with isClosed during consumption") {
+        ZIO.attemptBlocking {
+          val n                  = 1000
+          val reader             = Stream.range(0, n).mapPar(2)(identity).compile(0, Stream.DefaultBufferSize)
+          var sawClosedBeforeEnd = false
+          val s                  = Long.MinValue
+          var v                  = reader.readInt(s)(zio.blocks.streams.internal.unsafeEvidence)
+          while (v != s) {
+            if (reader.isClosed) sawClosedBeforeEnd = true
+            v = reader.readInt(s)(zio.blocks.streams.internal.unsafeEvidence)
+          }
+          assertTrue(!sawClosedBeforeEnd) && assertTrue(reader.isClosed)
+        }
+      } @@ TestAspect.timeout(15.seconds)
+    ),
+
+    suite("mergeAll isClosed must not be true while elements remain (#6 regression)")(
+      test("generic mergeAll: isClosed false until all elements consumed") {
+        ZIO.attemptBlocking {
+          val n       = 5_000
+          val streams = Stream.fromIterable(
+            (0 until 5).map(i => Stream.fromIterable((i * n until (i + 1) * n).map(_.toString)))
+          )
+          val result = Stream.mergeAll(3)(streams).runFold(0L)((acc, _) => acc + 1L)
+          assertTrue(result == Right(n.toLong * 5))
+        }
+      } @@ TestAspect.timeout(15.seconds),
+
+      test("Int mergeAll: isClosed false until all elements consumed") {
+        ZIO.attemptBlocking {
+          val n       = 5_000
+          val streams = Stream.fromIterable(
+            (0 until 5).map(i => Stream.range(i * n, (i + 1) * n))
+          )
+          val result = Stream.mergeAll(3)(streams).runFold(0L)((acc, _) => acc + 1L)
+          assertTrue(result == Right(n.toLong * 5))
+        }
+      } @@ TestAspect.timeout(15.seconds),
+
+      test("Long mergeAll: isClosed false until all elements consumed") {
+        ZIO.attemptBlocking {
+          val n       = 5_000
+          val streams = Stream.fromIterable(
+            (0 until 5).map(i => Stream.range(i * n, (i + 1) * n).map(_.toLong))
+          )
+          val result = Stream.mergeAll(3)(streams).runFold(0L)((acc, _) => acc + 1L)
+          assertTrue(result == Right(n.toLong * 5))
+        }
+      } @@ TestAspect.timeout(15.seconds)
+    ),
+
+    suite("mergeAll readUpToN returns correct count through sentinels (#4 regression)")(
+      test("readUpToN on mergeAll does not lose elements across InnerDone boundaries") {
+        ZIO.attemptBlocking {
+          val streams = Stream.fromIterable(
+            (0 until 20).map(i => Stream.range(i * 50, (i + 1) * 50))
+          )
+          val result   = Stream.mergeAll(4)(streams).runFold(0L)(_ + _)
+          val n        = 1000
+          val expected = n.toLong * (n - 1) / 2
+          assertTrue(result == Right(expected))
+        }
+      } @@ TestAspect.timeout(15.seconds)
+    )
+  )
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/MergeInnerErrorSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/MergeInnerErrorSpec.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio._
+import zio.test._
+
+object MergeInnerErrorSpec extends StreamsBaseSpec {
+
+  private val errorMsg = "inner-boom"
+
+  private def failingIntStream(failAt: Int): Stream[String, Int] =
+    Stream.range(0, failAt) ++ Stream.fail(errorMsg)
+
+  private def failingLongStream(failAt: Int): Stream[String, Long] =
+    Stream.range(0, failAt).map(_.toLong) ++ Stream.fail(errorMsg)
+
+  private def failingDoubleStream(failAt: Int): Stream[String, Double] =
+    Stream.range(0, failAt).map(_.toDouble) ++ Stream.fail(errorMsg)
+
+  private def failingFloatStream(failAt: Int): Stream[String, Float] =
+    Stream.range(0, failAt).map(_.toFloat) ++ Stream.fail(errorMsg)
+
+  def spec: Spec[TestEnvironment, Any] = suite("MergeInnerErrorSpec")(
+    suite("error in inner stream does not hang (InnerDone-in-finally regression)")(
+      test("generic mergeAll: error in inner terminates without hang") {
+        ZIO.attemptBlocking {
+          val streams: Stream[String, Stream[String, String]] = Stream.fromIterable(
+            Seq(
+              Stream.fromIterable(Seq("a", "b", "c")),
+              Stream.fromIterable(Seq("d")) ++ Stream.fail(errorMsg),
+              Stream.fromIterable(Seq("e", "f"))
+            )
+          )
+          val result = Stream.mergeAll(3)(streams).runCollect
+          assertTrue(result.isLeft)
+        }
+      } @@ TestAspect.timeout(10.seconds),
+
+      test("Int mergeAll: error in inner terminates without hang") {
+        ZIO.attemptBlocking {
+          val streams = Stream.fromIterable(
+            Seq(Stream.range(0, 100), failingIntStream(50), Stream.range(200, 300))
+          )
+          val result = Stream.mergeAll(3)(streams).runCollect
+          assertTrue(result.isLeft)
+        }
+      } @@ TestAspect.timeout(10.seconds),
+
+      test("Long mergeAll: error in inner terminates without hang") {
+        ZIO.attemptBlocking {
+          val streams = Stream.fromIterable(
+            Seq(
+              Stream.range(0, 100).map(_.toLong),
+              failingLongStream(50),
+              Stream.range(200, 300).map(_.toLong)
+            )
+          )
+          val result = Stream.mergeAll(3)(streams).runCollect
+          assertTrue(result.isLeft)
+        }
+      } @@ TestAspect.timeout(10.seconds),
+
+      test("Double mergeAll: error in inner terminates without hang") {
+        ZIO.attemptBlocking {
+          val streams = Stream.fromIterable(
+            Seq(
+              Stream.range(0, 100).map(_.toDouble),
+              failingDoubleStream(50),
+              Stream.range(200, 300).map(_.toDouble)
+            )
+          )
+          val result = Stream.mergeAll(3)(streams).runCollect
+          assertTrue(result.isLeft)
+        }
+      } @@ TestAspect.timeout(10.seconds),
+
+      test("Float mergeAll: error in inner terminates without hang") {
+        ZIO.attemptBlocking {
+          val streams = Stream.fromIterable(
+            Seq(
+              Stream.range(0, 100).map(_.toFloat),
+              failingFloatStream(50),
+              Stream.range(200, 300).map(_.toFloat)
+            )
+          )
+          val result = Stream.mergeAll(3)(streams).runCollect
+          assertTrue(result.isLeft)
+        }
+      } @@ TestAspect.timeout(10.seconds)
+    ),
+
+    suite("multiple concurrent inner errors do not hang")(
+      test("Int: 8 streams, half error, does not hang") {
+        ZIO.attemptBlocking {
+          var i = 0
+          while (i < 10) {
+            val streams = Stream.fromIterable(
+              (0 until 8).map(j =>
+                if (j % 2 == 0) failingIntStream(100)
+                else Stream.range(j * 1000, j * 1000 + 200)
+              )
+            )
+            val result = Stream.mergeAll(8)(streams).runCollect
+            require(result.isLeft, s"iteration $i expected Left")
+            i += 1
+          }
+          assertTrue(true)
+        }
+      } @@ TestAspect.timeout(30.seconds),
+
+      test("Long: 8 streams, half error, does not hang") {
+        ZIO.attemptBlocking {
+          var i = 0
+          while (i < 10) {
+            val streams = Stream.fromIterable(
+              (0 until 8).map(j =>
+                if (j % 2 == 0) failingLongStream(100)
+                else Stream.range(j * 1000, j * 1000 + 200).map(_.toLong)
+              )
+            )
+            val result = Stream.mergeAll(8)(streams).runCollect
+            require(result.isLeft, s"iteration $i expected Left")
+            i += 1
+          }
+          assertTrue(true)
+        }
+      } @@ TestAspect.timeout(30.seconds)
+    )
+  )
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/PlatformSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/PlatformSpec.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.ZIO
+import zio.durationInt
+import zio.test._
+
+object PlatformSpec extends StreamsBaseSpec {
+  override def aspects: zio.Chunk[TestAspectAtLeastR[TestEnvironment]] =
+    zio.Chunk(TestAspect.timeout(60.seconds), TestAspect.timed, TestAspect.sequential)
+
+  private def isExactRange(chunk: zio.blocks.chunk.Chunk[Int], n: Int): Boolean =
+    if (chunk.length != n) false
+    else {
+      val iterator = chunk.iterator
+      var i        = 0
+      var ok       = true
+      while (ok && iterator.hasNext) {
+        if (iterator.next() != i) ok = false
+        i += 1
+      }
+      ok && i == n
+    }
+
+  def spec: Spec[TestEnvironment, Any] = suite("Platform")(
+    test("startVirtualThread runs the task") {
+      ZIO.attemptBlocking {
+        val flag = new java.util.concurrent.atomic.AtomicBoolean(false)
+        val t    = Platform.startVirtualThread("test-vthread", () => flag.set(true))
+        t.join(5000)
+        assertTrue(flag.get())
+      }
+    },
+    test("buffer collects range with full fidelity") {
+      ZIO.attemptBlocking {
+        val n      = 200
+        val result = Stream.range(0, n).buffer(8).runCollect
+        assertTrue(result match {
+          case Right(chunk) => isExactRange(chunk, n)
+          case _            => false
+        })
+      }
+    },
+    test("buffer propagates stream failures") {
+      ZIO.attemptBlocking {
+        val result = Stream.fail("boom").buffer(16).runCollect
+        assertTrue(result == Left("boom"))
+      }
+    },
+    test("buffer supports early termination") {
+      ZIO.attemptBlocking {
+        val result = Stream.range(0, Int.MaxValue).buffer(64).take(10).runCollect
+        assertTrue(result match {
+          case Right(chunk) => isExactRange(chunk, 10)
+          case _            => false
+        })
+      }
+    }
+  )
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/ReadNJvmSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/ReadNJvmSpec.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.blocks.chunk.Chunk
+import zio.test._
+
+import java.nio.ByteBuffer
+import java.nio.channels.{Channels, ReadableByteChannel}
+
+object ReadNJvmSpec extends StreamsBaseSpec {
+
+  private def intBuf(ints: Int*): ByteBuffer = {
+    val bb = ByteBuffer.allocate(ints.size * 4)
+    ints.foreach(bb.putInt)
+    bb.flip()
+    bb
+  }
+
+  private def longBuf(longs: Long*): ByteBuffer = {
+    val bb = ByteBuffer.allocate(longs.size * 8)
+    longs.foreach(bb.putLong)
+    bb.flip()
+    bb
+  }
+
+  private def doubleBuf(ds: Double*): ByteBuffer = {
+    val bb = ByteBuffer.allocate(ds.size * 8)
+    ds.foreach(bb.putDouble)
+    bb.flip()
+    bb
+  }
+
+  private def floatBuf(fs: Float*): ByteBuffer = {
+    val bb = ByteBuffer.allocate(fs.size * 4)
+    fs.foreach(bb.putFloat)
+    bb.flip()
+    bb
+  }
+
+  private def channel(bytes: Byte*): ReadableByteChannel =
+    Channels.newChannel(new java.io.ByteArrayInputStream(bytes.toArray))
+
+  def spec: Spec[TestEnvironment, Any] = suite("readN JVM overrides")(
+    suite("NioReaders.fromByteBuffer (Byte)")(
+      test("bulk read returns correct bytes") {
+        val r = NioReaders.fromByteBuffer(ByteBuffer.wrap(Array[Byte](1, 2, 3, 4, 5)))
+        assertTrue(r.readN[Byte](3) == Chunk[Byte](1, 2, 3))
+      },
+      test("successive reads advance position") {
+        val r  = NioReaders.fromByteBuffer(ByteBuffer.wrap(Array[Byte](10, 20, 30, 40)))
+        val c1 = r.readN[Byte](2)
+        val c2 = r.readN[Byte](2)
+        assertTrue(c1 == Chunk[Byte](10, 20)) && assertTrue(c2 == Chunk[Byte](30, 40))
+      },
+      test("readN beyond remaining returns all and closes") {
+        val r = NioReaders.fromByteBuffer(ByteBuffer.wrap(Array[Byte](1, 2, 3)))
+        assertTrue(r.readN[Byte](10) == Chunk[Byte](1, 2, 3)) && assertTrue(r.isClosed)
+      },
+      test("readN(0) returns empty") {
+        val r = NioReaders.fromByteBuffer(ByteBuffer.wrap(Array[Byte](1, 2)))
+        assertTrue(r.readN[Byte](0) == Chunk.empty)
+      }
+    ),
+    suite("NioReaders.fromByteBufferInt (Int)")(
+      test("bulk read returns correct ints") {
+        val r = NioReaders.fromByteBufferInt(intBuf(10, 20, 30, 40, 50))
+        assertTrue(r.readN[Int](3) == Chunk(10, 20, 30))
+      },
+      test("partial: n > available returns all") {
+        val r = NioReaders.fromByteBufferInt(intBuf(1, 2, 3))
+        assertTrue(r.readN[Int](10) == Chunk(1, 2, 3)) && assertTrue(r.isClosed)
+      },
+      test("successive reads") {
+        val r  = NioReaders.fromByteBufferInt(intBuf(1, 2, 3, 4))
+        val c1 = r.readN[Int](2)
+        val c2 = r.readN[Int](2)
+        assertTrue(c1 == Chunk(1, 2)) && assertTrue(c2 == Chunk(3, 4))
+      }
+    ),
+    suite("NioReaders.fromByteBufferLong (Long)")(
+      test("bulk read returns correct longs") {
+        val r = NioReaders.fromByteBufferLong(longBuf(100L, 200L, 300L))
+        assertTrue(r.readN[Long](2) == Chunk(100L, 200L))
+      },
+      test("partial: n > available returns all") {
+        val r = NioReaders.fromByteBufferLong(longBuf(1L, 2L))
+        assertTrue(r.readN[Long](100) == Chunk(1L, 2L)) && assertTrue(r.isClosed)
+      }
+    ),
+    suite("NioReaders.fromByteBufferDouble (Double)")(
+      test("bulk read returns correct doubles") {
+        val r = NioReaders.fromByteBufferDouble(doubleBuf(1.1, 2.2, 3.3))
+        assertTrue(r.readN[Double](2) == Chunk(1.1, 2.2))
+      },
+      test("successive reads") {
+        val r  = NioReaders.fromByteBufferDouble(doubleBuf(1.0, 2.0, 3.0, 4.0))
+        val c1 = r.readN[Double](2)
+        val c2 = r.readN[Double](2)
+        assertTrue(c1 == Chunk(1.0, 2.0)) && assertTrue(c2 == Chunk(3.0, 4.0))
+      }
+    ),
+    suite("NioReaders.fromByteBufferFloat (Float)")(
+      test("bulk read returns correct floats") {
+        val r = NioReaders.fromByteBufferFloat(floatBuf(1.0f, 2.0f, 3.0f))
+        assertTrue(r.readN[Float](3) == Chunk(1.0f, 2.0f, 3.0f))
+      },
+      test("readN(0) returns empty") {
+        val r = NioReaders.fromByteBufferFloat(floatBuf(1.0f))
+        assertTrue(r.readN[Float](0) == Chunk.empty)
+      }
+    ),
+    suite("NioReaders.fromChannel (Byte)")(
+      test("accumulates across buffer refills with small internal buffer") {
+        val r = NioReaders.fromChannel(channel(1, 2, 3, 4, 5, 6), 2)
+        assertTrue(r.readN[Byte](5) == Chunk[Byte](1, 2, 3, 4, 5))
+      },
+      test("successive readN calls advance position") {
+        val r  = NioReaders.fromChannel(channel(10, 20, 30, 40), 2)
+        val c1 = r.readN[Byte](2)
+        val c2 = r.readN[Byte](2)
+        assertTrue(c1 == Chunk[Byte](10, 20)) && assertTrue(c2 == Chunk[Byte](30, 40))
+      },
+      test("readN beyond end returns all available") {
+        val r = NioReaders.fromChannel(channel(1, 2, 3), 4)
+        assertTrue(r.readN[Byte](100) == Chunk[Byte](1, 2, 3)) && assertTrue(r.isClosed)
+      }
+    )
+  )
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/ReadUpToNSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/ReadUpToNSpec.scala
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.blocks.chunk.Chunk
+import zio.test._
+
+object ReadUpToNSpec extends StreamsBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("Reader#readUpToN")(
+    suite("FromChunk[String] (generic)")(
+      test("readUpToN(0) returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk("a", "b", "c")))
+        assertTrue(reader.readUpToN[String](0) == Chunk.empty)
+      },
+      test("readUpToN(1) returns single element") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk("a", "b", "c")))
+        assertTrue(reader.readUpToN[String](1) == Chunk("a"))
+      },
+      test("readUpToN(n < total) returns exactly n elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk("a", "b", "c", "d", "e")))
+        assertTrue(reader.readUpToN[String](3) == Chunk("a", "b", "c"))
+      },
+      test("readUpToN(n > total) returns all remaining elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk("a", "b", "c")))
+        assertTrue(reader.readUpToN[String](100) == Chunk("a", "b", "c"))
+      },
+      test("readUpToN on exhausted reader returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk("a", "b")))
+        val _      = reader.readUpToN[String](2)
+        assertTrue(reader.readUpToN[String](5) == Chunk.empty)
+      }
+    ),
+    suite("FromChunkInt")(
+      test("readUpToN(0) returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1, 2, 3)))
+        assertTrue(reader.readUpToN[Int](0) == Chunk.empty)
+      },
+      test("readUpToN(1) returns single element") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1, 2, 3)))
+        assertTrue(reader.readUpToN[Int](1) == Chunk(1))
+      },
+      test("readUpToN(n < total) returns exactly n elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1, 2, 3, 4, 5)))
+        assertTrue(reader.readUpToN[Int](3) == Chunk(1, 2, 3))
+      },
+      test("readUpToN(n > total) returns all remaining elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1, 2, 3)))
+        assertTrue(reader.readUpToN[Int](100) == Chunk(1, 2, 3))
+      },
+      test("readUpToN on exhausted reader returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1, 2, 3)))
+        val _      = reader.readUpToN[Int](3)
+        assertTrue(reader.readUpToN[Int](1) == Chunk.empty)
+      },
+      test("successive readUpToN calls advance position") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(10, 20, 30, 40, 50)))
+        val c1     = reader.readUpToN[Int](2)
+        val c2     = reader.readUpToN[Int](2)
+        val c3     = reader.readUpToN[Int](5)
+        assertTrue(c1 == Chunk(10, 20)) &&
+        assertTrue(c2 == Chunk(30, 40)) &&
+        assertTrue(c3 == Chunk(50))
+      }
+    ),
+    suite("FromChunkLong")(
+      test("readUpToN(0) returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1L, 2L, 3L)))
+        assertTrue(reader.readUpToN[Long](0) == Chunk.empty)
+      },
+      test("readUpToN(1) returns single element") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1L, 2L, 3L)))
+        assertTrue(reader.readUpToN[Long](1) == Chunk(1L))
+      },
+      test("readUpToN(n < total) returns exactly n elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(10L, 20L, 30L, 40L, 50L)))
+        assertTrue(reader.readUpToN[Long](3) == Chunk(10L, 20L, 30L))
+      },
+      test("readUpToN(n > total) returns all remaining elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1L, 2L)))
+        assertTrue(reader.readUpToN[Long](100) == Chunk(1L, 2L))
+      },
+      test("readUpToN on exhausted reader returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1L, 2L)))
+        val _      = reader.readUpToN[Long](2)
+        assertTrue(reader.readUpToN[Long](1) == Chunk.empty)
+      }
+    ),
+    suite("FromChunkDouble")(
+      test("readUpToN(0) returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.0, 2.0, 3.0)))
+        assertTrue(reader.readUpToN[Double](0) == Chunk.empty)
+      },
+      test("readUpToN(1) returns single element") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.0, 2.0, 3.0)))
+        assertTrue(reader.readUpToN[Double](1) == Chunk(1.0))
+      },
+      test("readUpToN(n < total) returns exactly n elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.5, 2.5, 3.5, 4.5)))
+        assertTrue(reader.readUpToN[Double](2) == Chunk(1.5, 2.5))
+      },
+      test("readUpToN(n > total) returns all remaining elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.0, 2.0)))
+        assertTrue(reader.readUpToN[Double](100) == Chunk(1.0, 2.0))
+      },
+      test("readUpToN on exhausted reader returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.0, 2.0)))
+        val _      = reader.readUpToN[Double](2)
+        assertTrue(reader.readUpToN[Double](1) == Chunk.empty)
+      }
+    ),
+    suite("FromChunkFloat")(
+      test("readUpToN(0) returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.0f, 2.0f, 3.0f)))
+        assertTrue(reader.readUpToN[Float](0) == Chunk.empty)
+      },
+      test("readUpToN(1) returns single element") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.0f, 2.0f, 3.0f)))
+        assertTrue(reader.readUpToN[Float](1) == Chunk(1.0f))
+      },
+      test("readUpToN(n < total) returns exactly n elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.1f, 2.2f, 3.3f, 4.4f)))
+        assertTrue(reader.readUpToN[Float](2) == Chunk(1.1f, 2.2f))
+      },
+      test("readUpToN(n > total) returns all remaining elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.0f, 2.0f)))
+        assertTrue(reader.readUpToN[Float](100) == Chunk(1.0f, 2.0f))
+      },
+      test("readUpToN on exhausted reader returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.0f, 2.0f)))
+        val _      = reader.readUpToN[Float](2)
+        assertTrue(reader.readUpToN[Float](1) == Chunk.empty)
+      }
+    ),
+    suite("FromRange")(
+      test("readUpToN(0) returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.range(0, 10))
+        assertTrue(reader.readUpToN[Int](0) == Chunk.empty)
+      },
+      test("readUpToN(1) returns single element") {
+        val reader = Stream.compileToReader(Stream.range(0, 10))
+        assertTrue(reader.readUpToN[Int](1) == Chunk(0))
+      },
+      test("readUpToN(n < total) returns at most n elements") {
+        val reader = Stream.compileToReader(Stream.range(0, 10))
+        val chunk  = reader.readUpToN[Int](5)
+        assertTrue(chunk.length <= 5 && chunk.length >= 1)
+      },
+      test("readUpToN(n > total) returns all remaining elements") {
+        val reader = Stream.compileToReader(Stream.range(0, 3))
+        val chunk  = reader.readUpToN[Int](100)
+        assertTrue(chunk == Chunk(0, 1, 2))
+      },
+      test("readUpToN on exhausted reader returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.range(0, 2))
+        val _      = reader.readUpToN[Int](2)
+        assertTrue(reader.readUpToN[Int](1) == Chunk.empty)
+      },
+      test("successive readUpToN calls consume range in order") {
+        val reader = Stream.compileToReader(Stream.range(0, 7))
+        val c1     = reader.readUpToN[Int](3)
+        val c1len  = c1.length
+        val c2     = reader.readUpToN[Int](3)
+        val c2len  = c2.length
+        val c3     = reader.readUpToN[Int](10)
+        assertTrue(c1 == Chunk.fromIterable(0 until c1len)) &&
+        assertTrue(c2 == Chunk.fromIterable(c1len until (c1len + c2len))) &&
+        assertTrue((c1 ++ c2 ++ c3) == Chunk(0, 1, 2, 3, 4, 5, 6))
+      }
+    ),
+    suite("Filtered (Int)")(
+      test("readUpToN returns at most n filtered elements") {
+        val reader = Stream.compileToReader(Stream.range(0, 20).filter(_ % 2 == 0))
+        val chunk  = reader.readUpToN[Int](5)
+        assertTrue(chunk.length <= 5 && chunk.length >= 1) &&
+        assertTrue(chunk.toList.forall(_ % 2 == 0))
+      },
+      test("readUpToN on empty filter result returns empty") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1, 3, 5)).filter(_ % 2 == 0))
+        assertTrue(reader.readUpToN[Int](5) == Chunk.empty)
+      }
+    ),
+    suite("Mapped (Int)")(
+      test("readUpToN returns at most n mapped elements") {
+        val reader = Stream.compileToReader(Stream.range(0, 10).map(_ * 10))
+        val chunk  = reader.readUpToN[Int](5)
+        assertTrue(chunk.length <= 5 && chunk.length >= 1) &&
+        assertTrue(chunk.toList.forall(_ % 10 == 0))
+      },
+      test("readUpToN on mapped reader successive calls consume in order") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1, 2, 3, 4, 5)).map(_ * 2))
+        val c1     = reader.readUpToN[Int](3)
+        val c2     = reader.readUpToN[Int](3)
+        assertTrue((c1 ++ c2) == Chunk(2, 4, 6, 8, 10))
+      }
+    ),
+    suite("ConcatReader (boundary spanning)")(
+      test("readUpToN spans concatenation boundary") {
+        val s1     = Stream.fromChunk(Chunk(1, 2, 3))
+        val s2     = Stream.fromChunk(Chunk(4, 5, 6))
+        val reader = Stream.compileToReader(s1 ++ s2)
+        val c1     = reader.readUpToN[Int](3)
+        val c2     = reader.readUpToN[Int](3)
+        val c3     = reader.readUpToN[Int](3)
+        assertTrue((c1 ++ c2 ++ c3) == Chunk(1, 2, 3, 4, 5, 6))
+      },
+      test("readUpToN returns at least one element from each call until exhausted") {
+        val s1     = Stream.fromChunk(Chunk("a", "b"))
+        val s2     = Stream.fromChunk(Chunk("c", "d"))
+        val reader = Stream.compileToReader(s1 ++ s2)
+        var all    = Chunk.empty: Chunk[String]
+        var done   = false
+        while (!done) {
+          val chunk = reader.readUpToN[String](2)
+          if (chunk.isEmpty) done = true
+          else all = all ++ chunk
+        }
+        assertTrue(all == Chunk("a", "b", "c", "d"))
+      }
+    ),
+    suite("Taken")(
+      test("readUpToN respects take limit") {
+        val reader = Stream.compileToReader(Stream.range(0, 100).take(5))
+        var all    = Chunk.empty: Chunk[Int]
+        var done   = false
+        while (!done) {
+          val chunk = reader.readUpToN[Int](10)
+          if (chunk.isEmpty) done = true
+          else all = all ++ chunk
+        }
+        assertTrue(all == Chunk(0, 1, 2, 3, 4))
+      },
+      test("readUpToN(3) on take(3) returns exactly 3 elements") {
+        val reader = Stream.compileToReader(Stream.range(0, 100).take(3))
+        val chunk  = reader.readUpToN[Int](3)
+        assertTrue(chunk == Chunk(0, 1, 2))
+      }
+    ),
+    suite("TakenWhile")(
+      test("readUpToN respects takeWhile predicate") {
+        val reader = Stream.compileToReader(Stream.range(0, 100).takeWhile(_ < 5))
+        var all    = Chunk.empty: Chunk[Int]
+        var done   = false
+        while (!done) {
+          val chunk = reader.readUpToN[Int](10)
+          if (chunk.isEmpty) done = true
+          else all = all ++ chunk
+        }
+        assertTrue(all == Chunk(0, 1, 2, 3, 4))
+      },
+      test("readUpToN on takeWhile that immediately fails returns empty") {
+        val reader = Stream.compileToReader(Stream.range(10, 20).takeWhile(_ < 5))
+        assertTrue(reader.readUpToN[Int](5) == Chunk.empty)
+      }
+    ),
+    suite("SkipLimitReader")(
+      test("readUpToN respects skip and limit") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk.fromIterable(0 until 20)).drop(5).take(5))
+        var all    = Chunk.empty: Chunk[Int]
+        var done   = false
+        while (!done) {
+          val chunk = reader.readUpToN[Int](10)
+          if (chunk.isEmpty) done = true
+          else all = all ++ chunk
+        }
+        assertTrue(all == Chunk(5, 6, 7, 8, 9))
+      },
+      test("readUpToN(2) on skip+limit reader returns at most 2 elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk.fromIterable(0 until 20)).drop(3).take(10))
+        val chunk  = reader.readUpToN[Int](2)
+        assertTrue(chunk.length <= 2 && chunk.length >= 1)
+      }
+    ),
+    suite("ConcurrentBufferedReader (JVM)")(
+      test("readUpToN returns available elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1, 2, 3, 4, 5)).buffer(4))
+        Thread.sleep(50)
+        var all  = Chunk.empty: Chunk[Int]
+        var done = false
+        while (!done) {
+          val chunk = reader.readUpToN[Int](10)
+          if (chunk.isEmpty) done = true
+          else all = all ++ chunk
+        }
+        reader.close()
+        assertTrue(all == Chunk(1, 2, 3, 4, 5))
+      },
+      test("readUpToN(0) returns empty on buffered reader") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1, 2, 3)).buffer(4))
+        val result = reader.readUpToN[Int](0)
+        reader.close()
+        assertTrue(result == Chunk.empty)
+      }
+    ),
+    suite("ConcurrentMergeReader (JVM)")(
+      test("readUpToN returns elements from merged streams") {
+        val inner1 = Stream.fromChunk(Chunk(1, 2, 3))
+        val inner2 = Stream.fromChunk(Chunk(4, 5, 6))
+        val merged = Stream.mergeAll(2)(Stream.fromIterable(List(inner1, inner2)))
+        val reader = Stream.compileToReader(merged)
+        Thread.sleep(100)
+        var all  = Chunk.empty: Chunk[Int]
+        var done = false
+        while (!done) {
+          val chunk = reader.readUpToN[Int](10)
+          if (chunk.isEmpty) done = true
+          else all = all ++ chunk
+        }
+        reader.close()
+        assertTrue(all.toSet == Set(1, 2, 3, 4, 5, 6)) &&
+        assertTrue(all.length == 6)
+      }
+    )
+  )
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/queues/BlockingMpmcQueueSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/queues/BlockingMpmcQueueSpec.scala
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.queues
+
+import zio._
+import zio.blocks.streams.StreamsBaseSpec
+import zio.test._
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong}
+
+object BlockingMpmcQueueSpec extends StreamsBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("BlockingMpmcQueue")(
+    suite("unit tests")(
+      test("offer/take works") {
+        val q = new BlockingMpmcQueue[Integer](16)
+        q.offer(Integer.valueOf(1))
+        q.offer(Integer.valueOf(2))
+        val a = q.take()
+        val b = q.take()
+        assertTrue(a.intValue() + b.intValue() == 3)
+      },
+      test("capacity rounds up to next power of two") {
+        val q     = new BlockingMpmcQueue[Integer](3)
+        var count = 0
+        while (count < 4 && q.offer(Integer.valueOf(count))) count += 1
+        assertTrue(count == 4)
+      },
+      test("closed semantics: offer fails, take on empty returns null") {
+        val q = new BlockingMpmcQueue[Integer](4)
+        q.close()
+        assertTrue(q.isClosed) &&
+        assertTrue(!q.offer(Integer.valueOf(1))) &&
+        assertTrue(q.take() == null)
+      }
+    ),
+    suite("concurrency tests")(
+      test("4 producers + 4 consumers: 100K elements, no data loss, correct sum") {
+        ZIO.attemptBlocking {
+          val n             = 100_000
+          val producerCount = 4
+          val consumerCount = 4
+          val perProducer   = n / producerCount
+          val q             = new BlockingMpmcQueue[Integer](1024)
+          val sum           = new AtomicLong(0L)
+          val received      = new AtomicInteger(0)
+          val producersDone = new CountDownLatch(producerCount)
+          val done          = new CountDownLatch(producerCount + consumerCount)
+          val failed        = new AtomicBoolean(false)
+
+          val producers = (0 until producerCount).map { p =>
+            new Thread(() => {
+              try {
+                val start = p * perProducer
+                val end   = start + perProducer
+                var i     = start
+                while (i < end) { q.offer(Integer.valueOf(i)); i += 1 }
+              } catch { case _: Throwable => failed.set(true) }
+              finally {
+                producersDone.countDown()
+                done.countDown()
+              }
+            })
+          }
+
+          val consumers = (0 until consumerCount).map { _ =>
+            new Thread(() => {
+              try {
+                var running = true
+                while (running) {
+                  val v = q.take()
+                  if (v != null) {
+                    sum.addAndGet(v.longValue())
+                    received.incrementAndGet()
+                  } else if (q.isClosed) {
+                    running = false
+                  }
+                }
+              } catch { case _: Throwable => failed.set(true) }
+              finally done.countDown()
+            })
+          }
+
+          producers.foreach(_.start())
+          consumers.foreach(_.start())
+          val producersCompleted = producersDone.await(30, TimeUnit.SECONDS)
+          val receiveDeadline    = java.lang.System.nanoTime() + TimeUnit.SECONDS.toNanos(30)
+          while (received.get() < n && java.lang.System.nanoTime() < receiveDeadline) Thread.sleep(1)
+          q.close()
+          val completed = done.await(30, TimeUnit.SECONDS)
+          val expected  = n.toLong * (n - 1) / 2
+          assertTrue(producersCompleted, completed, !failed.get(), received.get() == n, sum.get() == expected)
+        }
+      } @@ TestAspect.timeout(40.seconds),
+      test("close unblocks all consumers and producers") {
+        ZIO.attemptBlocking {
+          val q      = new BlockingMpmcQueue[Integer](2)
+          val closed = new AtomicBoolean(false)
+          val latch  = new CountDownLatch(2)
+
+          val consumer1 = new Thread(() => { q.take(); latch.countDown() })
+          val consumer2 = new Thread(() => { q.take(); latch.countDown() })
+          consumer1.start(); consumer2.start()
+          Thread.sleep(50)
+          q.close()
+          closed.set(true)
+          val ok = latch.await(5, TimeUnit.SECONDS)
+          assertTrue(ok, closed.get())
+        }
+      }
+    ),
+    suite("stress test")(
+      test("4 producers + 4 consumers, 1M elements, no data loss") {
+        ZIO.attemptBlocking {
+          val n             = 1_000_000
+          val producerCount = 4
+          val consumerCount = 4
+          val perProducer   = n / producerCount
+          val q             = new BlockingMpmcQueue[Integer](65536)
+          val sum           = new AtomicLong(0L)
+          val received      = new AtomicInteger(0)
+          val producersDone = new CountDownLatch(producerCount)
+          val done          = new CountDownLatch(producerCount + consumerCount)
+          val failed        = new AtomicBoolean(false)
+
+          val producers = (0 until producerCount).map { p =>
+            new Thread(() => {
+              try {
+                val start = p * perProducer
+                val end   = start + perProducer
+                var i     = start
+                while (i < end) { q.offer(Integer.valueOf(i)); i += 1 }
+              } catch { case _: Throwable => failed.set(true) }
+              finally {
+                producersDone.countDown()
+                done.countDown()
+              }
+            })
+          }
+
+          val consumers = (0 until consumerCount).map { _ =>
+            new Thread(() => {
+              try {
+                var running = true
+                while (running) {
+                  val v = q.take()
+                  if (v != null) {
+                    sum.addAndGet(v.longValue())
+                    received.incrementAndGet()
+                  } else if (q.isClosed) {
+                    running = false
+                  }
+                }
+              } catch { case _: Throwable => failed.set(true) }
+              finally done.countDown()
+            })
+          }
+
+          producers.foreach(_.start())
+          consumers.foreach(_.start())
+          val producersCompleted = producersDone.await(120, TimeUnit.SECONDS)
+          val receiveDeadline    = java.lang.System.nanoTime() + TimeUnit.SECONDS.toNanos(120)
+          while (received.get() < n && java.lang.System.nanoTime() < receiveDeadline) Thread.sleep(1)
+          q.close()
+          val completed = done.await(120, TimeUnit.SECONDS)
+          val expected  = n.toLong * (n - 1) / 2
+          val result    =
+            assertTrue(producersCompleted, completed, !failed.get(), received.get() == n, sum.get() == expected)
+          Thread.sleep(500)
+          result
+        }
+      } @@ TestAspect.timeout(150.seconds)
+    )
+  )
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/queues/BlockingMpscQueueSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/queues/BlockingMpscQueueSpec.scala
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.queues
+
+import zio._
+import zio.blocks.streams.StreamsBaseSpec
+import zio.test._
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong, AtomicReference}
+
+object BlockingMpscQueueSpec extends StreamsBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("BlockingMpscQueue")(
+    suite("unit tests")(
+      test("offer/take preserves FIFO ordering") {
+        val q = new BlockingMpscQueue[Integer](16)
+        var i = 0
+        while (i < 10) {
+          q.offer(Integer.valueOf(i))
+          i += 1
+        }
+        val results = (0 until 10).map(_ => q.take().intValue())
+        assertTrue(results.toList == (0 until 10).toList)
+      },
+      test("capacity is rounded up to next power of two") {
+        val q     = new BlockingMpscQueue[Integer](3)
+        var count = 0
+        while (count < 4 && q.offer(Integer.valueOf(count))) {
+          count += 1
+        }
+        assertTrue(count == 4)
+      },
+      test("closed semantics: offer fails, take on closed-empty returns null") {
+        val q = new BlockingMpscQueue[Integer](4)
+        q.close()
+        assertTrue(q.isClosed) &&
+        assertTrue(!q.offer(Integer.valueOf(1))) &&
+        assertTrue(q.take() == null)
+      }
+    ),
+    suite("concurrency tests")(
+      test("4 producers + 1 consumer: 100K elements, no data loss, correct sum") {
+        ZIO.attemptBlocking {
+          val n             = 100_000
+          val producerCount = 4
+          val perProducer   = n / producerCount
+          val q             = new BlockingMpscQueue[Integer](16384)
+          val sum           = new AtomicLong(0L)
+          val received      = new AtomicInteger(0)
+          val done          = new CountDownLatch(producerCount + 1)
+          val failed        = new AtomicBoolean(false)
+
+          val producers = (0 until producerCount).map { p =>
+            new Thread(() => {
+              try {
+                val start = p * perProducer
+                val end   = start + perProducer
+                var i     = start
+                while (i < end) {
+                  q.offer(Integer.valueOf(i))
+                  i += 1
+                }
+              } catch {
+                case _: Throwable => failed.set(true)
+              } finally done.countDown()
+            })
+          }
+
+          val consumer = new Thread(() => {
+            try {
+              while (received.get() < n) {
+                val v = q.take()
+                if (v != null) {
+                  sum.addAndGet(v.longValue())
+                  received.incrementAndGet()
+                }
+              }
+            } catch {
+              case _: Throwable => failed.set(true)
+            } finally done.countDown()
+          })
+
+          producers.foreach(_.start())
+          consumer.start()
+          val completed = done.await(25, TimeUnit.SECONDS)
+          val expected  = n.toLong * (n - 1) / 2
+
+          assertTrue(completed, !failed.get(), received.get() == n, sum.get() == expected)
+        }
+      } @@ TestAspect.timeout(35.seconds),
+      test("close unblocks consumer blocked on empty queue") {
+        ZIO.attemptBlocking {
+          val q            = new BlockingMpscQueue[Integer](4)
+          val started      = new CountDownLatch(1)
+          val returnedTake = new AtomicBoolean(false)
+          val result       = new AtomicReference[Integer](Integer.valueOf(-1))
+
+          val consumer = new Thread(() => {
+            started.countDown()
+            val v = q.take()
+            result.set(v)
+            returnedTake.set(true)
+          })
+
+          consumer.start()
+          started.await()
+
+          var blockedObserved = false
+          var spins           = 0
+          while (!blockedObserved && spins < 1_000_000) {
+            val state = consumer.getState
+            blockedObserved = !returnedTake.get() && (state == Thread.State.WAITING || state == Thread.State.BLOCKED)
+            if (!blockedObserved) Thread.onSpinWait()
+            spins += 1
+          }
+
+          q.close()
+          consumer.join(5000)
+
+          assertTrue(blockedObserved, !consumer.isAlive, returnedTake.get(), result.get() == null)
+        }
+      },
+      test("close unblocks producers blocked on full queue") {
+        ZIO.attemptBlocking {
+          val q = new BlockingMpscQueue[Integer](1)
+          q.offer(Integer.valueOf(0))
+
+          val producerCount = 4
+          val started       = new CountDownLatch(producerCount)
+          val done          = new CountDownLatch(producerCount)
+          val returned      = new AtomicInteger(0)
+          val success       = new AtomicInteger(0)
+
+          val producers = (0 until producerCount).map { i =>
+            new Thread(() => {
+              started.countDown()
+              val ok = q.offer(Integer.valueOf(i + 1))
+              if (ok) success.incrementAndGet()
+              returned.incrementAndGet()
+              done.countDown()
+            })
+          }
+
+          producers.foreach(_.start())
+          started.await()
+
+          var blockedObserved = false
+          var spins           = 0
+          while (!blockedObserved && spins < 1_000_000) {
+            val states = producers.map(_.getState)
+            blockedObserved = returned.get() < producerCount &&
+              states.exists(s =>
+                s == Thread.State.TIMED_WAITING || s == Thread.State.WAITING || s == Thread.State.BLOCKED
+              )
+            if (!blockedObserved) Thread.onSpinWait()
+            spins += 1
+          }
+
+          q.close()
+          val completed = done.await(5, TimeUnit.SECONDS)
+
+          assertTrue(blockedObserved, completed, returned.get() == producerCount, success.get() == 0)
+        }
+      }
+    ),
+    suite("stress test")(
+      test("8 producers, 1M elements: no data loss, correct sum") {
+        ZIO.attemptBlocking {
+          val n             = 1_000_000
+          val producerCount = 8
+          val perProducer   = n / producerCount
+          val q             = new BlockingMpscQueue[Integer](262144)
+          val sum           = new AtomicLong(0L)
+          val received      = new AtomicInteger(0)
+          val done          = new CountDownLatch(producerCount + 1)
+          val failed        = new AtomicBoolean(false)
+
+          val producers = (0 until producerCount).map { p =>
+            new Thread(() => {
+              try {
+                val start = p * perProducer
+                val end   = start + perProducer
+                var i     = start
+                while (i < end) {
+                  q.offer(Integer.valueOf(i))
+                  i += 1
+                }
+              } catch {
+                case _: Throwable => failed.set(true)
+              } finally done.countDown()
+            })
+          }
+
+          val consumer = new Thread(() => {
+            try {
+              while (received.get() < n) {
+                val v = q.take()
+                if (v != null) {
+                  sum.addAndGet(v.longValue())
+                  received.incrementAndGet()
+                }
+              }
+            } catch {
+              case _: Throwable => failed.set(true)
+            } finally done.countDown()
+          })
+
+          producers.foreach(_.start())
+          consumer.start()
+
+          val completed = done.await(60, TimeUnit.SECONDS)
+          val expected  = n.toLong * (n - 1) / 2
+
+          val result = assertTrue(completed, !failed.get(), received.get() == n, sum.get() == expected)
+          // Allow threads to fully terminate before next test
+          Thread.sleep(500)
+          result
+        }
+      } @@ TestAspect.timeout(120.seconds)
+    )
+  )
+}

--- a/streams/jvm/src/test/scala/zio/blocks/streams/queues/BlockingSpscQueueSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/queues/BlockingSpscQueueSpec.scala
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.queues
+
+import zio._
+import zio.blocks.streams.StreamsBaseSpec
+import zio.test._
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
+
+object BlockingSpscQueueSpec extends StreamsBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("BlockingSpscQueue")(
+    suite("unit tests")(
+      test("offer then take returns same element") {
+        val q = new BlockingSpscQueue[Integer](4)
+        assertTrue(q.offer(Integer.valueOf(42))) &&
+        assertTrue(q.take() == Integer.valueOf(42))
+      },
+      test("take from closed empty queue returns null") {
+        val q = new BlockingSpscQueue[Integer](4)
+        q.close()
+        assertTrue(q.isClosed) &&
+        assertTrue(q.take() == null)
+      },
+      test("offer to closed queue returns false") {
+        val q = new BlockingSpscQueue[Integer](4)
+        q.close()
+        assertTrue(!q.offer(Integer.valueOf(1)))
+      },
+      test("isEmpty is true initially, false after offer") {
+        val q = new BlockingSpscQueue[Integer](4)
+        assertTrue(q.isEmpty) &&
+        assertTrue(q.offer(Integer.valueOf(1))) &&
+        assertTrue(!q.isEmpty) &&
+        assertTrue(q.take() == Integer.valueOf(1)) &&
+        assertTrue(q.isEmpty)
+      },
+      test("ordering: offer N elements, take N in same order") {
+        val q = new BlockingSpscQueue[Integer](16)
+        (0 until 10).foreach(i => q.offer(Integer.valueOf(i)))
+        val results = (0 until 10).map(_ => q.take().intValue())
+        assertTrue(results.toList == (0 until 10).toList)
+      },
+      test("double close is safe (no exception)") {
+        val q = new BlockingSpscQueue[Integer](4)
+        q.close()
+        q.close()
+        assertTrue(q.isClosed)
+      },
+      test("capacity is rounded up to next power of two") {
+        val q     = new BlockingSpscQueue[Integer](3)
+        var count = 0
+        while (count < 4 && q.offer(Integer.valueOf(count))) {
+          count += 1
+        }
+        assertTrue(count == 4)
+      }
+    ),
+    suite("concurrency tests")(
+      test("producer-consumer: 100K elements, correct order and sum") {
+        ZIO.attemptBlocking {
+          val n      = 100_000
+          val q      = new BlockingSpscQueue[Integer](16384)
+          val sum    = new AtomicLong(0L)
+          val order  = new AtomicBoolean(true)
+          val done   = new CountDownLatch(2)
+          val failed = new AtomicBoolean(false)
+
+          val producer = new Thread(() => {
+            try {
+              var i = 0
+              while (i < n) {
+                q.offer(Integer.valueOf(i))
+                i += 1
+              }
+            } catch {
+              case _: Throwable => failed.set(true)
+            } finally done.countDown()
+          })
+
+          val consumer = new Thread(() => {
+            try {
+              var expected = 0
+              var received = 0
+              while (received < n) {
+                val v = q.take()
+                if (v != null) {
+                  if (v.intValue() != expected) order.set(false)
+                  sum.addAndGet(v.longValue())
+                  expected += 1
+                  received += 1
+                }
+              }
+            } catch {
+              case _: Throwable => failed.set(true)
+            } finally done.countDown()
+          })
+
+          producer.start()
+          consumer.start()
+          val completed = done.await(20, TimeUnit.SECONDS)
+
+          assertTrue(
+            completed,
+            !failed.get(),
+            order.get(),
+            sum.get() == n.toLong * (n - 1) / 2
+          )
+        }
+      } @@ TestAspect.timeout(30.seconds),
+      test("close unblocks consumer blocked on empty queue") {
+        ZIO.attemptBlocking {
+          val q            = new BlockingSpscQueue[Integer](4)
+          val started      = new CountDownLatch(1)
+          val returnedTake = new AtomicBoolean(false)
+          val result       = new AtomicReference[Integer](Integer.valueOf(-1))
+
+          val consumer = new Thread(() => {
+            started.countDown()
+            val v = q.take()
+            result.set(v)
+            returnedTake.set(true)
+          })
+
+          consumer.start()
+          started.await()
+
+          var blockedObserved = false
+          var spins           = 0
+          while (!blockedObserved && spins < 1_000_000) {
+            val state = consumer.getState
+            blockedObserved = !returnedTake.get() && (state == Thread.State.WAITING || state == Thread.State.BLOCKED)
+            if (!blockedObserved) Thread.onSpinWait()
+            spins += 1
+          }
+
+          q.close()
+          consumer.join(5000)
+
+          assertTrue(blockedObserved, !consumer.isAlive, returnedTake.get(), result.get() == null)
+        }
+      },
+      test("close unblocks producer blocked on full queue") {
+        ZIO.attemptBlocking {
+          val q = new BlockingSpscQueue[Integer](4)
+
+          var i = 0
+          while (i < 4) {
+            q.offer(Integer.valueOf(i))
+            i += 1
+          }
+
+          val enteredOffer  = new CountDownLatch(1)
+          val returnedOffer = new AtomicBoolean(false)
+          val result        = new AtomicBoolean(true)
+
+          val producer = new Thread(() => {
+            enteredOffer.countDown()
+            result.set(q.offer(Integer.valueOf(99)))
+            returnedOffer.set(true)
+          })
+
+          producer.start()
+          enteredOffer.await()
+
+          var blockedObserved = false
+          var spins           = 0
+          while (!blockedObserved && spins < 1_000_000) {
+            val state = producer.getState
+            blockedObserved = !returnedOffer.get() && (state == Thread.State.WAITING || state == Thread.State.BLOCKED)
+            if (!blockedObserved) Thread.onSpinWait()
+            spins += 1
+          }
+
+          q.close()
+          producer.join(5000)
+
+          assertTrue(blockedObserved, !producer.isAlive, returnedOffer.get(), !result.get())
+        }
+      }
+    ),
+    suite("stress test")(
+      test("1M elements: no data loss, correct order, correct sum") {
+        ZIO.attemptBlocking {
+          val n        = 1_000_000
+          val q        = new BlockingSpscQueue[Integer](262144)
+          val sum      = new AtomicLong(0L)
+          val order    = new AtomicBoolean(true)
+          val done     = new CountDownLatch(2)
+          val failed   = new AtomicBoolean(false)
+          val expected = n.toLong * (n - 1) / 2
+
+          val producer = new Thread(() => {
+            try {
+              var i = 0
+              while (i < n) {
+                q.offer(Integer.valueOf(i))
+                i += 1
+              }
+            } catch {
+              case _: Throwable => failed.set(true)
+            } finally done.countDown()
+          })
+
+          val consumer = new Thread(() => {
+            try {
+              var exp = 0
+              var got = 0
+              while (got < n) {
+                val v = q.take()
+                if (v != null) {
+                  if (v.intValue() != exp) order.set(false)
+                  sum.addAndGet(v.longValue())
+                  exp += 1
+                  got += 1
+                }
+              }
+            } catch {
+              case _: Throwable => failed.set(true)
+            } finally done.countDown()
+          })
+
+          producer.start()
+          consumer.start()
+          val completed = done.await(25, TimeUnit.SECONDS)
+
+          assertTrue(completed, !failed.get(), order.get(), sum.get() == expected)
+        }
+      } @@ TestAspect.timeout(90.seconds)
+    )
+  )
+}

--- a/streams/shared/src/main/scala/zio/blocks/streams/Pipeline.scala
+++ b/streams/shared/src/main/scala/zio/blocks/streams/Pipeline.scala
@@ -16,6 +16,7 @@
 
 package zio.blocks.streams
 
+import zio.blocks.chunk.Chunk
 import zio.blocks.streams.io.Reader
 
 /**
@@ -82,6 +83,18 @@ object Pipeline {
   /** A pipeline that passes through at most the first `n` elements. */
   def take[A](n: Long): Pipeline[A, A] = new TakePipeline(n)
 
+  /** A pipeline that buffers up to `n` elements from the upstream. */
+  def buffer[A](n: Int): Pipeline[A, A] = {
+    require(n >= 1, s"buffer requires n >= 1, got n=$n")
+    new BufferPipeline(n)
+  }
+
+  /** A pipeline that groups elements into fixed-size [[Chunk]]s. */
+  def chunked[A](n: Int): Pipeline[A, Chunk[A]] = {
+    require(n >= 1, s"chunked requires n >= 1, got n=$n")
+    new ChunkedPipeline(n)
+  }
+
   private[streams] def runViaSink[A, B, E, Z](
     pipe: Pipeline[A, B],
     sink: Sink[E, B, Z]
@@ -121,6 +134,22 @@ object Pipeline {
       new Stream.Dropped(stream, n)
     def applyToSink[E, Z](sink: Sink[E, A, Z]): Sink[E, A, Z] =
       Pipeline.runViaSink[A, A, E, Z](this, sink)
+  }
+
+  /** Pipeline that buffers up to `n` elements. */
+  private[streams] final class BufferPipeline[A](n: Int) extends Pipeline[A, A] {
+    def applyToStream[E](stream: Stream[E, A]): Stream[E, A] =
+      new Stream.Buffered(stream, n)
+    def applyToSink[E, Z](sink: Sink[E, A, Z]): Sink[E, A, Z] =
+      Pipeline.runViaSink[A, A, E, Z](this, sink)
+  }
+
+  /** Pipeline that groups elements into fixed-size chunks. */
+  private[streams] final class ChunkedPipeline[A](n: Int) extends Pipeline[A, Chunk[A]] {
+    def applyToStream[E](stream: Stream[E, A]): Stream[E, Chunk[A]] =
+      stream.chunked(n)
+    def applyToSink[E, Z](sink: Sink[E, Chunk[A], Z]): Sink[E, A, Z] =
+      Pipeline.runViaSink[A, Chunk[A], E, Z](this, sink)
   }
 
   /** Pipeline that emits only elements satisfying `pred`. */

--- a/streams/shared/src/main/scala/zio/blocks/streams/Platform.scala
+++ b/streams/shared/src/main/scala/zio/blocks/streams/Platform.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.blocks.streams.io.Reader
+
+/**
+ * Cross-platform abstraction for thread management in the streams module.
+ *
+ * Platform-specific implementations are provided in:
+ *   - jvm/src/main/scala/zio/blocks/streams/PlatformSpecific.scala (JVM)
+ *   - js/src/main/scala/zio/blocks/streams/PlatformSpecific.scala (JS)
+ *
+ * On the JVM, [[startVirtualThread]] launches a virtual thread (JDK 21+,
+ * detected via reflection) or a raw daemon thread as fallback. On Scala.js
+ * there is no concurrency, so [[supportsConcurrency]] is `false` and
+ * [[startVirtualThread]] throws [[UnsupportedOperationException]].
+ *
+ * [[createBufferedReader]] is a factory that returns a platform-appropriate
+ * buffered reader: concurrent on JVM, synchronous prefetch on JS.
+ */
+trait Platform {
+
+  /**
+   * Whether this platform supports true concurrent threads. `true` on JVM,
+   * `false` on Scala.js.
+   */
+  def supportsConcurrency: Boolean
+
+  /**
+   * Starts a new thread and runs `task` on it. Returns the started thread
+   * (which can be [[java.lang.Thread#join]]ed). On JVM, uses a virtual thread
+   * (JDK 21+) if available, otherwise a raw daemon thread. On Scala.js, always
+   * throws [[UnsupportedOperationException]].
+   */
+  def startVirtualThread(name: String, task: Runnable): Thread
+
+  /**
+   * Returns a [[Reader]] that buffers elements produced by `upstream` into a
+   * bounded buffer of size `bufferSize`. On JVM, the producer runs on a
+   * separate virtual thread (concurrent). On JS, the reader prefetches elements
+   * synchronously.
+   */
+  def createBufferedReader[A](upstream: Reader[A], bufferSize: Int): Reader[A]
+
+  /**
+   * Returns a [[Reader]] that merges elements from N inner streams produced by
+   * `outerReader`, up to `maxOpen` concurrent inner streams at a time. On JVM,
+   * producers run on virtual threads. On JS, degrades to sequential flatMap.
+   */
+  def createMergeReader[A](outerReader: Reader[?], maxOpen: Int, bufferSize: Int, elemType: JvmType): Reader[A]
+
+  /**
+   * Returns a [[Reader]] that applies `f` to each element of `upstream` using
+   * `n` concurrent workers. On JVM, workers run on virtual threads. On JS,
+   * degrades to sequential map.
+   */
+  def createMapParReader[A, B](
+    upstream: Reader[A],
+    n: Int,
+    f: A => B,
+    bufferSize: Int,
+    inType: JvmType,
+    outType: JvmType
+  ): Reader[B]
+}
+
+object Platform extends PlatformSpecific

--- a/streams/shared/src/main/scala/zio/blocks/streams/Sink.scala
+++ b/streams/shared/src/main/scala/zio/blocks/streams/Sink.scala
@@ -312,31 +312,22 @@ object Sink {
     }
 
   /** A sink that folds elements with `f` starting from `z`. */
-  def foldLeft[A, Z](z: Z)(f: (Z, A) => Z): Sink[Nothing, A, Z] =
+  def foldLeft[A, Z](z: Z)(f: (Z, A) => Z)(implicit jtZ: JvmType.Infer[Z]): Sink[Nothing, A, Z] = {
+    val zt = jtZ.jvmType
     new Sink[Nothing, A, Z] {
       private[streams] def drain(reader: Reader[_]): Z = {
         var acc = z
         val et  = reader.jvmType
         if (et eq JvmType.Int) {
-          val fi = f.asInstanceOf[(Z, Int) => Z]; val s = Long.MinValue
-          var v  = reader.readInt(s)(unsafeEvidence)
-          while (v != s) { acc = fi(acc, v.toInt); v = reader.readInt(s)(unsafeEvidence) }
+          acc = foldWithInt(acc, zt, reader, f)
         } else if (et eq JvmType.Long) {
-          val fl = f.asInstanceOf[(Z, Long) => Z]; val s = Long.MaxValue;
-          var v  = reader.readLong(s)(unsafeEvidence)
-          while (v != s) { acc = fl(acc, v); v = reader.readLong(s)(unsafeEvidence) }
+          acc = foldWithLong(acc, zt, reader, f)
         } else if (et eq JvmType.Float) {
-          val ff = f.asInstanceOf[(Z, Float) => Z]; val s = Double.MaxValue;
-          var v  = reader.readFloat(s)(unsafeEvidence)
-          while (v != s) { acc = ff(acc, v.toFloat); v = reader.readFloat(s)(unsafeEvidence) }
+          acc = foldWithFloat(acc, zt, reader, f)
         } else if (et eq JvmType.Double) {
-          val fd = f.asInstanceOf[(Z, Double) => Z]; val s = Double.MaxValue;
-          var v  = reader.readDouble(s)(unsafeEvidence)
-          while (v != s) { acc = fd(acc, v); v = reader.readDouble(s)(unsafeEvidence) }
+          acc = foldWithDouble(acc, zt, reader, f)
         } else if (et eq JvmType.Byte) {
-          val fb = f.asInstanceOf[(Z, Byte) => Z]; val s = Long.MinValue
-          var v  = reader.readInt(s)(unsafeEvidence)
-          while (v != s) { acc = fb(acc, v.toByte); v = reader.readInt(s)(unsafeEvidence) }
+          acc = foldWithByte(acc, zt, reader, f)
         } else {
           var v = reader.read(EndOfStream)
           while (v.asInstanceOf[AnyRef] ne EndOfStream) {
@@ -346,6 +337,157 @@ object Sink {
         acc
       }
     }
+  }
+
+  private def foldWithInt[Z, A](acc: Z, zt: JvmType, reader: Reader[?], f: (Z, A) => Z): Z = {
+    val s = Long.MinValue
+    if (zt eq JvmType.Int) {
+      val fi = f.asInstanceOf[(Int, Int) => Int]; var a = acc.asInstanceOf[Int]
+      var v  = reader.readInt(s)(unsafeEvidence)
+      while (v != s) { a = fi(a, v.toInt); v = reader.readInt(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Long) {
+      val fl = f.asInstanceOf[(Long, Int) => Long]; var a = acc.asInstanceOf[Long]
+      var v  = reader.readInt(s)(unsafeEvidence)
+      while (v != s) { a = fl(a, v.toInt); v = reader.readInt(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Float) {
+      val ff = f.asInstanceOf[(Float, Int) => Float]; var a = acc.asInstanceOf[Float]
+      var v  = reader.readInt(s)(unsafeEvidence)
+      while (v != s) { a = ff(a, v.toInt); v = reader.readInt(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Double) {
+      val fd = f.asInstanceOf[(Double, Int) => Double]; var a = acc.asInstanceOf[Double]
+      var v  = reader.readInt(s)(unsafeEvidence)
+      while (v != s) { a = fd(a, v.toInt); v = reader.readInt(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else {
+      val fi = f.asInstanceOf[(Z, Int) => Z]; var a = acc
+      var v  = reader.readInt(s)(unsafeEvidence)
+      while (v != s) { a = fi(a, v.toInt); v = reader.readInt(s)(unsafeEvidence) }
+      a
+    }
+  }
+
+  private def foldWithLong[Z, A](acc: Z, zt: JvmType, reader: Reader[?], f: (Z, A) => Z): Z = {
+    val s = Long.MaxValue
+    if (zt eq JvmType.Int) {
+      val fi = f.asInstanceOf[(Int, Long) => Int]; var a = acc.asInstanceOf[Int]
+      var v  = reader.readLong(s)(unsafeEvidence)
+      while (v != s) { a = fi(a, v); v = reader.readLong(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Long) {
+      val fl = f.asInstanceOf[(Long, Long) => Long]; var a = acc.asInstanceOf[Long]
+      var v  = reader.readLong(s)(unsafeEvidence)
+      while (v != s) { a = fl(a, v); v = reader.readLong(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Float) {
+      val ff = f.asInstanceOf[(Float, Long) => Float]; var a = acc.asInstanceOf[Float]
+      var v  = reader.readLong(s)(unsafeEvidence)
+      while (v != s) { a = ff(a, v); v = reader.readLong(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Double) {
+      val fd = f.asInstanceOf[(Double, Long) => Double]; var a = acc.asInstanceOf[Double]
+      var v  = reader.readLong(s)(unsafeEvidence)
+      while (v != s) { a = fd(a, v); v = reader.readLong(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else {
+      val fl = f.asInstanceOf[(Z, Long) => Z]; var a = acc
+      var v  = reader.readLong(s)(unsafeEvidence)
+      while (v != s) { a = fl(a, v); v = reader.readLong(s)(unsafeEvidence) }
+      a
+    }
+  }
+
+  private def foldWithFloat[Z, A](acc: Z, zt: JvmType, reader: Reader[?], f: (Z, A) => Z): Z = {
+    val s = Double.MaxValue
+    if (zt eq JvmType.Int) {
+      val fi = f.asInstanceOf[(Int, Float) => Int]; var a = acc.asInstanceOf[Int]
+      var v  = reader.readFloat(s)(unsafeEvidence)
+      while (v != s) { a = fi(a, v.toFloat); v = reader.readFloat(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Long) {
+      val fl = f.asInstanceOf[(Long, Float) => Long]; var a = acc.asInstanceOf[Long]
+      var v  = reader.readFloat(s)(unsafeEvidence)
+      while (v != s) { a = fl(a, v.toFloat); v = reader.readFloat(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Float) {
+      val ff = f.asInstanceOf[(Float, Float) => Float]; var a = acc.asInstanceOf[Float]
+      var v  = reader.readFloat(s)(unsafeEvidence)
+      while (v != s) { a = ff(a, v.toFloat); v = reader.readFloat(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Double) {
+      val fd = f.asInstanceOf[(Double, Float) => Double]; var a = acc.asInstanceOf[Double]
+      var v  = reader.readFloat(s)(unsafeEvidence)
+      while (v != s) { a = fd(a, v.toFloat); v = reader.readFloat(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else {
+      val ff = f.asInstanceOf[(Z, Float) => Z]; var a = acc
+      var v  = reader.readFloat(s)(unsafeEvidence)
+      while (v != s) { a = ff(a, v.toFloat); v = reader.readFloat(s)(unsafeEvidence) }
+      a
+    }
+  }
+
+  private def foldWithDouble[Z, A](acc: Z, zt: JvmType, reader: Reader[?], f: (Z, A) => Z): Z = {
+    val s = Double.MaxValue
+    if (zt eq JvmType.Int) {
+      val fi = f.asInstanceOf[(Int, Double) => Int]; var a = acc.asInstanceOf[Int]
+      var v  = reader.readDouble(s)(unsafeEvidence)
+      while (v != s) { a = fi(a, v); v = reader.readDouble(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Long) {
+      val fl = f.asInstanceOf[(Long, Double) => Long]; var a = acc.asInstanceOf[Long]
+      var v  = reader.readDouble(s)(unsafeEvidence)
+      while (v != s) { a = fl(a, v); v = reader.readDouble(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Float) {
+      val ff = f.asInstanceOf[(Float, Double) => Float]; var a = acc.asInstanceOf[Float]
+      var v  = reader.readDouble(s)(unsafeEvidence)
+      while (v != s) { a = ff(a, v); v = reader.readDouble(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Double) {
+      val fd = f.asInstanceOf[(Double, Double) => Double]; var a = acc.asInstanceOf[Double]
+      var v  = reader.readDouble(s)(unsafeEvidence)
+      while (v != s) { a = fd(a, v); v = reader.readDouble(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else {
+      val fd = f.asInstanceOf[(Z, Double) => Z]; var a = acc
+      var v  = reader.readDouble(s)(unsafeEvidence)
+      while (v != s) { a = fd(a, v); v = reader.readDouble(s)(unsafeEvidence) }
+      a
+    }
+  }
+
+  private def foldWithByte[Z, A](acc: Z, zt: JvmType, reader: Reader[?], f: (Z, A) => Z): Z = {
+    val s = Long.MinValue
+    if (zt eq JvmType.Int) {
+      val fi = f.asInstanceOf[(Int, Byte) => Int]; var a = acc.asInstanceOf[Int]
+      var v  = reader.readInt(s)(unsafeEvidence)
+      while (v != s) { a = fi(a, v.toByte); v = reader.readInt(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Long) {
+      val fl = f.asInstanceOf[(Long, Byte) => Long]; var a = acc.asInstanceOf[Long]
+      var v  = reader.readInt(s)(unsafeEvidence)
+      while (v != s) { a = fl(a, v.toByte); v = reader.readInt(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Float) {
+      val ff = f.asInstanceOf[(Float, Byte) => Float]; var a = acc.asInstanceOf[Float]
+      var v  = reader.readInt(s)(unsafeEvidence)
+      while (v != s) { a = ff(a, v.toByte); v = reader.readInt(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else if (zt eq JvmType.Double) {
+      val fd = f.asInstanceOf[(Double, Byte) => Double]; var a = acc.asInstanceOf[Double]
+      var v  = reader.readInt(s)(unsafeEvidence)
+      while (v != s) { a = fd(a, v.toByte); v = reader.readInt(s)(unsafeEvidence) }
+      a.asInstanceOf[Z]
+    } else {
+      val fb = f.asInstanceOf[(Z, Byte) => Z]; var a = acc
+      var v  = reader.readInt(s)(unsafeEvidence)
+      while (v != s) { a = fb(a, v.toByte); v = reader.readInt(s)(unsafeEvidence) }
+      a
+    }
+  }
 
   /**
    * A sink that writes all stream chars to a [[java.io.Writer]]. Does ''not''

--- a/streams/shared/src/main/scala/zio/blocks/streams/Stream.scala
+++ b/streams/shared/src/main/scala/zio/blocks/streams/Stream.scala
@@ -17,7 +17,7 @@
 package zio.blocks.streams
 
 import scala.annotation.unchecked.uncheckedVariance
-import zio.blocks.chunk.{Chunk, ChunkBuilder}
+import zio.blocks.chunk.Chunk
 import zio.blocks.combinators.{Concat, Tuples}
 import zio.blocks.scope.{Resource, Scope}
 import zio.blocks.streams.internal.{EndOfStream, Interpreter, StreamError, pullDouble, pullFloat, pullInt, pullLong}
@@ -194,6 +194,21 @@ abstract class Stream[+E, +A] {
   )(implicit jtA: JvmType.Infer[A], jtB: JvmType.Infer[B]): Stream[E1, B] =
     new Stream.FlatMapped[E, E1, A, B](this, f, jtA, jtB)
 
+  /**
+   * Applies `f` to each element to produce an inner stream, then merges up to
+   * `n` inner streams concurrently. Output is unordered (arrival order, not
+   * input order). On JVM, each inner stream runs on a virtual thread. On JS,
+   * degrades to sequential flatMap.
+   */
+  def flatMapPar[E1 >: E, B](n: Int)(f: A => Stream[E1, B])(implicit
+    jtA: JvmType.Infer[A],
+    jtB: JvmType.Infer[B]
+  ): Stream[E1, B] = {
+    require(n >= 1, s"flatMapPar requires n >= 1, got $n")
+    jtB.jvmType
+    Stream.mergeAll[E1, B](n)(this.asInstanceOf[Stream[E1, A]].map(f))
+  }
+
   /** Returns `true` if all elements satisfy `pred`, short-circuiting. */
   def forall(pred: A => Boolean): Either[E, Boolean] = run(Sink.forall(pred))
 
@@ -205,113 +220,26 @@ abstract class Stream[+E, +A] {
   /**
    * Groups elements into `Chunk`s of size `n`. The last group may be smaller.
    */
-  def grouped(n: Int): Stream[E, Chunk[A]] = {
-    require(n >= 1, s"grouped requires n >= 1, got n=$n")
+  def chunked(n: Int): Stream[E, Chunk[A]] = {
+    require(n >= 1, s"chunked requires n >= 1, got n=$n")
     new Stream.FromReader[E, Chunk[A]](
       () => {
         val source = Stream.compileToReader(this)
-        val et     = source.jvmType
-        if (et eq JvmType.Byte) {
-          new Reader[Chunk[A]] {
-            def isClosed                               = source.isClosed
-            def read[A1 >: Chunk[A]](sentinel: A1): A1 = {
-              val builder = new ChunkBuilder.Byte()
-              var i       = 0
-              var v       = pullInt(source, Long.MinValue)
-              while (v != Long.MinValue && i < n) {
-                builder.addOne(v.toByte)
-                i += 1
-                if (i < n) v = pullInt(source, Long.MinValue)
-              }
-              if (i == 0) sentinel else builder.result().asInstanceOf[A1]
-            }
-            def close() = source.close()
+        new Reader[Chunk[A]] {
+          def isClosed                               = source.isClosed
+          def read[A1 >: Chunk[A]](sentinel: A1): A1 = {
+            val c = source.readN[A](n)
+            if (c.isEmpty) sentinel else c.asInstanceOf[A1]
           }
-        } else if (et eq JvmType.Int) {
-          new Reader[Chunk[A]] {
-            def isClosed                               = source.isClosed
-            def read[A1 >: Chunk[A]](sentinel: A1): A1 = {
-              val builder = new ChunkBuilder.Int()
-              var i       = 0
-              var v       = pullInt(source, Long.MinValue)
-              while (v != Long.MinValue && i < n) {
-                builder.addOne(v.toInt)
-                i += 1
-                if (i < n) v = pullInt(source, Long.MinValue)
-              }
-              if (i == 0) sentinel else builder.result().asInstanceOf[A1]
-            }
-            def close() = source.close()
-          }
-        } else if (et eq JvmType.Long) {
-          new Reader[Chunk[A]] {
-            def isClosed                               = source.isClosed
-            def read[A1 >: Chunk[A]](sentinel: A1): A1 = {
-              val builder = new ChunkBuilder.Long()
-              var i       = 0
-              var v       = pullLong(source, Long.MaxValue)
-              while (v != Long.MaxValue && i < n) {
-                builder.addOne(v)
-                i += 1
-                if (i < n) v = pullLong(source, Long.MaxValue)
-              }
-              if (i == 0) sentinel else builder.result().asInstanceOf[A1]
-            }
-            def close() = source.close()
-          }
-        } else if (et eq JvmType.Float) {
-          new Reader[Chunk[A]] {
-            def isClosed                               = source.isClosed
-            def read[A1 >: Chunk[A]](sentinel: A1): A1 = {
-              val builder = new ChunkBuilder.Float()
-              var i       = 0
-              var v       = pullFloat(source, Double.MaxValue)
-              while (v != Double.MaxValue && i < n) {
-                builder.addOne(v.toFloat)
-                i += 1
-                if (i < n) v = pullFloat(source, Double.MaxValue)
-              }
-              if (i == 0) sentinel else builder.result().asInstanceOf[A1]
-            }
-            def close() = source.close()
-          }
-        } else if (et eq JvmType.Double) {
-          new Reader[Chunk[A]] {
-            def isClosed                               = source.isClosed
-            def read[A1 >: Chunk[A]](sentinel: A1): A1 = {
-              val builder = new ChunkBuilder.Double()
-              var i       = 0
-              var v       = pullDouble(source, Double.MaxValue)
-              while (v != Double.MaxValue && i < n) {
-                builder.addOne(v)
-                i += 1
-                if (i < n) v = pullDouble(source, Double.MaxValue)
-              }
-              if (i == 0) sentinel else builder.result().asInstanceOf[A1]
-            }
-            def close() = source.close()
-          }
-        } else {
-          new Reader[Chunk[A]] {
-            def isClosed                               = source.isClosed
-            def read[A1 >: Chunk[A]](sentinel: A1): A1 = {
-              val builder = ChunkBuilder.make[A](n)
-              var i       = 0
-              var v       = source.read[Any](EndOfStream)
-              while ((v.asInstanceOf[AnyRef] ne EndOfStream) && i < n) {
-                builder += v.asInstanceOf[A]
-                i += 1
-                if (i < n) v = source.read[Any](EndOfStream)
-              }
-              if (i == 0) sentinel else builder.result().asInstanceOf[A1]
-            }
-            def close() = source.close()
-          }
+          def close() = source.close()
         }
       },
-      s"${this.render}.grouped($n)"
+      s"${this.render}.chunked($n)"
     )
   }
+
+  /** Alias for [[chunked]]. Matches upstream naming. */
+  def grouped(n: Int): Stream[E, Chunk[A]] = chunked(n)
 
   /** Returns the first element, or `None` if empty. */
   def head: Either[E, Option[A]] = run(Sink.head)
@@ -346,6 +274,26 @@ abstract class Stream[+E, +A] {
   /** Lazily transforms each element with `f`. */
   def map[B](f: A => B)(implicit jtA: JvmType.Infer[A], jtB: JvmType.Infer[B]): Stream[E, B] =
     new Stream.Mapped(this, f, jtA, jtB)
+
+  /**
+   * Applies `f` to each element using `n` concurrent workers. Output is
+   * UNORDERED (arrival order, not input order). On JVM, workers run on virtual
+   * threads. On JS, degrades to sequential map.
+   *
+   * @param n
+   *   number of concurrent workers
+   * @param f
+   *   transformation to apply to each element
+   */
+  def mapPar[B](n: Int)(f: A => B)(implicit
+    jtA: JvmType.Infer[A],
+    jtB: JvmType.Infer[B]
+  ): Stream[E, B] = {
+    require(n >= 1, s"mapPar requires n >= 1, got $n")
+    jtA.jvmType
+    jtB.jvmType
+    new Stream.MapPar[E, A, B](this, n, f, jtA.jvmType, jtB.jvmType)
+  }
 
   /**
    * Transforms elements with a stateful function `f`, threading state `S`
@@ -419,7 +367,7 @@ abstract class Stream[+E, +A] {
     run(new Sink.FoldLeftLong(z, f))
 
   /** Runs the stream, folding elements with `f` starting from `z`. */
-  def runFold[Z](z: Z)(f: (Z, A) => Z): Either[E, Z] = run(Sink.foldLeft(z)(f))
+  def runFold[Z](z: Z)(f: (Z, A) => Z)(implicit jtZ: JvmType.Infer[Z]): Either[E, Z] = run(Sink.foldLeft(z)(f))
 
   /** Runs the stream, applying `f` to each element for its side-effects. */
   def runForeach(f: A => Unit): Either[E, Unit] = run(Sink.foreach(f))
@@ -807,10 +755,19 @@ abstract class Stream[+E, +A] {
    * closed automatically when the scope closes.
    */
   def start(implicit scope: Scope): scope.$[Reader[A]] =
-    scope.allocate(Resource.acquireRelease(compile(0))(_.close()))
+    scope.allocate(Resource.acquireRelease(compile(0, Stream.DefaultBufferSize))(_.close()))
 
   /** Emits at most the first `n` elements, then closes. */
   def take(n: Long): Stream[E, A] = new Stream.Taken(this, n)
+
+  /**
+   * Decouples upstream production from downstream consumption with a bounded
+   * buffer of `n` elements.
+   */
+  def buffer(n: Int): Stream[E, A] = {
+    require(n >= 1, s"buffer requires n >= 1, got n=$n")
+    new Stream.Buffered(this, n)
+  }
 
   /**
    * Emits elements while `pred` holds, then closes on the first element where
@@ -830,7 +787,9 @@ abstract class Stream[+E, +A] {
     pipe.applyToStream(this)
 
   /** Compiles this stream into a [[Reader]] for pull-based evaluation. */
-  private[streams] def compile(depth: Int): Reader[A]
+  private[streams] def compile(depth: Int, bufferSize: Int): Reader[A]
+
+  private[streams] def compile(depth: Int): Reader[A] = compile(depth, Stream.DefaultBufferSize)
 
   /** Compiles this stream description into the given [[Interpreter]]. */
   private[streams] def compileInterpreter(pipeline: Interpreter): Unit
@@ -915,6 +874,29 @@ object Stream {
   def flattenAll[E, A](streams: Stream[E, Stream[E, A]]): Stream[E, A] =
     streams.flatMap(identity)
 
+  /**
+   * Merges up to `maxOpen` inner streams concurrently into a single output
+   * stream. Elements arrive in completion order (unordered with respect to
+   * input position). On JVM, each inner stream runs on a virtual thread. On JS,
+   * degrades to sequential flatMap.
+   *
+   * @param maxOpen
+   *   maximum number of concurrently active inner streams
+   * @param streams
+   *   a stream of inner streams to merge
+   */
+  def mergeAll[E, A](maxOpen: Int)(streams: Stream[E, Stream[E, A]])(implicit
+    jtA: JvmType.Infer[A]
+  ): Stream[E, A] = {
+    require(maxOpen >= 1, s"mergeAll requires maxOpen >= 1, got $maxOpen")
+    new Stream.MergedAll[E, A](streams, maxOpen, jtA.jvmType)
+  }
+
+  def bufferSize[E, A](n: Int)(body: => Stream[E, A]): Stream[E, A] = {
+    require(n >= 1 && (n & (n - 1)) == 0, s"bufferSize must be a positive power of 2, got $n")
+    new Stream.WithBufferSize(body, n)
+  }
+
   /** Creates a resource-safe stream: acquires `R`, uses it, then releases. */
   def fromAcquireRelease[R, E, A](
     acquire: => R,
@@ -934,10 +916,10 @@ object Stream {
     new FromChunkStream(chunk, jt)
 
   /**
-   * Wraps a [[java.io.InputStream]] as a stream of bytes widened to Int
-   * (0–255). Closes the stream when done.
+   * Wraps a [[java.io.InputStream]] as a stream of bytes. Closes the stream
+   * when done.
    */
-  def fromInputStream(is: java.io.InputStream): Stream[java.io.IOException, Int] =
+  def fromInputStream(is: java.io.InputStream): Stream[java.io.IOException, Byte] =
     fromAcquireRelease(
       is,
       (s: java.io.InputStream) =>
@@ -946,11 +928,10 @@ object Stream {
     )(s => fromInputStreamUnmanaged(s))
 
   /**
-   * Wraps a [[java.io.InputStream]] as a stream of bytes widened to Int (0–255)
-   * without managing its lifecycle. The caller is responsible for closing the
-   * stream.
+   * Wraps a [[java.io.InputStream]] as a stream of bytes without managing its
+   * lifecycle. The caller is responsible for closing the stream.
    */
-  def fromInputStreamUnmanaged(is: java.io.InputStream): Stream[java.io.IOException, Int] =
+  def fromInputStreamUnmanaged(is: java.io.InputStream): Stream[java.io.IOException, Byte] =
     new FromReader(() => Reader.fromInputStream(is), "Stream.fromInputStreamUnmanaged(...)")
 
   /**
@@ -1103,14 +1084,15 @@ object Stream {
 
   /** Compiles a stream for pull-based evaluation. */
   private[streams] def compileToReader[E, A](stream: Stream[E, A]): Reader[A] =
-    stream.compile(0)
+    stream.compile(0, Stream.DefaultBufferSize)
 
   /**
    * Depth threshold; beyond this, compilation falls back to the flat-array
    * [[Interpreter]] to prevent stack overflow during recursive stream
    * compilation.
    */
-  private[streams] val DepthCutoff = 100
+  private[streams] val DepthCutoff       = 100
+  private[streams] val DefaultBufferSize = 64
 
   /** Recovers from all errors by switching to the stream returned by `f`. */
   private[streams] final class CatchAll[E, E2, A](
@@ -1122,8 +1104,8 @@ object Stream {
       val innerReader = compileToReader(self)
       pipeline.appendRead(new CatchAllReader[E, A](innerReader.asInstanceOf[Reader[A]], f))
     }
-    override private[streams] def compile(depth: Int): Reader[A] =
-      new CatchAllReader[E, A](self.compile(depth), f)
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] =
+      new CatchAllReader[E, A](self.compile(depth, bufferSize), f)
   }
 
   /** Catches StreamErrors and switches to a recovery stream. */
@@ -1174,6 +1156,12 @@ object Stream {
         catch { case e: StreamError => doSwitch(e); pullDouble(current, sentinel) }
       } else pullDouble(current, sentinel)
 
+    override def readUpToN[A1 >: A](n: Int): Chunk[A1] =
+      if (!switched) {
+        try cur.readUpToN(n)
+        catch { case e: StreamError => doSwitch(e); cur.readUpToN(n) }
+      } else cur.readUpToN(n)
+
     override def skip(n: Long): Unit = current.skip(n)
     def close(): Unit                = try current.close()
     catch { case _: Throwable => () }
@@ -1189,8 +1177,8 @@ object Stream {
       val innerReader = compileToReader(self)
       pipeline.appendRead(new CatchDefectReader[E, A](innerReader.asInstanceOf[Reader[A]], f))
     }
-    override private[streams] def compile(depth: Int): Reader[A] =
-      new CatchDefectReader[E, A](self.compile(depth), f)
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] =
+      new CatchDefectReader[E, A](self.compile(depth, bufferSize), f)
   }
 
   /** Catches non-fatal defects and switches to a recovery stream. */
@@ -1246,6 +1234,12 @@ object Stream {
         catch { case t: Throwable => if (trySwitch(t)) pullDouble(current, sentinel) else throw t }
       } else pullDouble(current, sentinel)
 
+    override def readUpToN[A1 >: A](n: Int): Chunk[A1] =
+      if (!switched) {
+        try cur.readUpToN(n)
+        catch { case t: Throwable => if (trySwitch(t)) cur.readUpToN(n) else throw t }
+      } else cur.readUpToN(n)
+
     override def skip(n: Long): Unit = current.skip(n)
     def close(): Unit                = try current.close()
     catch { case _: Throwable => () }
@@ -1262,17 +1256,21 @@ object Stream {
         src.asInstanceOf[Reader[A]].concat(() => compileToReader(that))
       }
     }
-    override private[streams] def compile(depth: Int): Reader[A] = {
-      val r1 = self.compile(depth)
-      r1.concat(() => compileToReader(that))
-    }
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] =
+      if (depth >= Stream.DepthCutoff) {
+        Interpreter.fromStream(this).asInstanceOf[Reader[A]]
+      } else {
+        val r1 = self.compile(depth + 1, bufferSize)
+        r1.concat(() => that.compile(depth + 1, bufferSize))
+      }
   }
 
   /** Defers stream construction until run-time. */
   private[streams] final class Deferred[E, A](mkStream: () => Stream[E, A]) extends Stream[E, A] {
-    def render: String                                                   = "Stream.suspend(...)"
-    private[streams] def compileInterpreter(pipeline: Interpreter): Unit = mkStream().compileInterpreter(pipeline)
-    override private[streams] def compile(depth: Int): Reader[A]         = mkStream().compile(depth)
+    def render: String                                                            = "Stream.suspend(...)"
+    private[streams] def compileInterpreter(pipeline: Interpreter): Unit          = mkStream().compileInterpreter(pipeline)
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] =
+      mkStream().compile(depth, bufferSize)
   }
 
   /** Skips the first `n` elements. */
@@ -1283,10 +1281,72 @@ object Stream {
       self.compileInterpreter(pipeline)
       pipeline.wrapLastRead { r => if (!r.setSkip(n)) r.skip(n); r }
     }
-    override private[streams] def compile(depth: Int): Reader[A] = {
-      val r = self.compile(depth)
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] = {
+      val r = self.compile(depth, bufferSize)
       if (!r.setSkip(n)) r.skip(n)
       r
+    }
+  }
+
+  /** Buffers up to `n` elements between upstream and downstream. */
+  private[streams] final class Buffered[E, A](self: Stream[E, A], n: Int) extends Stream[E, A] {
+    def render: String = s"${self.render}.buffer($n)"
+
+    private[streams] def compileInterpreter(pipeline: Interpreter): Unit = {
+      val upstreamReader = compileToReader(self)
+      val bufferedReader = Platform.createBufferedReader(upstreamReader, n)
+      pipeline.appendRead(bufferedReader)
+    }
+
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] =
+      Platform.createBufferedReader(self.compile(depth, bufferSize), n)
+  }
+
+  private[streams] final class WithBufferSize[E, A](inner: Stream[E, A], n: Int) extends Stream[E, A] {
+    def render: String                                                            = s"Stream.bufferSize($n)(...)"
+    private[streams] def compileInterpreter(pipeline: Interpreter): Unit          = inner.compileInterpreter(pipeline)
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] = inner.compile(depth, n)
+  }
+
+  private[streams] final class MapPar[E, A, B](
+    self: Stream[E, A],
+    n: Int,
+    f: A => B,
+    inType: JvmType,
+    outType: JvmType
+  ) extends Stream[E, B] {
+
+    def render: String = s"${self.render}.mapPar($n)(...)"
+
+    private[streams] def compileInterpreter(pipeline: Interpreter): Unit = {
+      val upstream = compileToReader(self)
+      val par      = Platform.createMapParReader[A, B](upstream, n, f, Stream.DefaultBufferSize, inType, outType)
+      pipeline.appendRead(par)
+    }
+
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[B] = {
+      val upstream = self.compile(depth, bufferSize)
+      Platform.createMapParReader[A, B](upstream, n, f, bufferSize, inType, outType)
+    }
+  }
+
+  private[streams] final class MergedAll[E, A](
+    outerStream: Stream[E, Stream[E, A]],
+    maxOpen: Int,
+    elemType: JvmType
+  ) extends Stream[E, A] {
+
+    def render: String = s"Stream.mergeAll($maxOpen)(...)"
+
+    private[streams] def compileInterpreter(pipeline: Interpreter): Unit = {
+      val outerReader = compileToReader(outerStream)
+      val merged      = Platform.createMergeReader[A](outerReader, maxOpen, Stream.DefaultBufferSize, elemType)
+      pipeline.appendRead(merged)
+    }
+
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] = {
+      val outerReader = outerStream.compile(depth, bufferSize)
+      Platform.createMergeReader[A](outerReader, maxOpen, bufferSize, elemType)
     }
   }
 
@@ -1312,8 +1372,8 @@ object Stream {
         }
       )
     }
-    override private[streams] def compile(depth: Int): Reader[A] = {
-      val src = self.compile(depth)
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] = {
+      val src = self.compile(depth, bufferSize)
       new Reader.DelegatingReader[A](src) {
         override def close(): Unit = try src.close()
         finally finalizer
@@ -1329,8 +1389,8 @@ object Stream {
       self.compileInterpreter(pipeline)
       pipeline.wrapLastRead(r => new ErrorMappedReader[E, A](r.asInstanceOf[Reader[A]], f))
     }
-    override private[streams] def compile(depth: Int): Reader[A] =
-      new ErrorMappedReader[E, A](self.compile(depth), f)
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] =
+      new ErrorMappedReader[E, A](self.compile(depth, bufferSize), f)
   }
 
   /** Transforms StreamError values with `f` during pull-based evaluation. */
@@ -1354,6 +1414,9 @@ object Stream {
       catch { case e: StreamError => throw new StreamError(f(e.value.asInstanceOf[E])) }
     override def readByte(): Int =
       try upstream.readByte()
+      catch { case e: StreamError => throw new StreamError(f(e.value.asInstanceOf[E])) }
+    override def readUpToN[A1 >: A](n: Int): Chunk[A1] =
+      try upstream.readUpToN[A1](n)
       catch { case e: StreamError => throw new StreamError(f(e.value.asInstanceOf[E])) }
     override def skip(n: Long): Unit = upstream.skip(n)
     def close(): Unit                = upstream.close()
@@ -1380,10 +1443,10 @@ object Stream {
       self.compileInterpreter(pipeline)
       pipeline.addFilter(Interpreter.laneOf(jtA.jvmType))(pred)
     }
-    override private[streams] def compile(depth: Int): Reader[A] = {
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] = {
       if (depth >= Stream.DepthCutoff)
         return Interpreter.fromStream(this).asInstanceOf[Reader[A]]
-      val sourceReader = self.compile(depth + 1)
+      val sourceReader = self.compile(depth + 1, bufferSize)
       val inLane       = Interpreter.laneOf(jtA.jvmType)
       sourceReader match {
         case p: Interpreter =>
@@ -1428,10 +1491,10 @@ object Stream {
         pipeline.addMap(Interpreter.OUT_R, Interpreter.outLaneOf(jtB.jvmType))((b: Any) => b)
       }
     }
-    override private[streams] def compile(depth: Int): Reader[B] = {
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[B] = {
       if (depth >= Stream.DepthCutoff)
         return Interpreter.fromStream(this).asInstanceOf[Reader[B]]
-      val sourceReader = self.compile(depth + 1)
+      val sourceReader = self.compile(depth + 1, bufferSize)
       sourceReader match {
         case p: Interpreter =>
           val inLane    = Interpreter.laneOf(jtA.jvmType)
@@ -1465,10 +1528,10 @@ object Stream {
       self.compileInterpreter(pipeline)
       pipeline.addPush(Interpreter.laneOf(jtA.jvmType))(f)
     }
-    override private[streams] def compile(depth: Int): Reader[B] = {
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[B] = {
       if (depth >= Stream.DepthCutoff)
         return Interpreter.fromStream(this).asInstanceOf[Reader[B]]
-      val sourceReader = self.compile(depth + 1)
+      val sourceReader = self.compile(depth + 1, bufferSize)
       val inLane       = Interpreter.laneOf(jtA.jvmType)
       sourceReader match {
         case p: Interpreter =>
@@ -1477,7 +1540,7 @@ object Stream {
           p.asInstanceOf[Reader[B]]
         case r =>
           val compileInner: AnyRef => Reader[Any] = (stream: AnyRef) =>
-            stream.asInstanceOf[Stream[Any, Any]].compile(0).asInstanceOf[Reader[Any]]
+            stream.asInstanceOf[Stream[Any, Any]].compile(0, Stream.DefaultBufferSize).asInstanceOf[Reader[Any]]
           val outType = jtB.jvmType
           val reader  = (inLane: @scala.annotation.switch) match {
             case 0 => new Reader.FlatMappedInt(r, f, compileInner, outType)
@@ -1515,10 +1578,10 @@ object Stream {
           throw t
       }
     }
-    override private[streams] def compile(depth: Int): Reader[A] = {
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] = {
       val r = acquire
       try {
-        val src = use(r).compile(depth)
+        val src = use(r).compile(depth, bufferSize)
         new Reader.DelegatingReader[A](src) {
           override def close(): Unit = try src.close()
           finally release(r)
@@ -1542,7 +1605,7 @@ object Stream {
     override def knownLength: Option[Long]                               = Some(chunk.length.toLong)
     private[streams] def compileInterpreter(pipeline: Interpreter): Unit =
       pipeline.appendRead(Reader.fromChunk(chunk)(jt))
-    override private[streams] def compile(depth: Int): Reader[A] =
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] =
       Reader.fromChunk(chunk)(jt)
   }
 
@@ -1556,7 +1619,7 @@ object Stream {
       val reader = mkReader()
       pipeline.appendRead(reader)
     }
-    override private[streams] def compile(depth: Int): Reader[A] = mkReader()
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] = mkReader()
   }
 
   /** Resource-safe stream backed by a Resource managed in a Scope. */
@@ -1584,12 +1647,12 @@ object Stream {
           throw t
       }
     }
-    override private[streams] def compile(depth: Int): Reader[A] = {
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] = {
       val os    = Scope.global.open()
       val scope = os.scope
       val r     = scope.leak(scope.allocate(resource))
       try {
-        val src = use(r).compile(depth)
+        val src = use(r).compile(depth, bufferSize)
         new Reader.DelegatingReader[A](src) {
           override def close(): Unit = try src.close()
           finally os.close()
@@ -1616,10 +1679,10 @@ object Stream {
       self.compileInterpreter(pipeline)
       pipeline.addMap(Interpreter.laneOf(jtA.jvmType), Interpreter.outLaneOf(jtB.jvmType))(f)
     }
-    override private[streams] def compile(depth: Int): Reader[B] = {
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[B] = {
       if (depth >= Stream.DepthCutoff)
         return Interpreter.fromStream(this).asInstanceOf[Reader[B]]
-      val sourceReader = self.compile(depth + 1)
+      val sourceReader = self.compile(depth + 1, bufferSize)
       val inLane       = Interpreter.laneOf(jtA.jvmType)
       val outLane      = Interpreter.outLaneOf(jtB.jvmType)
       sourceReader match {
@@ -1648,8 +1711,8 @@ object Stream {
       self.compileInterpreter(pipeline)
       pipeline.wrapLastRead(r => Reader.repeated[A](r.asInstanceOf[Reader[A]]))
     }
-    override private[streams] def compile(depth: Int): Reader[A] =
-      Reader.repeated[A](self.compile(depth))
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] =
+      Reader.repeated[A](self.compile(depth, bufferSize))
   }
 
   /** Emits at most the first `n` elements. */
@@ -1660,8 +1723,8 @@ object Stream {
       self.compileInterpreter(pipeline)
       pipeline.wrapLastRead(r => if (!r.setLimit(n)) Reader.withSkipLimit(r, 0, n) else r)
     }
-    override private[streams] def compile(depth: Int): Reader[A] = {
-      val r = self.compile(depth)
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] = {
+      val r = self.compile(depth, bufferSize)
       (if (!r.setLimit(n)) Reader.withSkipLimit(r, 0, n) else r).asInstanceOf[Reader[A]]
     }
   }
@@ -1673,8 +1736,8 @@ object Stream {
       self.compileInterpreter(pipeline)
       pipeline.wrapLastRead(r => new Reader.TakenWhile[A](r.asInstanceOf[Reader[A]], pred))
     }
-    override private[streams] def compile(depth: Int): Reader[A] =
-      new Reader.TakenWhile[A](self.compile(depth), pred)
+    override private[streams] def compile(depth: Int, bufferSize: Int): Reader[A] =
+      new Reader.TakenWhile[A](self.compile(depth, bufferSize), pred)
   }
 
 }

--- a/streams/shared/src/main/scala/zio/blocks/streams/internal/SyncBufferedReader.scala
+++ b/streams/shared/src/main/scala/zio/blocks/streams/internal/SyncBufferedReader.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams.internal
+
+import zio.blocks.chunk.{Chunk, ChunkBuilder}
+import zio.blocks.streams.io.Reader
+
+/**
+ * A buffered reader that prefetches up to `bufferSize` elements from `upstream`
+ * into an internal buffer and serves reads from it.
+ *
+ * Used on Scala.js where true concurrency is not available. Refills the
+ * internal buffer lazily (only when exhausted). Elements are read using the
+ * generic AnyRef lane (boxing is acceptable since no concurrency benefit exists
+ * on JS).
+ *
+ * @param upstream
+ *   the source reader
+ * @param bufferSize
+ *   maximum elements to prefetch per fill
+ */
+private[streams] final class SyncBufferedReader[A](upstream: Reader[A], bufferSize: Int) extends Reader[A] {
+  private val buf: Array[AnyRef] = new Array[AnyRef](bufferSize)
+  private var pos: Int           = 0
+  private var limit: Int         = 0
+  private var upstreamDone       = false
+
+  def isClosed: Boolean = pos >= limit && (upstreamDone || upstream.isClosed)
+
+  def read[A1 >: A](sentinel: A1): A1 =
+    if (pos < limit) {
+      val v = buf(pos)
+      pos += 1
+      v.asInstanceOf[A1]
+    } else if (upstreamDone) {
+      sentinel
+    } else {
+      pos = 0
+      limit = 0
+      var i = 0
+      while (i < bufferSize) {
+        val v = upstream.read[Any](EndOfStream)
+        if (v.asInstanceOf[AnyRef] eq EndOfStream) {
+          upstreamDone = true
+          i = bufferSize
+        } else {
+          buf(i) = v.asInstanceOf[AnyRef]
+          limit += 1
+          i += 1
+        }
+      }
+      if (limit > 0) {
+        val v = buf(pos)
+        pos += 1
+        v.asInstanceOf[A1]
+      } else {
+        sentinel
+      }
+    }
+
+  override def readUpToN[A1 >: A](n: Int): Chunk[A1] = {
+    if (n <= 0) return Chunk.empty
+    if (pos >= limit && !upstreamDone) {
+      val first = read[Any](EndOfStream)
+      if (first.asInstanceOf[AnyRef] eq EndOfStream) return Chunk.empty
+      if (n == 1 || pos >= limit) return Chunk.single(first.asInstanceOf[A1])
+      val count = math.min(n - 1, limit - pos)
+      val b     = ChunkBuilder.make[A1](count + 1)
+      b += first.asInstanceOf[A1]
+      var i = 0
+      while (i < count) {
+        b += buf(pos).asInstanceOf[A1]
+        pos += 1
+        i += 1
+      }
+      b.result()
+    } else if (pos >= limit) {
+      Chunk.empty
+    } else {
+      val count = math.min(n, limit - pos)
+      val b     = ChunkBuilder.make[A1](count)
+      var i     = 0
+      while (i < count) {
+        b += buf(pos).asInstanceOf[A1]
+        pos += 1
+        i += 1
+      }
+      b.result()
+    }
+  }
+
+  def close(): Unit = upstream.close()
+}

--- a/streams/shared/src/main/scala/zio/blocks/streams/io/Reader.scala
+++ b/streams/shared/src/main/scala/zio/blocks/streams/io/Reader.scala
@@ -146,12 +146,99 @@ abstract class Reader[+Elem] {
       var v = readInt(s)(unsafeEvidence);
       while (v != s) { b.addOne(v.toByte); v = readInt(s)(unsafeEvidence) }
       b.result().asInstanceOf[Chunk[A]]
+    } else if (et eq JvmType.Byte) {
+      val b = new ChunkBuilder.Byte()
+      var v = readByte()
+      while (v >= 0) { b.addOne(v.toByte); v = readByte() }
+      b.result().asInstanceOf[Chunk[A]]
     } else {
       val b = ChunkBuilder.make[A](16)
       var v = read[Any](EndOfStream);
       while (v.asInstanceOf[AnyRef] ne EndOfStream) { b += v.asInstanceOf[A]; v = read[Any](EndOfStream) }
       b.result()
     }
+  }
+
+  /**
+   * Reads at most `n` elements into a [[Chunk]], returning early if the reader
+   * is exhausted. Returns [[Chunk.empty]] when `n <= 0` or the reader is
+   * already closed. Dispatches on [[jvmType]] for zero-boxing on primitive
+   * streams.
+   */
+  def readN[A >: Elem](n: Int): Chunk[A] = {
+    if (n <= 0) return Chunk.empty
+    val et = jvmType
+    if (et eq JvmType.Int) {
+      val b = new ChunkBuilder.Int(); b.sizeHint(math.min(n, 4096))
+      val s = Long.MinValue; var i = 0
+      var v = readInt(s)(unsafeEvidence)
+      while (v != s && i < n) { b.addOne(v.toInt); i += 1; if (i < n) v = readInt(s)(unsafeEvidence) }
+      b.result().asInstanceOf[Chunk[A]]
+    } else if (et eq JvmType.Long) {
+      val b = new ChunkBuilder.Long(); b.sizeHint(math.min(n, 4096))
+      val s = Long.MaxValue; var i = 0
+      var v = readLong(s)(unsafeEvidence)
+      while (v != s && i < n) { b.addOne(v); i += 1; if (i < n) v = readLong(s)(unsafeEvidence) }
+      b.result().asInstanceOf[Chunk[A]]
+    } else if (et eq JvmType.Float) {
+      val b = new ChunkBuilder.Float(); b.sizeHint(math.min(n, 4096))
+      val s = Double.MaxValue; var i = 0
+      var v = readFloat(s)(unsafeEvidence)
+      while (v != s && i < n) { b.addOne(v.toFloat); i += 1; if (i < n) v = readFloat(s)(unsafeEvidence) }
+      b.result().asInstanceOf[Chunk[A]]
+    } else if (et eq JvmType.Double) {
+      val b = new ChunkBuilder.Double(); b.sizeHint(math.min(n, 4096))
+      val s = Double.MaxValue; var i = 0
+      var v = readDouble(s)(unsafeEvidence)
+      while (v != s && i < n) { b.addOne(v); i += 1; if (i < n) v = readDouble(s)(unsafeEvidence) }
+      b.result().asInstanceOf[Chunk[A]]
+    } else if (et eq JvmType.Byte) {
+      val b = new ChunkBuilder.Byte(); b.sizeHint(math.min(n, 4096)); var i = 0
+      var v = readByte()
+      while (v >= 0 && i < n) { b.addOne(v.toByte); i += 1; if (i < n) v = readByte() }
+      b.result().asInstanceOf[Chunk[A]]
+    } else {
+      val b = ChunkBuilder.make[A](math.min(n, 16)); var i = 0
+      var v = read[Any](EndOfStream)
+      while ((v.asInstanceOf[AnyRef] ne EndOfStream) && i < n) {
+        b += v.asInstanceOf[A]; i += 1; if (i < n) v = read[Any](EndOfStream)
+      }
+      b.result()
+    }
+  }
+
+  /**
+   * Reads up to `n` elements that are currently available. Blocks for at least
+   * 1 element if none are ready yet. Returns fewer than `n` if fewer are
+   * available without additional blocking. Returns [[Chunk.empty]] if `n <= 0`
+   * or if the reader is closed and empty.
+   *
+   * Differs from [[readN]] in that [[readN]] blocks until exactly `n` elements
+   * have been read. [[readUpToN]] returns as soon as at least one element is
+   * read, without waiting for further elements.
+   *
+   * @param n
+   *   maximum number of elements to read
+   * @return
+   *   a [[Chunk]] with between 1 and `n` elements, or empty on EOS
+   */
+  def readUpToN[A >: Elem](n: Int): Chunk[A] = {
+    if (n <= 0) return Chunk.empty
+    val first = read[Any](EndOfStream)
+    if (first.asInstanceOf[AnyRef] eq EndOfStream) return Chunk.empty
+    if (n == 1) return Chunk.single(first.asInstanceOf[A])
+    val b = ChunkBuilder.make[A](math.min(n, 64))
+    b += first.asInstanceOf[A]
+    var i = 1
+    while (i < n && readable()) {
+      val v = read[Any](EndOfStream)
+      if (v.asInstanceOf[AnyRef] eq EndOfStream) {
+        return b.result()
+      }
+      b += v.asInstanceOf[A]
+      i += 1
+    }
+    b.result()
   }
 
   /**
@@ -205,15 +292,36 @@ abstract class Reader[+Elem] {
   }
 
   /**
-   * Box-free bulk byte pull into a caller-supplied buffer.
+   * Box-free bulk byte pull into a caller-supplied buffer. Requires
+   * compile-time evidence that this reader's element type is `Byte`.
    *
    * Contract mirrors `java.io.InputStream.read(byte[], int, int)`:
    *   - Blocks until at least 1 byte is available.
    *   - Returns the number of bytes read (`1 <= r <= len`).
    *   - Returns `-1` when closed and empty.
    *   - Returns `0` immediately when `len == 0`.
+   *
+   * @param buf
+   *   the destination byte array
+   * @param offset
+   *   the start position in `buf` to write into
+   * @param len
+   *   the maximum number of bytes to read
+   * @param ev
+   *   compile-time evidence that `Elem` is a subtype of `Byte`; this method is
+   *   only available on `Reader[Byte]` instances
+   * @return
+   *   the number of bytes read, or `-1` on end-of-stream
+   *
+   * @example
+   *   {{{
+   * val reader: Reader[Byte] = Reader.fromInputStream(inputStream)
+   * val buf = new Array[Byte](1024)
+   * val n = reader.readBytes(buf, 0, buf.length)
+   * if (n > 0) process(buf, 0, n)
+   *   }}}
    */
-  def readBytes(buf: Array[Byte], offset: Int, len: Int): Int = {
+  def readBytes(buf: Array[Byte], offset: Int, len: Int)(implicit ev: Elem <:< Byte): Int = {
     if (len == 0) return 0
     var i = 0
     while (i < len) {
@@ -221,6 +329,134 @@ abstract class Reader[+Elem] {
       if (b < 0) return if (i > 0) i else -1
       buf(offset + i) = b.toByte
       i += 1
+    }
+    i
+  }
+
+  /**
+   * Box-free bulk Int pull into a caller-supplied buffer.
+   *
+   * Contract mirrors [[readBytes]]:
+   *   - Blocks until at least 1 element is available.
+   *   - Returns the number of elements read (`1 <= r <= maxLen`).
+   *   - Returns `-1` when closed and empty.
+   *   - Returns `0` immediately when `maxLen == 0`.
+   *
+   * @param buf
+   *   destination array
+   * @param offset
+   *   starting position in `buf`
+   * @param maxLen
+   *   maximum number of elements to read
+   * @return
+   *   number of elements read, `-1` on end-of-stream, or `0` when `maxLen == 0`
+   */
+  def readInts(buf: Array[Int], offset: Int, maxLen: Int)(implicit ev: Elem <:< Int): Int = {
+    if (maxLen == 0) return 0
+    val sentinel = Long.MinValue
+    var i        = 0
+    while (i < maxLen) {
+      val v = readInt(sentinel)(unsafeEvidence)
+      if (v == sentinel) return if (i > 0) i else -1
+      buf(offset + i) = v.toInt
+      i += 1
+      if (i < maxLen && !readable()) return i
+    }
+    i
+  }
+
+  /**
+   * Box-free bulk Long pull into a caller-supplied buffer.
+   *
+   * Contract mirrors [[readBytes]]:
+   *   - Blocks until at least 1 element is available.
+   *   - Returns the number of elements read (`1 <= r <= maxLen`).
+   *   - Returns `-1` when closed and empty.
+   *   - Returns `0` immediately when `maxLen == 0`.
+   *
+   * @param buf
+   *   destination array
+   * @param offset
+   *   starting position in `buf`
+   * @param maxLen
+   *   maximum number of elements to read
+   * @return
+   *   number of elements read, `-1` on end-of-stream, or `0` when `maxLen == 0`
+   */
+  def readLongs(buf: Array[Long], offset: Int, maxLen: Int)(implicit ev: Elem <:< Long): Int = {
+    if (maxLen == 0) return 0
+    val sentinel = Long.MaxValue
+    var i        = 0
+    while (i < maxLen) {
+      val v = readLong(sentinel)(unsafeEvidence)
+      if (v == sentinel) return if (i > 0) i else -1
+      buf(offset + i) = v
+      i += 1
+      if (i < maxLen && !readable()) return i
+    }
+    i
+  }
+
+  /**
+   * Box-free bulk Double pull into a caller-supplied buffer.
+   *
+   * Contract mirrors [[readBytes]]:
+   *   - Blocks until at least 1 element is available.
+   *   - Returns the number of elements read (`1 <= r <= maxLen`).
+   *   - Returns `-1` when closed and empty.
+   *   - Returns `0` immediately when `maxLen == 0`.
+   *
+   * @param buf
+   *   destination array
+   * @param offset
+   *   starting position in `buf`
+   * @param maxLen
+   *   maximum number of elements to read
+   * @return
+   *   number of elements read, `-1` on end-of-stream, or `0` when `maxLen == 0`
+   */
+  def readDoubles(buf: Array[Double], offset: Int, maxLen: Int)(implicit ev: Elem <:< Double): Int = {
+    if (maxLen == 0) return 0
+    val sentinel = Double.MaxValue
+    var i        = 0
+    while (i < maxLen) {
+      val v = readDouble(sentinel)(unsafeEvidence)
+      if (v == sentinel) return if (i > 0) i else -1
+      buf(offset + i) = v
+      i += 1
+      if (i < maxLen && !readable()) return i
+    }
+    i
+  }
+
+  /**
+   * Box-free bulk Float pull into a caller-supplied buffer.
+   *
+   * Contract mirrors [[readBytes]]:
+   *   - Blocks until at least 1 element is available.
+   *   - Returns the number of elements read (`1 <= r <= maxLen`).
+   *   - Returns `-1` when closed and empty.
+   *   - Returns `0` immediately when `maxLen == 0`.
+   *
+   * @param buf
+   *   destination array
+   * @param offset
+   *   starting position in `buf`
+   * @param maxLen
+   *   maximum number of elements to read
+   * @return
+   *   number of elements read, `-1` on end-of-stream, or `0` when `maxLen == 0`
+   */
+  def readFloats(buf: Array[Float], offset: Int, maxLen: Int)(implicit ev: Elem <:< Float): Int = {
+    if (maxLen == 0) return 0
+    val sentinel = Double.MaxValue
+    var i        = 0
+    while (i < maxLen) {
+      val v = readFloat(sentinel)(unsafeEvidence)
+      if (v == sentinel) return if (i > 0) i else -1
+      buf(offset + i) = v.toFloat
+      i += 1
+      if (i < maxLen && !readable()) return i
     }
     i
   }
@@ -403,12 +639,8 @@ object Reader {
       case _              => new FromChunk(chunk)
     }
 
-  /**
-   * Wraps a [[java.io.InputStream]] as a `Reader[Int]` where each element is a
-   * byte widened to Int (0–255). This avoids boxing on `.map`/`.filter` since
-   * `Function1` is specialized for `Int` but not `Byte`.
-   */
-  def fromInputStream(is: InputStream): Reader[Int] =
+  /** Wraps a [[java.io.InputStream]] as a `Reader[Byte]`. */
+  def fromInputStream(is: InputStream): Reader[Byte] =
     new InputStreamReader(is)
 
   /**
@@ -768,6 +1000,46 @@ object Reader {
       -1 // unreachable
     }
 
+    override def readInts(buf: Array[Int], offset: Int, maxLen: Int)(implicit ev: Elem <:< Int): Int = {
+      if (maxLen == 0) return 0
+      val n = current.readInts(buf, offset, maxLen)(unsafeEvidence)
+      if (n > 0) n
+      else if (advance()) current.readInts(buf, offset, maxLen)(unsafeEvidence)
+      else -1
+    }
+
+    override def readLongs(buf: Array[Long], offset: Int, maxLen: Int)(implicit ev: Elem <:< Long): Int = {
+      if (maxLen == 0) return 0
+      val n = current.readLongs(buf, offset, maxLen)(unsafeEvidence)
+      if (n > 0) n
+      else if (advance()) current.readLongs(buf, offset, maxLen)(unsafeEvidence)
+      else -1
+    }
+
+    override def readFloats(buf: Array[Float], offset: Int, maxLen: Int)(implicit ev: Elem <:< Float): Int = {
+      if (maxLen == 0) return 0
+      val n = current.readFloats(buf, offset, maxLen)(unsafeEvidence)
+      if (n > 0) n
+      else if (advance()) current.readFloats(buf, offset, maxLen)(unsafeEvidence)
+      else -1
+    }
+
+    override def readDoubles(buf: Array[Double], offset: Int, maxLen: Int)(implicit ev: Elem <:< Double): Int = {
+      if (maxLen == 0) return 0
+      val n = current.readDoubles(buf, offset, maxLen)(unsafeEvidence)
+      if (n > 0) n
+      else if (advance()) current.readDoubles(buf, offset, maxLen)(unsafeEvidence)
+      else -1
+    }
+
+    override def readUpToN[A1 >: Elem](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val chunk = current.readUpToN[A1](n)
+      if (chunk.nonEmpty) chunk
+      else if (advance()) current.readUpToN[A1](n)
+      else Chunk.empty
+    }
+
     override def skip(n: Long): Unit = Reader.skipViaSentinel(this, n)
 
     def close(): Unit =
@@ -804,11 +1076,20 @@ object Reader {
       inner.readFloat(sentinel)(unsafeEvidence)
     override def readDouble(sentinel: Double)(implicit ev: Elem <:< Double): Double =
       inner.readDouble(sentinel)(unsafeEvidence)
-    override def readByte(): Int     = inner.readByte()
-    override def skip(n: Long): Unit = inner.skip(n)
-    def close(): Unit                = inner.close()
-    override def reset(): Unit       = inner.reset()
-    override def readable(): Boolean = inner.readable()
+    override def readInts(buf: Array[Int], offset: Int, maxLen: Int)(implicit ev: Elem <:< Int): Int =
+      inner.readInts(buf, offset, maxLen)(unsafeEvidence)
+    override def readLongs(buf: Array[Long], offset: Int, maxLen: Int)(implicit ev: Elem <:< Long): Int =
+      inner.readLongs(buf, offset, maxLen)(unsafeEvidence)
+    override def readFloats(buf: Array[Float], offset: Int, maxLen: Int)(implicit ev: Elem <:< Float): Int =
+      inner.readFloats(buf, offset, maxLen)(unsafeEvidence)
+    override def readDoubles(buf: Array[Double], offset: Int, maxLen: Int)(implicit ev: Elem <:< Double): Int =
+      inner.readDoubles(buf, offset, maxLen)(unsafeEvidence)
+    override def readByte(): Int                          = inner.readByte()
+    override def readUpToN[A1 >: Elem](n: Int): Chunk[A1] = inner.readUpToN(n)
+    override def skip(n: Long): Unit                      = inner.skip(n)
+    def close(): Unit                                     = inner.close()
+    override def reset(): Unit                            = inner.reset()
+    override def readable(): Boolean                      = inner.readable()
   }
 
   /**
@@ -830,6 +1111,19 @@ object Reader {
     def read[A1 >: Any](sentinel: A1): A1 = {
       val v = readDouble(Double.MaxValue)(unsafeEvidence);
       if (v == Double.MaxValue) sentinel else Double.box(v).asInstanceOf[A1]
+    }
+    override def readUpToN[A1 >: Any](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val b = new ChunkBuilder.Double(); b.sizeHint(math.min(n, 64))
+      val s = Double.MaxValue
+      var v = readDouble(s)(unsafeEvidence)
+      if (v == s) return Chunk.empty
+      var i = 0
+      while (v != s && i < n) {
+        b.addOne(v); i += 1
+        if (i < n) v = readDouble(s)(unsafeEvidence)
+      }
+      b.result().asInstanceOf[Chunk[A1]]
     }
     def close(): Unit                = source.close()
     override def reset(): Unit       = source.reset()
@@ -861,6 +1155,19 @@ object Reader {
     def read[A1 >: Any](sentinel: A1): A1 = {
       val v = readFloat(Double.MaxValue)(unsafeEvidence);
       if (v == Double.MaxValue) sentinel else Float.box(v.toFloat).asInstanceOf[A1]
+    }
+    override def readUpToN[A1 >: Any](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val b = new ChunkBuilder.Float(); b.sizeHint(math.min(n, 64))
+      val s = Double.MaxValue
+      var v = readFloat(s)(unsafeEvidence)
+      if (v == s) return Chunk.empty
+      var i = 0
+      while (v != s && i < n) {
+        b.addOne(v.toFloat); i += 1
+        if (i < n) v = readFloat(s)(unsafeEvidence)
+      }
+      b.result().asInstanceOf[Chunk[A1]]
     }
     def close(): Unit                = source.close()
     override def reset(): Unit       = source.reset()
@@ -897,6 +1204,19 @@ object Reader {
       val v = readInt(Long.MinValue)(unsafeEvidence);
       if (v == Long.MinValue) sentinel else Int.box(v.toInt).asInstanceOf[A1]
     }
+    override def readUpToN[A1 >: Any](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val b = new ChunkBuilder.Int(); b.sizeHint(math.min(n, 64))
+      val s = Long.MinValue
+      var v = readInt(s)(unsafeEvidence)
+      if (v == s) return Chunk.empty
+      var i = 0
+      while (v != s && i < n) {
+        b.addOne(v.toInt); i += 1
+        if (i < n) v = readInt(s)(unsafeEvidence)
+      }
+      b.result().asInstanceOf[Chunk[A1]]
+    }
     def close(): Unit                = source.close()
     override def reset(): Unit       = source.reset()
     override def skip(n: Long): Unit = {
@@ -928,6 +1248,19 @@ object Reader {
       val v = readLong(Long.MaxValue)(unsafeEvidence);
       if (v == Long.MaxValue) sentinel else Long.box(v).asInstanceOf[A1]
     }
+    override def readUpToN[A1 >: Any](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val b = new ChunkBuilder.Long(); b.sizeHint(math.min(n, 64))
+      val s = Long.MaxValue
+      var v = readLong(s)(unsafeEvidence)
+      if (v == s) return Chunk.empty
+      var i = 0
+      while (v != s && i < n) {
+        b.addOne(v); i += 1
+        if (i < n) v = readLong(s)(unsafeEvidence)
+      }
+      b.result().asInstanceOf[Chunk[A1]]
+    }
     def close(): Unit                = source.close()
     override def reset(): Unit       = source.reset()
     override def skip(n: Long): Unit = {
@@ -957,6 +1290,18 @@ object Reader {
       while ((v.asInstanceOf[AnyRef] ne EndOfStream) && !pred.asInstanceOf[AnyRef => Boolean](v.asInstanceOf[AnyRef]))
         v = source.read[Any](EndOfStream)
       if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel else v.asInstanceOf[A1]
+    }
+    override def readUpToN[A1 >: Any](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val b = ChunkBuilder.make[A1](math.min(n, 64))
+      var v = read[Any](EndOfStream)
+      if (v.asInstanceOf[AnyRef] eq EndOfStream) return Chunk.empty
+      var i = 0
+      while ((v.asInstanceOf[AnyRef] ne EndOfStream) && i < n) {
+        b += v.asInstanceOf[A1]; i += 1
+        if (i < n) v = read[Any](EndOfStream)
+      }
+      b.result()
     }
     def close(): Unit                = source.close()
     override def reset(): Unit       = source.reset()
@@ -997,6 +1342,18 @@ object Reader {
         }
       }
       sentinel // unreachable, but needed for the compiler
+    }
+    override def readUpToN[A1 >: Any](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val b = ChunkBuilder.make[A1](math.min(n, 64))
+      var v = read[Any](EndOfStream)
+      if (v.asInstanceOf[AnyRef] eq EndOfStream) return Chunk.empty
+      var i = 0
+      while ((v.asInstanceOf[AnyRef] ne EndOfStream) && i < n) {
+        b += v.asInstanceOf[A1]; i += 1
+        if (i < n) v = read[Any](EndOfStream)
+      }
+      b.result()
     }
     def close(): Unit                = source.close()
     override def reset(): Unit       = source.reset()
@@ -1078,6 +1435,65 @@ object Reader {
         if (!advance()) return sentinel
       }
       sentinel
+    }
+    override def readUpToN[A1 >: Any](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val et = jvmType
+      if (et eq JvmType.Int) {
+        val b = new ChunkBuilder.Int(); b.sizeHint(math.min(n, 64))
+        val s = Long.MinValue
+        var v = readInt(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v.toInt); i += 1
+          if (i < n) v = readInt(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Long) {
+        val b = new ChunkBuilder.Long(); b.sizeHint(math.min(n, 64))
+        val s = Long.MaxValue
+        var v = readLong(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v); i += 1
+          if (i < n) v = readLong(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Float) {
+        val b = new ChunkBuilder.Float(); b.sizeHint(math.min(n, 64))
+        val s = Double.MaxValue
+        var v = readFloat(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v.toFloat); i += 1
+          if (i < n) v = readFloat(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Double) {
+        val b = new ChunkBuilder.Double(); b.sizeHint(math.min(n, 64))
+        val s = Double.MaxValue
+        var v = readDouble(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v); i += 1
+          if (i < n) v = readDouble(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else {
+        val b = ChunkBuilder.make[A1](math.min(n, 64))
+        var v = read[Any](EndOfStream)
+        if (v.asInstanceOf[AnyRef] eq EndOfStream) return Chunk.empty
+        var i = 0
+        while ((v.asInstanceOf[AnyRef] ne EndOfStream) && i < n) {
+          b += v.asInstanceOf[A1]; i += 1
+          if (i < n) v = read[Any](EndOfStream)
+        }
+        b.result()
+      }
     }
     def close(): Unit = {
       _closed = true
@@ -1193,6 +1609,20 @@ object Reader {
     def read[A1 >: A](sentinel: A1): A1 =
       if (idx < effectiveLen) { val i = idx; idx += 1; chunk(i).asInstanceOf[A1] }
       else sentinel
+    override def readN[A1 >: A](n: Int): Chunk[A1] = {
+      if (n <= 0 || idx >= effectiveLen) return Chunk.empty
+      val from  = idx
+      val until = math.min(idx + n, effectiveLen)
+      idx = until
+      chunk.slice(from, until).asInstanceOf[Chunk[A1]]
+    }
+    override def readUpToN[A1 >: A](n: Int): Chunk[A1] = {
+      if (n <= 0 || idx >= effectiveLen) return Chunk.empty
+      val from  = idx
+      val until = math.min(idx + n, effectiveLen)
+      idx = until
+      chunk.slice(from, until).asInstanceOf[Chunk[A1]]
+    }
     override def readByte(): Int =
       if (idx < effectiveLen) { val i = idx; idx += 1; (chunk(i).asInstanceOf[java.lang.Number].intValue() & 0xff) }
       else -1
@@ -1233,6 +1663,20 @@ object Reader {
     def read[A1 >: Double](sentinel: A1): A1 =
       if (idx < effectiveLen) { val i = idx; idx += 1; Double.box(chunk.double(i)).asInstanceOf[A1] }
       else sentinel
+    override def readN[A1 >: Double](n: Int): Chunk[A1] = {
+      if (n <= 0 || idx >= effectiveLen) return Chunk.empty
+      val from  = idx
+      val until = math.min(idx + n, effectiveLen)
+      idx = until
+      chunk.slice(from, until).asInstanceOf[Chunk[A1]]
+    }
+    override def readUpToN[A1 >: Double](n: Int): Chunk[A1] = {
+      if (n <= 0 || idx >= effectiveLen) return Chunk.empty
+      val from  = idx
+      val until = math.min(idx + n, effectiveLen)
+      idx = until
+      chunk.slice(from, until).asInstanceOf[Chunk[A1]]
+    }
     override def readDouble(sentinel: Double)(implicit ev: Double <:< Double): Double =
       if (idx < effectiveLen) { val v = chunk.double(idx); idx += 1; v }
       else sentinel
@@ -1277,6 +1721,20 @@ object Reader {
     def read[A1 >: Float](sentinel: A1): A1 =
       if (idx < effectiveLen) { val i = idx; idx += 1; Float.box(chunk.float(i)).asInstanceOf[A1] }
       else sentinel
+    override def readN[A1 >: Float](n: Int): Chunk[A1] = {
+      if (n <= 0 || idx >= effectiveLen) return Chunk.empty
+      val from  = idx
+      val until = math.min(idx + n, effectiveLen)
+      idx = until
+      chunk.slice(from, until).asInstanceOf[Chunk[A1]]
+    }
+    override def readUpToN[A1 >: Float](n: Int): Chunk[A1] = {
+      if (n <= 0 || idx >= effectiveLen) return Chunk.empty
+      val from  = idx
+      val until = math.min(idx + n, effectiveLen)
+      idx = until
+      chunk.slice(from, until).asInstanceOf[Chunk[A1]]
+    }
     override def readFloat(sentinel: Double)(implicit ev: Float <:< Float): Double =
       if (idx < effectiveLen) { val v = chunk.float(idx); idx += 1; v.toDouble }
       else sentinel
@@ -1327,7 +1785,7 @@ object Reader {
     override def readByte(): Int =
       if (idx < effectiveLen) { val v = chunk.byte(idx); idx += 1; v.toInt & 0xff }
       else -1
-    override def readBytes(buf: Array[Byte], offset: Int, len: Int): Int = {
+    override def readBytes(buf: Array[Byte], offset: Int, len: Int)(implicit ev: Byte <:< Byte): Int = {
       if (len == 0) return 0
       val avail = effectiveLen - idx
       if (avail <= 0) return -1
@@ -1373,6 +1831,20 @@ object Reader {
     def read[A1 >: Int](sentinel: A1): A1 =
       if (idx < effectiveLen) { val i = idx; idx += 1; Int.box(chunk.int(i)).asInstanceOf[A1] }
       else sentinel
+    override def readN[A1 >: Int](n: Int): Chunk[A1] = {
+      if (n <= 0 || idx >= effectiveLen) return Chunk.empty
+      val from  = idx
+      val until = math.min(idx + n, effectiveLen)
+      idx = until
+      chunk.slice(from, until).asInstanceOf[Chunk[A1]]
+    }
+    override def readUpToN[A1 >: Int](n: Int): Chunk[A1] = {
+      if (n <= 0 || idx >= effectiveLen) return Chunk.empty
+      val from  = idx
+      val until = math.min(idx + n, effectiveLen)
+      idx = until
+      chunk.slice(from, until).asInstanceOf[Chunk[A1]]
+    }
     override def readInt(sentinel: Long)(implicit ev: Int <:< Int): Long =
       if (idx < effectiveLen) { val v = chunk.int(idx); idx += 1; v.toLong }
       else sentinel
@@ -1417,6 +1889,20 @@ object Reader {
     def read[A1 >: Long](sentinel: A1): A1 =
       if (idx < effectiveLen) { val i = idx; idx += 1; Long.box(chunk.long(i)).asInstanceOf[A1] }
       else sentinel
+    override def readN[A1 >: Long](n: Int): Chunk[A1] = {
+      if (n <= 0 || idx >= effectiveLen) return Chunk.empty
+      val from  = idx
+      val until = math.min(idx + n, effectiveLen)
+      idx = until
+      chunk.slice(from, until).asInstanceOf[Chunk[A1]]
+    }
+    override def readUpToN[A1 >: Long](n: Int): Chunk[A1] = {
+      if (n <= 0 || idx >= effectiveLen) return Chunk.empty
+      val from  = idx
+      val until = math.min(idx + n, effectiveLen)
+      idx = until
+      chunk.slice(from, until).asInstanceOf[Chunk[A1]]
+    }
     override def readLong(sentinel: Long)(implicit ev: Long <:< Long): Long =
       if (idx < effectiveLen) { val v = chunk.long(idx); idx += 1; v }
       else sentinel
@@ -1487,6 +1973,15 @@ object Reader {
     override def readByte(): Int =
       if (idx < effectiveLen) { val v = current; idx += 1; current += rangeStep; (v & 0xff) }
       else -1
+    override def readN[A1 >: Int](n: Int): Chunk[A1] = {
+      if (n <= 0 || idx >= effectiveLen) return Chunk.empty
+      val count = math.min(n, effectiveLen - idx)
+      val arr   = new Array[Int](count)
+      var i     = 0
+      while (i < count) { arr(i) = current; current += rangeStep; i += 1 }
+      idx += count
+      Chunk.fromArray(arr).asInstanceOf[Chunk[A1]]
+    }
     def close(): Unit          = idx = effectiveLen
     override def reset(): Unit = {
       val s = math.max(0L, math.min(skipN, originalLen.toLong)).toInt
@@ -1497,12 +1992,8 @@ object Reader {
     }
   }
 
-  /**
-   * Reader adapter that reads bytes from a `java.io.InputStream`, widened to
-   * `Int` (0–255) so that downstream `.map`/`.filter` use Int-specialized
-   * `Function1` and avoid boxing.
-   */
-  private[streams] final class InputStreamReader(is: InputStream) extends Reader[Int] {
+  /** Reader adapter for `java.io.InputStream`. Emits elements as `Byte`. */
+  private[streams] final class InputStreamReader(is: InputStream) extends Reader[Byte] {
 
     private var closed               = false
     private var errored: IOException = null
@@ -1517,31 +2008,26 @@ object Reader {
       var r = n; while (r > 0) { val b = readByte(); if (b < 0) r = 0 else r -= 1 }
     }
 
-    override def jvmType: JvmType = JvmType.Int
+    override def jvmType: JvmType = JvmType.Byte
 
-    override def readInt(sentinel: Long)(implicit ev: Int <:< Int): Long = {
-      if (closed) return sentinel
+    override def readByte(): Int = {
+      if (closed) return -1
       if (errored ne null) throw new StreamError(errored)
       try {
         val b = is.read()
-        if (b < 0) { closed = true; sentinel }
-        else b.toLong
+        if (b < 0) { closed = true; -1 }
+        else b
       } catch {
         case e: IOException => closed = true; errored = e; throw new StreamError(e)
       }
     }
 
-    override def readByte(): Int = {
-      val v = readInt(-1L)(unsafeEvidence)
-      if (v >= 0) v.toInt else -1
+    def read[A1 >: Byte](sentinel: A1): A1 = {
+      val b = readByte()
+      if (b >= 0) Byte.box(b.toByte).asInstanceOf[A1] else sentinel
     }
 
-    def read[A1 >: Int](sentinel: A1): A1 = {
-      val b = readInt(-1L)(unsafeEvidence)
-      if (b >= 0) Int.box(b.toInt).asInstanceOf[A1] else sentinel
-    }
-
-    override def readBytes(buf: Array[Byte], offset: Int, len: Int): Int =
+    override def readBytes(buf: Array[Byte], offset: Int, len: Int)(implicit ev: Byte <:< Byte): Int =
       if (len == 0) 0
       else if (closed) -1
       else if (errored ne null) throw new StreamError(errored)
@@ -1553,6 +2039,37 @@ object Reader {
         } catch {
           case e: IOException => closed = true; errored = e; throw new StreamError(e)
         }
+
+    override def readN[A1 >: Byte](n: Int): Chunk[A1] = {
+      if (n <= 0 || closed) return Chunk.empty
+      if (errored ne null) throw new StreamError(errored)
+      if (n <= 8192) {
+        val arr   = new Array[Byte](n)
+        var total = 0
+        while (total < n && !closed) {
+          val read = readBytes(arr, total, n - total)(unsafeEvidence)
+          if (read < 0) ()
+          else total += read
+        }
+        if (total == 0) Chunk.empty
+        else if (total == n) Chunk.fromArray(arr).asInstanceOf[Chunk[A1]]
+        else Chunk.fromArray(java.util.Arrays.copyOf(arr, total)).asInstanceOf[Chunk[A1]]
+      } else {
+        val b   = new ChunkBuilder.Byte()
+        val buf = new Array[Byte](8192)
+        var rem = n
+        while (rem > 0 && !closed) {
+          val toRead = math.min(rem, 8192)
+          val read   = readBytes(buf, 0, toRead)
+          if (read > 0) {
+            var k = 0
+            while (k < read) { b.addOne(buf(k)); k += 1 }
+            rem -= read
+          }
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      }
+    }
 
     def close(): Unit = closed = true
   }
@@ -1596,6 +2113,65 @@ object Reader {
       else if (outType eq JvmType.Boolean) {
         Boolean.box(f.asInstanceOf[Double => Boolean](v)).asInstanceOf[A1]
       } else f.asInstanceOf[Double => AnyRef](v).asInstanceOf[A1]
+    }
+    override def readUpToN[A1 >: Any](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val et = jvmType
+      if (et eq JvmType.Int) {
+        val b = new ChunkBuilder.Int(); b.sizeHint(math.min(n, 64))
+        val s = Long.MinValue
+        var v = readInt(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v.toInt); i += 1
+          if (i < n) v = readInt(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Long) {
+        val b = new ChunkBuilder.Long(); b.sizeHint(math.min(n, 64))
+        val s = Long.MaxValue
+        var v = readLong(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v); i += 1
+          if (i < n) v = readLong(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Float) {
+        val b = new ChunkBuilder.Float(); b.sizeHint(math.min(n, 64))
+        val s = Double.MaxValue
+        var v = readFloat(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v.toFloat); i += 1
+          if (i < n) v = readFloat(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Double) {
+        val b = new ChunkBuilder.Double(); b.sizeHint(math.min(n, 64))
+        val s = Double.MaxValue
+        var v = readDouble(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v); i += 1
+          if (i < n) v = readDouble(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else {
+        val b = ChunkBuilder.make[A1](math.min(n, 64))
+        var v = read[Any](EndOfStream)
+        if (v.asInstanceOf[AnyRef] eq EndOfStream) return Chunk.empty
+        var i = 0
+        while ((v.asInstanceOf[AnyRef] ne EndOfStream) && i < n) {
+          b += v.asInstanceOf[A1]; i += 1
+          if (i < n) v = read[Any](EndOfStream)
+        }
+        b.result()
+      }
     }
     def close(): Unit                = source.close()
     override def reset(): Unit       = source.reset()
@@ -1653,6 +2229,65 @@ object Reader {
       else if (outType eq JvmType.Boolean) {
         Boolean.box(f.asInstanceOf[Float => Boolean](v.toFloat)).asInstanceOf[A1]
       } else f.asInstanceOf[Float => AnyRef](v.toFloat).asInstanceOf[A1]
+    }
+    override def readUpToN[A1 >: Any](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val et = jvmType
+      if (et eq JvmType.Int) {
+        val b = new ChunkBuilder.Int(); b.sizeHint(math.min(n, 64))
+        val s = Long.MinValue
+        var v = readInt(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v.toInt); i += 1
+          if (i < n) v = readInt(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Long) {
+        val b = new ChunkBuilder.Long(); b.sizeHint(math.min(n, 64))
+        val s = Long.MaxValue
+        var v = readLong(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v); i += 1
+          if (i < n) v = readLong(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Float) {
+        val b = new ChunkBuilder.Float(); b.sizeHint(math.min(n, 64))
+        val s = Double.MaxValue
+        var v = readFloat(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v.toFloat); i += 1
+          if (i < n) v = readFloat(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Double) {
+        val b = new ChunkBuilder.Double(); b.sizeHint(math.min(n, 64))
+        val s = Double.MaxValue
+        var v = readDouble(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v); i += 1
+          if (i < n) v = readDouble(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else {
+        val b = ChunkBuilder.make[A1](math.min(n, 64))
+        var v = read[Any](EndOfStream)
+        if (v.asInstanceOf[AnyRef] eq EndOfStream) return Chunk.empty
+        var i = 0
+        while ((v.asInstanceOf[AnyRef] ne EndOfStream) && i < n) {
+          b += v.asInstanceOf[A1]; i += 1
+          if (i < n) v = read[Any](EndOfStream)
+        }
+        b.result()
+      }
     }
     def close(): Unit                = source.close()
     override def reset(): Unit       = source.reset()
@@ -1712,6 +2347,65 @@ object Reader {
         Boolean.box(f.asInstanceOf[Int => Boolean](v.toInt)).asInstanceOf[A1]
       } else f.asInstanceOf[Int => AnyRef](v.toInt).asInstanceOf[A1]
     }
+    override def readUpToN[A1 >: Any](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val et = jvmType
+      if (et eq JvmType.Int) {
+        val b = new ChunkBuilder.Int(); b.sizeHint(math.min(n, 64))
+        val s = Long.MinValue
+        var v = readInt(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v.toInt); i += 1
+          if (i < n) v = readInt(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Long) {
+        val b = new ChunkBuilder.Long(); b.sizeHint(math.min(n, 64))
+        val s = Long.MaxValue
+        var v = readLong(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v); i += 1
+          if (i < n) v = readLong(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Float) {
+        val b = new ChunkBuilder.Float(); b.sizeHint(math.min(n, 64))
+        val s = Double.MaxValue
+        var v = readFloat(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v.toFloat); i += 1
+          if (i < n) v = readFloat(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Double) {
+        val b = new ChunkBuilder.Double(); b.sizeHint(math.min(n, 64))
+        val s = Double.MaxValue
+        var v = readDouble(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v); i += 1
+          if (i < n) v = readDouble(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else {
+        val b = ChunkBuilder.make[A1](math.min(n, 64))
+        var v = read[Any](EndOfStream)
+        if (v.asInstanceOf[AnyRef] eq EndOfStream) return Chunk.empty
+        var i = 0
+        while ((v.asInstanceOf[AnyRef] ne EndOfStream) && i < n) {
+          b += v.asInstanceOf[A1]; i += 1
+          if (i < n) v = read[Any](EndOfStream)
+        }
+        b.result()
+      }
+    }
     def close(): Unit                = source.close()
     override def reset(): Unit       = source.reset()
     override def skip(n: Long): Unit = {
@@ -1769,6 +2463,65 @@ object Reader {
         Boolean.box(f.asInstanceOf[Long => Boolean](v)).asInstanceOf[A1]
       } else f.asInstanceOf[Long => AnyRef](v).asInstanceOf[A1]
     }
+    override def readUpToN[A1 >: Any](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val et = jvmType
+      if (et eq JvmType.Int) {
+        val b = new ChunkBuilder.Int(); b.sizeHint(math.min(n, 64))
+        val s = Long.MinValue
+        var v = readInt(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v.toInt); i += 1
+          if (i < n) v = readInt(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Long) {
+        val b = new ChunkBuilder.Long(); b.sizeHint(math.min(n, 64))
+        val s = Long.MaxValue
+        var v = readLong(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v); i += 1
+          if (i < n) v = readLong(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Float) {
+        val b = new ChunkBuilder.Float(); b.sizeHint(math.min(n, 64))
+        val s = Double.MaxValue
+        var v = readFloat(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v.toFloat); i += 1
+          if (i < n) v = readFloat(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Double) {
+        val b = new ChunkBuilder.Double(); b.sizeHint(math.min(n, 64))
+        val s = Double.MaxValue
+        var v = readDouble(s)(unsafeEvidence)
+        if (v == s) return Chunk.empty
+        var i = 0
+        while (v != s && i < n) {
+          b.addOne(v); i += 1
+          if (i < n) v = readDouble(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else {
+        val b = ChunkBuilder.make[A1](math.min(n, 64))
+        var v = read[Any](EndOfStream)
+        if (v.asInstanceOf[AnyRef] eq EndOfStream) return Chunk.empty
+        var i = 0
+        while ((v.asInstanceOf[AnyRef] ne EndOfStream) && i < n) {
+          b += v.asInstanceOf[A1]; i += 1
+          if (i < n) v = read[Any](EndOfStream)
+        }
+        b.result()
+      }
+    }
     def close(): Unit                = source.close()
     override def reset(): Unit       = source.reset()
     override def skip(n: Long): Unit = {
@@ -1802,22 +2555,35 @@ object Reader {
     override def readInt(sentinel: Long)(implicit ev: Any <:< Int): Long = {
       val v = source.read[Any](EndOfStream);
       if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
-      else f.asInstanceOf[AnyRef => Int](v.asInstanceOf[AnyRef]).toLong
+      else if (outType eq JvmType.Int)
+        f.asInstanceOf[AnyRef => Int](v.asInstanceOf[AnyRef]).toLong
+      else
+        // Byte / Short / Char / other numeric outputs: extract via Number.
+        f.asInstanceOf[AnyRef => AnyRef](v.asInstanceOf[AnyRef]).asInstanceOf[java.lang.Number].longValue()
     }
     override def readLong(sentinel: Long)(implicit ev: Any <:< Long): Long = {
       val v = source.read[Any](EndOfStream);
       if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
-      else f.asInstanceOf[AnyRef => Long](v.asInstanceOf[AnyRef])
+      else if (outType eq JvmType.Long)
+        f.asInstanceOf[AnyRef => Long](v.asInstanceOf[AnyRef])
+      else
+        f.asInstanceOf[AnyRef => AnyRef](v.asInstanceOf[AnyRef]).asInstanceOf[java.lang.Number].longValue()
     }
     override def readFloat(sentinel: Double)(implicit ev: Any <:< Float): Double = {
       val v = source.read[Any](EndOfStream);
       if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
-      else f.asInstanceOf[AnyRef => Float](v.asInstanceOf[AnyRef]).toDouble
+      else if (outType eq JvmType.Float)
+        f.asInstanceOf[AnyRef => Float](v.asInstanceOf[AnyRef]).toDouble
+      else
+        f.asInstanceOf[AnyRef => AnyRef](v.asInstanceOf[AnyRef]).asInstanceOf[java.lang.Number].doubleValue()
     }
     override def readDouble(sentinel: Double)(implicit ev: Any <:< Double): Double = {
       val v = source.read[Any](EndOfStream);
       if (v.asInstanceOf[AnyRef] eq EndOfStream) sentinel
-      else f.asInstanceOf[AnyRef => Double](v.asInstanceOf[AnyRef])
+      else if (outType eq JvmType.Double)
+        f.asInstanceOf[AnyRef => Double](v.asInstanceOf[AnyRef])
+      else
+        f.asInstanceOf[AnyRef => AnyRef](v.asInstanceOf[AnyRef]).asInstanceOf[java.lang.Number].doubleValue()
     }
     def read[A1 >: Any](sentinel: A1): A1 = {
       val v = source.read[Any](EndOfStream);
@@ -1825,6 +2591,18 @@ object Reader {
       else if (outType eq JvmType.Boolean) {
         Boolean.box(f.asInstanceOf[AnyRef => Boolean](v.asInstanceOf[AnyRef])).asInstanceOf[A1]
       } else f.asInstanceOf[AnyRef => AnyRef](v.asInstanceOf[AnyRef]).asInstanceOf[A1]
+    }
+    override def readUpToN[A1 >: Any](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val b = ChunkBuilder.make[A1](math.min(n, 64))
+      var v = read[Any](EndOfStream)
+      if (v.asInstanceOf[AnyRef] eq EndOfStream) return Chunk.empty
+      var i = 0
+      while ((v.asInstanceOf[AnyRef] ne EndOfStream) && i < n) {
+        b += v.asInstanceOf[A1]; i += 1
+        if (i < n) v = read[Any](EndOfStream)
+      }
+      b.result()
     }
     def close(): Unit                = source.close()
     override def reset(): Unit       = source.reset()
@@ -1900,6 +2678,15 @@ object Reader {
         else { done = true; return sentinel }
       }
       sentinel // unreachable
+    }
+    override def readUpToN[A1 >: A](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val chunk = inner.readUpToN[A1](n)
+      if (chunk.nonEmpty) chunk
+      else if (inner.isClosed) {
+        inner.reset()
+        inner.readUpToN[A1](n)
+      } else Chunk.empty
     }
     override def skip(n: Long): Unit = Reader.skipViaSentinel(this, n)
     override def readByte(): Int     = {
@@ -2073,6 +2860,14 @@ object Reader {
       v
     }
 
+    override def readUpToN[A1 >: A](n: Int): Chunk[A1] = {
+      if (remaining <= 0 || n <= 0) return Chunk.empty
+      val toRead = math.min(n.toLong, remaining).toInt
+      val chunk  = inner.readUpToN[A1](toRead)
+      remaining -= chunk.length
+      chunk
+    }
+
     override def skip(n: Long): Unit = inner.skip(n)
     override def readByte(): Int     = {
       val v = read[Any](EndOfStream);
@@ -2138,6 +2933,15 @@ object Reader {
         if (v != sentinel) { remaining -= 1; v }
         else { doneSent = true; sentinel }
       }
+    override def readUpToN[A1 >: Elem](n: Int): Chunk[A1] = {
+      if (doneSent || n <= 0 || remaining <= 0) return Chunk.empty
+      val toRead = math.min(n.toLong, remaining).toInt
+      val chunk  = self.readUpToN[A1](toRead)
+      if (chunk.isEmpty) doneSent = true
+      remaining -= chunk.length
+      if (remaining <= 0) doneSent = true
+      chunk
+    }
     override def skip(n: Long): Unit = {
       val toSkip = math.min(n, remaining); self.skip(toSkip); remaining -= toSkip
     }
@@ -2193,6 +2997,61 @@ object Reader {
         if (v != sentinel) { if (pred.asInstanceOf[Double => Boolean](v)) v else { doneSent = true; sentinel } }
         else { doneSent = true; sentinel }
       }
+    override def readUpToN[A1 >: Elem](n: Int): Chunk[A1] = {
+      if (n <= 0 || doneSent) return Chunk.empty
+      val et = jvmType
+      if (et eq JvmType.Int) {
+        val b = new ChunkBuilder.Int(); b.sizeHint(math.min(n, 64))
+        val s = Long.MinValue
+        var i = 0
+        var v = readInt(s)(unsafeEvidence)
+        while (v != s && i < n) {
+          b.addOne(v.toInt); i += 1
+          if (i < n) v = readInt(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Long) {
+        val b = new ChunkBuilder.Long(); b.sizeHint(math.min(n, 64))
+        val s = Long.MaxValue
+        var i = 0
+        var v = readLong(s)(unsafeEvidence)
+        while (v != s && i < n) {
+          b.addOne(v); i += 1
+          if (i < n) v = readLong(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Float) {
+        val b = new ChunkBuilder.Float(); b.sizeHint(math.min(n, 64))
+        val s = Double.MaxValue
+        var i = 0
+        var v = readFloat(s)(unsafeEvidence)
+        while (v != s && i < n) {
+          b.addOne(v.toFloat); i += 1
+          if (i < n) v = readFloat(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else if (et eq JvmType.Double) {
+        val b = new ChunkBuilder.Double(); b.sizeHint(math.min(n, 64))
+        val s = Double.MaxValue
+        var i = 0
+        var v = readDouble(s)(unsafeEvidence)
+        while (v != s && i < n) {
+          b.addOne(v); i += 1
+          if (i < n) v = readDouble(s)(unsafeEvidence)
+        }
+        b.result().asInstanceOf[Chunk[A1]]
+      } else {
+        val b = ChunkBuilder.make[A1](math.min(n, 16))
+        var i = 0
+        while (i < n && !doneSent) {
+          val v = read[Any](EndOfStream)
+          if (v.asInstanceOf[AnyRef] eq EndOfStream) return b.result()
+          b += v.asInstanceOf[A1]
+          i += 1
+        }
+        b.result()
+      }
+    }
     override def skip(n: Long): Unit = Reader.skipViaSentinel(this, n)
     override def readByte(): Int     = {
       val v = read[Any](EndOfStream);
@@ -2218,6 +3077,18 @@ object Reader {
           case Some((a, next)) => state = next; a.asInstanceOf[A1]
           case None            => finished = true; sentinel
         }
+    override def readUpToN[A1 >: A](n: Int): Chunk[A1] = {
+      if (n <= 0) return Chunk.empty
+      val b = ChunkBuilder.make[A1](math.min(n, 16))
+      var i = 0
+      while (i < n && !isClosed) {
+        val v = read[Any](EndOfStream)
+        if (v.asInstanceOf[AnyRef] eq EndOfStream) return b.result()
+        b += v.asInstanceOf[A1]
+        i += 1
+      }
+      b.result()
+    }
     override def readByte(): Int = {
       val v = read[Any](EndOfStream);
       if (v.asInstanceOf[AnyRef] eq EndOfStream) -1 else (v.asInstanceOf[java.lang.Number].intValue() & 0xff)

--- a/streams/shared/src/test/scala-3/zio/blocks/streams/ReadBytesScopeAuditSpec.scala
+++ b/streams/shared/src/test/scala-3/zio/blocks/streams/ReadBytesScopeAuditSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.test._
+
+/**
+ * Audit tests documenting which Reader methods are OUT OF SCOPE for the
+ * readBytes evidence-hardening pass. Each test asserts CURRENT (unconstrained)
+ * behavior as a baseline; a future pass adding evidence constraints will cause
+ * the corresponding test to fail deliberately.
+ *
+ * Scope boundary: only `readBytes` received `using Elem <:< Byte` (commit
+ * 4fb69bce). See .sisyphus/evidence/task-8-followup-matrix.txt for full
+ * rationale.
+ */
+object ReadBytesScopeAuditSpec extends StreamsBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("Reader method scope audit")(
+    test("readByte remains unconstrained - deferred: existential callers in Sink/NioSinks") {
+      // Sink.fromOutputStream, NioSinks.fromByteBuffer/fromChannel call readByte() on Reader[?].
+      assertTrue(scala.compiletime.testing.typeChecks("""
+import zio.blocks.chunk.Chunk
+import zio.blocks.streams.io.Reader
+val r: Reader[Int] = Reader.fromChunk(Chunk[Int](1, 2, 3))
+r.readByte()
+"""))
+    },
+    test("readAll remains polymorphic - correct by design via jvmType dispatch") {
+      assertTrue(scala.compiletime.testing.typeChecks("""
+import zio.blocks.chunk.Chunk
+import zio.blocks.streams.io.Reader
+val r: Reader[Int] = Reader.fromChunk(Chunk[Int](1, 2, 3))
+r.readAll[Int]()
+"""))
+    },
+    test("readN remains polymorphic - correct by design via jvmType dispatch") {
+      assertTrue(scala.compiletime.testing.typeChecks("""
+import zio.blocks.chunk.Chunk
+import zio.blocks.streams.io.Reader
+val r: Reader[Int] = Reader.fromChunk(Chunk[Int](1, 2, 3))
+r.readN[Int](2)
+"""))
+    },
+    test("skip remains unconstrained - independent of readBytes") {
+      assertTrue(scala.compiletime.testing.typeChecks("""
+import zio.blocks.chunk.Chunk
+import zio.blocks.streams.io.Reader
+val r: Reader[Int] = Reader.fromChunk(Chunk[Int](1, 2, 3))
+r.skip(2)
+"""))
+    }
+  )
+}

--- a/streams/shared/src/test/scala-3/zio/blocks/streams/ReadBytesSoundnessSpec.scala
+++ b/streams/shared/src/test/scala-3/zio/blocks/streams/ReadBytesSoundnessSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.test._
+
+object ReadBytesSoundnessSpec extends StreamsBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("Reader.readBytes compile-time soundness")(
+    test("readBytes compiles for Reader[Byte]") {
+      assertTrue(scala.compiletime.testing.typeChecks("""
+import zio.blocks.chunk.Chunk
+import zio.blocks.streams.io.Reader
+val r: Reader[Byte] = Reader.fromChunk(Chunk[Byte](1, 2, 3))
+val buf = new Array[Byte](4)
+r.readBytes(buf, 0, 4)
+"""))
+    },
+    test("readBytes does not compile for Reader[Int]") {
+      assertTrue(!scala.compiletime.testing.typeChecks("""
+import zio.blocks.chunk.Chunk
+import zio.blocks.streams.io.Reader
+val r: Reader[Int] = Reader.fromChunk(Chunk[Int](1, 2, 3))
+val buf = new Array[Byte](4)
+r.readBytes(buf, 0, 4)
+"""))
+    },
+    test("readBytes does not compile for Reader[Char]") {
+      assertTrue(!scala.compiletime.testing.typeChecks("""
+import zio.blocks.chunk.Chunk
+import zio.blocks.streams.io.Reader
+val r: Reader[Char] = Reader.fromChunk(Chunk[Char]('a', 'b'))
+val buf = new Array[Byte](4)
+r.readBytes(buf, 0, 4)
+"""))
+    },
+    test("Reader[Int] compile error mentions byte evidence") {
+      val errors = scala.compiletime.testing.typeCheckErrors("""
+import zio.blocks.chunk.Chunk
+import zio.blocks.streams.io.Reader
+val r: Reader[Int] = Reader.fromChunk(Chunk[Int](1, 2, 3))
+val buf = new Array[Byte](4)
+r.readBytes(buf, 0, 4)
+""")
+      assertTrue(errors.exists(_.message.contains("<:< Byte")))
+    }
+  )
+}

--- a/streams/shared/src/test/scala/zio/blocks/streams/BufferSpec.scala
+++ b/streams/shared/src/test/scala/zio/blocks/streams/BufferSpec.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.blocks.chunk.Chunk
+import zio.test._
+
+object BufferSpec extends StreamsBaseSpec {
+
+  def spec = suite("Buffer")(
+    correctnessSuite,
+    errorHandlingSuite,
+    pipelineCompositionSuite,
+    resourceSafetySuite,
+    earlyTerminationSuite,
+    platformDetectionSuite
+  ) @@ TestAspect.sequential
+
+  // =========================================================================
+  //  Correctness
+  // =========================================================================
+
+  private val correctnessSuite = suite("correctness")(
+    test("empty stream yields empty chunk") {
+      val result = Stream.empty.buffer(8).runCollect
+      assertTrue(result == Right(Chunk.empty))
+    },
+    test("single element") {
+      val result = Stream.succeed(42).buffer(4).runCollect
+      assertTrue(result == Right(Chunk(42)))
+    },
+    test("multiple elements preserve order") {
+      val result = Stream.range(1, 6).buffer(8).runCollect
+      assertTrue(result == Right(Chunk(1, 2, 3, 4, 5)))
+    },
+    test("ordering preserved for larger range") {
+      val result = Stream.range(0, 50).buffer(64).runCollect
+      assertTrue(result == Right(Chunk.fromIterable(0 until 50)))
+    },
+    test("buffer larger than stream") {
+      val result = Stream(1, 2, 3).buffer(1024).runCollect
+      assertTrue(result == Right(Chunk(1, 2, 3)))
+    },
+    test("buffer equal to stream size") {
+      val result = Stream.range(0, 8).buffer(16).runCollect
+      assertTrue(result == Right(Chunk.fromIterable(0 until 8)))
+    },
+    test("string elements preserve order") {
+      val result = Stream("a", "b", "c", "d").buffer(8).runCollect
+      assertTrue(result == Right(Chunk("a", "b", "c", "d")))
+    }
+  )
+
+  // =========================================================================
+  //  Error handling
+  // =========================================================================
+
+  private val errorHandlingSuite = suite("error handling")(
+    test("error-only stream propagates error") {
+      val result = Stream.fail("boom").buffer(16).runCollect
+      assertTrue(result == Left("boom"))
+    },
+    test("error after elements propagates error") {
+      val result = Stream(1, 2, 3).concat(Stream.fail[String]("mid")).buffer(16).runCollect
+      assertTrue(result == Left("mid"))
+    },
+    test("invalid buffer size 0 throws IllegalArgumentException") {
+      assertTrue {
+        try { Pipeline.buffer[Int](0); false }
+        catch { case _: IllegalArgumentException => true }
+      }
+    },
+    test("invalid buffer size -1 throws IllegalArgumentException") {
+      assertTrue {
+        try { Pipeline.buffer[Int](-1); false }
+        catch { case _: IllegalArgumentException => true }
+      }
+    },
+    test("Stream#buffer(0) throws IllegalArgumentException") {
+      assertTrue {
+        try { Stream.succeed(1).buffer(0); false }
+        catch { case _: IllegalArgumentException => true }
+      }
+    }
+  )
+
+  // =========================================================================
+  //  Pipeline composition
+  // =========================================================================
+
+  private val pipelineCompositionSuite = suite("pipeline composition")(
+    test("via Pipeline.buffer(n)") {
+      val result = Stream.range(0, 5).via(Pipeline.buffer(8)).runCollect
+      assertTrue(result == Right(Chunk.fromIterable(0 until 5)))
+    },
+    test("andThen composition: buffer then map") {
+      val result =
+        Stream.range(0, 5).via(Pipeline.buffer[Int](8).andThen(Pipeline.map[Int, Int](_ * 2))).runCollect
+      assertTrue(result == Right(Chunk(0, 2, 4, 6, 8)))
+    },
+    test("andThen composition: map then buffer") {
+      val result =
+        Stream.range(0, 5).via(Pipeline.map[Int, Int](_ + 10).andThen(Pipeline.buffer[Int](8))).runCollect
+      assertTrue(result == Right(Chunk(10, 11, 12, 13, 14)))
+    },
+    test("render contains .buffer(n)") {
+      assertTrue(Stream.succeed(1).buffer(8).render.contains(".buffer(8)"))
+    }
+  )
+
+  // =========================================================================
+  //  Resource safety
+  // =========================================================================
+
+  private val resourceSafetySuite = suite("resource safety")(
+    test("ensuring finalizer runs after buffer") {
+      val ref = new java.util.concurrent.atomic.AtomicBoolean(false)
+      val _   = Stream.succeed(1).ensuring(ref.set(true)).buffer(8).runCollect
+      assertTrue(ref.get())
+    },
+    test("ensuring finalizer runs on error after buffer") {
+      val ref = new java.util.concurrent.atomic.AtomicBoolean(false)
+      val _   = Stream.fail("err").ensuring(ref.set(true)).buffer(8).runCollect
+      assertTrue(ref.get())
+    }
+  )
+
+  // =========================================================================
+  //  Early termination
+  // =========================================================================
+
+  private val earlyTerminationSuite = suite("early termination")(
+    test("take(5) after buffer") {
+      val result = Stream.range(0, 1000).buffer(16).take(5).runCollect
+      assertTrue(result == Right(Chunk.fromIterable(0 until 5)))
+    },
+    test("head after buffer") {
+      val result = Stream.range(0, 1000).buffer(16).head
+      assertTrue(result == Right(Some(0)))
+    }
+  )
+
+  // =========================================================================
+  //  Platform detection
+  // =========================================================================
+
+  private val platformDetectionSuite = suite("platform detection")(
+    test("Platform.supportsConcurrency is consistent with TestPlatform") {
+      assertTrue(Platform.supportsConcurrency == TestPlatform.isJVM)
+    }
+  )
+}

--- a/streams/shared/src/test/scala/zio/blocks/streams/ConcurrentLawsSpec.scala
+++ b/streams/shared/src/test/scala/zio/blocks/streams/ConcurrentLawsSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.ZIO
+import zio.blocks.chunk.Chunk
+import zio.durationInt
+import zio.test._
+
+object ConcurrentLawsSpec extends StreamsBaseSpec {
+
+  override def aspects: zio.Chunk[TestAspectAtLeastR[TestEnvironment]] =
+    zio.Chunk(TestAspect.timeout(120.seconds), TestAspect.timed)
+
+  def spec: Spec[TestEnvironment, Any] = suite("Concurrent laws")(
+    test("mergeAll(1) ≡ flatMap(identity) as sets") {
+      check(Gen.listOfBounded(0, 5)(Gen.listOfBounded(0, 5)(Gen.int(0, 100)))) { lists =>
+        ZIO.attemptBlocking {
+          val chunks          = Chunk.fromIterable(lists.map(Chunk.fromIterable(_)))
+          val streamOfStreams = Stream.fromChunk(chunks.map(Stream.fromChunk(_)))
+
+          val merged = Stream
+            .mergeAll(1)(streamOfStreams)
+            .runCollect
+            .fold(_ => Chunk.empty[Int], identity)
+            .toSet
+
+          val flatMapped = Stream
+            .fromChunk(chunks.map(Stream.fromChunk(_)))
+            .flatMap(identity)
+            .runCollect
+            .fold(_ => Chunk.empty[Int], identity)
+            .toSet
+
+          assertTrue(merged == flatMapped)
+        }
+      }
+    },
+    test("mapPar(1)(f) ≡ map(f) as sets") {
+      check(Gen.listOf(Gen.int(0, 100))) { values =>
+        ZIO.attemptBlocking {
+          val chunk  = Chunk.fromIterable(values)
+          val stream = Stream.fromChunk(chunk)
+
+          val byMapPar = stream.mapPar(1)(_ * 2).runCollect.fold(_ => Chunk.empty[Int], identity).toSet
+          val byMap    = stream.map(_ * 2).runCollect.fold(_ => Chunk.empty[Int], identity).toSet
+
+          assertTrue(byMapPar == byMap)
+        }
+      }
+    },
+    test("flatMapPar(n)(f) ≡ mergeAll(n)(map(f)) as sets") {
+      check(Gen.listOf(Gen.int(0, 10))) { values =>
+        ZIO.attemptBlocking {
+          val chunk  = Chunk.fromIterable(values)
+          val stream = Stream.fromChunk(chunk)
+          val f      = (i: Int) => Stream(i, i * 10)
+
+          val byFlatMapPar = stream.flatMapPar(4)(f).runCollect.fold(_ => Chunk.empty[Int], identity).toSet
+          val byMergeAll   = Stream.mergeAll(4)(stream.map(f)).runCollect.fold(_ => Chunk.empty[Int], identity).toSet
+
+          assertTrue(byFlatMapPar == byMergeAll)
+        }
+      }
+    }
+  ) @@ TestAspect.sequential
+}

--- a/streams/shared/src/test/scala/zio/blocks/streams/GenericFoldSpec.scala
+++ b/streams/shared/src/test/scala/zio/blocks/streams/GenericFoldSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio._
+import zio.test._
+
+/**
+ * Tests the generic `Sink.foldLeft[A, Z]` dispatch paths, which specialize on
+ * both element JvmType and accumulator JvmType to call Function2 specialized
+ * apply methods. Each (Z, A) combination must produce correct results.
+ */
+object GenericFoldSpec extends StreamsBaseSpec {
+
+  private val n = 100
+
+  // Helpers that force the GENERIC runFold[Z] path (not the specialized overloads)
+  private def foldInts[Z](z: Z)(f: (Z, Int) => Z): Either[Nothing, Z]   = Stream.range(0, n).runFold[Z](z)(f)
+  private def foldLongs[Z](z: Z)(f: (Z, Long) => Z): Either[Nothing, Z] =
+    Stream.range(0, n).map(_.toLong).runFold[Z](z)(f)
+  private def foldDoubles[Z](z: Z)(f: (Z, Double) => Z): Either[Nothing, Z] =
+    Stream.range(0, n).map(_.toDouble).runFold[Z](z)(f)
+  private def foldFloats[Z](z: Z)(f: (Z, Float) => Z): Either[Nothing, Z] =
+    Stream.range(0, n).map(_.toFloat).runFold[Z](z)(f)
+
+  private val intSum    = n * (n - 1) / 2
+  private val longSum   = intSum.toLong
+  private val doubleSum = intSum.toDouble
+  private val floatSum  = intSum.toFloat
+
+  def spec: Spec[TestEnvironment, Any] = suite("GenericFoldSpec")(
+    suite("Int elements")(
+      test("Z=Int, A=Int")(assertTrue(foldInts[Int](0)((a, b) => a + b) == Right(intSum))),
+      test("Z=Long, A=Int")(assertTrue(foldInts[Long](0L)((a, b) => a + b) == Right(longSum))),
+      test("Z=Double, A=Int")(assertTrue(foldInts[Double](0.0)((a, b) => a + b) == Right(doubleSum))),
+      test("Z=Float, A=Int")(assertTrue(foldInts[Float](0.0f)((a, b) => a + b) == Right(floatSum))),
+      test("Z=String, A=Int")(assertTrue(foldInts[String]("")((a, b) => a + b.toString).map(_.length) == Right(n + 90)))
+    ),
+
+    suite("Long elements")(
+      test("Z=Int, A=Long")(assertTrue(foldLongs[Int](0)((a, b) => a + b.toInt) == Right(intSum))),
+      test("Z=Long, A=Long")(assertTrue(foldLongs[Long](0L)((a, b) => a + b) == Right(longSum))),
+      test("Z=Double, A=Long")(assertTrue(foldLongs[Double](0.0)((a, b) => a + b) == Right(doubleSum))),
+      test("Z=Float, A=Long")(assertTrue(foldLongs[Float](0.0f)((a, b) => a + b) == Right(floatSum))),
+      test("Z=String, A=Long") {
+        assertTrue(foldLongs[String]("")((a, b) => a + b.toString).map(_.length) == Right(n + 90))
+      }
+    ),
+
+    suite("Double elements")(
+      test("Z=Int, A=Double")(assertTrue(foldDoubles[Int](0)((a, b) => a + b.toInt) == Right(intSum))),
+      test("Z=Long, A=Double")(assertTrue(foldDoubles[Long](0L)((a, b) => a + b.toLong) == Right(longSum))),
+      test("Z=Double, A=Double")(assertTrue(foldDoubles[Double](0.0)((a, b) => a + b) == Right(doubleSum))),
+      test("Z=Float, A=Double")(assertTrue(foldDoubles[Float](0.0f)((a, b) => a + b.toFloat) == Right(floatSum))),
+      test("Z=String, A=Double") {
+        assertTrue(foldDoubles[String]("")((a, b) => a + b.toInt.toString).map(_.length) == Right(n + 90))
+      }
+    ),
+
+    suite("Float elements")(
+      test("Z=Int, A=Float")(assertTrue(foldFloats[Int](0)((a, b) => a + b.toInt) == Right(intSum))),
+      test("Z=Long, A=Float")(assertTrue(foldFloats[Long](0L)((a, b) => a + b.toLong) == Right(longSum))),
+      test("Z=Double, A=Float")(assertTrue(foldFloats[Double](0.0)((a, b) => a + b) == Right(doubleSum))),
+      test("Z=Float, A=Float")(assertTrue(foldFloats[Float](0.0f)((a, b) => a + b) == Right(floatSum))),
+      test("Z=String, A=Float") {
+        assertTrue(foldFloats[String]("")((a, b) => a + b.toInt.toString).map(_.length) == Right(n + 90))
+      }
+    ),
+
+    suite("AnyRef elements")(
+      test("Z=Long, A=String") {
+        val result = Stream.fromIterable((0 until n).map(_.toString)).runFold[Long](0L)((a, b) => a + b.toLong)
+        assertTrue(result == Right(longSum))
+      },
+      test("Z=String, A=String") {
+        val result = Stream.fromIterable(Seq("a", "b", "c")).runFold[String]("")(_ + _)
+        assertTrue(result == Right("abc"))
+      }
+    )
+  )
+}

--- a/streams/shared/src/test/scala/zio/blocks/streams/IntSpecializationSpec.scala
+++ b/streams/shared/src/test/scala/zio/blocks/streams/IntSpecializationSpec.scala
@@ -428,8 +428,8 @@ object IntSpecializationSpec extends StreamsBaseSpec {
       { dq.reset(); assertTrue(dq.read[Any](null) == Int.box(42)) }
     },
     test("InputStreamReader reset throws") {
-      val is = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
-      val dq = Reader.fromInputStream(is)
+      val is               = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
+      val dq: Reader[Byte] = Reader.fromInputStream(is)
       assertTrue(
         try { dq.reset(); false }
         catch { case _: UnsupportedOperationException => true }

--- a/streams/shared/src/test/scala/zio/blocks/streams/MapParJvmTypeSpec.scala
+++ b/streams/shared/src/test/scala/zio/blocks/streams/MapParJvmTypeSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio._
+import zio.test._
+
+object MapParJvmTypeSpec extends StreamsBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("MapParJvmTypeSpec")(
+    test("mapPar Int=>Int reader propagates JvmType.Int (#5 regression)") {
+      val reader = Stream.range(0, 10).mapPar(2)(identity).compile(0, Stream.DefaultBufferSize)
+      try assertTrue(reader.jvmType eq JvmType.Int)
+      finally reader.close()
+    },
+
+    test("mapPar Int=>Long reader propagates JvmType.Long") {
+      val reader = Stream.range(0, 10).mapPar(2)(_.toLong).compile(0, Stream.DefaultBufferSize)
+      try assertTrue(reader.jvmType eq JvmType.Long)
+      finally reader.close()
+    },
+
+    test("mapPar Int=>String reader propagates JvmType.AnyRef") {
+      val reader = Stream.range(0, 10).mapPar(2)(_.toString).compile(0, Stream.DefaultBufferSize)
+      try assertTrue(reader.jvmType eq JvmType.AnyRef)
+      finally reader.close()
+    }
+  )
+}

--- a/streams/shared/src/test/scala/zio/blocks/streams/MapParSpec.scala
+++ b/streams/shared/src/test/scala/zio/blocks/streams/MapParSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import scala.util.Try
+import zio.blocks.chunk.Chunk
+import zio.test._
+
+object MapParSpec extends StreamsBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("MapPar")(
+    test("basic correctness") {
+      val result      = Stream.range(0, 100).mapPar(4)(_ * 2).runCollect
+      val expectedSum = 2 * (0 until 100).sum
+
+      assertTrue(result.exists(_.toList.sum == expectedSum))
+    },
+    test("mapPar(1) has same elements as map") {
+      val par = Stream.range(0, 100).mapPar(1)(_ * 2).runCollect
+      val seq = Stream.range(0, 100).map(_ * 2).runCollect
+
+      assertTrue(
+        par match {
+          case Right(p) =>
+            seq match {
+              case Right(s) => p.toSet == s.toSet
+              case Left(_)  => false
+            }
+          case Left(_) => false
+        }
+      )
+    },
+    test("empty stream") {
+      val empty: Stream[Nothing, Int] = Stream.empty
+      val result                      = empty.mapPar(4)(identity).runCollect
+      assertTrue(result == Right(Chunk.empty))
+    },
+    test("error in f propagates") {
+      val result = Try {
+        Stream
+          .range(0, 100)
+          .mapPar(4)(i => if (i == 50) throw new RuntimeException("boom") else i)
+          .runCollect
+      }
+
+      assertTrue(result.isFailure)
+    },
+    test("early termination with take(5) completes") {
+      val result = Stream.range(0, 100000).mapPar(4)(_ * 2).take(5).runCollect
+      assertTrue(result.exists(_.length == 5))
+    },
+    test("null element preservation") {
+      val result = Stream("a", null.asInstanceOf[String], "b").mapPar(4)(identity).runCollect
+      assertTrue(result.exists(_.toList.contains(null)))
+    }
+  ) @@ TestAspect.sequential
+}

--- a/streams/shared/src/test/scala/zio/blocks/streams/MergeAllSpec.scala
+++ b/streams/shared/src/test/scala/zio/blocks/streams/MergeAllSpec.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.blocks.chunk.Chunk
+import zio.test._
+
+object MergeAllSpec extends StreamsBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("MergeAll and flatMapPar")(
+    test("basic mergeAll: all elements from all inner streams are present") {
+      val streams = Stream(
+        Stream.range(0, 100),
+        Stream.range(100, 200),
+        Stream.range(200, 300)
+      )
+
+      val result = Stream.mergeAll(3)(streams).runCollect
+
+      assertTrue(
+        result match {
+          case Right(values) =>
+            val set = values.toSet
+            set.size == 300 && (0 until 300).forall(set.contains)
+          case Left(_) => false
+        }
+      )
+    },
+    test("empty outer stream") {
+      val emptyOuter: Stream[Nothing, Stream[Nothing, Int]] = Stream.empty
+      val result                                            = Stream.mergeAll(4)(emptyOuter).runCollect
+      assertTrue(result == Right(Chunk.empty))
+    },
+    test("single inner stream") {
+      val result = Stream.mergeAll(1)(Stream(Stream(1, 2, 3))).runCollect
+      assertTrue(result == Right(Chunk(1, 2, 3)))
+    },
+    test("maxOpen larger than number of inner streams") {
+      val streams = Stream(
+        Stream.range(0, 10),
+        Stream.range(10, 20),
+        Stream.range(20, 30)
+      )
+
+      val result = Stream.mergeAll(100)(streams).runCollect
+
+      assertTrue(
+        result match {
+          case Right(values) =>
+            val set = values.toSet
+            set.size == 30 && (0 until 30).forall(set.contains)
+          case Left(_) => false
+        }
+      )
+    },
+    test("error propagation from inner stream") {
+      val streams: Stream[Nothing, Stream[String, Int]] = Stream(
+        Stream(1, 2),
+        Stream.fail("boom"),
+        Stream(3, 4)
+      )
+
+      val result = Stream.mergeAll(3)(streams).runCollect
+      assertTrue(result == Left("boom"))
+    },
+    test("early termination with take(5) completes") {
+      val streams = Stream(
+        Stream.range(0, 100000),
+        Stream.range(100000, 200000),
+        Stream.range(200000, 300000)
+      )
+
+      val result = Stream.mergeAll(3)(streams).take(5).runCollect
+      assertTrue(result.exists(_.length == 5))
+    },
+    test("flatMapPar basic") {
+      val result   = Stream.range(0, 10).flatMapPar(4)(i => Stream(i, i * 10)).runCollect
+      val expected = Chunk.fromIterable(
+        (0 until 10).flatMap(i => List(i, i * 10))
+      )
+
+      assertTrue(result.exists(values => values.length == 20 && values.toList.sorted == expected.toList.sorted))
+    },
+    test("flatMapPar equals mergeAll(n)(map(f))") {
+      val source = Stream.range(0, 50)
+      val f      = (i: Int) => Stream(i, i + 1000)
+
+      val par       = source.flatMapPar(8)(f).runCollect
+      val desugared = Stream.mergeAll(8)(source.map(f)).runCollect
+
+      assertTrue(
+        par match {
+          case Right(p) =>
+            desugared match {
+              case Right(m) => p.toList.sorted == m.toList.sorted
+              case Left(_)  => false
+            }
+          case Left(_) => false
+        }
+      )
+    }
+  ) @@ TestAspect.sequential
+}

--- a/streams/shared/src/test/scala/zio/blocks/streams/NewCombinatorsSpec.scala
+++ b/streams/shared/src/test/scala/zio/blocks/streams/NewCombinatorsSpec.scala
@@ -75,12 +75,12 @@ object NewCombinatorsSpec extends StreamsBaseSpec {
       }
     ),
 
-    // ---- grouped ------------------------------------------------------------
+    // ---- chunked ------------------------------------------------------------
 
-    suite("grouped")(
+    suite("chunked")(
       test("exact multiple") {
         val s      = Stream.fromIterable(List(1, 2, 3, 4, 5, 6))
-        val result = collect(s.grouped(3))
+        val result = collect(s.chunked(3))
         assert(result)(
           equalTo(
             Chunk.fromIterable(
@@ -94,7 +94,7 @@ object NewCombinatorsSpec extends StreamsBaseSpec {
       },
       test("partial last group") {
         val s      = Stream.fromIterable(List(1, 2, 3, 4, 5))
-        val result = collect(s.grouped(3))
+        val result = collect(s.chunked(3))
         assert(result)(
           equalTo(
             Chunk.fromIterable(
@@ -108,11 +108,11 @@ object NewCombinatorsSpec extends StreamsBaseSpec {
       },
       test("empty stream") {
         val s: Stream[Nothing, Int] = Stream.empty
-        assert(collect(s.grouped(3)))(equalTo(Chunk.empty))
+        assert(collect(s.chunked(3)))(equalTo(Chunk.empty))
       },
       test("n = 1") {
         val s      = Stream.fromIterable(List(1, 2, 3))
-        val result = collect(s.grouped(1))
+        val result = collect(s.chunked(1))
         assert(result)(
           equalTo(
             Chunk.fromIterable(
@@ -127,7 +127,7 @@ object NewCombinatorsSpec extends StreamsBaseSpec {
       },
       test("single element") {
         val s      = Stream.fromIterable(List(42))
-        val result = collect(s.grouped(5))
+        val result = collect(s.chunked(5))
         assert(result)(
           equalTo(
             Chunk.fromIterable(
@@ -140,7 +140,7 @@ object NewCombinatorsSpec extends StreamsBaseSpec {
       },
       test("group size larger than stream") {
         val s      = Stream.fromIterable(List(1, 2))
-        val result = collect(s.grouped(10))
+        val result = collect(s.chunked(10))
         assert(result)(
           equalTo(
             Chunk.fromIterable(
@@ -240,7 +240,7 @@ object NewCombinatorsSpec extends StreamsBaseSpec {
           )
         )
       },
-      test("step = n (same as grouped)") {
+      test("step = n (same as chunked)") {
         val s      = Stream.fromIterable(List(1, 2, 3, 4, 5, 6))
         val result = collect(s.sliding(3, 3))
         assert(result)(
@@ -324,9 +324,9 @@ object NewCombinatorsSpec extends StreamsBaseSpec {
     // ---- validation ---------------------------------------------------------
 
     suite("validation")(
-      test("grouped(0) throws") {
+      test("chunked(0) throws") {
         assert(try {
-          Stream.fromIterable(List(1)).grouped(0); "ok"
+          Stream.fromIterable(List(1)).chunked(0); "ok"
         } catch { case _: IllegalArgumentException => "threw" })(equalTo("threw"))
       },
       test("sliding(0, 1) throws") {
@@ -344,9 +344,9 @@ object NewCombinatorsSpec extends StreamsBaseSpec {
     // ---- render labels ------------------------------------------------------
 
     suite("render labels")(
-      test("grouped render includes combinator name") {
-        val s = Stream.range(0, 10).grouped(3)
-        assert(s.render.contains("grouped"))(isTrue)
+      test("chunked render includes combinator name") {
+        val s = Stream.range(0, 10).chunked(3)
+        assert(s.render.contains("chunked"))(isTrue)
       },
       test("sliding render includes combinator name") {
         val s = Stream.range(0, 10).sliding(3)
@@ -390,11 +390,11 @@ object NewCombinatorsSpec extends StreamsBaseSpec {
       }
     ),
 
-    // ---- specialization tests for grouped/sliding on primitive streams ------
+    // ---- specialization tests for chunked/sliding on primitive streams ------
 
-    suite("grouped specialization")(
-      test("grouped specialization with Int stream") {
-        val s      = Stream.range(0, 6).grouped(3)
+    suite("chunked specialization")(
+      test("chunked specialization with Int stream") {
+        val s      = Stream.range(0, 6).chunked(3)
         val result = s.runCollect
         assert(result)(
           isRight(
@@ -444,9 +444,9 @@ object NewCombinatorsSpec extends StreamsBaseSpec {
         val s = Stream.fromIterable(List(1, 2))
         assert(collect(s.take(100)))(equalTo(Chunk.fromIterable(List(1, 2))))
       },
-      test("grouped(1) wraps each element like List.grouped(1)") {
+      test("chunked(1) wraps each element like List.grouped(1)") {
         val s = Stream.fromIterable(List(1, 2, 3))
-        assert(collect(s.grouped(1)))(
+        assert(collect(s.chunked(1)))(
           equalTo(
             Chunk.fromIterable(
               List(
@@ -488,7 +488,8 @@ object NewCombinatorsSpec extends StreamsBaseSpec {
           override def read(): Int   = -1
           override def close(): Unit = closed = true
         }
-        Stream.fromInputStream(is).runDrain
+        val stream: Stream[java.io.IOException, Byte] = Stream.fromInputStream(is)
+        stream.runDrain
         assert(closed)(isTrue)
       },
       test("fromInputStreamUnmanaged does not close the stream") {
@@ -497,7 +498,8 @@ object NewCombinatorsSpec extends StreamsBaseSpec {
           override def read(): Int   = -1
           override def close(): Unit = closed = true
         }
-        Stream.fromInputStreamUnmanaged(is).runDrain
+        val stream: Stream[java.io.IOException, Byte] = Stream.fromInputStreamUnmanaged(is)
+        stream.runDrain
         assert(closed)(isFalse)
       }
     ),

--- a/streams/shared/src/test/scala/zio/blocks/streams/ReadNSpec.scala
+++ b/streams/shared/src/test/scala/zio/blocks/streams/ReadNSpec.scala
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.streams
+
+import zio.blocks.chunk.Chunk
+import zio.test._
+
+object ReadNSpec extends StreamsBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("Reader#readN")(
+    suite("Byte branch (InputStreamReader)")(
+      test("reads bytes from InputStream") {
+        val is     = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3, 4, 5))
+        val reader = Stream.compileToReader(Stream.fromInputStreamUnmanaged(is))
+        assertTrue(reader.readN[Byte](3) == Chunk[Byte](1, 2, 3))
+      },
+      test("successive readN calls advance InputStream position") {
+        val is     = new java.io.ByteArrayInputStream(Array[Byte](10, 20, 30, 40, 50))
+        val reader = Stream.compileToReader(Stream.fromInputStreamUnmanaged(is))
+        val c1     = reader.readN[Byte](2)
+        val c2     = reader.readN[Byte](2)
+        val c3     = reader.readN[Byte](5)
+        assertTrue(c1 == Chunk[Byte](10, 20)) &&
+        assertTrue(c2 == Chunk[Byte](30, 40)) &&
+        assertTrue(c3 == Chunk[Byte](50))
+      },
+      test("readN on exhausted InputStream returns empty chunk") {
+        val is     = new java.io.ByteArrayInputStream(Array[Byte](1, 2))
+        val reader = Stream.compileToReader(Stream.fromInputStreamUnmanaged(is))
+        reader.readN[Byte](2)
+        assertTrue(reader.readN[Byte](1) == Chunk.empty)
+      },
+      test("readN(0) on InputStream returns empty chunk") {
+        val is     = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
+        val reader = Stream.compileToReader(Stream.fromInputStreamUnmanaged(is))
+        assertTrue(reader.readN[Byte](0) == Chunk.empty)
+      }
+    ),
+    suite("FromRange override")(
+      test("readN on range reader returns correct slice") {
+        val reader = Stream.compileToReader(Stream.range(0, 10))
+        assertTrue(reader.readN[Int](5) == Chunk(0, 1, 2, 3, 4))
+      },
+      test("successive FromRange readN calls advance position") {
+        val reader = Stream.compileToReader(Stream.range(0, 7))
+        val c1     = reader.readN[Int](3)
+        val c2     = reader.readN[Int](3)
+        val c3     = reader.readN[Int](5)
+        assertTrue(c1 == Chunk(0, 1, 2)) &&
+        assertTrue(c2 == Chunk(3, 4, 5)) &&
+        assertTrue(c3 == Chunk(6))
+      },
+      test("FromRange readN with step > 1") {
+        val reader = Stream.compileToReader(Stream.fromRange(Range(0, 20, 3)))
+        assertTrue(reader.readN[Int](4) == Chunk(0, 3, 6, 9))
+      },
+      test("FromRange readN partial (n > remaining)") {
+        val reader = Stream.compileToReader(Stream.range(0, 3))
+        assertTrue(reader.readN[Int](100) == Chunk(0, 1, 2))
+      }
+    ),
+    suite("Int branch (FromRange)")(
+      test("reads at most n elements from range") {
+        val reader = Stream.compileToReader(Stream.range(0, 10))
+        assertTrue(reader.readN[Int](5) == Chunk(0, 1, 2, 3, 4))
+      },
+      test("successive readN calls advance position") {
+        val reader = Stream.compileToReader(Stream.range(0, 7))
+        val c1     = reader.readN[Int](3)
+        val c2     = reader.readN[Int](3)
+        val c3     = reader.readN[Int](3)
+        assertTrue(c1 == Chunk(0, 1, 2)) &&
+        assertTrue(c2 == Chunk(3, 4, 5)) &&
+        assertTrue(c3 == Chunk(6))
+      },
+      test("readN(1) returns a single-element chunk") {
+        val reader = Stream.compileToReader(Stream.range(0, 3))
+        assertTrue(reader.readN[Int](1) == Chunk(0))
+      },
+      test("readN(100) on 5 elements returns all remaining elements") {
+        val reader = Stream.compileToReader(Stream.range(0, 5))
+        assertTrue(reader.readN[Int](100) == Chunk(0, 1, 2, 3, 4))
+      },
+      test("readN after exhausting reader returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.range(0, 2))
+        val _      = reader.readN[Int](2)
+        assertTrue(reader.readN[Int](2) == Chunk.empty)
+      }
+    ),
+    suite("Long branch (FromChunkLong)")(
+      test("reads long values from specialized chunk reader") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1L, 2L, 3L, 4L, 5L)))
+        assertTrue(reader.readN[Long](3) == Chunk(1L, 2L, 3L))
+      },
+      test("large n performs partial read and returns all remaining longs") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1L, 2L, 3L, 4L, 5L)))
+        assertTrue(reader.readN[Long](100) == Chunk(1L, 2L, 3L, 4L, 5L))
+      }
+    ),
+    suite("Float branch (FromChunkFloat)")(
+      test("reads float values from specialized chunk reader") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.0f, 2.0f, 3.0f)))
+        assertTrue(reader.readN[Float](2) == Chunk(1.0f, 2.0f))
+      },
+      test("readN(0) returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.0f, 2.0f, 3.0f)))
+        assertTrue(reader.readN[Float](0) == Chunk.empty)
+      }
+    ),
+    suite("Double branch (FromChunkDouble)")(
+      test("reads double values from specialized chunk reader") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.0, 2.0, 3.0)))
+        assertTrue(reader.readN[Double](2) == Chunk(1.0, 2.0))
+      },
+      test("remaining doubles can be read after initial readN") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.0, 2.0, 3.0)))
+        val _      = reader.readN[Double](2)
+        assertTrue(reader.readN[Double](2) == Chunk(3.0))
+      }
+    ),
+    suite("AnyRef branch (FromIterable)")(
+      test("reads reference values from iterable reader") {
+        val reader = Stream.compileToReader(Stream.fromIterable(List("a", "b", "c")))
+        assertTrue(reader.readN[String](2) == Chunk("a", "b"))
+      },
+      test("readN on an already-closed reader returns empty chunk") {
+        val reader = Stream.compileToReader(Stream.fromIterable(List("a", "b", "c")))
+        reader.close()
+        assertTrue(reader.readN[String](1) == Chunk.empty)
+      }
+    ),
+    suite("FromChunk* overrides")(
+      test("FromChunkInt successive readN: full then partial") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1, 2, 3, 4, 5)))
+        val c1     = reader.readN[Int](3)
+        val c2     = reader.readN[Int](3)
+        assertTrue(c1 == Chunk(1, 2, 3)) &&
+        assertTrue(c2 == Chunk(4, 5))
+      },
+      test("FromChunkLong readN returns correct typed Chunk[Long]") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(10L, 20L, 30L, 40L)))
+        val result = reader.readN[Long](2)
+        assertTrue(result == Chunk(10L, 20L))
+      },
+      test("FromChunkFloat readN returns correct typed Chunk[Float]") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.1f, 2.2f, 3.3f, 4.4f)))
+        val result = reader.readN[Float](2)
+        assertTrue(result == Chunk(1.1f, 2.2f))
+      },
+      test("FromChunkDouble readN returns correct typed Chunk[Double]") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1.5, 2.5, 3.5, 4.5)))
+        val result = reader.readN[Double](2)
+        assertTrue(result == Chunk(1.5, 2.5))
+      },
+      test("FromChunk[String] readN returns correct elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk("a", "b", "c")))
+        val result = reader.readN[String](2)
+        assertTrue(result == Chunk("a", "b"))
+      },
+      test("readN respects setLimit") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk.fromIterable(0 until 10)))
+        reader.setLimit(3)
+        val result = reader.readN[Int](10)
+        assertTrue(result == Chunk(0, 1, 2))
+      },
+      test("readN after exhaustion returns empty chunk and isClosed is true") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1, 2, 3)))
+        val _      = reader.readN[Int](3)
+        val empty  = reader.readN[Int](5)
+        assertTrue(empty == Chunk.empty) &&
+        assertTrue(reader.isClosed)
+      },
+      test("readN on zero-length chunk returns empty") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk.empty: Chunk[Int]))
+        val result = reader.readN[Int](5)
+        assertTrue(result == Chunk.empty)
+      },
+      test("setSkip then readN skips initial elements") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk(10, 20, 30, 40, 50)))
+        reader.setSkip(2)
+        val result = reader.readN[Int](2)
+        assertTrue(result == Chunk(30, 40))
+      },
+      test("setLimit then setSkip interaction") {
+        val reader = Stream.compileToReader(Stream.fromChunk(Chunk.fromIterable(0 until 10)))
+        reader.setLimit(5)
+        reader.setSkip(3)
+        val result = reader.readN[Int](10)
+        assertTrue(result == Chunk(3, 4, 5, 6, 7))
+      }
+    )
+  )
+}

--- a/streams/shared/src/test/scala/zio/blocks/streams/ReaderFromJavaSpec.scala
+++ b/streams/shared/src/test/scala/zio/blocks/streams/ReaderFromJavaSpec.scala
@@ -69,11 +69,11 @@ object ReaderFromJavaSpec extends StreamsBaseSpec {
 
   def spec: Spec[TestEnvironment, Any] = suite("Reader.fromInputStream / fromReader")(
     suite("fromInputStream")(
-      test("read() returns widened Int (0-255) then null on EOF") {
+      test("read() returns each Byte (signed) then null on EOF") {
         val dq = Reader.fromInputStream(streamOf(1, 2, 3))
-        assertTrue(dq.read[Any](null) == Int.box(1)) &&
-        assertTrue(dq.read[Any](null) == Int.box(2)) &&
-        assertTrue(dq.read[Any](null) == Int.box(3)) &&
+        assertTrue(dq.read[Any](null) == Byte.box(1.toByte)) &&
+        assertTrue(dq.read[Any](null) == Byte.box(2.toByte)) &&
+        assertTrue(dq.read[Any](null) == Byte.box(3.toByte)) &&
         assertTrue(dq.read[Any](null) == null)
       },
       test("read() returns null on empty stream") {
@@ -83,7 +83,7 @@ object ReaderFromJavaSpec extends StreamsBaseSpec {
       test("IOException during read throws StreamError and marks reader as closed") {
         val is = new FailableInputStream(Array[Byte](1))
         val dq = Reader.fromInputStream(is)
-        assertTrue(dq.read[Any](null) == Int.box(1))
+        assertTrue(dq.read[Any](null) == Byte.box(1.toByte))
         is.boom = true
         val result = scala.util.Try(dq.read[Any](null))
         assertTrue(result.isFailure) &&
@@ -127,10 +127,10 @@ object ReaderFromJavaSpec extends StreamsBaseSpec {
       },
       test("drains bytes in order via read()") {
         val dq = Reader.fromInputStream(streamOf(5, 6, 7))
-        val b  = Chunk.newBuilder[Int]
+        val b  = Chunk.newBuilder[Byte]
         var v  = dq.read[Any](null)
-        while (v != null) { b += v.asInstanceOf[Int]; v = dq.read[Any](null) }
-        assert(b.result())(equalTo(Chunk(5, 6, 7)))
+        while (v != null) { b += v.asInstanceOf[Byte]; v = dq.read[Any](null) }
+        assert(b.result())(equalTo(Chunk(5.toByte, 6.toByte, 7.toByte)))
       },
       test("close is idempotent") {
         val dq = Reader.fromInputStream(streamOf(1, 2))
@@ -153,6 +153,29 @@ object ReaderFromJavaSpec extends StreamsBaseSpec {
         val dq = Reader.fromInputStream(streamOf(10))
         dq.close()
         assert(dq.readByte())(equalTo(-1))
+      },
+      test("readBytes partial fill: stream has 2 bytes, request 5 returns 2") {
+        val dq  = Reader.fromInputStream(streamOf(42, 99))
+        val buf = new Array[Byte](5)
+        val n   = dq.readBytes(buf, 0, 5)
+        assertTrue(n == 2) && assert(buf.take(n).toList)(equalTo(List[Byte](42, 99)))
+      },
+      test("readBytes with offset: writes to correct position in buffer") {
+        val dq  = Reader.fromInputStream(streamOf(10, 20))
+        val buf = new Array[Byte](4)
+        val n   = dq.readBytes(buf, 2, 2)
+        assertTrue(n == 2) &&
+        assertTrue(buf(0) == 0) &&
+        assertTrue(buf(1) == 0) &&
+        assertTrue(buf(2) == 10) &&
+        assertTrue(buf(3) == 20)
+      },
+      test("readBytes invalid bounds: offset + len > buf.length throws IndexOutOfBoundsException") {
+        val dq     = Reader.fromInputStream(streamOf(1, 2, 3, 4, 5))
+        val buf    = new Array[Byte](4)
+        val result = scala.util.Try(dq.readBytes(buf, 0, 10))
+        assertTrue(result.isFailure) &&
+        assertTrue(result.failed.get.isInstanceOf[IndexOutOfBoundsException])
       }
     ),
 


### PR DESCRIPTION
## Motivation

ZIO Blocks streams previously had no concurrent operators. Long-running streams that wanted to fan out per-element work (`mapPar`), drain multiple sub-streams concurrently (`mergeAll`, `flatMapPar`), or hand off batches between producer and consumer threads, had to fall back to either external concurrency frameworks or homegrown thread pools — losing the typed-error, synchronous, pull-based `Reader[A]` programming model that the rest of the library is built around.

This PR adds three concurrent stream operators, the ring-buffer machinery that backs them, and keeps the existing programming model: the consumer thread still receives `Either[E, Z]` — no effect system required, no `IO`/`Task` boilerplate.

## What changed

### New `Stream` operators (JVM-only; degrade to sequential on Scala.js)

| Operator | Semantics |
|---|---|
| `Stream#mapPar(n)(f)` | Apply `f` to each element on up to `n` worker threads. Output is **unordered** (arrival order). |
| `Stream.mergeAll(n)(streams)` | Drain up to `n` inner streams concurrently; interleave their elements as they arrive. |
| `Stream#flatMapPar(n)(f)` | Per element, produce a sub-stream via `f`; drain up to `n` sub-streams concurrently. |

All three use virtual threads on JDK 21+ (reflective probe at class init; falls back to plain `Thread` on JDK <21). Errors from any worker terminate all concurrent work and surface as `Left(e)` from the terminal operation. Resource safety is deterministic — closing the consumer reader, an error, or a scope finalizer shuts down workers and drains queues.

Buffer sizing is exposed via `Stream.bufferSize(n) { ... }` (powers of two) and `Pipeline.buffer(n)`.

### Primitive specialization

Per-`JvmType` specialized readers are picked in `PlatformSpecific.createMapParReader` / `createMergeReader`:

- `Int/Long/Float/Double` flows go through primitive-typed readers that use the new primitive SPSC ring buffers for the cross-thread handoff (zero boxing on the producer side).
- Generic `AnyRef` flows fall back to `ConcurrentMapParReader[A, B]` / `ConcurrentMergeReader[A]`.

### Primitive SPSC ring buffers (`ringbuffer` project)

Four new classes in `ringbuffer/jvm/src/main/scala/zio/blocks/ringbuffer/`:

| Type | Class | Slot encoding |
|---|---|---|
| `Int`    | `IntSpscRingBuffer`    | one `Long` per slot: high 32 bits hold a 0/1 occupancy tag, low 32 bits hold the `Int` payload. The whole 64-bit word is `0L` when empty, so any tagged value is non-zero regardless of payload bits — all `Int` values are representable. |
| `Long`   | `LongSpscRingBuffer`   | one `Long` per slot. `Long.MinValue` is reserved as the empty marker; offering it throws `IllegalArgumentException`. |
| `Float`  | `FloatSpscRingBuffer`  | one `Long` per slot: high 32 bits tag, low 32 bits hold `floatToRawIntBits(value)`. All `Float` values representable. |
| `Double` | `DoubleSpscRingBuffer` | one `Long` per slot. `doubleToRawLongBits(value)` is stored directly; a reserved non-canonical NaN bit pattern marks empty. Any payload `NaN` is canonicalized to `Double.NaN` on offer so it can never collide with the empty marker. |

All four use the same FastFlow algorithm as the generic `SpscRingBuffer` (single backing `Array[Long]`, padded indices, look-ahead cache) and expose identical operations (`offer`, `take`, `peek`, `isEmpty`, `isFull`, `size`, `capacity`, `drain`, `fill`).

JMH benchmarks in `ringbuffer-benchmarks/PrimitiveSpscThroughputBenchmark` cover SPSC throughput for all four variants.

### Coordinator/worker queue primitives

For the multi-worker fan-out coordinator-to-worker channels, three blocking queue primitives in `streams/jvm/src/main/scala/zio/blocks/streams/queues/`:

- `BlockingSpscQueue[A]` / `BlockingMpscQueue[A]` / `BlockingMpmcQueue[A]` — array-backed, fixed-capacity, parked-thread blocking variants tuned for the specific concurrency shape each reader uses.

## Correctness fixes uncovered during stabilization

Two real races were found and fixed before this PR:

1. **Specialized mapPar lost-element race.** The Int/Long/Float/Double mapPar readers use a *separate* control queue from the input queue (the generic reader uses a single combined queue). A worker could observe `DoneSentinel` on the control queue before all prior input writes were visible and exit early, dropping the tail of the stream. Reproduced as a flake in `ConcurrentLawsSpec` (`mapPar(1)(f) ≡ map(f) as sets`).

   Fix: a `stopSeen` flag in `workerLoop`. Once `DoneSentinel` is observed, the loop defers exit until `inputQueues(idx)` is actually drained, ensuring writes that happened-before the stop signal are picked up.

2. **`isClosed` reported true before consumer observed EOS.** The previous predicate `workersRunning.get() == 0 && allOutputQueuesEmpty()` could flip to `true` between the last producer write and the consumer's matching `read`, racing the consumer's loop termination check (reproduced in `IsClosedRegressionSpec` `mapPar: readable() is consistent with isClosed during consumption`).

   Fix: track an `eofReturned` flag set on the read that actually returns the sentinel to the consumer; `isClosed` becomes `eofReturned || consumerClosed`. The reader only signals "closed" once EOS has actually been delivered, not when it has merely become inevitable.

## Tests

| Suite | Scala 3 | Scala 2.13.18 |
|---|---|---|
| `streamsJVM/test` | 1294 passed | 1286 passed |
| `streamsJS/test` | 1067 passed, 1 ignored | 1059 passed, 1 ignored |
| `ringbufferJVM/test` | 190 passed | 190 passed |

New JVM specs added in this PR (selected): `ConcurrentMapParReaderSpec`, `ConcurrentMergeReaderSpec`, `ConcurrentStressSpec`, `ConcurrentLawsSpec`, `BufferSizeSpec`, `BufferStressSpec`, `BufferSpec`, `IsClosedRegressionSpec`, `MergeInnerErrorSpec`, `MapParSpec`, `MapParJvmTypeSpec`, `MergeAllSpec`, `FloatDoubleMapParSpec` (lifts Float/Double mapPar coverage from 0% to ~87%), `ReadNSpec`/`ReadNJvmSpec`/`ReadUpToNSpec`, `GenericFoldSpec`, `PlatformSpec`, `ReadBytesScopeAuditSpec`, `ReadBytesSoundnessSpec`, `BlockingMpmcQueueSpec`, `BlockingMpscQueueSpec`, `BlockingSpscQueueSpec`, `PrimitiveSpscRingBufferSpec`.

Coverage (Scala 2.13.18 streamsJVM): 56.84% statement / 52.05% branch overall; specialized concurrent readers ~87–90% statement. Ringbuffer: 98.86% statement / 96.61% branch.

## Docs

- **`docs/reference/streams/concurrent-operators.md`** — new reference page covering semantics, error behaviour, buffer sizing, examples for `mapPar`/`mergeAll`/`flatMapPar`, and a feature comparison with fs2, Kyo, Ox, and Pekko.
- **`docs/reference/ringbuffer/spsc.mdx`** — new "Primitive variants" section documenting the four primitive `SpscRingBuffer` classes, their slot encodings, the `Long.MinValue` / NaN-canonicalization reservation rules, and the `peek` + `take` usage pattern.

## Verification

- Scala 3.3.7 / 2.13.18: `streamsJVM/test`, `streamsJS/test`, `ringbufferJVM/test` all green (see table above).
- `streams-benchmark`, `ringbufferBenchmarks`, `benchmarks` projects compile clean.
- `docs/mdoc` compiles clean (0 errors).
- `fmtDirty` applied; tree clean.
