### PR TITLE
fix(ci): cache deps and drop retry wrapper in release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,12 +234,10 @@ jobs:
         with:
           jvm: temurin:25
           apps: sbt
+      - name: Cache Dependencies
+        uses: coursier/cache-action@v8
       - name: Release
-        uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: 30
-          max_attempts: 3
-          command: sbt ci-release
+        run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}


### PR DESCRIPTION
## The problem

The `release` job (the one that runs `sbt ci-release` and publishes to Maven Central) has two defects that, combined, make releases unreliable and their failures hard to interpret.

### 1. No dependency cache

Every other job in `ci.yml` (`lint`, `testJVM`, `testJS`, `testGolem`, `buildDocs`) has a `coursier/cache-action@v8` step. The `release` job does not:

```yaml
release:
  steps:
    - Checkout current branch
    - Setup Action (coursier/setup-action)
    # <- no cache step here
    - Release (sbt ci-release)
```

`sbt ci-release` compiles and generates Scaladoc (needed for the `-javadoc.jar`) across every module, cross-built for Scala **2.13 / 3.3 / 3.8** on **JVM and JS**. From a cold Coursier/Ivy cache this is slow — on the v0.0.49 release it was still compiling and generating Scaladoc an hour in.

### 2. Two nested timeouts race each other

```yaml
release:
  timeout-minutes: 60          # job-level cap
  steps:
    - name: Release
      uses: nick-fields/retry@v4
      with:
        timeout_minutes: 30    # per-attempt cap
        max_attempts: 3
        command: sbt ci-release
```

On the v0.0.49 release (run [30568016306](https://github.com/zio/zio-blocks/actions/runs/30568016306)):

- The first execution of the job ([job 90963068241](https://github.com/zio/zio-blocks/actions/runs/30568016306/job/90963068241)) ran `ci-release` on a cold cache. The publish to Sonatype/Central actually **succeeded mid-build** (confirmed: `zio-blocks-schema_3-0.0.49.pom` returned `200` on `repo1.maven.org` while the job was still running), but the build kept going (further modules / Scaladoc) until the **60-minute job timeout** killed it. The job is recorded as `cancelled`, even though the release had already landed.
- A re-run of the same run ([run_attempt=2](https://github.com/zio/zio-blocks/actions/runs/30568016306), [job 90985540789](https://github.com/zio/zio-blocks/actions/runs/30568016306/job/90985540789)) started ~30 minutes later. Because every artifact was already published, **all three of `nick-fields/retry`'s internal attempts** (1, 2, 3 — each ~12 minutes) failed immediately with Sonatype's `Component with package url: '...@0.0.49' already exists` rejection, repeated for ~140+ artifacts, three times over. Maven Central artifacts are immutable, so no amount of retrying can ever succeed once a version is published — the retry wrapper burned ~36 minutes reproducing an unwinnable error three times instead of failing once, fast.

Net effect: the job's color no longer reliably tells you what happened. `cancelled`/`failure` can mean "actually published, just slow" just as easily as "genuinely broken," and a re-run after a timeout is guaranteed to fail loudly even when there is nothing wrong.

## The fix

Two changes to the `release` job, one per defect:

**1. Add the cache**, matching every other job, so the build has a realistic chance of finishing inside the timeout:

```yaml
- name: Cache Dependencies
  uses: coursier/cache-action@v8
```

**2. Drop `nick-fields/retry`** and run `sbt ci-release` as a plain step, so one attempt gets the entire `timeout-minutes: 60` budget instead of being sliced into 30-minute chunks that force a cold restart on every retry:

```yaml
- name: Release
  run: sbt ci-release
  env:
    PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
    PGP_SECRET: ${{ secrets.PGP_SECRET }}
    SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
    SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
```

If the build still fails, it now fails once, fast, with a clean signal — instead of masking a real outcome (or reproducing a guaranteed rejection) across multiple retries.

## Why the retry wrapper was there in the first place

`nick-fields/retry` wasn't arbitrary — it was added in #1507 (*"harden release pipeline against intermittent scala3#24183 scaladoc NPE"*) to work around a real, intermittent Scaladoc NullPointerException in the Scala 3 compiler ([scala/scala3#24183](https://github.com/scala/scala3/issues/24183)) that could crash a release build. Retrying the whole build was a reasonable way to paper over a rare compiler crash.

The problem is that the same wrapper also fires on an *unrelated* failure mode: a cold-cache build that's merely slow, or a re-run after the publish already succeeded. Unlike a compiler crash, neither of those is helped by blindly retrying — a slow build restarts just as cold on attempt 2, and a completed publish can only ever fail again (Central is immutable). The wrapper can't tell these apart, so it "fixes" the rare NPE case while making the common slow/already-published case worse. If the NPE recurs, a human re-running the single plain step is just as effective — and unlike the automatic wrapper, a human can check Central first before re-running.

## What this does *not* fix

Automatic retry of a publish step is inherently unsafe against an immutable target like Maven Central: if the release job fails or is cancelled after a partial or complete publish, re-running it will fail on every artifact that already landed. That's a process risk, not something a workflow change alone can close. Before re-running a failed/cancelled `release` job, check Central first, e.g.:

```
curl -sI https://repo1.maven.org/maven2/dev/zio/zio-blocks-schema_3/<version>/zio-blocks-schema_3-<version>.pom
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
