### PR TITLE
fix(ci): drop npm cache from Release Docs setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,5 @@ jobs:
         with:
           node-version: 24.12.0
           registry-url: https://registry.npmjs.org
-          cache: 'npm'
       - name: Publish Docs to NPM Registry
         run: sbt docs/publishToNpm


### PR DESCRIPTION
## Problem

The `Release Docs` job in `ci.yml` fails at the `Setup NodeJs` step, before `sbt docs/publishToNpm` ever runs:

```
##[error]Dependencies lock file is not found in /home/runner/work/zio-blocks/zio-blocks.
Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock
```

Observed on the v0.0.48 release run ([job](https://github.com/zio/zio-blocks/actions/runs/30526673128/job/90829301825)). The Maven `release` job succeeded and 0.0.48 published to Central; only the docs→NPM publish was lost.

## Root cause

`actions/setup-node` with `cache: 'npm'` hashes a lockfile to build its cache key. It globs the repo root and hard-errors when nothing matches. This repo has:

- no root `package.json` / `package-lock.json`
- only `website/yarn.lock` (wrong directory *and* wrong package manager for `cache: 'npm'`)

The cache is also semantically useless here: this job never runs `npm install` — `sbt docs/publishToNpm` generates the npm package (zio-sbt-website). So the cache would only ever hash deps that are never installed.

## Fix

Remove `cache: 'npm'`. No lockfile hashing → the step passes → the publish step runs. No functional caching is lost (there was none).

## History — why this line keeps coming back

The `Release Docs` job has had **two independent bugs**. This PR closes out a regression of the first.

| Bug | Symptom | Fixed by | 
|-----|---------|----------|
| **A** — `cache: 'npm'` lockfile error | `setup-node` hard-fails before publish | #1495 (2026-07-01) |
| **B** — `npm` not on `PATH` inside the retry wrapper | `publishToNpm` runs but dies: `Child_process exited with error code 1` at `zio.sbt.WebsitePlugin.publishToNpmTask` | #1531 (plain `run:` step) |

Timeline, verified against CI:

1. **#1495 (Jul 1)** removed `cache: 'npm'` — correctly fixed bug A. Confirmed on the **v0.0.47** release run: `setup-node` passed with no lockfile error and `sbt docs/publishToNpm` actually compiled the docs. The job still failed there, but on **bug B** (child-process/`npm` PATH), not the lockfile.
2. **#1531** fixed bug B by switching to a plain `run:` step so `npm` is on `PATH`. Present on `main` today (the publish step is already a plain `run:`).
3. **#1224 (Jul 9, `da387214`)** re-introduced `cache: 'npm'`. Its merge-base with #1495 **is** #1495, so #1224 was branched on top of the fix and re-added the line in its own diff — a regression, not a stale-branch overwrite.
4. **v0.0.48 (Jul 30)** therefore hit bug A again — the lockfile error above.

Bug B is already fixed on `main`, so removing `cache: 'npm'` here should make `Release Docs` green end-to-end for the first time.

## Follow-up

The v0.0.48 docs did not publish to NPM. After merge, re-run `Release Docs` via `workflow_dispatch` (the job's `if:` allows it) to ship them without cutting a new release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)