### PR TITLE
fix(sql,build): stop scalac -rewrite from dirtying git tree during release

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -191,7 +191,6 @@ object BuildHelper {
           Seq(
             "-release",
             if (minor < 8) "11" else "17",
-            "-rewrite",
             "-no-indent",
             "-explain",
             "-explain-cyclic",

--- a/sql/shared/src/main/scala/zio/blocks/sql/Repo.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Repo.scala
@@ -50,8 +50,9 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
    * final class UserRepo extends Repo[User, UserId]
    * }}}
    */
-  protected def this()(using schema: Schema[E], idSchema: Schema[ID], idCodec: DbCodec[ID]) =
+  protected def this()(using schema: Schema[E], idSchema: Schema[ID], idCodec: DbCodec[ID]) = {
     this(Repo.derivedMetadata[E, ID])
+  }
 
   /** The table this repository operates on. */
   final val table: Table[E] = metadata.table

--- a/sql/shared/src/main/scala/zio/blocks/sql/Repo.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Repo.scala
@@ -50,9 +50,11 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
    * final class UserRepo extends Repo[User, UserId]
    * }}}
    */
-  protected def this()(using schema: Schema[E], idSchema: Schema[ID], idCodec: DbCodec[ID]) = {
-    this(Repo.derivedMetadata[E, ID])
-  }
+  protected def this()(using
+    schema: Schema[E],
+    idSchema: Schema[ID],
+    idCodec: DbCodec[ID]
+  ) = this(Repo.derivedMetadata[E, ID])
 
   /** The table this repository operates on. */
   final val table: Table[E] = metadata.table


### PR DESCRIPTION
## Summary

Root cause of the `v0.0.48` release failure (job [29984499089](https://github.com/zio/zio-blocks/actions/runs/29984499089/job/89148431435), cancelled after burning the full 60-minute job timeout across 3 retried attempts):

- `project/BuildHelper.scala` set `-rewrite` + `-no-indent` unconditionally for every Scala 3.x cross-build target. `-rewrite` makes the compiler **mutate tracked source files on disk** to fix syntax that doesn't match `-no-indent`'s brace requirement.
- `sql/shared/src/main/scala/zio/blocks/sql/Repo.scala` (new in this release) had an indentation-style constructor. Its first-ever compile under `-rewrite` silently rewrote the file, dirtying the git working tree mid-build.
- `sbt-dynver` saw the dirty tree and computed a fresh `SNAPSHOT+<timestamp>` version at every settings reload during the cross-build (5 different timestamps logged in one run), instead of resolving the clean tag version once, as it did for the successful `v0.0.47` release.
- Central Portal's final bundle-upload step rejects `SNAPSHOT` versions outright (`SNAPSHOTs are not supported on the Central Portal`), failing the release and triggering `nick-fields/retry`'s retry-from-scratch loop — which re-ran the entire publish two more times and blew the job's 60-minute timeout.

## Changes

1. **`sql/.../Repo.scala`** — reshape the `Repo.this()` constructor (wrap the `using` parameter list instead of adding braces) so scalafmt's `RedundantBraces` rewrite rule and scalac's `-rewrite`/`-no-indent` no longer disagree on its formatting. (An earlier commit on this branch tried braces first — that satisfied scalac but failed `scalafmtCheckAll`, since scalafmt strips those same braces back off. This shape satisfies both.)
2. **`project/BuildHelper.scala`** — drop `-rewrite` from `scalacOptions`. `-no-indent` still enforces brace-style, but now non-conforming code fails compilation with a clear, visible error instead of being silently rewritten on disk. This turns the whole failure class into an ordinary PR-time compile error instead of a release-day incident, and removes the mechanism that can dirty the git tree mid-build.

## Test plan
- [x] Reproduced locally: `sbt compile` on the pre-fix source mutated exactly `Repo.scala` (confirmed via `git status --porcelain` / `git diff`, then reverted).
- [x] Applied the `Repo.scala` fix, recompiled under both `sql` cross-targets (Scala 3.8.3 and 3.3.7) — confirmed no further drift.
- [x] Ran `scalafmtCheckAll` — passes (previous braces-only attempt failed this check).
- [x] Ran `sqlJVM/test` — 362 passed, 1 unrelated failure (`JdbcInstantTimezoneSpec`, requires a Postgres testcontainer unavailable in the sandbox).
- [x] Removed `-rewrite`, then ran a full-repo `compile` on both Scala 3.8.3 and 3.3.7 — no new failures; only 3 pre-existing, unrelated ones remain (an ambiguous import in `JsonCodecDeriver.scala`, and a JDK-version mismatch in a benchmark module), present before this change too.
- [x] CI green on all jobs (lint, Build Docs, Test Golem, testJS/testJVM matrix) — https://github.com/zio/zio-blocks/actions/runs/30036924665
- [ ] Confirm on the next tagged release that only one version string appears across all published artifacts and the Central Portal upload succeeds without retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)