### PR TITLE
fix(schema): resolve primitive register for wrappers over a primitive typeId

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/PrimitiveType.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/PrimitiveType.scala
@@ -746,45 +746,47 @@ object PrimitiveType {
       else if (typeId.isAlias) typeId.aliasedTo
       else None
 
-    underlyingRepr.flatMap { repr =>
-      typeReprToPrimitiveType(repr).asInstanceOf[Option[PrimitiveType[A]]]
-    }
+    underlyingRepr
+      .flatMap(typeReprToPrimitiveType)
+      .orElse(primitiveTypeByFullName(typeId.fullName)) // typeId may itself be a primitive
+      .asInstanceOf[Option[PrimitiveType[A]]]
   }
 
   private[this] def typeReprToPrimitiveType(repr: TypeRepr): Option[PrimitiveType[?]] = repr match {
-    case TypeRepr.Ref(id) =>
-      val fullName = id.fullName
-      if (fullName == "scala.Unit") Some(PrimitiveType.Unit)
-      else if (fullName == "scala.Boolean") Some(PrimitiveType.Boolean(Validation.None))
-      else if (fullName == "scala.Byte") Some(PrimitiveType.Byte(Validation.None))
-      else if (fullName == "scala.Short") Some(PrimitiveType.Short(Validation.None))
-      else if (fullName == "scala.Int") Some(PrimitiveType.Int(Validation.None))
-      else if (fullName == "scala.Long") Some(PrimitiveType.Long(Validation.None))
-      else if (fullName == "scala.Float") Some(PrimitiveType.Float(Validation.None))
-      else if (fullName == "scala.Double") Some(PrimitiveType.Double(Validation.None))
-      else if (fullName == "scala.Char") Some(PrimitiveType.Char(Validation.None))
-      else if (fullName == "java.lang.String") Some(PrimitiveType.String(Validation.None))
-      else if (fullName == "scala.BigInt") Some(PrimitiveType.BigInt(Validation.None))
-      else if (fullName == "scala.BigDecimal") Some(PrimitiveType.BigDecimal(Validation.None))
-      else if (fullName == "java.util.UUID") Some(PrimitiveType.UUID(Validation.None))
-      else if (fullName == "java.util.Currency") Some(PrimitiveType.Currency(Validation.None))
-      else if (fullName == "java.time.DayOfWeek") Some(PrimitiveType.DayOfWeek(Validation.None))
-      else if (fullName == "java.time.Duration") Some(PrimitiveType.Duration(Validation.None))
-      else if (fullName == "java.time.Instant") Some(PrimitiveType.Instant(Validation.None))
-      else if (fullName == "java.time.LocalDate") Some(PrimitiveType.LocalDate(Validation.None))
-      else if (fullName == "java.time.LocalDateTime") Some(PrimitiveType.LocalDateTime(Validation.None))
-      else if (fullName == "java.time.LocalTime") Some(PrimitiveType.LocalTime(Validation.None))
-      else if (fullName == "java.time.Month") Some(PrimitiveType.Month(Validation.None))
-      else if (fullName == "java.time.MonthDay") Some(PrimitiveType.MonthDay(Validation.None))
-      else if (fullName == "java.time.OffsetDateTime") Some(PrimitiveType.OffsetDateTime(Validation.None))
-      else if (fullName == "java.time.OffsetTime") Some(PrimitiveType.OffsetTime(Validation.None))
-      else if (fullName == "java.time.Period") Some(PrimitiveType.Period(Validation.None))
-      else if (fullName == "java.time.Year") Some(PrimitiveType.Year(Validation.None))
-      else if (fullName == "java.time.YearMonth") Some(PrimitiveType.YearMonth(Validation.None))
-      else if (fullName == "java.time.ZoneId") Some(PrimitiveType.ZoneId(Validation.None))
-      else if (fullName == "java.time.ZoneOffset") Some(PrimitiveType.ZoneOffset(Validation.None))
-      else if (fullName == "java.time.ZonedDateTime") Some(PrimitiveType.ZonedDateTime(Validation.None))
-      else None
-    case _ => None
+    case TypeRepr.Ref(id) => primitiveTypeByFullName(id.fullName)
+    case _                => None
   }
+
+  private[this] def primitiveTypeByFullName(fullName: Predef.String): Option[PrimitiveType[?]] =
+    if (fullName == "scala.Unit") Some(PrimitiveType.Unit)
+    else if (fullName == "scala.Boolean") Some(PrimitiveType.Boolean(Validation.None))
+    else if (fullName == "scala.Byte") Some(PrimitiveType.Byte(Validation.None))
+    else if (fullName == "scala.Short") Some(PrimitiveType.Short(Validation.None))
+    else if (fullName == "scala.Int") Some(PrimitiveType.Int(Validation.None))
+    else if (fullName == "scala.Long") Some(PrimitiveType.Long(Validation.None))
+    else if (fullName == "scala.Float") Some(PrimitiveType.Float(Validation.None))
+    else if (fullName == "scala.Double") Some(PrimitiveType.Double(Validation.None))
+    else if (fullName == "scala.Char") Some(PrimitiveType.Char(Validation.None))
+    else if (fullName == "java.lang.String") Some(PrimitiveType.String(Validation.None))
+    else if (fullName == "scala.BigInt") Some(PrimitiveType.BigInt(Validation.None))
+    else if (fullName == "scala.BigDecimal") Some(PrimitiveType.BigDecimal(Validation.None))
+    else if (fullName == "java.util.UUID") Some(PrimitiveType.UUID(Validation.None))
+    else if (fullName == "java.util.Currency") Some(PrimitiveType.Currency(Validation.None))
+    else if (fullName == "java.time.DayOfWeek") Some(PrimitiveType.DayOfWeek(Validation.None))
+    else if (fullName == "java.time.Duration") Some(PrimitiveType.Duration(Validation.None))
+    else if (fullName == "java.time.Instant") Some(PrimitiveType.Instant(Validation.None))
+    else if (fullName == "java.time.LocalDate") Some(PrimitiveType.LocalDate(Validation.None))
+    else if (fullName == "java.time.LocalDateTime") Some(PrimitiveType.LocalDateTime(Validation.None))
+    else if (fullName == "java.time.LocalTime") Some(PrimitiveType.LocalTime(Validation.None))
+    else if (fullName == "java.time.Month") Some(PrimitiveType.Month(Validation.None))
+    else if (fullName == "java.time.MonthDay") Some(PrimitiveType.MonthDay(Validation.None))
+    else if (fullName == "java.time.OffsetDateTime") Some(PrimitiveType.OffsetDateTime(Validation.None))
+    else if (fullName == "java.time.OffsetTime") Some(PrimitiveType.OffsetTime(Validation.None))
+    else if (fullName == "java.time.Period") Some(PrimitiveType.Period(Validation.None))
+    else if (fullName == "java.time.Year") Some(PrimitiveType.Year(Validation.None))
+    else if (fullName == "java.time.YearMonth") Some(PrimitiveType.YearMonth(Validation.None))
+    else if (fullName == "java.time.ZoneId") Some(PrimitiveType.ZoneId(Validation.None))
+    else if (fullName == "java.time.ZoneOffset") Some(PrimitiveType.ZoneOffset(Validation.None))
+    else if (fullName == "java.time.ZonedDateTime") Some(PrimitiveType.ZonedDateTime(Validation.None))
+    else None
 }

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/SchemaVersionSpecificSpec.scala
@@ -25,6 +25,22 @@ import zio.blocks.typeid.TypeId
 import zio.test.Assertion._
 import zio.test._
 
+// Must stay top-level: nested opaque types get dealiased to a plain Primitive during derivation,
+// which hides the Wrapper-over-primitive register layout under test.
+sealed trait ParamOpaquePhantom
+opaque type ParamOpaqueId[+A] = Int
+object ParamOpaqueId {
+  def apply[A](value: Int): ParamOpaqueId[A]         = value
+  extension [A](id: ParamOpaqueId[A]) def value: Int = id
+  given [A]: Schema[ParamOpaqueId[A]]                =
+    Schema.int.transform[ParamOpaqueId[A]](ParamOpaqueId.apply[A], _.value)
+}
+
+case class ParamOpaqueRecord(
+  id: ParamOpaqueId[ParamOpaquePhantom],
+  ids: Set[ParamOpaqueId[ParamOpaquePhantom]]
+) derives Schema
+
 object SchemaVersionSpecificSpec extends SchemaBaseSpec {
 
   private def textDoc(s: String): Doc =
@@ -864,6 +880,26 @@ object SchemaVersionSpecificSpec extends SchemaBaseSpec {
         val schema: Schema[IntWrapper] = Schema[Int].transform(to = IntWrapper(_), from = _.value)
         val wrapper                    = schema.reflect.asWrapperUnknown
         assert(wrapper.flatMap(_.wrapper.underlyingPrimitiveType))(isNone)
+      },
+      test("underlyingPrimitiveType returns Some for a parameterized opaque type over a primitive") {
+        val rec   = Schema[ParamOpaqueRecord].reflect.asInstanceOf[Reflect.Record[Binding, ParamOpaqueRecord]]
+        val field = rec.fields.find(_.name == "id").get.value.asWrapperUnknown
+        assert(field.flatMap(_.wrapper.underlyingPrimitiveType))(
+          isSome(equalTo(PrimitiveType.Int(Validation.None)))
+        )
+      },
+      test("Reflect.Record.registers agrees with the derived binding for wrappers over primitives") {
+        // registers must match the derived binding's layout, else field values land in the wrong
+        // register slots (ClassCastException on construct/deconstruct).
+        val rec  = Schema[ParamOpaqueRecord].reflect.asInstanceOf[Reflect.Record[Binding, ParamOpaqueRecord]]
+        val regs = Reflect.Record.registers(rec.fields.map(_.value).toArray)
+
+        val sample = ParamOpaqueRecord(ParamOpaqueId(7), Set(ParamOpaqueId(8)))
+        val out    = Registers(rec.deconstructor.usedRegisters)
+        rec.deconstructor.deconstruct(out, RegisterOffset.Zero, sample)
+
+        assert(regs(0).isInstanceOf[Register.Int])(isTrue) &&
+        assert(regs(0).asInstanceOf[Register.Int].get(out, RegisterOffset.Zero))(equalTo(7))
       }
     )
   )


### PR DESCRIPTION
## Problem

`Reflect.Wrapper.underlyingPrimitiveType` uses `PrimitiveType.fromTypeId` to decide whether a wrapper field (opaque type / newtype) should occupy a **primitive** or **object** register. `fromTypeId` only resolved primitives reached *through* an opaque `representation` or an alias's `aliasedTo` — it returned `None` when the typeId is **itself** directly a primitive.

A parameterized opaque type with a generic transform-based `Schema` triggers exactly that case:

```scala
opaque type Id[+A] = Int
object Id {
  def apply[A](v: Int): Id[A] = v
  given [A]: Schema[Id[A]] = Schema.int.transform[Id[A]](Id.apply[A], _ => ...)
}

case class Rec(id: Id[Foo], ids: Set[Id[Foo]]) derives Schema
```

The wrapper captures a bare `scala.Int` typeId (`isOpaque = false`), so `fromTypeId` returned `None`. Consequently `Reflect.Record.registers` allocated an **object** register for `id`, while the derived binding stored it in an **int** register. The two layouts disagreed and construct/deconstruct threw:

```
java.lang.ClassCastException: class java.lang.Integer cannot be cast to class scala.collection.immutable.Set
```

## Fix

Add an `orElse` fallback in `fromTypeId` so a typeId that is itself a primitive resolves correctly, and reuse the `fullName` lookup for both the representation path and the direct path.

The wrapping type's typeId remains the discriminator (not the wrapped type), so genuine case-class wrappers over a primitive still correctly resolve to `None` / an object register.

## Tests

Two regression tests added to `SchemaVersionSpecificSpec` (scala-3), using top-level fixtures (nested opaque types get dealiased to a plain `Primitive` during derivation and don't reproduce the layout under test):

- `underlyingPrimitiveType` returns `Some` for a parameterized opaque type over a primitive.
- `Reflect.Record.registers` agrees with the derived binding for wrappers over primitives.

Both fail without the fix (the second reproduces the `ClassCastException`). Full `schemaJVM/test` is green.
