### PR TITLE
fix(build): align websiteDir with mdocOut in docs project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1658,7 +1658,8 @@ lazy val docs = project
           "[![ZIO Blocks](https://img.shields.io/github/stars/zio/zio-blocks?style=social)](https://github.com/zio/zio-blocks)"
       )
     ),
-    mdocOut := (ThisBuild / baseDirectory).value / "website" / "docs"
+    websiteDir := (ThisBuild / baseDirectory).value.toPath.resolve("website"),
+    mdocOut    := (ThisBuild / baseDirectory).value / "website" / "docs"
   )
   .dependsOn(
     schema.jvm,


### PR DESCRIPTION
## The problem

The `Release Docs` job has been failing on every recent release with:

```
java.io.IOException: Cannot run program "npm" (in directory ".../zio-blocks-docs/target/website/docs"): error=2, No such file or directory
```

This looked like a PATH problem (and was treated as one in #1531, which moved the step off `nick-fields/retry` onto a plain `run:` step) because Java's `ProcessBuilder` throws the *exact same generic message* whether the executable is missing **or the working directory doesn't exist**. It's the latter here.

## Root cause

`docs/publishToNpm` (`zio.sbt.WebsitePlugin.publishToNpmTask`) computes its docs directory as:

```scala
val docsDir: File = new File(websiteDir.value.toString, "docs")
```

`websiteDir` defaults to `target.value/website` (i.e. `zio-blocks-docs/target/website`). But this project's `build.sbt` overrides `mdocOut` to write compiled docs to the repo-root `website/docs` instead — the real, git-tracked Docusaurus site — without ever updating `websiteDir` to match. So `publishToNpmTask` always looks for docs in `zio-blocks-docs/target/website/docs`, a directory nothing ever creates, while mdoc actually writes to `<repo-root>/website/docs`.

## The fix

```diff
-    mdocOut := (ThisBuild / baseDirectory).value / "website" / "docs"
+    websiteDir := (ThisBuild / baseDirectory).value.toPath.resolve("website"),
+    mdocOut    := (ThisBuild / baseDirectory).value / "website" / "docs"
```

Confirmed safe: `websiteDir` is also used by the plugin's `installWebsiteTask`/`buildWebsiteTask`, which `rm -Rvf` and rescaffold it from scratch. Neither task is invoked anywhere in this repo (`buildDocs` CI job uses plain `yarn`/`mdoc` commands directly), so redirecting `websiteDir` to the real `website/` directory doesn't risk it being wiped.

## Verification

On this branch:
```
sbt "show docs/websiteDir" "show docs/mdocOut"
# -> .../website
# -> .../website/docs      (now consistent)

rm -rf website/docs
sbt docs/mdoc                 # regenerates 153 files into website/docs, 0 errors
cd website && npm run build   # Docusaurus build succeeds
```

And, to verify the actual failing task's code path (not just docs generation), ran the exact command sequence `publishToNpmTask` executes, from inside the resolved `docsDir`:
```
npm version 99.99.99 --no-git-tag-version
npm pkg set repository.url=https://github.com/zio/zio-blocks
npm config set access public
npm publish --dry-run
# -> + @zio.dev/zio-blocks@99.99.99   (exit 0)
```
`--dry-run` substituted only for the final publish step to avoid a real, irreversible push to the npm registry; everything upstream ran for real and succeeded.

## Prior art

This exact root cause and fix were already found by #1512 (2026-07-06), which is still open as a draft and never merged — it's now stale against main (predates the `sql` module and other changes). This PR supersedes it with the same one-line fix applied fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)