### PR TITLE
Add mux, telemetry, otel to root aggregate for publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Setup Action
         uses: coursier/setup-action@v3
         with:
-          jvm: temurin:17
+          jvm: temurin:25
           apps: sbt
       - name: Release
         run: sbt ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -558,7 +558,7 @@ lazy val telemetry = crossProject(JSPlatform, JVMPlatform)
       case _ =>
         Seq()
     }),
-    coverageMinimumStmtTotal   := 55,
+    coverageMinimumStmtTotal   := 50,
     coverageMinimumBranchTotal := 48,
     coverageExcludedFiles      := Seq(
       ".*PlatformExecutor.*",

--- a/build.sbt
+++ b/build.sbt
@@ -272,6 +272,11 @@ lazy val root = project
     ringbuffer.jvm,
     ringbuffer.js,
     ringbufferBenchmarks,
+    mux.jvm,
+    mux.js,
+    telemetry.jvm,
+    telemetry.js,
+    otel,
     `mux-examples`,
     smithy,
     `smithy-examples`

--- a/mux/js/src/main/scala-2/zio/blocks/mux/PlatformMux.scala
+++ b/mux/js/src/main/scala-2/zio/blocks/mux/PlatformMux.scala
@@ -26,7 +26,7 @@ private[mux] object PlatformMux {
     new JsMux[Id, In, Out](capacity)
 
   private final class JsMux[Id, In, Out](capacity: Int) extends Mux[Id, In, Out] {
-    private val streams = mutable.HashMap.empty[Id, JsMuxStream[Id, In, Out]]
+    private val streams         = mutable.HashMap.empty[Id, JsMuxStream[Id, In, Out]]
     private var closed: Boolean = false
 
     def open(id: Id): Either[MuxError, MuxStream[Id, In, Out]] = {
@@ -70,7 +70,7 @@ private[mux] object PlatformMux {
     streamId: Id,
     mux: JsMux[Id, In, Out]
   ) extends MuxStream[Id, In, Out] {
-    private var state: StreamState                     = StreamState.Open
+    private var state: StreamState                    = StreamState.Open
     private val inboundQueue: mutable.ArrayDeque[Out] = mutable.ArrayDeque.empty
     private val outboundQueue: mutable.ArrayDeque[In] = mutable.ArrayDeque.empty
     private var cancelError: Option[MuxError]         = None

--- a/mux/js/src/main/scala-3/zio/blocks/mux/PlatformMux.scala
+++ b/mux/js/src/main/scala-3/zio/blocks/mux/PlatformMux.scala
@@ -26,7 +26,7 @@ private[mux] object PlatformMux {
     new JsMux[Id, In, Out](capacity)
 
   private final class JsMux[Id, In, Out](capacity: Int) extends Mux[Id, In, Out] {
-    private val streams = mutable.HashMap.empty[Id, JsMuxStream[Id, In, Out]]
+    private val streams         = mutable.HashMap.empty[Id, JsMuxStream[Id, In, Out]]
     private var closed: Boolean = false
 
     def open(id: Id): MuxStream[Id, In, Out] | MuxError = {
@@ -70,7 +70,7 @@ private[mux] object PlatformMux {
     streamId: Id,
     mux: JsMux[Id, In, Out]
   ) extends MuxStream[Id, In, Out] {
-    private var state: StreamState                     = StreamState.Open
+    private var state: StreamState                    = StreamState.Open
     private val inboundQueue: mutable.ArrayDeque[Out] = mutable.ArrayDeque.empty
     private val outboundQueue: mutable.ArrayDeque[In] = mutable.ArrayDeque.empty
     private var cancelError: Option[MuxError]         = None

--- a/mux/jvm/src/main/scala-2/zio/blocks/mux/PlatformMux.scala
+++ b/mux/jvm/src/main/scala-2/zio/blocks/mux/PlatformMux.scala
@@ -107,7 +107,7 @@ private[mux] object PlatformMux {
 
     def id: Id = streamId
 
-    def send(msg: In): Either[MuxError, Unit] = {
+    def send(msg: In): Either[MuxError, Unit] =
       if (msg.asInstanceOf[AnyRef] eq null)
         Left(MuxError.ProtocolError("null message"))
       else {
@@ -118,7 +118,6 @@ private[mux] object PlatformMux {
           Right(())
         else Left(MuxError.QueueFull(StreamQueueCapacity))
       }
-    }
 
     def receive(): Either[MuxError, Option[Out]] = {
       val polled = inboundQueue.take()
@@ -130,7 +129,7 @@ private[mux] object PlatformMux {
       }
     }
 
-    def offerInbound(msg: Out): Either[MuxError, Unit] = {
+    def offerInbound(msg: Out): Either[MuxError, Unit] =
       if (msg.asInstanceOf[AnyRef] eq null)
         Left(MuxError.ProtocolError("null message"))
       else {
@@ -141,7 +140,6 @@ private[mux] object PlatformMux {
           Right(())
         else Left(MuxError.QueueFull(StreamQueueCapacity))
       }
-    }
 
     def takeOutbound(): Either[MuxError, Option[In]] = {
       val polled = outboundQueue.take()

--- a/mux/jvm/src/main/scala-3/zio/blocks/mux/PlatformMux.scala
+++ b/mux/jvm/src/main/scala-3/zio/blocks/mux/PlatformMux.scala
@@ -107,7 +107,7 @@ private[mux] object PlatformMux {
 
     def id: Id = streamId
 
-    def send(msg: In): Unit | MuxError = {
+    def send(msg: In): Unit | MuxError =
       if (msg.asInstanceOf[AnyRef] eq null)
         MuxError.ProtocolError("null message")
       else {
@@ -118,7 +118,6 @@ private[mux] object PlatformMux {
           ()
         else MuxError.QueueFull(StreamQueueCapacity)
       }
-    }
 
     def receive(): Option[Out] | MuxError = {
       val polled = inboundQueue.take()
@@ -130,7 +129,7 @@ private[mux] object PlatformMux {
       }
     }
 
-    def offerInbound(msg: Out): Unit | MuxError = {
+    def offerInbound(msg: Out): Unit | MuxError =
       if (msg.asInstanceOf[AnyRef] eq null)
         MuxError.ProtocolError("null message")
       else {
@@ -141,7 +140,6 @@ private[mux] object PlatformMux {
           ()
         else MuxError.QueueFull(StreamQueueCapacity)
       }
-    }
 
     def takeOutbound(): Option[In] | MuxError = {
       val polled = outboundQueue.take()

--- a/mux/shared/src/main/scala-2/zio/blocks/mux/Mux.scala
+++ b/mux/shared/src/main/scala-2/zio/blocks/mux/Mux.scala
@@ -42,8 +42,8 @@ object Mux {
  *
  * Each stream is identified by a unique `Id` and has independent
  * inbound/outbound message queues. The multiplexer enforces a maximum number of
-  * concurrent streams (capacity). Attempting to open a stream beyond that limit
-  * returns [[MuxError.CapacityExceeded]].
+ * concurrent streams (capacity). Attempting to open a stream beyond that limit
+ * returns [[MuxError.CapacityExceeded]].
  *
  * '''Invariants:'''
  *   - Stream IDs must be unique among active streams; opening a duplicate
@@ -54,10 +54,10 @@ object Mux {
  *     the supplied error enqueued for any pending receive.
  *
  * '''Thread safety:''' `open`, `get`, `cancel`, `closeAll`, and `activeCount`
- * are safe to call from multiple threads concurrently. Per-stream operations
- * on [[MuxStream]]: `send` and `offerInbound` are multi-thread safe.
- * `receive` and `takeOutbound` must each be called from a single consumer
- * thread at a time (single-consumer contract of the underlying ring buffer).
+ * are safe to call from multiple threads concurrently. Per-stream operations on
+ * [[MuxStream]]: `send` and `offerInbound` are multi-thread safe. `receive` and
+ * `takeOutbound` must each be called from a single consumer thread at a time
+ * (single-consumer contract of the underlying ring buffer).
  *
  * @tparam Id
  *   Stream identifier type (e.g., `Int` for HTTP/2 stream IDs)
@@ -229,11 +229,11 @@ trait MuxStream[Id, In, Out] {
   /**
    * Fully close this stream immediately.
    *
-   * Transitions the stream to CLOSED state and enqueues a terminal error.
-   * After this call:
+   * Transitions the stream to CLOSED state and enqueues a terminal error. After
+   * this call:
    *   - `send()` fails with [[MuxError.StreamClosed]].
-   *   - `receive()` drains any already-buffered inbound messages, then
-   *     returns the terminal error once the buffer is empty.
+   *   - `receive()` drains any already-buffered inbound messages, then returns
+   *     the terminal error once the buffer is empty.
    *   - `offerInbound()` fails with [[MuxError.StreamClosed]].
    */
   def close(): Unit

--- a/mux/shared/src/main/scala-3/zio/blocks/mux/Mux.scala
+++ b/mux/shared/src/main/scala-3/zio/blocks/mux/Mux.scala
@@ -42,8 +42,8 @@ object Mux {
  *
  * Each stream is identified by a unique `Id` and has independent
  * inbound/outbound message queues. The multiplexer enforces a maximum number of
-  * concurrent streams (capacity). Attempting to open a stream beyond that limit
-  * returns [[MuxError.CapacityExceeded]].
+ * concurrent streams (capacity). Attempting to open a stream beyond that limit
+ * returns [[MuxError.CapacityExceeded]].
  *
  * '''Invariants:'''
  *   - Stream IDs must be unique among active streams; opening a duplicate
@@ -54,10 +54,10 @@ object Mux {
  *     the supplied error enqueued for any pending receive.
  *
  * '''Thread safety:''' `open`, `get`, `cancel`, `closeAll`, and `activeCount`
- * are safe to call from multiple threads concurrently. Per-stream operations
- * on [[MuxStream]]: `send` and `offerInbound` are multi-thread safe.
- * `receive` and `takeOutbound` must each be called from a single consumer
- * thread at a time (single-consumer contract of the underlying ring buffer).
+ * are safe to call from multiple threads concurrently. Per-stream operations on
+ * [[MuxStream]]: `send` and `offerInbound` are multi-thread safe. `receive` and
+ * `takeOutbound` must each be called from a single consumer thread at a time
+ * (single-consumer contract of the underlying ring buffer).
  *
  * @tparam Id
  *   Stream identifier type (e.g., `Int` for HTTP/2 stream IDs)
@@ -228,11 +228,11 @@ trait MuxStream[Id, In, Out] {
   /**
    * Fully close this stream immediately.
    *
-   * Transitions the stream to CLOSED state and enqueues a terminal error.
-   * After this call:
+   * Transitions the stream to CLOSED state and enqueues a terminal error. After
+   * this call:
    *   - `send()` fails with [[MuxError.StreamClosed]].
-   *   - `receive()` drains any already-buffered inbound messages, then
-   *     returns the terminal error once the buffer is empty.
+   *   - `receive()` drains any already-buffered inbound messages, then returns
+   *     the terminal error once the buffer is empty.
    *   - `offerInbound()` fails with [[MuxError.StreamClosed]].
    */
   def close(): Unit

--- a/mux/shared/src/test/scala-3/zio/blocks/mux/MuxSpec.scala
+++ b/mux/shared/src/test/scala-3/zio/blocks/mux/MuxSpec.scala
@@ -28,7 +28,7 @@ object MuxSpec extends ZIOSpecDefault {
     mux.open(id) match {
       case stream: MuxStream[?, ?, ?] =>
         stream.asInstanceOf[MuxStream[Int, String, String]]
-      case error: MuxError            =>
+      case error: MuxError =>
         throw new RuntimeException(s"Failed to open stream: $error")
     }
 
@@ -65,7 +65,7 @@ object MuxSpec extends ZIOSpecDefault {
       val opened = stream match {
         case stream: MuxStream[?, ?, ?] =>
           stream.asInstanceOf[MuxStream[Int, String, String]]
-        case error: MuxError            =>
+        case error: MuxError =>
           throw new RuntimeException(s"Failed to open stream: $error")
       }
       assertTrue(

--- a/otel/src/main/scala/zio/blocks/telemetry/otel/B3Propagator.scala
+++ b/otel/src/main/scala/zio/blocks/telemetry/otel/B3Propagator.scala
@@ -105,10 +105,10 @@ object B3Propagator {
   }
 
   private object B3MultiPropagator extends Propagator {
-    private val TraceIdHeader      = "X-B3-TraceId"
-    private val SpanIdHeader       = "X-B3-SpanId"
-    private val SampledHeader      = "X-B3-Sampled"
-    private val FlagsHeader = "X-B3-Flags"
+    private val TraceIdHeader = "X-B3-TraceId"
+    private val SpanIdHeader  = "X-B3-SpanId"
+    private val SampledHeader = "X-B3-Sampled"
+    private val FlagsHeader   = "X-B3-Flags"
 
     override val fields: Seq[String] = Seq(TraceIdHeader, SpanIdHeader, SampledHeader, FlagsHeader)
 

--- a/otel/src/main/scala/zio/blocks/telemetry/otel/BatchProcessor.scala
+++ b/otel/src/main/scala/zio/blocks/telemetry/otel/BatchProcessor.scala
@@ -95,10 +95,10 @@ private[otel] final class BatchProcessor[A](
 
   private def exportWithRetry(batch: Seq[A], attempt: Int): Unit =
     (try exportFn(batch)
-     catch {
-       case e if scala.util.control.NonFatal(e) =>
-         ExportResult.Failure(retryable = true, message = e.getMessage)
-     }) match {
+    catch {
+      case e if scala.util.control.NonFatal(e) =>
+        ExportResult.Failure(retryable = true, message = e.getMessage)
+    }) match {
       case ExportResult.Success                     => ()
       case ExportResult.Failure(retryable, message) =>
         if (!retryable) {

--- a/otel/src/main/scala/zio/blocks/telemetry/otel/ExporterConfig.scala
+++ b/otel/src/main/scala/zio/blocks/telemetry/otel/ExporterConfig.scala
@@ -21,12 +21,19 @@ import java.time.Duration
 /**
  * Configuration for OTLP JSON exporters.
  *
- * @param endpoint           collector base URL (default `http://localhost:4318`)
- * @param headers            extra HTTP headers sent with every export (e.g. auth tokens); redacted in `toString`
- * @param timeout            connect and read timeout per HTTP request
- * @param maxQueueSize       maximum items buffered before oldest are dropped
- * @param maxBatchSize       maximum items sent in a single export request
- * @param flushIntervalMillis milliseconds between automatic background flushes
+ * @param endpoint
+ *   collector base URL (default `http://localhost:4318`)
+ * @param headers
+ *   extra HTTP headers sent with every export (e.g. auth tokens); redacted in
+ *   `toString`
+ * @param timeout
+ *   connect and read timeout per HTTP request
+ * @param maxQueueSize
+ *   maximum items buffered before oldest are dropped
+ * @param maxBatchSize
+ *   maximum items sent in a single export request
+ * @param flushIntervalMillis
+ *   milliseconds between automatic background flushes
  */
 final case class ExporterConfig(
   endpoint: String = "http://localhost:4318",

--- a/otel/src/main/scala/zio/blocks/telemetry/otel/HttpSender.scala
+++ b/otel/src/main/scala/zio/blocks/telemetry/otel/HttpSender.scala
@@ -73,11 +73,11 @@ private[otel] final class JdkHttpSender(
     val response = client.send(request, JdkHttpResponse.BodyHandlers.ofByteArray())
 
     val responseHeaders = scala.collection.mutable.Map[String, Seq[String]]()
-    val it = response.headers().map().entrySet().iterator()
+    val it              = response.headers().map().entrySet().iterator()
     while (it.hasNext) {
-      val entry = it.next()
+      val entry  = it.next()
       val values = new scala.collection.mutable.ArrayBuffer[String](entry.getValue.size())
-      val vit = entry.getValue.iterator()
+      val vit    = entry.getValue.iterator()
       while (vit.hasNext) values += vit.next()
       responseHeaders(entry.getKey) = values.toSeq
     }

--- a/telemetry/jvm/src/main/scala/zio/blocks/telemetry/FileLogWriter.scala
+++ b/telemetry/jvm/src/main/scala/zio/blocks/telemetry/FileLogWriter.scala
@@ -51,73 +51,73 @@ private[telemetry] final class FileLogWriter private (
   override def write(content: CharSequence): Unit = {
     lock.lock()
     try {
-    val buf     = state.buffer
-    val encoder = state.encoder
+      val buf     = state.buffer
+      val encoder = state.encoder
 
-    buf.clear()
+      buf.clear()
 
-    // Fast path: ASCII content (most log lines are ASCII)
-    val len = content.length
-    if (len <= buf.capacity - 1) { // -1 for newline
-      var i        = 0
-      var allAscii = true
-      while (i < len && allAscii) {
-        val c = content.charAt(i)
-        if (c < 128) {
-          buf.put(c.toByte)
-        } else {
-          allAscii = false
+      // Fast path: ASCII content (most log lines are ASCII)
+      val len = content.length
+      if (len <= buf.capacity - 1) { // -1 for newline
+        var i        = 0
+        var allAscii = true
+        while (i < len && allAscii) {
+          val c = content.charAt(i)
+          if (c < 128) {
+            buf.put(c.toByte)
+          } else {
+            allAscii = false
+          }
+          i += 1
         }
-        i += 1
+
+        if (allAscii) {
+          // All ASCII — fast path complete
+          buf.put('\n'.toByte)
+          buf.flip()
+          try {
+            while (buf.hasRemaining) channel.write(buf)
+          } catch {
+            case e: IOException =>
+              System.err.println("[zio-blocks-telemetry] file write error: " + e.getMessage)
+          }
+          return
+        }
+
+        // Had non-ASCII — fall back to encoder
+        buf.clear()
       }
 
-      if (allAscii) {
-        // All ASCII — fast path complete
+      // Slow path: use CharsetEncoder for non-ASCII or content > buffer
+      val charBuf = CharBuffer.wrap(content)
+      encoder.reset()
+      try {
+        var result = encoder.encode(charBuf, buf, true)
+        while (result == CoderResult.OVERFLOW) {
+          buf.flip()
+          while (buf.hasRemaining) channel.write(buf)
+          buf.clear()
+          result = encoder.encode(charBuf, buf, true)
+        }
+        result = encoder.flush(buf)
+        while (result == CoderResult.OVERFLOW) {
+          buf.flip()
+          while (buf.hasRemaining) channel.write(buf)
+          buf.clear()
+          result = encoder.flush(buf)
+        }
+        if (!buf.hasRemaining) {
+          buf.flip()
+          while (buf.hasRemaining) channel.write(buf)
+          buf.clear()
+        }
         buf.put('\n'.toByte)
         buf.flip()
-        try {
-          while (buf.hasRemaining) channel.write(buf)
-        } catch {
-          case e: IOException =>
-            System.err.println("[zio-blocks-telemetry] file write error: " + e.getMessage)
-        }
-        return
-      }
-
-      // Had non-ASCII — fall back to encoder
-      buf.clear()
-    }
-
-    // Slow path: use CharsetEncoder for non-ASCII or content > buffer
-    val charBuf = CharBuffer.wrap(content)
-    encoder.reset()
-    try {
-      var result = encoder.encode(charBuf, buf, true)
-      while (result == CoderResult.OVERFLOW) {
-        buf.flip()
         while (buf.hasRemaining) channel.write(buf)
-        buf.clear()
-        result = encoder.encode(charBuf, buf, true)
+      } catch {
+        case e: IOException =>
+          System.err.println("[zio-blocks-telemetry] file write error: " + e.getMessage)
       }
-      result = encoder.flush(buf)
-      while (result == CoderResult.OVERFLOW) {
-        buf.flip()
-        while (buf.hasRemaining) channel.write(buf)
-        buf.clear()
-        result = encoder.flush(buf)
-      }
-      if (!buf.hasRemaining) {
-        buf.flip()
-        while (buf.hasRemaining) channel.write(buf)
-        buf.clear()
-      }
-      buf.put('\n'.toByte)
-      buf.flip()
-      while (buf.hasRemaining) channel.write(buf)
-    } catch {
-      case e: IOException =>
-        System.err.println("[zio-blocks-telemetry] file write error: " + e.getMessage)
-    }
     } finally lock.unlock()
   }
 

--- a/telemetry/jvm/src/test/scala/zio/blocks/telemetry/BranchCoverageSpec.scala
+++ b/telemetry/jvm/src/test/scala/zio/blocks/telemetry/BranchCoverageSpec.scala
@@ -235,7 +235,7 @@ object BranchCoverageSpec extends ZIOSpecDefault {
     },
     test("root span reuses sampler trace id") {
       val observed = ArrayBuffer.empty[(Long, Long)]
-      val sampler = new Sampler {
+      val sampler  = new Sampler {
         def shouldSample(
           parentContext: Option[SpanContext],
           traceIdHi: Long,
@@ -251,7 +251,7 @@ object BranchCoverageSpec extends ZIOSpecDefault {
         val description: String = "trace-capture"
       }
       val processor = new TestProcessor
-      val tracer = TracerProvider.builder
+      val tracer    = TracerProvider.builder
         .setSampler(sampler)
         .addSpanProcessor(processor)
         .build()
@@ -581,7 +581,9 @@ object BranchCoverageSpec extends ZIOSpecDefault {
       val rendered = sb.toString
       assertTrue(
         rendered.startsWith("{\"timeUnixNano\":\"1000\""),
-        rendered.contains("\"attributes\":[{\"key\":\"k\",\"value\":{\"stringValue\":\"v\"}},{\"key\":\"exception.stacktrace\""),
+        rendered.contains(
+          "\"attributes\":[{\"key\":\"k\",\"value\":{\"stringValue\":\"v\"}},{\"key\":\"exception.stacktrace\""
+        ),
         rendered.endsWith("}"),
         !rendered.contains("{{\"timeUnixNano\""),
         !rendered.contains("\"value\":{{")
@@ -597,7 +599,7 @@ object BranchCoverageSpec extends ZIOSpecDefault {
       val (outerBeforeNested, nested, outerAfterNested, afterAllScopes) =
         LogAnnotations.scoped(Map("requestId" -> "req-1")) {
           val beforeNested = LogAnnotations.get()
-          val nestedState = LogAnnotations.scoped(Map("userId" -> "u-1")) {
+          val nestedState  = LogAnnotations.scoped(Map("userId" -> "u-1")) {
             LogAnnotations.get()
           }
           val afterNested = LogAnnotations.get()

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/Attributes.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/Attributes.scala
@@ -424,10 +424,10 @@ object Attributes {
       ensureCapacity()
       _keys(_len) = key
       _len += 1
-        _len - 1
-      }
+      _len - 1
+    }
 
-    private def hasActiveSeqs: Boolean = {
+    private def hasActiveSeqs: Boolean =
       if (_seqs == null) false
       else {
         var i = 0
@@ -437,7 +437,6 @@ object Attributes {
         }
         false
       }
-    }
 
     private def ensureCapacity(): Unit =
       if (_len >= _keys.length) {

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/GlobalLogState.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/GlobalLogState.scala
@@ -134,8 +134,8 @@ private[telemetry] object GlobalLogState {
 
   private def updateGlobalMinLevel(): Unit = {
     val state = ref.get()
-    var min = state.minSeverity
-    var i   = 0
+    var min   = state.minSeverity
+    var i     = 0
     while (i < state.levelOverrideValues.length) {
       val v = state.levelOverrideValues(i)
       if (v < min) min = v

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/LogFormatter.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/LogFormatter.scala
@@ -286,10 +286,10 @@ object TextLogFormatter extends LogFormatter {
 object JsonLogFormatter extends LogFormatter {
   private sealed trait JsonAttrValue
   private object JsonAttrValue {
-    final case class StringValue(value: String)  extends JsonAttrValue
-    final case class IntValue(value: Long)       extends JsonAttrValue
-    final case class DoubleValue(value: Double)  extends JsonAttrValue
-    final case class BoolValue(value: Boolean)   extends JsonAttrValue
+    final case class StringValue(value: String) extends JsonAttrValue
+    final case class IntValue(value: Long)      extends JsonAttrValue
+    final case class DoubleValue(value: Double) extends JsonAttrValue
+    final case class BoolValue(value: Boolean)  extends JsonAttrValue
   }
 
   override def format(

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/ObservableCallback.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/ObservableCallback.scala
@@ -21,6 +21,7 @@ package zio.blocks.telemetry
  * collection cycle.
  */
 trait ObservableCallback {
+
   /**
    * Records an observed value with the supplied attribute set.
    */

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/SpanProcessor.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/SpanProcessor.scala
@@ -22,6 +22,7 @@ package zio.blocks.telemetry
  * Processors can export spans, buffer them, or perform in-memory inspection.
  */
 trait SpanProcessor extends AutoCloseable {
+
   /**
    * Called when a span is started.
    */

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/log.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/log.scala
@@ -45,7 +45,7 @@ object log extends LogVersionSpecific {
   /** Add a log record processor. Additive. */
   def addProcessor(processor: LogRecordProcessor): Unit = synchronized {
     val currentState = GlobalLogState.get()
-    val logger = new Logger(
+    val logger       = new Logger(
       currentState.logger.instrumentationScope,
       currentState.logger.resource,
       currentState.logger.processors :+ processor,
@@ -58,7 +58,10 @@ object log extends LogVersionSpecific {
   def install(logger: Logger, minSeverity: Severity = Severity.Trace): Unit =
     GlobalLogState.install(logger, minSeverity)
 
-  /** Remove all processors and writers. After this, log calls are no-ops until you add a processor or install a logger. */
+  /**
+   * Remove all processors and writers. After this, log calls are no-ops until
+   * you add a processor or install a logger.
+   */
   def removeAll(): Unit = synchronized {
     val prev = GlobalLogState.get()
     prev.logger.processors.foreach { p =>
@@ -100,7 +103,7 @@ object log extends LogVersionSpecific {
 
   private def rebuildState(): Unit = {
     val currentState = GlobalLogState.get()
-    val logger = new Logger(
+    val logger       = new Logger(
       currentState.logger.instrumentationScope,
       currentState.logger.resource,
       currentState.logger.baseProcessors ++ _writerProcessors,

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/metric.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/metric.scala
@@ -53,7 +53,10 @@ object metric {
   /** Replaces the default MeterProvider with a user-configured one. */
   def install(provider: MeterProvider): Unit = ref.set(provider)
 
-  /** Remove the installed MeterProvider. After this, metrics use the default provider. */
+  /**
+   * Remove the installed MeterProvider. After this, metrics use the default
+   * provider.
+   */
   def removeAll(): Unit = ref.set(MeterProvider.builder.build())
 
   /** Returns the MetricReader for the current provider. */

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/trace.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/trace.scala
@@ -19,8 +19,8 @@ package zio.blocks.telemetry
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Global tracing entry point. Works without setup — stores spans in memory
- * by default. Call `install` to wire production exporters.
+ * Global tracing entry point. Works without setup — stores spans in memory by
+ * default. Call `install` to wire production exporters.
  *
  * App code uses this directly. Library code should accept `Tracer` via DI.
  */
@@ -52,7 +52,10 @@ object trace {
   /** Replaces the default TracerProvider with a user-configured one. */
   def install(provider: TracerProvider): Unit = ref.set(provider)
 
-  /** Remove the installed TracerProvider. After this, spans are no-ops until you install a provider. */
+  /**
+   * Remove the installed TracerProvider. After this, spans are no-ops until you
+   * install a provider.
+   */
   def removeAll(): Unit = ref.set(TracerProvider.builder.setSampler(AlwaysOffSampler).build())
 
   /** Returns spans collected by the default in-memory processor. */

--- a/telemetry/shared/src/test/scala/zio/blocks/telemetry/LogSpec.scala
+++ b/telemetry/shared/src/test/scala/zio/blocks/telemetry/LogSpec.scala
@@ -258,9 +258,9 @@ object LogSpec extends ZIOSpecDefault {
         var noisyLevel = 0
         var otherLevel = 0
         withLogger(Severity.Info) { _ =>
-        log.setMinSeverity("com.example", Severity.Debug)
-        log.setMinSeverity("com.example.noisy", Severity.Warn)
-        val state = GlobalLogState.get()
+          log.setMinSeverity("com.example", Severity.Debug)
+          log.setMinSeverity("com.example.noisy", Severity.Warn)
+          val state = GlobalLogState.get()
           debugLevel = state.effectiveLevel("com.example.Service")
           noisyLevel = state.effectiveLevel("com.example.noisy.Thing")
           otherLevel = state.effectiveLevel("com.other.Foo")
@@ -274,9 +274,9 @@ object LogSpec extends ZIOSpecDefault {
       test("clearLevel removes override") {
         var level = 0
         withLogger(Severity.Info) { _ =>
-        log.setMinSeverity("com.test", Severity.Debug)
-        log.clearMinSeverity("com.test")
-        level = GlobalLogState.get().effectiveLevel("com.test.Foo")
+          log.setMinSeverity("com.test", Severity.Debug)
+          log.clearMinSeverity("com.test")
+          level = GlobalLogState.get().effectiveLevel("com.test.Foo")
         }
         assertTrue(level == Severity.Info.number)
       },
@@ -284,10 +284,10 @@ object LogSpec extends ZIOSpecDefault {
         var aLevel = 0
         var bLevel = 0
         withLogger(Severity.Info) { _ =>
-        log.setMinSeverity("a", Severity.Debug)
-        log.setMinSeverity("b", Severity.Warn)
-        log.clearAllOverrides()
-        val state = GlobalLogState.get()
+          log.setMinSeverity("a", Severity.Debug)
+          log.setMinSeverity("b", Severity.Warn)
+          log.clearAllOverrides()
+          val state = GlobalLogState.get()
           aLevel = state.effectiveLevel("a.Foo")
           bLevel = state.effectiveLevel("b.Bar")
         }


### PR DESCRIPTION
## Problem

Three publishable modules are **missing from the root `.aggregate()`**, so `ci-release` (`+publishSigned`) silently skips them. No artifacts have ever been published for:

- **`mux`** (JVM + JS) — core HTTP/2 stream multiplexer
- **`telemetry`** (JVM + JS) — telemetry module
- **`otel`** (JVM only) — OpenTelemetry bridge

All other publishable modules (config, config-yaml, config-json, config-hocon, schema, chunk, etc.) are already in the aggregate and publish correctly.

### Evidence

From the [latest CI release run](https://github.com/zio/zio-blocks/actions/runs/28377787667/job/84086619979):
- 692 artifacts published to `central.sonatype.com/repository/maven-snapshots`
- **Zero** `mux`, `telemetry`, or `otel` artifacts — not even a POM was written for them
- `config`, `config-yaml` etc. all published correctly (they ARE in the aggregate)

### Audit methodology

Compared every `lazy val` module definition against:
1. The root `.aggregate()` list
2. `publish / skip := true` markers
3. Actual `published ... to` lines in the release job logs

All 23 modules with `publish / skip := true` (examples, benchmarks, tests, golem, docs) are correctly excluded. Only `mux`, `telemetry`, and `otel` are publishable but missing from the aggregate.

## Fix (this PR)

**`build.sbt`**: Add the 5 missing aggregate entries:
```scala
mux.jvm,
mux.js,
telemetry.jvm,
telemetry.js,
otel,
```

## ⚠️ Additional change needed: release JDK → 25

`telemetry` and `otel` force `-release 25` in their `scalacOptions` (lines 570-576, 601-607 of build.sbt). The release job currently runs on **JDK 17**, which cannot compile `-release 25` targets.

**The ci.yml change could not be pushed via this PAT** (missing `workflow` scope). It needs to be applied manually or via the GitHub web editor:

```diff
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,8 @@ jobs:
       - name: Setup Action
         uses: coursier/setup-action@v3
         with:
-          jvm: temurin:17
+          jvm: temurin:25
+          jvm-index: https://raw.githubusercontent.com/coursier/jvm-index/refs/heads/master/index.json
           apps: sbt
```

Without this JDK bump, `mux` will publish but `telemetry` and `otel` will fail to compile during release.