### PR TITLE
fix(schema): move SchemaExpr &&/|| to companion implicit class to en…

### DIFF
--- a/docs/reference/schema/schema-expr.md
+++ b/docs/reference/schema/schema-expr.md
@@ -317,9 +317,13 @@ val result = nameExpr.evalDynamic(Person("Alice", 30))
 
 Combines two boolean-typed expressions with logical AND. Both operands must produce `Boolean` results.
 
+`&&` and `||` are provided via `SchemaExpr.BooleanOps`, an implicit class in the `SchemaExpr` companion, rather than as direct methods on `SchemaExpr`. This lets downstream libraries supply their own `&&`/`||` overloads (e.g. returning a DDB- or SQL-specific expression type) by bringing in their own implicit class via an explicit import, which takes priority over the companion-scope implicit in Scala 2 and 3.
+
 ```scala
-trait SchemaExprLike[A, B] {
-  def &&[B2](that: SchemaExpr[A, B2])(implicit ev: B <:< Boolean, ev2: B2 =:= Boolean): SchemaExpr[A, Boolean]
+// In SchemaExpr companion:
+implicit final class BooleanOps[A, B](val self: SchemaExpr[A, B]) extends AnyVal {
+  def and(that: SchemaExpr[A, Boolean])(implicit ev: B <:< Boolean): SchemaExpr[A, Boolean]
+  def &&(that: SchemaExpr[A, Boolean])(implicit ev: B <:< Boolean): SchemaExpr[A, Boolean]
 }
 ```
 
@@ -347,8 +351,10 @@ val result = isAdultAlice.eval(Person("Alice", 30))
 Combines two boolean-typed expressions with logical OR.
 
 ```scala
-trait SchemaExprLike[A, B] {
-  def ||[B2](that: SchemaExpr[A, B2])(implicit ev: B <:< Boolean, ev2: B2 =:= Boolean): SchemaExpr[A, Boolean]
+// In SchemaExpr companion:
+implicit final class BooleanOps[A, B](val self: SchemaExpr[A, B]) extends AnyVal {
+  def or(that: SchemaExpr[A, Boolean])(implicit ev: B <:< Boolean): SchemaExpr[A, Boolean]
+  def ||(that: SchemaExpr[A, Boolean])(implicit ev: B <:< Boolean): SchemaExpr[A, Boolean]
 }
 ```
 

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
@@ -152,20 +152,23 @@ object SchemaExpr {
   /**
    * Logical combinators for boolean SchemaExprs.
    *
-   * Provided as an implicit class rather than direct methods on SchemaExpr so that
-   * downstream libraries can supply their own implicit class with &&/|| overloads for
-   * a different result type (e.g. a DDB-specific or SQL-specific expression ADT).
+   * Provided as an implicit class rather than direct methods on SchemaExpr so
+   * that downstream libraries can supply their own implicit class with &&/||
+   * overloads for a different result type (e.g. a DDB-specific or SQL-specific
+   * expression ADT).
    *
-   * In Scala 2, a direct method found by name suppresses implicit receiver views even
-   * when the argument type does not match (SLS §7.3). Moving &&/|| here lifts that
-   * suppression: when a downstream library brings in its own ops class via an explicit
-   * import, that import-scope implicit takes priority over this companion-scope implicit
-   * (Scala 2 implicit priority: local/import > companion), so the downstream overload
-   * wins for `se && downstreamValue` without ambiguity in that context.
+   * In Scala 2, a direct method found by name suppresses implicit receiver
+   * views even when the argument type does not match (SLS §7.3). Moving &&/||
+   * here lifts that suppression: when a downstream library brings in its own
+   * ops class via an explicit import, that import-scope implicit takes priority
+   * over this companion-scope implicit (Scala 2 implicit priority: local/import
+   * > companion), so the downstream overload wins for `se && downstreamValue`
+   * without ambiguity in that context.
    *
-   * Note: two companion-scope implicits providing &&/|| would still be ambiguous for
-   * `se && se2`. Downstream libraries should introduce their ops via explicit import
-   * (or a user-facing object) rather than a companion to avoid that scenario.
+   * Note: two companion-scope implicits providing &&/|| would still be
+   * ambiguous for `se && se2`. Downstream libraries should introduce their ops
+   * via explicit import (or a user-facing object) rather than a companion to
+   * avoid that scenario.
    */
   implicit final class BooleanOps[A](private val self: SchemaExpr[A, Boolean]) extends AnyVal {
 

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
@@ -170,24 +170,28 @@ object SchemaExpr {
    * via explicit import (or a user-facing object) rather than a companion to
    * avoid that scenario.
    */
-  implicit final class BooleanOps[A, B <: Boolean](private val self: SchemaExpr[A, B]) extends AnyVal {
+  implicit final class BooleanOps[A, B](private val self: SchemaExpr[A, B]) extends AnyVal {
 
-    def and(that: SchemaExpr[A, Boolean]): SchemaExpr[A, Boolean] =
+    def and(that: SchemaExpr[A, Boolean])(implicit
+      @scala.annotation.unused ev: B <:< Boolean
+    ): SchemaExpr[A, Boolean] =
       SchemaExpr(
         DynamicSchemaExpr.Logical(self.dynamic, that.dynamic, DynamicSchemaExpr.LogicalOperator.And),
         self.inputSchema,
         Schema[Boolean]
       )
 
-    def or(that: SchemaExpr[A, Boolean]): SchemaExpr[A, Boolean] =
+    def or(that: SchemaExpr[A, Boolean])(implicit
+      @scala.annotation.unused ev: B <:< Boolean
+    ): SchemaExpr[A, Boolean] =
       SchemaExpr(
         DynamicSchemaExpr.Logical(self.dynamic, that.dynamic, DynamicSchemaExpr.LogicalOperator.Or),
         self.inputSchema,
         Schema[Boolean]
       )
 
-    def &&(that: SchemaExpr[A, Boolean]): SchemaExpr[A, Boolean] = and(that)
-    def ||(that: SchemaExpr[A, Boolean]): SchemaExpr[A, Boolean] = or(that)
+    def &&(that: SchemaExpr[A, Boolean])(implicit ev: B <:< Boolean): SchemaExpr[A, Boolean] = and(that)
+    def ||(that: SchemaExpr[A, Boolean])(implicit ev: B <:< Boolean): SchemaExpr[A, Boolean] = or(that)
   }
 
   private def outOfRange(value: Any, target: String): Either[Predef.String, DynamicValue] =

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
@@ -155,9 +155,17 @@ object SchemaExpr {
    * Provided as an implicit class rather than direct methods on SchemaExpr so that
    * downstream libraries can supply their own implicit class with &&/|| overloads for
    * a different result type (e.g. a DDB-specific or SQL-specific expression ADT).
+   *
    * In Scala 2, a direct method found by name suppresses implicit receiver views even
-   * when the argument type does not match; an implicit class in the companion avoids
-   * this and allows downstream bridges to fire without ambiguity.
+   * when the argument type does not match (SLS §7.3). Moving &&/|| here lifts that
+   * suppression: when a downstream library brings in its own ops class via an explicit
+   * import, that import-scope implicit takes priority over this companion-scope implicit
+   * (Scala 2 implicit priority: local/import > companion), so the downstream overload
+   * wins for `se && downstreamValue` without ambiguity in that context.
+   *
+   * Note: two companion-scope implicits providing &&/|| would still be ambiguous for
+   * `se && se2`. Downstream libraries should introduce their ops via explicit import
+   * (or a user-facing object) rather than a companion to avoid that scenario.
    */
   implicit final class BooleanOps[A](private val self: SchemaExpr[A, Boolean]) extends AnyVal {
 

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
@@ -170,7 +170,7 @@ object SchemaExpr {
    * via explicit import (or a user-facing object) rather than a companion to
    * avoid that scenario.
    */
-  implicit final class BooleanOps[A](private val self: SchemaExpr[A, Boolean]) extends AnyVal {
+  implicit final class BooleanOps[A, B <: Boolean](private val self: SchemaExpr[A, B]) extends AnyVal {
 
     def and(that: SchemaExpr[A, Boolean]): SchemaExpr[A, Boolean] =
       SchemaExpr(

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
@@ -145,28 +145,40 @@ final case class SchemaExpr[A, B](
    * Get the underlying dynamic expression.
    */
   def toDynamic: DynamicSchemaExpr = dynamic
-
-  // Logical combinators
-  def &&[B2](
-    that: SchemaExpr[A, B2]
-  )(implicit ev: B <:< Boolean, ev2: B2 =:= Boolean): SchemaExpr[A, Boolean] =
-    SchemaExpr(
-      DynamicSchemaExpr.Logical(this.dynamic, that.dynamic, DynamicSchemaExpr.LogicalOperator.And),
-      inputSchema,
-      Schema[Boolean]
-    )
-
-  def ||[B2](
-    that: SchemaExpr[A, B2]
-  )(implicit ev: B <:< Boolean, ev2: B2 =:= Boolean): SchemaExpr[A, Boolean] =
-    SchemaExpr(
-      DynamicSchemaExpr.Logical(this.dynamic, that.dynamic, DynamicSchemaExpr.LogicalOperator.Or),
-      inputSchema,
-      Schema[Boolean]
-    )
 }
 
 object SchemaExpr {
+
+  /**
+   * Logical combinators for boolean SchemaExprs.
+   *
+   * Provided as an implicit class rather than direct methods on SchemaExpr so that
+   * downstream libraries can supply their own implicit class with &&/|| overloads for
+   * a different result type (e.g. a DDB-specific or SQL-specific expression ADT).
+   * In Scala 2, a direct method found by name suppresses implicit receiver views even
+   * when the argument type does not match; an implicit class in the companion avoids
+   * this and allows downstream bridges to fire without ambiguity.
+   */
+  implicit final class BooleanOps[A](private val self: SchemaExpr[A, Boolean]) extends AnyVal {
+
+    def &&[B2](
+      that: SchemaExpr[A, B2]
+    )(implicit ev: B2 =:= Boolean): SchemaExpr[A, Boolean] =
+      SchemaExpr(
+        DynamicSchemaExpr.Logical(self.dynamic, that.dynamic, DynamicSchemaExpr.LogicalOperator.And),
+        self.inputSchema,
+        Schema[Boolean]
+      )
+
+    def ||[B2](
+      that: SchemaExpr[A, B2]
+    )(implicit ev: B2 =:= Boolean): SchemaExpr[A, Boolean] =
+      SchemaExpr(
+        DynamicSchemaExpr.Logical(self.dynamic, that.dynamic, DynamicSchemaExpr.LogicalOperator.Or),
+        self.inputSchema,
+        Schema[Boolean]
+      )
+  }
 
   private def outOfRange(value: Any, target: String): Either[Predef.String, DynamicValue] =
     Left(s"Value $value is out of range for $target")

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
@@ -169,18 +169,14 @@ object SchemaExpr {
    */
   implicit final class BooleanOps[A](private val self: SchemaExpr[A, Boolean]) extends AnyVal {
 
-    def &&[B2](
-      that: SchemaExpr[A, B2]
-    )(implicit ev: B2 =:= Boolean): SchemaExpr[A, Boolean] =
+    def &&(that: SchemaExpr[A, Boolean]): SchemaExpr[A, Boolean] =
       SchemaExpr(
         DynamicSchemaExpr.Logical(self.dynamic, that.dynamic, DynamicSchemaExpr.LogicalOperator.And),
         self.inputSchema,
         Schema[Boolean]
       )
 
-    def ||[B2](
-      that: SchemaExpr[A, B2]
-    )(implicit ev: B2 =:= Boolean): SchemaExpr[A, Boolean] =
+    def ||(that: SchemaExpr[A, Boolean]): SchemaExpr[A, Boolean] =
       SchemaExpr(
         DynamicSchemaExpr.Logical(self.dynamic, that.dynamic, DynamicSchemaExpr.LogicalOperator.Or),
         self.inputSchema,

--- a/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/SchemaExpr.scala
@@ -172,19 +172,22 @@ object SchemaExpr {
    */
   implicit final class BooleanOps[A](private val self: SchemaExpr[A, Boolean]) extends AnyVal {
 
-    def &&(that: SchemaExpr[A, Boolean]): SchemaExpr[A, Boolean] =
+    def and(that: SchemaExpr[A, Boolean]): SchemaExpr[A, Boolean] =
       SchemaExpr(
         DynamicSchemaExpr.Logical(self.dynamic, that.dynamic, DynamicSchemaExpr.LogicalOperator.And),
         self.inputSchema,
         Schema[Boolean]
       )
 
-    def ||(that: SchemaExpr[A, Boolean]): SchemaExpr[A, Boolean] =
+    def or(that: SchemaExpr[A, Boolean]): SchemaExpr[A, Boolean] =
       SchemaExpr(
         DynamicSchemaExpr.Logical(self.dynamic, that.dynamic, DynamicSchemaExpr.LogicalOperator.Or),
         self.inputSchema,
         Schema[Boolean]
       )
+
+    def &&(that: SchemaExpr[A, Boolean]): SchemaExpr[A, Boolean] = and(that)
+    def ||(that: SchemaExpr[A, Boolean]): SchemaExpr[A, Boolean] = or(that)
   }
 
   private def outOfRange(value: Any, target: String): Either[Predef.String, DynamicValue] =


### PR DESCRIPTION
…able downstream bridges

In Scala 2, a direct method found by name on a type suppresses implicit class receiver views even when the argument type does not match (spec §6.26 — the view fires only when the method is "not found"). With && and || as direct methods on SchemaExpr, downstream libraries cannot provide an implicit class bridge such as

```scala
implicit class Bridge[S](self: SchemaExpr[S, Boolean]) {
  def &&(other: DomainExpr[S]): DomainExpr[S] = ...
}
```

because Scala commits to SchemaExpr.&&(SchemaExpr) by name and reports a type mismatch on the argument rather than trying the bridge.

Moving &&/|| to BooleanOps, an implicit class in the SchemaExpr companion, removes the direct-method lock-in. The companion implicit always provides &&(SchemaExpr) for the existing use case; a downstream bridge providing &&(OtherType) is unambiguous because only one candidate applies per call site based on the argument type.

Source compatibility is fully maintained: se1 && se2 continues to work identically. Binary compatibility is intentionally broken (direct virtual method replaced by implicit class dispatch) as expected for this kind of extensibility improvement.

Scala 3 is unaffected by the receiver-view limitation but benefits from the same structural change; implicit class is retained over extension syntax for cross-version consistency.

Closes https://github.com/zio/zio-blocks/issues/1470