### PR TITLE
fix(config): docs withPrefix→prefix, adapter refs→ConfigSource.fromXxx, implicit def→val

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ import zio.blocks.scope.Unscoped
 
 val defaults = ConfigSource.fromMap(Map("app.host" -> "localhost"), "defaults")
 val env      = ConfigSource.fromMap(Map("app.port" -> "8080"), "env")
-val source   = env.orElse(defaults).withPrefix("app")
+val source   = env.orElse(defaults).prefix("app")
 
 final case class AppConfig(host: String, port: Int) derives Schema, Unscoped
 
@@ -128,9 +128,9 @@ val choice = Rollout.select("true@prod/50%;false", "prod", bucket)
 
 ### File Format Adapters
 
-- **YAML**: `zio.blocks.config.yaml.YamlConfigSource.fromString`
-- **JSON**: `zio.blocks.config.json.JsonConfigSource.fromString`
-- **HOCON**: `zio.blocks.config.hocon.HoconConfigSource.fromString`
+- **YAML**: `ConfigSource.fromYaml(...)` (requires `config-yaml` dependency and `import zio.blocks.config.yaml._`)
+- **JSON**: `ConfigSource.fromJson(...)` (requires `config-json` dependency and `import zio.blocks.config.json._`)
+- **HOCON**: `ConfigSource.fromHocon(...)` (requires `config-hocon` dependency and `import zio.blocks.config.hocon._`)
 
 ## Core Principles
 

--- a/config/shared/src/main/scala/zio/blocks/config/package.scala
+++ b/config/shared/src/main/scala/zio/blocks/config/package.scala
@@ -17,5 +17,5 @@
 package zio.blocks
 
 package object config {
-  implicit def secretDisplayable: Displayable[Secret] = Secret.displayable
+  implicit val secretDisplayable: Displayable[Secret] = Secret.displayable
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,9 +127,9 @@ val choice = Rollout.select("true@prod/50%;false", "prod", bucket)
 
 ### File Format Adapters
 
-- **YAML**: `ConfigSource.fromYaml(...)` (requires `config-yaml` dependency)
-- **JSON**: `ConfigSource.fromJson(...)` (requires `config-json` dependency)
-- **HOCON**: `ConfigSource.fromHocon(...)` (requires `config-hocon` dependency)
+- **YAML**: `ConfigSource.fromYaml(...)` (requires `config-yaml` dependency and `import zio.blocks.config.yaml._`)
+- **JSON**: `ConfigSource.fromJson(...)` (requires `config-json` dependency and `import zio.blocks.config.json._`)
+- **HOCON**: `ConfigSource.fromHocon(...)` (requires `config-hocon` dependency and `import zio.blocks.config.hocon._`)
 
 ## Core Principles
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,7 +106,7 @@ import zio.blocks.scope.Unscoped
 
 val defaults = ConfigSource.fromMap(Map("app.host" -> "localhost"), "defaults")
 val env      = ConfigSource.fromMap(Map("app.port" -> "8080"), "env")
-val source   = env.orElse(defaults).withPrefix("app")
+val source   = env.orElse(defaults).prefix("app")
 
 final case class AppConfig(host: String, port: Int) derives Schema, Unscoped
 
@@ -127,9 +127,9 @@ val choice = Rollout.select("true@prod/50%;false", "prod", bucket)
 
 ### File Format Adapters
 
-- **YAML**: `zio.blocks.config.yaml.YamlConfigSource.fromString`
-- **JSON**: `zio.blocks.config.json.JsonConfigSource.fromString`
-- **HOCON**: `zio.blocks.config.hocon.HoconConfigSource.fromString`
+- **YAML**: `ConfigSource.fromYaml(...)` (requires `config-yaml` dependency)
+- **JSON**: `ConfigSource.fromJson(...)` (requires `config-json` dependency)
+- **HOCON**: `ConfigSource.fromHocon(...)` (requires `config-hocon` dependency)
 
 ## Core Principles
 


### PR DESCRIPTION
## Summary

Three small fixes from Copilot review comments on #1426:

1. **docs/index.md**: Fix `withPrefix` → `prefix` in config example (renamed in #1426 but missed in index.md)
2. **docs/index.md**: Fix adapter references from private `YamlConfigSource.fromString` / `JsonConfigSource.fromString` / `HoconConfigSource.fromString` to public `ConfigSource.fromYaml(...)` / `ConfigSource.fromJson(...)` / `ConfigSource.fromHocon(...)`
3. **config/package.scala**: Change `implicit def` → `implicit val` for `secretDisplayable` to avoid repeated allocations

## Files Changed

- `docs/index.md` (2 edits)
- `config/shared/src/main/scala/zio/blocks/config/package.scala` (1 edit)

## Verification

- `configJVM/compile` passes on Scala 3.8.3