### PR TITLE
fix(ci): harden release pipeline against intermittent scala3#24183 scaladoc NPE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
       - published
 concurrency:
   group: ci-pr-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   buildDocs:
@@ -204,7 +204,10 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
     needs: [ci]
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -218,7 +221,11 @@ jobs:
           jvm: temurin:25
           apps: sbt
       - name: Release
-        run: sbt ci-release
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: sbt ci-release
         env:
           JAVA_TOOL_OPTIONS: -XX:+UseCompactObjectHeaders
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
@@ -230,6 +237,9 @@ jobs:
     name: Release Docs
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    concurrency:
+      group: release-docs-${{ github.ref }}
+      cancel-in-progress: false
     continue-on-error: false
     needs:
       - release
@@ -260,4 +270,8 @@ jobs:
           node-version: 24.12.0
           registry-url: https://registry.npmjs.org
       - name: Publish Docs to NPM Registry
-        run: sbt docs/publishToNpm
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: sbt docs/publishToNpm


### PR DESCRIPTION
`release` intermittently crashes during `sbt ci-release`'s doc generation with a known dotty scaladoc NPE (scala/scala3#24183), confirmed in 3 of the last 15 push-to-main CI runs (28571352619, 28539726510, 28528354112), all with the identical `SignatureBuilder.content()` NPE stack. Separately, run 28645182779 shows `sbt ci-release` completing successfully and then getting killed by the workflow-level `cancel-in-progress` concurrency group when a later commit landed on `main` mid-publish.

`release` cannot move off JDK 25 -- `telemetry.jvm` and `otel` both force `-release 25` in `Compile / scalacOptions` (see `build.sbt`), and are real published modules (no `publish / skip`). This is exactly why `release` was bumped to `temurin:25` in #1493 in the first place. `testJVM`'s own pre-existing `matrix.java >= 25` skip-docs workaround confirms the NPE is triggered by running scaladoc under JDK >= 25 itself, independent of any JVM flags -- so this PR does NOT attempt to dodge the JDK version. It leaves `release`'s `jvm: temurin:25` and `JAVA_TOOL_OPTIONS: -XX:+UseCompactObjectHeaders` untouched, and does not touch `testJVM` either (that flag is not experimental on JDK 25 and there's no strong evidence it's at fault for anything).

Changes:
- Workflow-level `concurrency.cancel-in-progress` (top of `ci.yml`) is now scoped to `pull_request` events only (`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`). This is the actual fix for "a later push to main cancels an in-flight release": the workflow-level group previously applied `cancel-in-progress: true` unconditionally, including to `push`-to-`main`, and that cancels the *entire run* -- job-level concurrency blocks provide no protection from that. PR runs keep the existing cancel-on-new-push behavior; push-to-main runs (when `release`/`release-docs` execute) are never cancelled by a subsequent push.
- `release`: add a job-level concurrency group (`release-${{ github.ref }}`, `cancel-in-progress: false`) so if two release runs on `main` somehow still overlap (manual reruns, `workflow_dispatch`), the second one queues instead of racing the first on Sonatype publishing. Bump `timeout-minutes` 45 -> 60 and wrap `sbt ci-release` in `nick-fields/retry@v3` (`max_attempts: 3`, `timeout_minutes: 15`) -- since the NPE is nondeterministic and JDK25 can't be avoided here, retry is the primary mitigation.
- `release-docs`: same concurrency isolation (`release-docs-${{ github.ref }}`) and retry treatment for `sbt docs/publishToNpm`.

Note: `release`/`release-docs` don't run on `pull_request` events, so this PR's own CI can't exercise them -- only `lint`/`testJVM`/`testJS`/`testGolem`/`buildDocs`/`ci` run here. The concurrency + retry fix will only be validated on the next real push to `main` after merge.