### PR TITLE
feat(http-model-schema): add QueryCodec, HeaderCodec and schema-driven derivers

### DIFF
--- a/http-model-schema/shared/src/main/scala/zio/http/schema/HeaderCodec.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/HeaderCodec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.schema
+
+import zio.blocks.schema.codec.Codec
+import zio.http.{Headers, HeadersBuilder}
+
+abstract class HeaderCodec[A] extends Codec[Headers, HeadersBuilder, A] {
+  final def encodeToHeaders(value: A): Headers = {
+    val builder = HeaderCodec.threadLocalBuilder.get()
+    builder.reset()
+    encode(value, builder)
+    builder.build()
+  }
+}
+
+object HeaderCodec {
+  private val threadLocalBuilder: ThreadLocal[HeadersBuilder] =
+    new ThreadLocal[HeadersBuilder] {
+      override def initialValue(): HeadersBuilder = HeadersBuilder.make()
+    }
+}

--- a/http-model-schema/shared/src/main/scala/zio/http/schema/HeaderCodecDeriver.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/HeaderCodecDeriver.scala
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.schema
+
+import zio.blocks.docs.Doc
+import zio.blocks.schema.binding.{Binding, HasBinding, Register, Registers}
+import zio.blocks.schema.derive.{BindingInstance, Deriver}
+import zio.blocks.schema.{Lazy, Modifier, PrimitiveType, Reflect, SchemaError, Term}
+import zio.blocks.typeid.TypeId
+import zio.http.{Headers, HeadersBuilder}
+
+import scala.util.control.NonFatal
+
+object HeaderCodecDeriver extends Deriver[HeaderCodec] {
+  private object ErrorFactory extends ParamCodecSupport.DecodeErrorFactory {
+    def malformed(name: String, raw: String, cause: String): String = HeaderError.Malformed(name, raw, cause).message
+  }
+
+  override def derivePrimitive[A](
+    primitiveType: PrimitiveType[A],
+    typeId: TypeId[A],
+    binding: Binding.Primitive[A],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[A],
+    examples: Seq[A]
+  ): Lazy[HeaderCodec[A]] =
+    Lazy {
+      buildTopLevelCodec(ParamCodecSupport.SinglePrimitive(primitiveType))
+    }
+
+  override def deriveRecord[F[_, _], A](
+    fields: IndexedSeq[Term[F, A, ?]],
+    typeId: TypeId[A],
+    binding: Binding.Record[A],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[A],
+    examples: Seq[A]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[HeaderCodec[A]] =
+    Lazy {
+      val fieldCodecs   = new Array[ParamCodecSupport.FieldCodec](fields.length)
+      val headerNames   = new Array[String](fields.length)
+      val fieldReflects = new Array[Reflect[F, Any]](fields.length)
+      var index         = 0
+      while (index < fields.length) {
+        val field = fields(index)
+        D.instance(field.value.metadata).force
+        headerNames(index) = toHeaderName(field.name)
+        fieldReflects(index) = field.value.asInstanceOf[Reflect[F, Any]]
+        fieldCodecs(index) = ParamCodecSupport.buildFieldCodec(field.value, field.name) match {
+          case Right(codec) => codec
+          case Left(error)  => throw new UnsupportedOperationException(error)
+        }
+        index += 1
+      }
+      val fieldRegs =
+        Reflect.Record.registers(fieldReflects.asInstanceOf[Array[Reflect[F, ?]]]).asInstanceOf[Array[Register[Any]]]
+
+      new HeaderCodec[A] {
+        private[this] val constructor   = binding.constructor
+        private[this] val deconstructor = binding.deconstructor
+
+        def encode(value: A, output: HeadersBuilder): Unit = {
+          val registers = Registers(deconstructor.usedRegisters)
+          deconstructor.deconstruct(registers, 0L, value)
+          var idx = 0
+          while (idx < fieldRegs.length) {
+            val encodedValues = fieldCodecs(idx).encodeAny(fieldRegs(idx).get(registers, 0L))
+            var valueIndex    = 0
+            while (valueIndex < encodedValues.length) {
+              output.add(headerNames(idx), encodedValues(valueIndex))
+              valueIndex += 1
+            }
+            idx += 1
+          }
+        }
+
+        def decode(input: Headers): Either[SchemaError, A] = {
+          val registers = Registers(constructor.usedRegisters)
+          var idx       = 0
+          while (idx < fieldRegs.length) {
+            val rawValues = {
+              val all = input.rawGetAll(headerNames(idx))
+              if (all.isEmpty) None else Some(all)
+            }
+            fieldCodecs(idx).decodeAny(headerNames(idx), rawValues, ErrorFactory) match {
+              case Right(decoded) => fieldRegs(idx).set(registers, 0L, decoded)
+              case Left(error)    => return Left(error)
+            }
+            idx += 1
+          }
+          Right(constructor.construct(registers, 0L))
+        }
+      }
+    }
+
+  override def deriveVariant[F[_, _], A](
+    cases: IndexedSeq[Term[F, A, ?]],
+    typeId: TypeId[A],
+    binding: Binding.Variant[A],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[A],
+    examples: Seq[A]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[HeaderCodec[A]] =
+    Lazy {
+      if (typeId.isOption && cases.length == 2)
+        ParamCodecSupport.buildOptionalCodec(cases(1).value, "value") match {
+          case Right(fieldCodec) => buildTopLevelCodec(fieldCodec)
+          case Left(_)           => unsupportedTopLevelCodec[A](s"HeaderCodec does not support variant schema ${typeId.fullName}")
+        }
+      else
+        unsupportedTopLevelCodec[A](s"HeaderCodec does not support variant schema ${typeId.fullName}")
+    }
+
+  override def deriveSequence[F[_, _], C[_], A](
+    element: Reflect[F, A],
+    typeId: TypeId[C[A]],
+    binding: Binding.Seq[C, A],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[C[A]],
+    examples: Seq[C[A]]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[HeaderCodec[C[A]]] =
+    Lazy {
+      ParamCodecSupport.buildSequenceCodec(element, binding.constructor, "value") match {
+        case Right(fieldCodec) => buildTopLevelCodec(fieldCodec).asInstanceOf[HeaderCodec[C[A]]]
+        case Left(_)           =>
+          unsupportedTopLevelCodec[C[A]](s"HeaderCodec does not support sequence schema ${typeId.fullName}")
+      }
+    }
+
+  override def deriveMap[F[_, _], M[_, _], K, V](
+    key: Reflect[F, K],
+    value: Reflect[F, V],
+    typeId: TypeId[M[K, V]],
+    binding: Binding.Map[M, K, V],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[M[K, V]],
+    examples: Seq[M[K, V]]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[HeaderCodec[M[K, V]]] =
+    Lazy(unsupportedTopLevelCodec[M[K, V]](s"HeaderCodec does not support map schema ${typeId.fullName}"))
+
+  override def deriveDynamic[F[_, _]](
+    binding: Binding.Dynamic,
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[zio.blocks.schema.DynamicValue],
+    examples: Seq[zio.blocks.schema.DynamicValue]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[HeaderCodec[zio.blocks.schema.DynamicValue]] =
+    Lazy(unsupportedTopLevelCodec[zio.blocks.schema.DynamicValue]("HeaderCodec does not support dynamic values"))
+
+  override def deriveWrapper[F[_, _], A, B](
+    wrapped: Reflect[F, B],
+    typeId: TypeId[A],
+    binding: Binding.Wrapper[A, B],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[A],
+    examples: Seq[A]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[HeaderCodec[A]] =
+    if (binding.isInstanceOf[Binding[?, ?]]) {
+      D.instance(wrapped.metadata).map { wrappedCodec =>
+        new HeaderCodec[A] {
+          def encode(value: A, output: HeadersBuilder): Unit = wrappedCodec.encode(binding.unwrap(value), output)
+
+          def decode(input: Headers): Either[SchemaError, A] =
+            wrappedCodec.decode(input).flatMap { value =>
+              try Right(binding.wrap(value))
+              catch {
+                case NonFatal(error) => Left(SchemaError.conversionFailed(Nil, error.getMessage))
+              }
+            }
+        }
+      }
+    } else binding.asInstanceOf[BindingInstance[HeaderCodec, ?, A]].instance
+
+  private def buildTopLevelCodec[A](fieldCodec: ParamCodecSupport.FieldCodec): HeaderCodec[A] =
+    new HeaderCodec[A] {
+      def encode(value: A, output: HeadersBuilder): Unit = {
+        val encodedValues = fieldCodec.encodeAny(value)
+        var index         = 0
+        while (index < encodedValues.length) {
+          output.add("Value", encodedValues(index))
+          index += 1
+        }
+      }
+
+      def decode(input: Headers): Either[SchemaError, A] = {
+        val rawValues = {
+          val all = input.rawGetAll("Value")
+          if (all.isEmpty) None else Some(all)
+        }
+        fieldCodec.decodeAny("Value", rawValues, ErrorFactory).asInstanceOf[Either[SchemaError, A]]
+      }
+    }
+
+  private def unsupportedTopLevelCodec[A](message: String): HeaderCodec[A] =
+    new HeaderCodec[A] {
+      def encode(value: A, output: HeadersBuilder): Unit =
+        throw new UnsupportedOperationException(message)
+
+      def decode(input: Headers): Either[SchemaError, A] =
+        throw new UnsupportedOperationException(message)
+    }
+
+  private def toHeaderName(fieldName: String): String = {
+    val builder = new StringBuilder
+    var index   = 0
+    while (index < fieldName.length) {
+      val char = fieldName.charAt(index)
+      if (index > 0 && char.isUpper) builder.append('-')
+      builder.append(char.toUpper)
+      index += 1
+    }
+    builder.toString()
+  }
+}

--- a/http-model-schema/shared/src/main/scala/zio/http/schema/HeaderFormat.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/HeaderFormat.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.schema
+
+import zio.blocks.schema.derive.{Derivable, Deriver}
+
+abstract class HeaderFormat[TC[A] <: HeaderCodec[A]](val mimeType: String, val deriver: Deriver[TC]) {
+
+  implicit final def derivable: Derivable[this.type, TC] =
+    new Derivable[this.type, TC] {
+      def deriver(d: HeaderFormat.this.type): Deriver[TC] = HeaderFormat.this.deriver
+    }
+}
+
+sealed abstract class DefaultHeaderFormat
+    extends HeaderFormat[HeaderCodec]("application/http-headers", HeaderCodecDeriver)
+
+case object DefaultHeaderFormat extends DefaultHeaderFormat

--- a/http-model-schema/shared/src/main/scala/zio/http/schema/ParamCodecSupport.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/ParamCodecSupport.scala
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.schema
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.binding.{HasBinding, SeqConstructor}
+import zio.blocks.schema.{PrimitiveType, Reflect, SchemaError}
+
+import java.util.UUID
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
+
+private[schema] object ParamCodecSupport {
+
+  trait DecodeErrorFactory {
+    def malformed(name: String, raw: String, cause: String): String
+  }
+
+  sealed trait FieldCodec {
+    def encodeAny(value: Any): Chunk[String]
+    def decodeAny(
+      fieldName: String,
+      rawValues: Option[Chunk[String]],
+      errorFactory: DecodeErrorFactory
+    ): Either[SchemaError, Any]
+  }
+
+  final case class SinglePrimitive[A](primitiveType: PrimitiveType[A]) extends FieldCodec {
+    def encodeAny(value: Any): Chunk[String] = Chunk.single(renderPrimitive(value.asInstanceOf[A], primitiveType))
+
+    def decodeAny(
+      fieldName: String,
+      rawValues: Option[Chunk[String]],
+      errorFactory: DecodeErrorFactory
+    ): Either[SchemaError, Any] =
+      rawValues match {
+        case Some(values) if values.nonEmpty =>
+          decodePrimitive(fieldName, values(0), primitiveType, errorFactory).asInstanceOf[Either[SchemaError, Any]]
+        case _ => Left(SchemaError.missingField(Nil, fieldName))
+      }
+  }
+
+  final case class OptionalValue(inner: FieldCodec) extends FieldCodec {
+    def encodeAny(value: Any): Chunk[String] =
+      value match {
+        case None             => Chunk.empty
+        case Some(innerValue) => inner.encodeAny(innerValue)
+      }
+
+    def decodeAny(
+      fieldName: String,
+      rawValues: Option[Chunk[String]],
+      errorFactory: DecodeErrorFactory
+    ): Either[SchemaError, Any] =
+      rawValues match {
+        case None                           => Right(None)
+        case Some(values) if values.isEmpty => Right(None)
+        case Some(values)                   => inner.decodeAny(fieldName, Some(Chunk.single(values(0))), errorFactory).map(Some(_))
+      }
+  }
+
+  final case class SequenceValue[C[_]](constructor: SeqConstructor[C], elementCodec: FieldCodec) extends FieldCodec {
+    def encodeAny(value: Any): Chunk[String] = {
+      val builder  = Chunk.newBuilder[String]
+      val iterator = value.asInstanceOf[Iterable[Any]].iterator
+      while (iterator.hasNext) {
+        val encodedValues = elementCodec.encodeAny(iterator.next())
+        var index         = 0
+        while (index < encodedValues.length) {
+          builder += encodedValues(index)
+          index += 1
+        }
+      }
+      builder.result()
+    }
+
+    def decodeAny(
+      fieldName: String,
+      rawValues: Option[Chunk[String]],
+      errorFactory: DecodeErrorFactory
+    ): Either[SchemaError, Any] = {
+      val values                           = rawValues.getOrElse(Chunk.empty)
+      implicit val classTag: ClassTag[Any] = ClassTag.Any
+      val builder                          = constructor.newBuilder[Any](values.length)
+      var index                            = 0
+      while (index < values.length) {
+        elementCodec.decodeAny(fieldName, Some(Chunk.single(values(index))), errorFactory) match {
+          case Right(decoded) => constructor.add(builder, decoded)
+          case Left(error)    => return Left(error)
+        }
+        index += 1
+      }
+      Right(constructor.result(builder))
+    }
+  }
+
+  final case class WrappedValue[A, B](wrap: B => A, unwrap: A => B, inner: FieldCodec) extends FieldCodec {
+    def encodeAny(value: Any): Chunk[String] = inner.encodeAny(unwrap(value.asInstanceOf[A]))
+
+    def decodeAny(
+      fieldName: String,
+      rawValues: Option[Chunk[String]],
+      errorFactory: DecodeErrorFactory
+    ): Either[SchemaError, Any] =
+      inner.decodeAny(fieldName, rawValues, errorFactory).flatMap { value =>
+        try Right(wrap(value.asInstanceOf[B]))
+        catch {
+          case NonFatal(error) => Left(SchemaError.conversionFailed(Nil, error.getMessage))
+        }
+      }
+  }
+
+  def buildFieldCodec[F[_, _], A](reflect: Reflect[F, A], fieldName: String)(implicit
+    F: HasBinding[F]
+  ): Either[String, FieldCodec] =
+    primitiveFieldCodec(reflect)
+      .orElse(optionalFieldCodec(reflect, fieldName))
+      .orElse(sequenceFieldCodec(reflect, fieldName))
+      .orElse(wrapperFieldCodec(reflect, fieldName))
+      .toRight {
+        if (reflect.isRecord) s"Nested records are not supported for field '$fieldName'"
+        else s"Unsupported schema type for field '$fieldName'"
+      }
+
+  def buildTopLevelCodec[F[_, _], A](reflect: Reflect[F, A])(implicit F: HasBinding[F]): Either[String, FieldCodec] =
+    primitiveFieldCodec(reflect)
+      .orElse(optionalFieldCodec(reflect, "value"))
+      .orElse(sequenceFieldCodec(reflect, "value"))
+      .orElse(wrapperFieldCodec(reflect, "value"))
+      .toRight("Only primitive, optional, sequence, and wrapped primitive schemas are supported at the top level")
+
+  def buildOptionalCodec[F[_, _], A](inner: Reflect[F, A], fieldName: String)(implicit
+    F: HasBinding[F]
+  ): Either[String, FieldCodec] =
+    buildFieldCodec(inner, fieldName).map(OptionalValue.apply)
+
+  def buildSequenceCodec[F[_, _], C[_], A](
+    element: Reflect[F, A],
+    constructor: SeqConstructor[C],
+    fieldName: String
+  )(implicit F: HasBinding[F]): Either[String, FieldCodec] =
+    buildFieldCodec(element, fieldName).map(SequenceValue(constructor, _))
+
+  private def primitiveFieldCodec[F[_, _], A](reflect: Reflect[F, A]): Option[FieldCodec] =
+    reflect.asPrimitive.map { primitive =>
+      SinglePrimitive(primitive.primitiveType)
+    }
+
+  private def optionalFieldCodec[F[_, _], A](reflect: Reflect[F, A], fieldName: String)(implicit
+    F: HasBinding[F]
+  ): Option[FieldCodec] =
+    if (reflect.isOption) {
+      reflect.optionInnerType
+        .map(_.asInstanceOf[Reflect[F, Any]])
+        .flatMap(inner => buildOptionalCodec(inner, fieldName).toOption)
+    } else None
+
+  private def sequenceFieldCodec[F[_, _], A](reflect: Reflect[F, A], fieldName: String)(implicit
+    F: HasBinding[F]
+  ): Option[FieldCodec] =
+    reflect.asSequenceUnknown.flatMap { unknown =>
+      val sequence = unknown.sequence
+      val element  = sequence.element.asInstanceOf[Reflect[F, Any]]
+      buildSequenceCodec(
+        element,
+        sequence.seqConstructor,
+        fieldName
+      ).toOption
+    }
+
+  private def wrapperFieldCodec[F[_, _], A](reflect: Reflect[F, A], fieldName: String)(implicit
+    F: HasBinding[F]
+  ): Option[FieldCodec] =
+    reflect.asWrapperUnknown.flatMap { unknown =>
+      val wrapper = unknown.wrapper
+      buildFieldCodec(wrapper.wrapped.asInstanceOf[Reflect[F, unknown.Wrapped]], fieldName).toOption.map { inner =>
+        WrappedValue(
+          wrapper.binding.wrap.asInstanceOf[unknown.Wrapped => unknown.Wrapping],
+          wrapper.binding.unwrap.asInstanceOf[unknown.Wrapping => unknown.Wrapped],
+          inner
+        )
+      }
+    }
+
+  private def decodePrimitive[A](
+    fieldName: String,
+    raw: String,
+    primitiveType: PrimitiveType[A],
+    errorFactory: DecodeErrorFactory
+  ): Either[SchemaError, A] =
+    decodePrimitiveString(raw, primitiveType).left.map(cause =>
+      SchemaError.conversionFailed(Nil, errorFactory.malformed(fieldName, raw, cause))
+    )
+
+  def decodePrimitiveString[A](raw: String, primitiveType: PrimitiveType[A]): Either[String, A] =
+    try {
+      primitiveType match {
+        case _: PrimitiveType.String     => Right(raw.asInstanceOf[A])
+        case _: PrimitiveType.Int        => Right(raw.toInt.asInstanceOf[A])
+        case _: PrimitiveType.Long       => Right(raw.toLong.asInstanceOf[A])
+        case _: PrimitiveType.Boolean    => Right(raw.toBoolean.asInstanceOf[A])
+        case _: PrimitiveType.Double     => Right(raw.toDouble.asInstanceOf[A])
+        case _: PrimitiveType.Float      => Right(raw.toFloat.asInstanceOf[A])
+        case _: PrimitiveType.Short      => Right(raw.toShort.asInstanceOf[A])
+        case _: PrimitiveType.Byte       => Right(raw.toByte.asInstanceOf[A])
+        case _: PrimitiveType.BigInt     => Right(scala.BigInt(raw).asInstanceOf[A])
+        case _: PrimitiveType.BigDecimal => Right(scala.BigDecimal(raw).asInstanceOf[A])
+        case _: PrimitiveType.UUID       => Right(UUID.fromString(raw).asInstanceOf[A])
+        case _: PrimitiveType.Char       =>
+          if (raw.length == 1) Right(raw.charAt(0).asInstanceOf[A])
+          else Left(s"Expected single character but got '$raw'")
+        case _ => Left("Unsupported primitive type for string decoding")
+      }
+    } catch {
+      case _: NumberFormatException    => Left(s"Cannot parse '$raw' as ${typeName(primitiveType)}")
+      case _: IllegalArgumentException => Left(s"Cannot parse '$raw' as ${typeName(primitiveType)}")
+    }
+
+  private def renderPrimitive[A](value: A, primitiveType: PrimitiveType[A]): String = primitiveType match {
+    case _: PrimitiveType.String     => value.asInstanceOf[String]
+    case _: PrimitiveType.Int        => value.toString
+    case _: PrimitiveType.Long       => value.toString
+    case _: PrimitiveType.Boolean    => value.toString
+    case _: PrimitiveType.Double     => value.toString
+    case _: PrimitiveType.Float      => value.toString
+    case _: PrimitiveType.Short      => value.toString
+    case _: PrimitiveType.Byte       => value.toString
+    case _: PrimitiveType.BigInt     => value.toString
+    case _: PrimitiveType.BigDecimal => value.toString
+    case _: PrimitiveType.UUID       => value.asInstanceOf[UUID].toString
+    case _: PrimitiveType.Char       => value.toString
+    case _                           => throw new UnsupportedOperationException(s"Unsupported primitive type: $primitiveType")
+  }
+
+  private def typeName[A](primitiveType: PrimitiveType[A]): String = primitiveType match {
+    case _: PrimitiveType.String     => "String"
+    case _: PrimitiveType.Int        => "Int"
+    case _: PrimitiveType.Long       => "Long"
+    case _: PrimitiveType.Boolean    => "Boolean"
+    case _: PrimitiveType.Double     => "Double"
+    case _: PrimitiveType.Float      => "Float"
+    case _: PrimitiveType.Short      => "Short"
+    case _: PrimitiveType.Byte       => "Byte"
+    case _: PrimitiveType.BigInt     => "BigInt"
+    case _: PrimitiveType.BigDecimal => "BigDecimal"
+    case _: PrimitiveType.UUID       => "UUID"
+    case _: PrimitiveType.Char       => "Char"
+    case _                           => "Unknown"
+  }
+}

--- a/http-model-schema/shared/src/main/scala/zio/http/schema/QueryCodec.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/QueryCodec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.schema
+
+import zio.blocks.schema.codec.Codec
+import zio.http.{QueryParams, QueryParamsBuilder}
+
+abstract class QueryCodec[A] extends Codec[QueryParams, QueryParamsBuilder, A] {
+  final def encodeToQueryParams(value: A): QueryParams = {
+    val builder = QueryCodec.threadLocalBuilder.get()
+    builder.reset()
+    encode(value, builder)
+    builder.build()
+  }
+}
+
+object QueryCodec {
+  private val threadLocalBuilder: ThreadLocal[QueryParamsBuilder] =
+    new ThreadLocal[QueryParamsBuilder] {
+      override def initialValue(): QueryParamsBuilder = QueryParamsBuilder.make()
+    }
+}

--- a/http-model-schema/shared/src/main/scala/zio/http/schema/QueryCodecDeriver.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/QueryCodecDeriver.scala
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.schema
+
+import zio.blocks.schema.binding.{Binding, HasBinding, Register, Registers}
+import zio.blocks.schema.derive.{BindingInstance, Deriver}
+import zio.blocks.schema.{Lazy, Modifier, PrimitiveType, Reflect, SchemaError, Term}
+import zio.blocks.docs.Doc
+import zio.blocks.typeid.TypeId
+import zio.http.{QueryParams, QueryParamsBuilder}
+
+import scala.util.control.NonFatal
+
+object QueryCodecDeriver extends Deriver[QueryCodec] {
+  private object ErrorFactory extends ParamCodecSupport.DecodeErrorFactory {
+    def malformed(name: String, raw: String, cause: String): String =
+      QueryParamError.Malformed(name, raw, cause).message
+  }
+
+  override def derivePrimitive[A](
+    primitiveType: PrimitiveType[A],
+    typeId: TypeId[A],
+    binding: Binding.Primitive[A],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[A],
+    examples: Seq[A]
+  ): Lazy[QueryCodec[A]] =
+    Lazy {
+      buildTopLevelCodec(ParamCodecSupport.SinglePrimitive(primitiveType))
+    }
+
+  override def deriveRecord[F[_, _], A](
+    fields: IndexedSeq[Term[F, A, ?]],
+    typeId: TypeId[A],
+    binding: Binding.Record[A],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[A],
+    examples: Seq[A]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[QueryCodec[A]] =
+    Lazy {
+      val fieldCodecs   = new Array[ParamCodecSupport.FieldCodec](fields.length)
+      val fieldNames    = new Array[String](fields.length)
+      val fieldReflects = new Array[Reflect[F, Any]](fields.length)
+      var index         = 0
+      while (index < fields.length) {
+        val field = fields(index)
+        D.instance(field.value.metadata).force
+        fieldNames(index) = field.name
+        fieldReflects(index) = field.value.asInstanceOf[Reflect[F, Any]]
+        fieldCodecs(index) = ParamCodecSupport.buildFieldCodec(field.value, field.name) match {
+          case Right(codec) => codec
+          case Left(error)  => throw new UnsupportedOperationException(error)
+        }
+        index += 1
+      }
+      val fieldRegs =
+        Reflect.Record.registers(fieldReflects.asInstanceOf[Array[Reflect[F, ?]]]).asInstanceOf[Array[Register[Any]]]
+
+      new QueryCodec[A] {
+        private[this] val constructor   = binding.constructor
+        private[this] val deconstructor = binding.deconstructor
+
+        def encode(value: A, output: QueryParamsBuilder): Unit = {
+          val registers = Registers(deconstructor.usedRegisters)
+          deconstructor.deconstruct(registers, 0L, value)
+          var idx = 0
+          while (idx < fieldRegs.length) {
+            val encodedValues = fieldCodecs(idx).encodeAny(fieldRegs(idx).get(registers, 0L))
+            var valueIndex    = 0
+            while (valueIndex < encodedValues.length) {
+              output.add(fieldNames(idx), encodedValues(valueIndex))
+              valueIndex += 1
+            }
+            idx += 1
+          }
+        }
+
+        def decode(input: QueryParams): Either[SchemaError, A] = {
+          val registers = Registers(constructor.usedRegisters)
+          var idx       = 0
+          while (idx < fieldRegs.length) {
+            val rawValues = input.get(fieldNames(idx))
+            fieldCodecs(idx).decodeAny(fieldNames(idx), rawValues, ErrorFactory) match {
+              case Right(decoded) => fieldRegs(idx).set(registers, 0L, decoded)
+              case Left(error)    => return Left(error)
+            }
+            idx += 1
+          }
+          Right(constructor.construct(registers, 0L))
+        }
+      }
+    }
+
+  override def deriveVariant[F[_, _], A](
+    cases: IndexedSeq[Term[F, A, ?]],
+    typeId: TypeId[A],
+    binding: Binding.Variant[A],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[A],
+    examples: Seq[A]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[QueryCodec[A]] =
+    Lazy {
+      if (typeId.isOption && cases.length == 2)
+        ParamCodecSupport.buildOptionalCodec(cases(1).value, "value") match {
+          case Right(fieldCodec) => buildTopLevelCodec(fieldCodec)
+          case Left(_)           => unsupportedTopLevelCodec[A](s"QueryCodec does not support variant schema ${typeId.fullName}")
+        }
+      else
+        unsupportedTopLevelCodec[A](s"QueryCodec does not support variant schema ${typeId.fullName}")
+    }
+
+  override def deriveSequence[F[_, _], C[_], A](
+    element: Reflect[F, A],
+    typeId: TypeId[C[A]],
+    binding: Binding.Seq[C, A],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[C[A]],
+    examples: Seq[C[A]]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[QueryCodec[C[A]]] =
+    Lazy {
+      ParamCodecSupport.buildSequenceCodec(element, binding.constructor, "value") match {
+        case Right(fieldCodec) => buildTopLevelCodec(fieldCodec).asInstanceOf[QueryCodec[C[A]]]
+        case Left(_)           =>
+          unsupportedTopLevelCodec[C[A]](s"QueryCodec does not support sequence schema ${typeId.fullName}")
+      }
+    }
+
+  override def deriveMap[F[_, _], M[_, _], K, V](
+    key: Reflect[F, K],
+    value: Reflect[F, V],
+    typeId: TypeId[M[K, V]],
+    binding: Binding.Map[M, K, V],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[M[K, V]],
+    examples: Seq[M[K, V]]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[QueryCodec[M[K, V]]] =
+    Lazy(unsupportedTopLevelCodec[M[K, V]](s"QueryCodec does not support map schema ${typeId.fullName}"))
+
+  override def deriveDynamic[F[_, _]](
+    binding: Binding.Dynamic,
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[zio.blocks.schema.DynamicValue],
+    examples: Seq[zio.blocks.schema.DynamicValue]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[QueryCodec[zio.blocks.schema.DynamicValue]] =
+    Lazy(unsupportedTopLevelCodec[zio.blocks.schema.DynamicValue]("QueryCodec does not support dynamic values"))
+
+  override def deriveWrapper[F[_, _], A, B](
+    wrapped: Reflect[F, B],
+    typeId: TypeId[A],
+    binding: Binding.Wrapper[A, B],
+    doc: Doc,
+    modifiers: Seq[Modifier.Reflect],
+    defaultValue: Option[A],
+    examples: Seq[A]
+  )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[QueryCodec[A]] =
+    if (binding.isInstanceOf[Binding[?, ?]]) {
+      D.instance(wrapped.metadata).map { wrappedCodec =>
+        new QueryCodec[A] {
+          def encode(value: A, output: QueryParamsBuilder): Unit = wrappedCodec.encode(binding.unwrap(value), output)
+
+          def decode(input: QueryParams): Either[SchemaError, A] =
+            wrappedCodec.decode(input).flatMap { value =>
+              try Right(binding.wrap(value))
+              catch {
+                case NonFatal(error) => Left(SchemaError.conversionFailed(Nil, error.getMessage))
+              }
+            }
+        }
+      }
+    } else binding.asInstanceOf[BindingInstance[QueryCodec, ?, A]].instance
+
+  private def buildTopLevelCodec[A](fieldCodec: ParamCodecSupport.FieldCodec): QueryCodec[A] =
+    new QueryCodec[A] {
+      def encode(value: A, output: QueryParamsBuilder): Unit = {
+        val encodedValues = fieldCodec.encodeAny(value)
+        var index         = 0
+        while (index < encodedValues.length) {
+          output.add("value", encodedValues(index))
+          index += 1
+        }
+      }
+
+      def decode(input: QueryParams): Either[SchemaError, A] =
+        fieldCodec.decodeAny("value", input.get("value"), ErrorFactory).asInstanceOf[Either[SchemaError, A]]
+    }
+
+  private def unsupportedTopLevelCodec[A](message: String): QueryCodec[A] =
+    new QueryCodec[A] {
+      def encode(value: A, output: QueryParamsBuilder): Unit =
+        throw new UnsupportedOperationException(message)
+
+      def decode(input: QueryParams): Either[SchemaError, A] =
+        throw new UnsupportedOperationException(message)
+    }
+}

--- a/http-model-schema/shared/src/main/scala/zio/http/schema/QueryFormat.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/QueryFormat.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.schema
+
+import zio.blocks.schema.derive.{Derivable, Deriver}
+
+abstract class QueryFormat[TC[A] <: QueryCodec[A]](val mimeType: String, val deriver: Deriver[TC]) {
+
+  implicit final def derivable: Derivable[this.type, TC] =
+    new Derivable[this.type, TC] {
+      def deriver(d: QueryFormat.this.type): Deriver[TC] = QueryFormat.this.deriver
+    }
+}
+
+sealed abstract class DefaultQueryFormat
+    extends QueryFormat[QueryCodec]("application/x-www-form-urlencoded", QueryCodecDeriver)
+
+case object DefaultQueryFormat extends DefaultQueryFormat

--- a/http-model-schema/shared/src/test/scala/zio/http/schema/HeaderCodecSpec.scala
+++ b/http-model-schema/shared/src/test/scala/zio/http/schema/HeaderCodecSpec.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.schema
+
+import zio.blocks.schema.{DynamicValue, PrimitiveValue, Schema}
+import zio.http.Headers
+import zio.test._
+
+import java.util.UUID
+import scala.util.Try
+
+object HeaderCodecSpec extends ZIOSpecDefault {
+  final case class SimpleHeaders(traceId: String, apiKey: String)
+  object SimpleHeaders {
+    implicit val schema: Schema[SimpleHeaders] = Schema.derived[SimpleHeaders]
+  }
+
+  final case class UserId(value: String) extends AnyVal
+  object UserId {
+    implicit val schema: Schema[UserId] = Schema[String].transform(UserId(_), _.value)
+  }
+
+  final case class RichHeaders(
+    shortValue: Short,
+    byteValue: Byte,
+    bigIntValue: BigInt,
+    bigDecimalValue: BigDecimal,
+    uuidValue: UUID,
+    charValue: Char
+  )
+  object RichHeaders {
+    implicit val schema: Schema[RichHeaders] = Schema.derived[RichHeaders]
+  }
+
+  def spec: Spec[TestEnvironment, Any] = suite("HeaderCodec")(
+    test("round-trips simple string record") {
+      val codec   = Schema[SimpleHeaders].derive(DefaultHeaderFormat)
+      val value   = SimpleHeaders("trace-1", "secret")
+      val encoded = codec.encodeToHeaders(value)
+
+      assertTrue(
+        codec.decode(encoded) == Right(value)
+      )
+    },
+    test("encodes camelCase field names as Kebab-Case") {
+      val codec   = Schema[SimpleHeaders].derive(DefaultHeaderFormat)
+      val value   = SimpleHeaders("trace-1", "secret")
+      val encoded = codec.encodeToHeaders(value)
+
+      assertTrue(
+        encoded.rawGet("Trace-Id").contains("trace-1"),
+        encoded.rawGet("Api-Key").contains("secret")
+      )
+    },
+    test("reads headers case-insensitively") {
+      val codec   = Schema[SimpleHeaders].derive(DefaultHeaderFormat)
+      val headers = Headers("trace-id" -> "trace-1", "API-KEY" -> "secret")
+
+      assertTrue(codec.decode(headers) == Right(SimpleHeaders("trace-1", "secret")))
+    },
+    test("round-trips remaining primitive branches") {
+      val codec   = Schema[RichHeaders].derive(DefaultHeaderFormat)
+      val uuid    = UUID.fromString("123e4567-e89b-12d3-a456-426614174001")
+      val value   = RichHeaders(7, 3, BigInt("1234567890123456789"), BigDecimal("12.34"), uuid, 'z')
+      val encoded = codec.encodeToHeaders(value)
+
+      assertTrue(
+        codec.decode(encoded) == Right(value),
+        encoded.rawGet("Short-Value").contains("7"),
+        encoded.rawGet("Byte-Value").contains("3"),
+        encoded.rawGet("Big-Int-Value").contains("1234567890123456789"),
+        encoded.rawGet("Big-Decimal-Value").contains("12.34"),
+        encoded.rawGet("Uuid-Value").contains(uuid.toString),
+        encoded.rawGet("Char-Value").contains("z")
+      )
+    },
+    test("supports top-level primitive, sequence, and wrapper codecs") {
+      val intCodec     = Schema[Int].derive(DefaultHeaderFormat)
+      val listCodec    = Schema[List[Int]].derive(DefaultHeaderFormat)
+      val wrapperCodec = Schema[UserId].derive(DefaultHeaderFormat)
+
+      assertTrue(
+        intCodec.encodeToHeaders(42).rawGet("Value").contains("42"),
+        intCodec.decode(Headers("value" -> "42")) == Right(42),
+        listCodec.encodeToHeaders(List(1, 2)).rawGetAll("Value") == zio.blocks.chunk.Chunk("1", "2"),
+        listCodec.decode(Headers("value" -> "1", "value" -> "2")) == Right(List(1, 2)),
+        wrapperCodec.encodeToHeaders(UserId("wrapped")).rawGet("Value").contains("wrapped"),
+        wrapperCodec.decode(Headers("value" -> "wrapped")) == Right(UserId("wrapped"))
+      )
+    },
+    test("reports malformed top-level char values") {
+      val codec = Schema[Char].derive(DefaultHeaderFormat)
+
+      assertTrue(
+        codec.decode(Headers("value" -> "too-long")).swap.exists(_.message.contains("Expected single character"))
+      )
+    },
+    test("rejects unsupported top-level option, map, and dynamic schemas") {
+      val optionCodec  = Schema[Option[Int]].derive(DefaultHeaderFormat)
+      val mapCodec     = Schema[Map[String, Int]].derive(DefaultHeaderFormat)
+      val dynamicCodec = Schema[DynamicValue].derive(DefaultHeaderFormat)
+      val dynamicValue = DynamicValue.Primitive(PrimitiveValue.Int(1))
+
+      assertTrue(
+        Try(optionCodec.encodeToHeaders(None)).isFailure,
+        Try(mapCodec.encodeToHeaders(Map("a" -> 1))).isFailure,
+        Try(dynamicCodec.encodeToHeaders(dynamicValue)).isFailure
+      )
+    }
+  ) @@ TestAspect.timeout(zio.Duration.fromSeconds(60))
+}

--- a/http-model-schema/shared/src/test/scala/zio/http/schema/QueryCodecSpec.scala
+++ b/http-model-schema/shared/src/test/scala/zio/http/schema/QueryCodecSpec.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.schema
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{DynamicValue, PrimitiveValue, Schema}
+import zio.http.QueryParams
+import zio.test._
+
+import java.util.UUID
+import scala.util.Try
+
+object QueryCodecSpec extends ZIOSpecDefault {
+  final case class Simple(page: Int, name: String, active: Boolean)
+  object Simple {
+    implicit val schema: Schema[Simple] = Schema.derived[Simple]
+  }
+
+  final case class OptionalFields(page: Option[Int], name: Option[String])
+  object OptionalFields {
+    implicit val schema: Schema[OptionalFields] = Schema.derived[OptionalFields]
+  }
+
+  final case class MultiValues(tags: List[String], ids: Chunk[Int])
+  object MultiValues {
+    implicit val schema: Schema[MultiValues] = Schema.derived[MultiValues]
+  }
+
+  final case class UserId(value: String) extends AnyVal
+  object UserId {
+    implicit val schema: Schema[UserId] = Schema[String].transform(UserId(_), _.value)
+  }
+
+  final case class Wrapped(id: UserId)
+  object Wrapped {
+    implicit val schema: Schema[Wrapped] = Schema.derived[Wrapped]
+  }
+
+  final case class RichPrimitives(
+    shortValue: Short,
+    byteValue: Byte,
+    bigIntValue: BigInt,
+    bigDecimalValue: BigDecimal,
+    uuidValue: UUID,
+    charValue: Char
+  )
+  object RichPrimitives {
+    implicit val schema: Schema[RichPrimitives] = Schema.derived[RichPrimitives]
+  }
+
+  def spec: Spec[TestEnvironment, Any] = suite("QueryCodec")(
+    test("round-trips simple primitive record") {
+      val codec   = Schema[Simple].derive(DefaultQueryFormat)
+      val value   = Simple(42, "alice", active = true)
+      val encoded = codec.encodeToQueryParams(value)
+
+      assertTrue(
+        encoded == QueryParams("page" -> "42", "name" -> "alice", "active" -> "true"),
+        codec.decode(encoded) == Right(value)
+      )
+    },
+    test("round-trips option fields with absent key as None") {
+      val codec   = Schema[OptionalFields].derive(DefaultQueryFormat)
+      val value   = OptionalFields(page = Some(7), name = None)
+      val encoded = codec.encodeToQueryParams(value)
+
+      assertTrue(
+        encoded == QueryParams("page" -> "7"),
+        codec.decode(encoded) == Right(value),
+        codec.decode(QueryParams.empty) == Right(OptionalFields(None, None))
+      )
+    },
+    test("round-trips list and chunk fields as repeated params") {
+      val codec   = Schema[MultiValues].derive(DefaultQueryFormat)
+      val value   = MultiValues(List("a", "b"), Chunk(1, 2, 3))
+      val encoded = codec.encodeToQueryParams(value)
+
+      assertTrue(
+        encoded == QueryParams("tags" -> "a", "tags" -> "b", "ids" -> "1", "ids" -> "2", "ids" -> "3"),
+        codec.decode(encoded) == Right(value)
+      )
+    },
+    test("round-trips wrapper fields") {
+      val codec   = Schema[Wrapped].derive(DefaultQueryFormat)
+      val value   = Wrapped(UserId("user-1"))
+      val encoded = codec.encodeToQueryParams(value)
+
+      assertTrue(
+        encoded == QueryParams("id" -> "user-1"),
+        codec.decode(encoded) == Right(value)
+      )
+    },
+    test("round-trips remaining primitive branches") {
+      val codec   = Schema[RichPrimitives].derive(DefaultQueryFormat)
+      val uuid    = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+      val value   = RichPrimitives(7, 3, BigInt("1234567890123456789"), BigDecimal("12.34"), uuid, 'z')
+      val encoded = codec.encodeToQueryParams(value)
+
+      assertTrue(
+        codec.decode(encoded) == Right(value),
+        encoded.getFirst("shortValue").contains("7"),
+        encoded.getFirst("byteValue").contains("3"),
+        encoded.getFirst("bigIntValue").contains("1234567890123456789"),
+        encoded.getFirst("bigDecimalValue").contains("12.34"),
+        encoded.getFirst("uuidValue").contains(uuid.toString),
+        encoded.getFirst("charValue").contains("z")
+      )
+    },
+    test("supports top-level primitive, sequence, and wrapper codecs") {
+      val intCodec     = Schema[Int].derive(DefaultQueryFormat)
+      val listCodec    = Schema[List[Int]].derive(DefaultQueryFormat)
+      val wrapperCodec = Schema[UserId].derive(DefaultQueryFormat)
+
+      assertTrue(
+        intCodec.encodeToQueryParams(42) == QueryParams("value" -> "42"),
+        intCodec.decode(QueryParams("value" -> "42")) == Right(42),
+        listCodec.encodeToQueryParams(List(1, 2)) == QueryParams("value" -> "1", "value" -> "2"),
+        listCodec.decode(QueryParams("value" -> "1", "value" -> "2")) == Right(List(1, 2)),
+        wrapperCodec.encodeToQueryParams(UserId("wrapped")) == QueryParams("value" -> "wrapped"),
+        wrapperCodec.decode(QueryParams("value" -> "wrapped")) == Right(UserId("wrapped"))
+      )
+    },
+    test("reports malformed top-level char values") {
+      val codec = Schema[Char].derive(DefaultQueryFormat)
+
+      assertTrue(
+        codec.decode(QueryParams("value" -> "too-long")).swap.exists(_.message.contains("Expected single character"))
+      )
+    },
+    test("rejects unsupported top-level option, map, and dynamic schemas") {
+      val optionCodec  = Schema[Option[Int]].derive(DefaultQueryFormat)
+      val mapCodec     = Schema[Map[String, Int]].derive(DefaultQueryFormat)
+      val dynamicCodec = Schema[DynamicValue].derive(DefaultQueryFormat)
+      val dynamicValue = DynamicValue.Primitive(PrimitiveValue.Int(1))
+
+      assertTrue(
+        Try(optionCodec.encodeToQueryParams(None)).isFailure,
+        Try(mapCodec.encodeToQueryParams(Map("a" -> 1))).isFailure,
+        Try(dynamicCodec.encodeToQueryParams(dynamicValue)).isFailure
+      )
+    }
+  ) @@ TestAspect.timeout(zio.Duration.fromSeconds(60))
+}

--- a/http-model/shared/src/main/scala/zio/http/Headers.scala
+++ b/http-model/shared/src/main/scala/zio/http/Headers.scala
@@ -336,6 +336,8 @@ final class HeadersBuilder private (
     len += 1
   }
 
+  def reset(): Unit = len = 0
+
   private def ensureCapacity(): Unit =
     if (len >= names.length) {
       val newCap       = Math.max(names.length * 2, 8)

--- a/http-model/shared/src/main/scala/zio/http/QueryParams.scala
+++ b/http-model/shared/src/main/scala/zio/http/QueryParams.scala
@@ -236,6 +236,8 @@ final class QueryParamsBuilder private (
   def addAll(params: QueryParams): Unit =
     params.toList.foreach { case (k, v) => add(k, v) }
 
+  def reset(): Unit = len = 0
+
   private def ensureCapacity(): Unit =
     if (len >= keys.length) {
       val newCap  = Math.max(keys.length * 2, 8)


### PR DESCRIPTION
## Summary

Add QueryCodec[A] and HeaderCodec[A] abstract codec classes enabling schema-driven encoding/decoding of case classes to/from HTTP query parameters and headers.

## Changes

### http-model
- QueryParamsBuilder.reset() and HeadersBuilder.reset() for thread-local builder reuse

### http-model-schema (new files)
- QueryCodec[A] with encodeToQueryParams convenience method
- HeaderCodec[A] with encodeToHeaders convenience method
- QueryCodecDeriver: Deriver[QueryCodec] walking Schema record fields
- HeaderCodecDeriver: Deriver[HeaderCodec] with camelCase to Kebab-Case mapping
- QueryFormat / HeaderFormat tags for Schema.derive(format) integration
- ParamCodecSupport: shared primitive encode/decode, Option, Seq, wrapper handling
- QueryCodecSpec / HeaderCodecSpec round-trip tests

## Motivation

These codecs are needed by zio-http v4 ToHandler to dispatch handler params to query/header/body via implicit resolution.

## Tests
- 51 tests pass in http-model-schema
- 1109 tests pass in http-model (no regressions)