### PR TITLE
fix(ci): cache dependencies in release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,8 @@ jobs:
         with:
           jvm: temurin:25
           apps: sbt
+      - name: Cache Dependencies
+        uses: coursier/cache-action@v8
       - name: Release
         uses: nick-fields/retry@v4
         with:


### PR DESCRIPTION
## The problem

The `release` job has no `coursier/cache-action` step, unlike every other job in this workflow (`lint`, `testJVM`, `testJS`, `testGolem`, `buildDocs`). `sbt ci-release` compiles and generates Scaladoc for every module, cross-built for Scala 2.13/3.3/3.8 on JVM and JS. From a cold Coursier/Ivy cache this can run long enough to collide with the job's 60-minute timeout mid-publish.

On the v0.0.49 release ([run 30568016306](https://github.com/zio/zio-blocks/actions/runs/30568016306)), the publish to Sonatype/Central actually succeeded mid-build, but the job kept running (further modules / Scaladoc) until the 60-minute timeout killed it — recorded as `cancelled` despite the release having landed. A subsequent re-run then failed immediately on Sonatype's `already exists` rejection for every artifact, since Central is immutable and everything was already published.

## The fix (this PR)

Add the missing cache step, matching every other job:

```yaml
- name: Cache Dependencies
  uses: coursier/cache-action@v8
```

That's the only change. The `nick-fields/retry` wrapper around `sbt ci-release` is left untouched here on purpose.

## Why isolated to just the cache

There's a second, related issue in the same job: `nick-fields/retry` wraps the release step with a 30-minute per-attempt timeout inside the 60-minute job timeout, which is unsafe to retry once a publish has actually succeeded (Central rejects re-publishing existing artifacts). I opened #1554 to address that too, but we're deliberately testing this smaller, single-variable change first — if the cache alone gets the build comfortably under both timeouts on the next release, the retry wrapper (which also guards against a real, if rare, intermittent Scala 3 Scaladoc NPE — see #1507) never gets triggered by slowness in the first place, and there's no need to touch it.

#1554 stays open as the fallback if this isn't sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)