### PR TITLE
fix(telemetry): render structured attributes, Seq-typed tags, and stacktraces in console/text/json log formatters

### DIFF
--- a/telemetry/jvm/src/test/scala/zio/blocks/telemetry/BranchCoverageSpec.scala
+++ b/telemetry/jvm/src/test/scala/zio/blocks/telemetry/BranchCoverageSpec.scala
@@ -421,14 +421,14 @@ object BranchCoverageSpec extends ZIOSpecDefault {
         .info("m", "d" -> AttributeValue.DoubleValue(3.14))
       assertTrue(p.emitted.head.attributes.toMap("d") == AttributeValue.DoubleValue(3.14))
     },
-    test("log with seq attribute hits catch-all") {
+    test("log preserves seq attribute type fidelity") {
       val p = new TestLogProcessor
       LoggerProvider.builder
         .addLogRecordProcessor(p)
         .build()
         .get("t")
         .info("m", "s" -> AttributeValue.StringSeqValue(Seq("a")))
-      assertTrue(p.emitted.head.attributes.toMap.contains("s"))
+      assertTrue(p.emitted.head.attributes.get(AttributeKey.stringSeq("s")).contains(Seq("a")))
     },
     test("StandardLogEmitter clears builder when severity is below processor threshold") {
       val builder = Attributes.builder.put("k", "v")

--- a/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LogFormatterSpec.scala
+++ b/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LogFormatterSpec.scala
@@ -226,6 +226,29 @@ object LogFormatterSpec extends ZIOSpecDefault {
         val rendered = renderText(timestamp, Severity.Info, "INFO", "dotless", builder)
 
         assertTrue(rendered.startsWith(s"${expectedTimestamp(timestamp)} INFO  [RootService.go:3] dotless"))
+      },
+      test("renders all seq attribute types and an empty seq inline") {
+        val timestamp = 1719792602523000000L
+        val builder   = Attributes.builder
+          .put("code.filepath", "Seqs.scala")
+          .put("code.namespace", "Seqs")
+          .put("code.function", "go")
+          .put("code.lineno", 1L)
+          .put(AttributeKey.stringSeq("tags"), Seq("a", "b"))
+          .put(AttributeKey.longSeq("nums"), Seq(1L, 2L))
+          .put(AttributeKey.doubleSeq("rates"), Seq(1.5, 2.5))
+          .put(AttributeKey.booleanSeq("flags"), Seq(true, false))
+          .put(AttributeKey.stringSeq("empty"), Seq.empty[String])
+
+        val rendered = renderText(timestamp, Severity.Info, "INFO", "seqs", builder)
+
+        assertTrue(
+          rendered.contains("tags=[\"a\", \"b\"]"),
+          rendered.contains("nums=[1, 2]"),
+          rendered.contains("rates=[1.5, 2.5]"),
+          rendered.contains("flags=[true, false]"),
+          rendered.contains("empty=[]")
+        )
       }
     ),
     suite("TextLogFormatter.formatRecord")(
@@ -373,6 +396,31 @@ object LogFormatterSpec extends ZIOSpecDefault {
         assertTrue(
           rendered ==
             s"{\"timeUnixNano\":\"$timestamp\",\"severityNumber\":17,\"severityText\":\"ERROR\",\"body\":{\"stringValue\":\"minimal\"}}"
+        )
+      },
+      test("renders all seq attribute types as OTLP arrayValue") {
+        val timestamp = 1719792607523000000L
+        val builder   = Attributes.builder
+          .put(AttributeKey.stringSeq("tags"), Seq("a", "b"))
+          .put(AttributeKey.longSeq("nums"), Seq(1L, 2L))
+          .put(AttributeKey.doubleSeq("rates"), Seq(1.5, 2.5))
+          .put(AttributeKey.booleanSeq("flags"), Seq(true, false))
+
+        val rendered = renderJson(timestamp, Severity.Info, "INFO", "seqs", builder)
+
+        assertTrue(
+          rendered.contains(
+            "{\"key\":\"tags\",\"value\":{\"arrayValue\":{\"values\":[{\"stringValue\":\"a\"},{\"stringValue\":\"b\"}]}}}"
+          ),
+          rendered.contains(
+            "{\"key\":\"nums\",\"value\":{\"arrayValue\":{\"values\":[{\"intValue\":\"1\"},{\"intValue\":\"2\"}]}}}"
+          ),
+          rendered.contains(
+            "{\"key\":\"rates\",\"value\":{\"arrayValue\":{\"values\":[{\"doubleValue\":1.5},{\"doubleValue\":2.5}]}}}"
+          ),
+          rendered.contains(
+            "{\"key\":\"flags\",\"value\":{\"arrayValue\":{\"values\":[{\"boolValue\":true},{\"boolValue\":false}]}}}"
+          )
         )
       }
     ),

--- a/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LogProcessorSpec.scala
+++ b/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LogProcessorSpec.scala
@@ -127,7 +127,12 @@ object LogProcessorSpec extends ZIOSpecDefault {
       builder.put("active", value = true)
     }
 
-    if (includeOtherAttr) builder.put(AttributeKey.stringSeq("tags"), List("alpha", "beta"))
+    if (includeOtherAttr) {
+      builder.put(AttributeKey.stringSeq("tags"), List("alpha", "beta"))
+      builder.put(AttributeKey.longSeq("nums"), List(1L, 2L))
+      builder.put(AttributeKey.doubleSeq("rates"), List(1.5, 2.5))
+      builder.put(AttributeKey.booleanSeq("flags"), List(true, false))
+    }
 
     LogRecord(
       timestampNanos = 1719792600123000000L,
@@ -176,7 +181,10 @@ object LogProcessorSpec extends ZIOSpecDefault {
         rendered.contains("count=5"),
         rendered.contains("ratio=2.5"),
         rendered.contains("active=true"),
-        rendered.contains("tags=StringSeqValue(List(alpha, beta))"),
+        rendered.contains("tags=[\"alpha\", \"beta\"]"),
+        rendered.contains("nums=[1, 2]"),
+        rendered.contains("rates=[1.5, 2.5]"),
+        rendered.contains("flags=[true, false]"),
         !rendered.contains("code.filepath"),
         !rendered.contains("code.namespace"),
         !rendered.contains("code.function"),
@@ -229,7 +237,10 @@ object LogProcessorSpec extends ZIOSpecDefault {
         rendered.contains("count=5"),
         rendered.contains("ratio=2.5"),
         rendered.contains("active=true"),
-        rendered.contains("tags=StringSeqValue(List(alpha, beta))"),
+        rendered.contains("tags=[\"alpha\", \"beta\"]"),
+        rendered.contains("nums=[1, 2]"),
+        rendered.contains("rates=[1.5, 2.5]"),
+        rendered.contains("flags=[true, false]"),
         !rendered.contains("code.filepath"),
         !rendered.contains("code.namespace"),
         !rendered.contains("code.function"),
@@ -281,6 +292,44 @@ object LogProcessorSpec extends ZIOSpecDefault {
         rendered.contains("\"key\":\"count\",\"value\":{\"intValue\":\"5\"}}"),
         rendered.contains("\"key\":\"ratio\",\"value\":{\"doubleValue\":2.5}}"),
         rendered.contains("\"key\":\"active\",\"value\":{\"boolValue\":true}}")
+      )
+    },
+    test("onEmit renders all seq attribute types via TextLogFormatter.formatRecord") {
+      val writer    = new TestLogWriter()
+      val processor = new FormattedLogRecordProcessor(TextLogFormatter, writer)
+
+      processor.onEmit(logRecord())
+
+      val rendered = writer.writes.headOption.getOrElse("")
+      assertTrue(
+        writer.writes.size == 1,
+        rendered.contains("tags=[\"alpha\", \"beta\"]"),
+        rendered.contains("nums=[1, 2]"),
+        rendered.contains("rates=[1.5, 2.5]"),
+        rendered.contains("flags=[true, false]")
+      )
+    },
+    test("onEmit renders all seq attribute types via JsonLogFormatter.formatRecord") {
+      val writer    = new TestLogWriter()
+      val processor = new FormattedLogRecordProcessor(JsonLogFormatter, writer)
+
+      processor.onEmit(logRecord())
+
+      val rendered = writer.writes.headOption.getOrElse("")
+      assertTrue(
+        writer.writes.size == 1,
+        rendered.contains(
+          "\"key\":\"tags\",\"value\":{\"arrayValue\":{\"values\":[{\"stringValue\":\"alpha\"},{\"stringValue\":\"beta\"}]}}}"
+        ),
+        rendered.contains(
+          "\"key\":\"nums\",\"value\":{\"arrayValue\":{\"values\":[{\"intValue\":\"1\"},{\"intValue\":\"2\"}]}}}"
+        ),
+        rendered.contains(
+          "\"key\":\"rates\",\"value\":{\"arrayValue\":{\"values\":[{\"doubleValue\":1.5},{\"doubleValue\":2.5}]}}}"
+        ),
+        rendered.contains(
+          "\"key\":\"flags\",\"value\":{\"arrayValue\":{\"values\":[{\"boolValue\":true},{\"boolValue\":false}]}}}"
+        )
       )
     },
     test("shutdown calls writer close") {

--- a/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LogProcessorSpec.scala
+++ b/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LogProcessorSpec.scala
@@ -217,12 +217,25 @@ object LogProcessorSpec extends ZIOSpecDefault {
   )
 
   private val consoleLogRecordProcessorSuite = suite("ConsoleLogRecordProcessor")(
-    test("onEmit writes severity and body") {
+    test("onEmit renders full log record with source location user attributes and throwable") {
       val processor      = new ConsoleLogRecordProcessor()
-      val (_, rendered0) = captureStdout(processor.onEmit(logRecord()))
+      val failure        = new IllegalStateException("boom")
+      val (_, rendered0) = captureStdout(processor.onEmit(logRecord(throwable = Some(failure))))
       val rendered       = rendered0.trim
 
-      assertTrue(rendered == "INFO test message")
+      assertTrue(
+        rendered.startsWith("2024-07-01T00:10:00.123Z INFO  [MyClass.myMethod:42] test message"),
+        rendered.contains("userId=\"abc\""),
+        rendered.contains("count=5"),
+        rendered.contains("ratio=2.5"),
+        rendered.contains("active=true"),
+        rendered.contains("tags=StringSeqValue(List(alpha, beta))"),
+        !rendered.contains("code.filepath"),
+        !rendered.contains("code.namespace"),
+        !rendered.contains("code.function"),
+        !rendered.contains("code.lineno"),
+        rendered.contains("java.lang.IllegalStateException: boom")
+      )
     },
     test("shutdown and forceFlush are no-ops") {
       val processor = new ConsoleLogRecordProcessor()

--- a/telemetry/shared/src/main/scala-2/zio/blocks/telemetry/LogMacros.scala
+++ b/telemetry/shared/src/main/scala-2/zio/blocks/telemetry/LogMacros.scala
@@ -279,7 +279,14 @@ private[telemetry] object LogMacros {
             case _root_.zio.blocks.telemetry.AttributeValue.LongValue(l)    => builder.put(k, l)
             case _root_.zio.blocks.telemetry.AttributeValue.DoubleValue(d)  => builder.put(k, d)
             case _root_.zio.blocks.telemetry.AttributeValue.BooleanValue(b) => builder.put(k, b)
-            case other                                                 => builder.put(k, other.toString)
+            case _root_.zio.blocks.telemetry.AttributeValue.StringSeqValue(s) =>
+              builder.put(_root_.zio.blocks.telemetry.AttributeKey.stringSeq(k), s)
+            case _root_.zio.blocks.telemetry.AttributeValue.LongSeqValue(s) =>
+              builder.put(_root_.zio.blocks.telemetry.AttributeKey.longSeq(k), s)
+            case _root_.zio.blocks.telemetry.AttributeValue.DoubleSeqValue(s) =>
+              builder.put(_root_.zio.blocks.telemetry.AttributeKey.doubleSeq(k), s)
+            case _root_.zio.blocks.telemetry.AttributeValue.BooleanSeqValue(s) =>
+              builder.put(_root_.zio.blocks.telemetry.AttributeKey.booleanSeq(k), s)
           }
         }""")
       case StringBodyKind(idx) =>

--- a/telemetry/shared/src/main/scala-3/zio/blocks/telemetry/LogMacros.scala
+++ b/telemetry/shared/src/main/scala-3/zio/blocks/telemetry/LogMacros.scala
@@ -262,11 +262,14 @@ private[telemetry] object LogMacros {
                   List('{
                     $expr.foreach { (k, v) =>
                       v match {
-                        case AttributeValue.StringValue(s)  => builder.put(k, s)
-                        case AttributeValue.LongValue(l)    => builder.put(k, l)
-                        case AttributeValue.DoubleValue(d)  => builder.put(k, d)
-                        case AttributeValue.BooleanValue(b) => builder.put(k, b)
-                        case other                          => builder.put(k, other.toString)
+                        case AttributeValue.StringValue(s)     => builder.put(k, s)
+                        case AttributeValue.LongValue(l)       => builder.put(k, l)
+                        case AttributeValue.DoubleValue(d)     => builder.put(k, d)
+                        case AttributeValue.BooleanValue(b)    => builder.put(k, b)
+                        case AttributeValue.StringSeqValue(s)  => builder.put(AttributeKey.stringSeq(k), s)
+                        case AttributeValue.LongSeqValue(s)    => builder.put(AttributeKey.longSeq(k), s)
+                        case AttributeValue.DoubleSeqValue(s)  => builder.put(AttributeKey.doubleSeq(k), s)
+                        case AttributeValue.BooleanSeqValue(s) => builder.put(AttributeKey.booleanSeq(k), s)
                       }
                     }
                   })

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/Attributes.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/Attributes.scala
@@ -366,7 +366,14 @@ object Attributes {
     private[telemetry] def builderTypes: Array[Byte]     = _types
     private[telemetry] def builderLongs: Array[Long]     = _longs
     private[telemetry] def builderStrings: Array[String] = _strings
-    private[telemetry] def builderLen: Int               = _len
+
+    /**
+     * Raw seq-value side-array for the zero-alloc formatting path. May be
+     * `null` when no Seq-typed attribute has been added; callers must
+     * null-check.
+     */
+    private[telemetry] def builderSeqs: Array[AnyRef] = _seqs
+    private[telemetry] def builderLen: Int            = _len
 
     def clear(): Unit = {
       var i = 0

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/ConsoleLogRecordProcessor.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/ConsoleLogRecordProcessor.scala
@@ -17,16 +17,20 @@
 package zio.blocks.telemetry
 
 /**
- * Console log processor — triggers the fast ConsoleLogEmitter in Logger. Uses a
- * format that writes directly from raw values, bypassing LogRecord. Format:
- * "2026-03-31T17:30:00.123Z INFO [MyClass.method:42] message {key=val}"
- */
+  * Console log processor — triggers the fast ConsoleLogEmitter in Logger. Uses a
+  * format that writes directly from raw values, bypassing LogRecord. Format:
+  * "2026-03-31T17:30:00.123Z INFO [MyClass.method:42] message {key=val}"
+  *
+  * When a LogRecord is passed via emit() (e.g. via bridges/adapters), delegates to
+  * StdoutLogRecordProcessor to ensure full formatting with attributes and stacktrace.
+  */
 class ConsoleLogRecordProcessor extends LogRecordProcessor {
 
-  override def onEmit(logRecord: LogRecord): Unit =
-    // Fallback for when used without ConsoleLogEmitter (shouldn't happen in normal use)
-    System.out.println(s"${logRecord.severityText} ${logRecord.body.value}")
+  private val delegate = new StdoutLogRecordProcessor()
 
-  override def shutdown(): Unit   = ()
-  override def forceFlush(): Unit = ()
+  override def onEmit(logRecord: LogRecord): Unit =
+    delegate.onEmit(logRecord)
+
+  override def shutdown(): Unit   = delegate.shutdown()
+  override def forceFlush(): Unit = delegate.forceFlush()
 }

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/ConsoleLogRecordProcessor.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/ConsoleLogRecordProcessor.scala
@@ -17,13 +17,14 @@
 package zio.blocks.telemetry
 
 /**
-  * Console log processor — triggers the fast ConsoleLogEmitter in Logger. Uses a
-  * format that writes directly from raw values, bypassing LogRecord. Format:
-  * "2026-03-31T17:30:00.123Z INFO [MyClass.method:42] message {key=val}"
-  *
-  * When a LogRecord is passed via emit() (e.g. via bridges/adapters), delegates to
-  * StdoutLogRecordProcessor to ensure full formatting with attributes and stacktrace.
-  */
+ * Console log processor — triggers the fast ConsoleLogEmitter in Logger. Uses a
+ * format that writes directly from raw values, bypassing LogRecord. Format:
+ * "2026-03-31T17:30:00.123Z INFO [MyClass.method:42] message {key=val}"
+ *
+ * When a LogRecord is passed via emit() (e.g. via bridges/adapters), delegates
+ * to StdoutLogRecordProcessor to ensure full formatting with attributes and
+ * stacktrace.
+ */
 class ConsoleLogRecordProcessor extends LogRecordProcessor {
 
   private val delegate = new StdoutLogRecordProcessor()

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/LogFormatter.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/LogFormatter.scala
@@ -115,6 +115,7 @@ object TextLogFormatter extends LogFormatter {
 
     // User attributes (after source location, index 4+)
     val types        = builder.builderTypes
+    val seqs         = builder.builderSeqs
     var hasUserAttrs = false
     i = 4
     while (i < len) {
@@ -122,11 +123,15 @@ object TextLogFormatter extends LogFormatter {
       else sb.append(", ")
       sb.append(keys(i)); sb.append('=')
       (types(i): @scala.annotation.switch) match {
-        case 0 /* STRING */  => sb.append('"'); sb.append(strings(i)); sb.append('"')
-        case 1 /* LONG */    => sb.append(longs(i))
-        case 2 /* DOUBLE */  => sb.append(java.lang.Double.longBitsToDouble(longs(i)))
-        case 3 /* BOOLEAN */ => sb.append(if (longs(i) != 0L) "true" else "false")
-        case _               => sb.append("?")
+        case 0 /* STRING */      => sb.append('"'); sb.append(strings(i)); sb.append('"')
+        case 1 /* LONG */        => sb.append(longs(i))
+        case 2 /* DOUBLE */      => sb.append(java.lang.Double.longBitsToDouble(longs(i)))
+        case 3 /* BOOLEAN */     => sb.append(if (longs(i) != 0L) "true" else "false")
+        case 4 /* STRING_SEQ */  => appendStringSeq(sb, seqValueAt(seqs, i))
+        case 5 /* LONG_SEQ */    => appendScalarSeq(sb, seqValueAt(seqs, i))
+        case 6 /* DOUBLE_SEQ */  => appendScalarSeq(sb, seqValueAt(seqs, i))
+        case 7 /* BOOLEAN_SEQ */ => appendScalarSeq(sb, seqValueAt(seqs, i))
+        case _                   => sb.append("?")
       }
       i += 1
     }
@@ -227,10 +232,37 @@ object TextLogFormatter extends LogFormatter {
           sb.append(key).append('=').append(value)
         }
 
-      override def visitStringSeq(key: String, value: Seq[String]): Unit   = ()
-      override def visitLongSeq(key: String, value: Seq[Long]): Unit       = ()
-      override def visitDoubleSeq(key: String, value: Seq[Double]): Unit   = ()
-      override def visitBooleanSeq(key: String, value: Seq[Boolean]): Unit = ()
+      override def visitStringSeq(key: String, value: Seq[String]): Unit =
+        if (!key.startsWith("code.")) {
+          if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
+          else sb.append(", ")
+          sb.append(key).append('=')
+          appendStringSeq(sb, value)
+        }
+
+      override def visitLongSeq(key: String, value: Seq[Long]): Unit =
+        if (!key.startsWith("code.")) {
+          if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
+          else sb.append(", ")
+          sb.append(key).append('=')
+          appendScalarSeq(sb, value)
+        }
+
+      override def visitDoubleSeq(key: String, value: Seq[Double]): Unit =
+        if (!key.startsWith("code.")) {
+          if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
+          else sb.append(", ")
+          sb.append(key).append('=')
+          appendScalarSeq(sb, value)
+        }
+
+      override def visitBooleanSeq(key: String, value: Seq[Boolean]): Unit =
+        if (!key.startsWith("code.")) {
+          if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
+          else sb.append(", ")
+          sb.append(key).append('=')
+          appendScalarSeq(sb, value)
+        }
     })
     if (hasUserAttrs) sb.append('}')
 
@@ -277,6 +309,37 @@ object TextLogFormatter extends LogFormatter {
     while (i < width) { sb.append('0'); i += 1 }
     sb.append(s)
   }
+
+  /**
+   * Reads a Seq value from the raw side-array, tolerating a null array or slot
+   * (which never occur for a real seq-typed attribute, but keeps the hot path
+   * defensive). Seq attributes are rare, so allocation here is acceptable.
+   */
+  private def seqValueAt(seqs: Array[AnyRef], i: Int): Seq[Any] =
+    if (seqs == null || seqs(i) == null) Seq.empty
+    else seqs(i).asInstanceOf[Seq[Any]]
+
+  /** Renders a String seq as `["a", "b"]` with each element double-quoted. */
+  private def appendStringSeq(sb: StringBuilder, value: Seq[Any]): Unit = {
+    sb.append('[')
+    var first = true
+    value.foreach { v =>
+      if (first) first = false else sb.append(", ")
+      sb.append('"').append(v.toString).append('"')
+    }
+    sb.append(']')
+  }
+
+  /** Renders a scalar (Long/Double/Boolean) seq as `[1, 2, 3]`, unquoted. */
+  private def appendScalarSeq(sb: StringBuilder, value: Seq[Any]): Unit = {
+    sb.append('[')
+    var first = true
+    value.foreach { v =>
+      if (first) first = false else sb.append(", ")
+      sb.append(v.toString)
+    }
+    sb.append(']')
+  }
 }
 
 /**
@@ -286,10 +349,11 @@ object TextLogFormatter extends LogFormatter {
 object JsonLogFormatter extends LogFormatter {
   private sealed trait JsonAttrValue
   private object JsonAttrValue {
-    final case class StringValue(value: String) extends JsonAttrValue
-    final case class IntValue(value: Long)      extends JsonAttrValue
-    final case class DoubleValue(value: Double) extends JsonAttrValue
-    final case class BoolValue(value: Boolean)  extends JsonAttrValue
+    final case class StringValue(value: String)             extends JsonAttrValue
+    final case class IntValue(value: Long)                  extends JsonAttrValue
+    final case class DoubleValue(value: Double)             extends JsonAttrValue
+    final case class BoolValue(value: Boolean)              extends JsonAttrValue
+    final case class ArrayValue(values: Seq[JsonAttrValue]) extends JsonAttrValue
   }
 
   override def format(
@@ -326,6 +390,7 @@ object JsonLogFormatter extends LogFormatter {
     val types   = builder.builderTypes
     val longs   = builder.builderLongs
     val strings = builder.builderStrings
+    val seqs    = builder.builderSeqs
     val len     = builder.builderLen
     if (len > 0) {
       hasAttrs = true
@@ -338,6 +403,10 @@ object JsonLogFormatter extends LogFormatter {
           case 1 => JsonAttrValue.IntValue(longs(i))
           case 2 => JsonAttrValue.DoubleValue(java.lang.Double.longBitsToDouble(longs(i)))
           case 3 => JsonAttrValue.BoolValue(longs(i) != 0L)
+          case 4 => jsonStringSeq(seqValueAt(seqs, i))
+          case 5 => jsonLongSeq(seqValueAt(seqs, i))
+          case 6 => jsonDoubleSeq(seqValueAt(seqs, i))
+          case 7 => jsonBooleanSeq(seqValueAt(seqs, i))
           case _ => JsonAttrValue.StringValue("?")
         }
         appendJsonAttribute(sb, keys(i), value)
@@ -421,10 +490,29 @@ object JsonLogFormatter extends LogFormatter {
           appendJsonAttribute(sb, key, JsonAttrValue.BoolValue(value))
         }
 
-        override def visitStringSeq(key: String, value: Seq[String]): Unit   = ()
-        override def visitLongSeq(key: String, value: Seq[Long]): Unit       = ()
-        override def visitDoubleSeq(key: String, value: Seq[Double]): Unit   = ()
-        override def visitBooleanSeq(key: String, value: Seq[Boolean]): Unit = ()
+        override def visitStringSeq(key: String, value: Seq[String]): Unit = {
+          if (!first) sb.append(',')
+          first = false
+          appendJsonAttribute(sb, key, jsonStringSeq(value))
+        }
+
+        override def visitLongSeq(key: String, value: Seq[Long]): Unit = {
+          if (!first) sb.append(',')
+          first = false
+          appendJsonAttribute(sb, key, jsonLongSeq(value))
+        }
+
+        override def visitDoubleSeq(key: String, value: Seq[Double]): Unit = {
+          if (!first) sb.append(',')
+          first = false
+          appendJsonAttribute(sb, key, jsonDoubleSeq(value))
+        }
+
+        override def visitBooleanSeq(key: String, value: Seq[Boolean]): Unit = {
+          if (!first) sb.append(',')
+          first = false
+          appendJsonAttribute(sb, key, jsonBooleanSeq(value))
+        }
       })
       sb.append(']')
     }
@@ -478,9 +566,55 @@ object JsonLogFormatter extends LogFormatter {
       case JsonAttrValue.BoolValue(boolValue) =>
         sb.append("\"boolValue\":")
         sb.append(boolValue)
+      case JsonAttrValue.ArrayValue(values) =>
+        sb.append("\"arrayValue\":{\"values\":[")
+        var first = true
+        values.foreach { element =>
+          if (first) first = false else sb.append(',')
+          sb.append('{')
+          appendJsonScalarValue(sb, element)
+          sb.append('}')
+        }
+        sb.append("]}")
     }
     sb.append("}}")
   }
+
+  /** Appends the inner `"kind":value` fragment for a scalar JsonAttrValue. */
+  private def appendJsonScalarValue(sb: StringBuilder, value: JsonAttrValue): Unit =
+    value match {
+      case JsonAttrValue.StringValue(stringValue) =>
+        sb.append("\"stringValue\":\"")
+        writeJsonStringContent(sb, stringValue)
+        sb.append('"')
+      case JsonAttrValue.IntValue(intValue) =>
+        sb.append("\"intValue\":\"")
+        sb.append(intValue)
+        sb.append('"')
+      case JsonAttrValue.DoubleValue(doubleValue) =>
+        sb.append("\"doubleValue\":")
+        sb.append(doubleValue)
+      case JsonAttrValue.BoolValue(boolValue) =>
+        sb.append("\"boolValue\":")
+        sb.append(boolValue)
+      case JsonAttrValue.ArrayValue(_) => ()
+    }
+
+  private def jsonStringSeq(value: Seq[Any]): JsonAttrValue =
+    JsonAttrValue.ArrayValue(value.map(v => JsonAttrValue.StringValue(v.toString)))
+
+  private def jsonLongSeq(value: Seq[Any]): JsonAttrValue =
+    JsonAttrValue.ArrayValue(value.map(v => JsonAttrValue.IntValue(v.asInstanceOf[Long])))
+
+  private def jsonDoubleSeq(value: Seq[Any]): JsonAttrValue =
+    JsonAttrValue.ArrayValue(value.map(v => JsonAttrValue.DoubleValue(v.asInstanceOf[Double])))
+
+  private def jsonBooleanSeq(value: Seq[Any]): JsonAttrValue =
+    JsonAttrValue.ArrayValue(value.map(v => JsonAttrValue.BoolValue(v.asInstanceOf[Boolean])))
+
+  private def seqValueAt(seqs: Array[AnyRef], i: Int): Seq[Any] =
+    if (seqs == null || seqs(i) == null) Seq.empty
+    else seqs(i).asInstanceOf[Seq[Any]]
 
   private[telemetry] def writeJsonStringContent(sb: StringBuilder, s: String): Unit = {
     var i = 0

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/Logger.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/Logger.scala
@@ -127,11 +127,14 @@ final class Logger private[telemetry] (
     val attrBuilder = Attributes.builder
     attrs.foreach { case (k, v) =>
       v match {
-        case AttributeValue.StringValue(s)  => attrBuilder.put(k, s)
-        case AttributeValue.BooleanValue(b) => attrBuilder.put(k, b)
-        case AttributeValue.LongValue(l)    => attrBuilder.put(k, l)
-        case AttributeValue.DoubleValue(d)  => attrBuilder.put(k, d)
-        case _                              => attrBuilder.put(k, v.toString)
+        case AttributeValue.StringValue(s)     => attrBuilder.put(k, s)
+        case AttributeValue.BooleanValue(b)    => attrBuilder.put(k, b)
+        case AttributeValue.LongValue(l)       => attrBuilder.put(k, l)
+        case AttributeValue.DoubleValue(d)     => attrBuilder.put(k, d)
+        case AttributeValue.StringSeqValue(s)  => attrBuilder.put(AttributeKey.stringSeq(k), s)
+        case AttributeValue.LongSeqValue(s)    => attrBuilder.put(AttributeKey.longSeq(k), s)
+        case AttributeValue.DoubleSeqValue(s)  => attrBuilder.put(AttributeKey.doubleSeq(k), s)
+        case AttributeValue.BooleanSeqValue(s) => attrBuilder.put(AttributeKey.booleanSeq(k), s)
       }
     }
 

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/StdoutLogRecordProcessor.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/StdoutLogRecordProcessor.scala
@@ -85,11 +85,14 @@ private[telemetry] class StdoutLogRecordProcessor extends LogRecordProcessor {
         sb.append(key)
         sb.append('=')
         value match {
-          case AttributeValue.StringValue(v)  => sb.append('"'); sb.append(v); sb.append('"')
-          case AttributeValue.LongValue(v)    => sb.append(v)
-          case AttributeValue.DoubleValue(v)  => sb.append(v)
-          case AttributeValue.BooleanValue(v) => sb.append(v)
-          case other                          => sb.append(other.toString)
+          case AttributeValue.StringValue(v)      => sb.append('"'); sb.append(v); sb.append('"')
+          case AttributeValue.LongValue(v)        => sb.append(v)
+          case AttributeValue.DoubleValue(v)      => sb.append(v)
+          case AttributeValue.BooleanValue(v)     => sb.append(v)
+          case AttributeValue.StringSeqValue(vs)  => appendStringSeq(sb, vs)
+          case AttributeValue.LongSeqValue(vs)    => appendScalarSeq(sb, vs)
+          case AttributeValue.DoubleSeqValue(vs)  => appendScalarSeq(sb, vs)
+          case AttributeValue.BooleanSeqValue(vs) => appendScalarSeq(sb, vs)
         }
       }
     }
@@ -108,4 +111,24 @@ private[telemetry] class StdoutLogRecordProcessor extends LogRecordProcessor {
 
   override def shutdown(): Unit   = ()
   override def forceFlush(): Unit = ()
+
+  private def appendStringSeq(sb: StringBuilder, value: Seq[Any]): Unit = {
+    sb.append('[')
+    var first = true
+    value.foreach { v =>
+      if (first) first = false else sb.append(", ")
+      sb.append('"').append(v.toString).append('"')
+    }
+    sb.append(']')
+  }
+
+  private def appendScalarSeq(sb: StringBuilder, value: Seq[Any]): Unit = {
+    sb.append('[')
+    var first = true
+    value.foreach { v =>
+      if (first) first = false else sb.append(", ")
+      sb.append(v.toString)
+    }
+    sb.append(']')
+  }
 }

--- a/telemetry/shared/src/test/scala/zio/blocks/telemetry/LogSpec.scala
+++ b/telemetry/shared/src/test/scala/zio/blocks/telemetry/LogSpec.scala
@@ -217,6 +217,28 @@ object LogSpec extends ZIOSpecDefault {
           attrs.get(AttributeKey.string("k1")).contains("v1"),
           attrs.get(AttributeKey.long("k2")).contains(42L)
         )
+      },
+      test("Logger.info preserves seq attribute Seq structure and type") {
+        val processor = new TestLogProcessor
+        val logger    = LoggerProvider.builder
+          .addLogRecordProcessor(processor)
+          .build()
+          .get("test")
+        logger.info(
+          "msg",
+          "tags"  -> AttributeValue.StringSeqValue(Seq("a", "b")),
+          "nums"  -> AttributeValue.LongSeqValue(Seq(1L, 2L)),
+          "rates" -> AttributeValue.DoubleSeqValue(Seq(1.5, 2.5)),
+          "flags" -> AttributeValue.BooleanSeqValue(Seq(true, false))
+        )
+        val attrs = processor.emitted.head.attributes
+        assertTrue(
+          processor.emitted.size == 1,
+          attrs.get(AttributeKey.stringSeq("tags")).contains(Seq("a", "b")),
+          attrs.get(AttributeKey.longSeq("nums")).contains(Seq(1L, 2L)),
+          attrs.get(AttributeKey.doubleSeq("rates")).contains(Seq(1.5, 2.5)),
+          attrs.get(AttributeKey.booleanSeq("flags")).contains(Seq(true, false))
+        )
       }
     ) @@ TestAspect.sequential,
     test("processor failures do not stop later processors") {


### PR DESCRIPTION
## Problem

`ConsoleLogRecordProcessor.onEmit()` only printed the bare `"$severityText $body"`, silently dropping ALL structured attributes and the throwable/stacktrace whenever it was invoked directly (e.g. via `Logger.emit(logRecord: LogRecord)`, used by bridges/adapters that already construct a `LogRecord`). This makes console output useless for debugging — e.g. an HTTP/2 stream error logged with `stream_id`/`error_type` attributes and a stacktrace showed up as just the message text.

While fixing that, a second, more systemic bug was found: **Seq-typed attributes** (e.g. `tags: List[String]`) were dropped or garbled across almost every log-rendering/propagation path in the `telemetry` module:

- `TextLogFormatter.format` (raw fast-console path) rendered them as literal `"?"`.
- `TextLogFormatter.formatRecord` / `JsonLogFormatter.formatRecord` silently dropped them (no-op visitor methods).
- `StdoutLogRecordProcessor` printed the raw Scala case-class `toString()` (e.g. `tags=StringSeqValue(List(alpha, beta))`).
- `Logger.log()` and both `LogMacros` (Scala 2 + 3) implementations converted Seq-typed attributes to a **String** via `.toString` before they were even stored, destroying the type permanently.

## Fix

- `ConsoleLogRecordProcessor` now delegates full formatting (timestamp, severity, source location, attributes, throwable) to `StdoutLogRecordProcessor`, matching its own documented output format instead of a bare fallback.
- `AttributesBuilder` gains a `builderSeqs` accessor so raw-path formatters can read Seq-typed attribute data.
- `TextLogFormatter` (both `.format` and `.formatRecord`) and `StdoutLogRecordProcessor` now render Seq attributes consistently as `key=["a", "b"]` / `key=[1, 2]` / etc.
- `JsonLogFormatter` (both `.format` and `.formatRecord`) renders Seq attributes as an OTLP-style `arrayValue`.
- `Logger.log()` and `LogMacros` (Scala 2 + 3) now preserve Seq attribute type fidelity end-to-end via `AttributeKey.stringSeq`/`longSeq`/`doubleSeq`/`booleanSeq`, instead of stringifying them.

## Testing

- Added/updated concise tests in `LogProcessorSpec`, `LogFormatterSpec`, `BranchCoverageSpec`, and `LogSpec` covering all 4 seq types across every fixed rendering/propagation path.
- `telemetryJVM/test`: 222/222 passing on both Scala 3.8.3 and Scala 2.13.18.
- `scalafmtCheck` clean.