### PR TITLE
fix(http-model-schema): address Copilot review — reset() memory leak, BindingInstance, Scaladoc

### DIFF
--- a/http-model-schema/shared/src/main/scala/zio/http/schema/HeaderCodec.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/HeaderCodec.scala
@@ -19,6 +19,13 @@ package zio.http.schema
 import zio.blocks.schema.codec.Codec
 import zio.http.{Headers, HeadersBuilder}
 
+/**
+ * A codec for encoding a value of type `A` into [[zio.http.Headers]] and
+ * decoding [[zio.http.Headers]] back into `A`.
+ *
+ * Instances are typically derived via [[HeaderFormat]] using the schema
+ * derivation framework.
+ */
 abstract class HeaderCodec[A] extends Codec[Headers, HeadersBuilder, A] {
   final def encodeToHeaders(value: A): Headers = {
     val builder = HeaderCodec.threadLocalBuilder.get()

--- a/http-model-schema/shared/src/main/scala/zio/http/schema/HeaderCodecDeriver.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/HeaderCodecDeriver.scala
@@ -39,9 +39,11 @@ object HeaderCodecDeriver extends Deriver[HeaderCodec] {
     defaultValue: Option[A],
     examples: Seq[A]
   ): Lazy[HeaderCodec[A]] =
-    Lazy {
-      buildTopLevelCodec(ParamCodecSupport.SinglePrimitive(primitiveType))
-    }
+    if (binding.isInstanceOf[Binding[?, ?]]) {
+      Lazy {
+        buildTopLevelCodec(ParamCodecSupport.SinglePrimitive(primitiveType))
+      }
+    } else binding.asInstanceOf[BindingInstance[HeaderCodec, ?, A]].instance
 
   override def deriveRecord[F[_, _], A](
     fields: IndexedSeq[Term[F, A, ?]],

--- a/http-model-schema/shared/src/main/scala/zio/http/schema/HeaderFormat.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/HeaderFormat.scala
@@ -18,6 +18,11 @@ package zio.http.schema
 
 import zio.blocks.schema.derive.{Derivable, Deriver}
 
+/**
+ * Base class for HTTP header serialization formats. Pairs a MIME type with a
+ * [[zio.blocks.schema.derive.Deriver]] that can derive [[HeaderCodec]]
+ * instances for arbitrary schema-described types.
+ */
 abstract class HeaderFormat[TC[A] <: HeaderCodec[A]](val mimeType: String, val deriver: Deriver[TC]) {
 
   implicit final def derivable: Derivable[this.type, TC] =

--- a/http-model-schema/shared/src/main/scala/zio/http/schema/QueryCodec.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/QueryCodec.scala
@@ -19,6 +19,13 @@ package zio.http.schema
 import zio.blocks.schema.codec.Codec
 import zio.http.{QueryParams, QueryParamsBuilder}
 
+/**
+ * A codec for encoding a value of type `A` into [[zio.http.QueryParams]] and
+ * decoding [[zio.http.QueryParams]] back into `A`.
+ *
+ * Instances are typically derived via [[QueryFormat]] using the schema
+ * derivation framework.
+ */
 abstract class QueryCodec[A] extends Codec[QueryParams, QueryParamsBuilder, A] {
   final def encodeToQueryParams(value: A): QueryParams = {
     val builder = QueryCodec.threadLocalBuilder.get()

--- a/http-model-schema/shared/src/main/scala/zio/http/schema/QueryCodecDeriver.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/QueryCodecDeriver.scala
@@ -40,9 +40,11 @@ object QueryCodecDeriver extends Deriver[QueryCodec] {
     defaultValue: Option[A],
     examples: Seq[A]
   ): Lazy[QueryCodec[A]] =
-    Lazy {
-      buildTopLevelCodec(ParamCodecSupport.SinglePrimitive(primitiveType))
-    }
+    if (binding.isInstanceOf[Binding[?, ?]]) {
+      Lazy {
+        buildTopLevelCodec(ParamCodecSupport.SinglePrimitive(primitiveType))
+      }
+    } else binding.asInstanceOf[BindingInstance[QueryCodec, ?, A]].instance
 
   override def deriveRecord[F[_, _], A](
     fields: IndexedSeq[Term[F, A, ?]],

--- a/http-model-schema/shared/src/main/scala/zio/http/schema/QueryFormat.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/QueryFormat.scala
@@ -18,6 +18,11 @@ package zio.http.schema
 
 import zio.blocks.schema.derive.{Derivable, Deriver}
 
+/**
+ * Base class for query-parameter serialization formats. Pairs a MIME type with
+ * a [[zio.blocks.schema.derive.Deriver]] that can derive [[QueryCodec]]
+ * instances for arbitrary schema-described types.
+ */
 abstract class QueryFormat[TC[A] <: QueryCodec[A]](val mimeType: String, val deriver: Deriver[TC]) {
 
   implicit final def derivable: Derivable[this.type, TC] =

--- a/http-model-schema/shared/src/test/scala/zio/http/schema/HeaderCodecSpec.scala
+++ b/http-model-schema/shared/src/test/scala/zio/http/schema/HeaderCodecSpec.scala
@@ -17,7 +17,10 @@
 package zio.http.schema
 
 import zio.blocks.schema.{DynamicValue, PrimitiveValue, Schema}
+import zio.blocks.schema.SchemaError
+import zio.blocks.typeid.TypeId
 import zio.http.Headers
+import zio.http.HeadersBuilder
 import zio.test._
 
 import java.util.UUID
@@ -100,6 +103,30 @@ object HeaderCodecSpec extends ZIOSpecDefault {
         listCodec.decode(Headers("value" -> "1", "value" -> "2")) == Right(List(1, 2)),
         wrapperCodec.encodeToHeaders(UserId("wrapped")).rawGet("Value").contains("wrapped"),
         wrapperCodec.decode(Headers("value" -> "wrapped")) == Right(UserId("wrapped"))
+      )
+    },
+    test("respects BindingInstance override for primitive codec") {
+      val customIntCodec = new HeaderCodec[Int] {
+        def encode(value: Int, output: HeadersBuilder): Unit =
+          output.add("Value", s"custom-$value")
+
+        def decode(input: Headers): Either[SchemaError, Int] = {
+          val raw = input.rawGet("Value")
+          raw match {
+            case Some(s) if s.startsWith("custom-") =>
+              Right(s.stripPrefix("custom-").toInt)
+            case other =>
+              Left(SchemaError(s"Expected custom- prefix, got: $other"))
+          }
+        }
+      }
+      val codec = Schema[Int].deriving(HeaderCodecDeriver).instance(TypeId.int, customIntCodec).derive
+
+      val encoded = codec.encodeToHeaders(42)
+
+      assertTrue(
+        encoded.rawGet("Value").contains("custom-42"),
+        codec.decode(encoded) == Right(42)
       )
     },
     test("reports malformed top-level char values") {

--- a/http-model-schema/shared/src/test/scala/zio/http/schema/QueryCodecSpec.scala
+++ b/http-model-schema/shared/src/test/scala/zio/http/schema/QueryCodecSpec.scala
@@ -18,7 +18,10 @@ package zio.http.schema
 
 import zio.blocks.chunk.Chunk
 import zio.blocks.schema.{DynamicValue, PrimitiveValue, Schema}
+import zio.blocks.schema.SchemaError
+import zio.blocks.typeid.TypeId
 import zio.http.QueryParams
+import zio.http.QueryParamsBuilder
 import zio.test._
 
 import java.util.UUID
@@ -132,6 +135,28 @@ object QueryCodecSpec extends ZIOSpecDefault {
         listCodec.decode(QueryParams("value" -> "1", "value" -> "2")) == Right(List(1, 2)),
         wrapperCodec.encodeToQueryParams(UserId("wrapped")) == QueryParams("value" -> "wrapped"),
         wrapperCodec.decode(QueryParams("value" -> "wrapped")) == Right(UserId("wrapped"))
+      )
+    },
+    test("respects BindingInstance override for primitive codec") {
+      val customIntCodec = new QueryCodec[Int] {
+        def encode(value: Int, output: QueryParamsBuilder): Unit =
+          output.add("value", s"custom-$value")
+
+        def decode(input: QueryParams): Either[SchemaError, Int] =
+          input.getFirst("value") match {
+            case Some(s) if s.startsWith("custom-") =>
+              Right(s.stripPrefix("custom-").toInt)
+            case other =>
+              Left(SchemaError(s"Expected custom- prefix, got: $other"))
+          }
+      }
+      val codec = Schema[Int].deriving(QueryCodecDeriver).instance(TypeId.int, customIntCodec).derive
+
+      val encoded = codec.encodeToQueryParams(42)
+
+      assertTrue(
+        encoded == QueryParams("value" -> "custom-42"),
+        codec.decode(encoded) == Right(42)
       )
     },
     test("reports malformed top-level char values") {

--- a/http-model/shared/src/main/scala/zio/http/Headers.scala
+++ b/http-model/shared/src/main/scala/zio/http/Headers.scala
@@ -336,7 +336,11 @@ final class HeadersBuilder private (
     len += 1
   }
 
-  def reset(): Unit = len = 0
+  def reset(): Unit = {
+    java.util.Arrays.fill(names.asInstanceOf[Array[AnyRef]], 0, len, null)
+    java.util.Arrays.fill(rawValues.asInstanceOf[Array[AnyRef]], 0, len, null)
+    len = 0
+  }
 
   private def ensureCapacity(): Unit =
     if (len >= names.length) {

--- a/http-model/shared/src/main/scala/zio/http/QueryParams.scala
+++ b/http-model/shared/src/main/scala/zio/http/QueryParams.scala
@@ -236,7 +236,11 @@ final class QueryParamsBuilder private (
   def addAll(params: QueryParams): Unit =
     params.toList.foreach { case (k, v) => add(k, v) }
 
-  def reset(): Unit = len = 0
+  def reset(): Unit = {
+    java.util.Arrays.fill(keys.asInstanceOf[Array[AnyRef]], 0, len, null)
+    java.util.Arrays.fill(vals.asInstanceOf[Array[AnyRef]], 0, len, null)
+    len = 0
+  }
 
   private def ensureCapacity(): Unit =
     if (len >= keys.length) {


### PR DESCRIPTION
## Summary

Follow-up to #1482 — addresses actionable Copilot review comments.

### Changes

**1. Fix memory leak in `reset()` (QueryParamsBuilder & HeadersBuilder)**

`reset()` previously only zeroed `len`, leaving stale object references in the backing arrays. This prevented GC from collecting values that were encoded in prior `encodeToQueryParams`/`encodeToHeaders` calls (both use thread-local builders).

Now nulls out array slots `[0, len)` before zeroing `len`, matching standard JDK collection behavior (e.g. `ArrayList.clear()`).

**2. Respect `BindingInstance` overrides in `derivePrimitive`**

`QueryCodecDeriver.derivePrimitive` and `HeaderCodecDeriver.derivePrimitive` always built codecs from `PrimitiveType`, ignoring user-supplied `BindingInstance` overrides. This meant custom codec bindings for primitive types were silently discarded.

Now follows the same guard pattern as `JsonCodecDeriver.derivePrimitive`: check `binding.isInstanceOf[Binding[?, ?]]` and fall through to the `BindingInstance` path when the user provides one.

**3. Add Scaladoc to public API classes**

Added documentation to `QueryCodec`, `HeaderCodec`, `QueryFormat`, and `HeaderFormat`.

### Verification

- `sbt fmt` — clean
- `sbt http-model-schemaJVM/compile; http-model-schemaJVM/test` — 59 tests passed
- `sbt http-modelJVM/compile; http-modelJVM/test` — 1109 tests passed
