### PR TITLE
fix(ci): use plain run step for docs/publishToNpm so npm is on PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,8 +284,4 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: 'npm'
       - name: Publish Docs to NPM Registry
-        uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          command: sbt docs/publishToNpm
+        run: sbt docs/publishToNpm


### PR DESCRIPTION
## Problem

The **Release Docs** job fails with:

```
java.io.IOException: Cannot run program "npm" (in directory ".../target/website/docs"): error=2, No such file or directory
    at zio.sbt.WebsitePlugin$.$anonfun$publishToNpmTask$1(WebsitePlugin.scala:281)
```

([failing run](https://github.com/zio/zio-blocks/actions/runs/28999744750/job/86068373292))

## Root cause

`actions/setup-node` installs Node correctly (log shows `node v24.12.0 / npm 11.6.2`) and exposes `npm` by appending node's bin dir to `GITHUB_PATH`. But `GITHUB_PATH` additions only propagate to subsequent **`run:` shell steps** — not to JS actions.

The publish step wrapped `sbt docs/publishToNpm` in `nick-fields/retry`, so sbt inherited an env without node's bin dir. When `WebsitePlugin` spawned `npm` via `ProcessBuilder`, it wasn't on PATH → `error=2`.

The build/lint job runs npm the same way via a plain `run:` step and works — the only difference was the retry wrapper.

## Fix

Replace the `nick-fields/retry` wrapper with a plain `run:` step. The publish is deterministic, so the retry bought little and was the thing breaking PATH inheritance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)