### PR TITLE
Pin zio-sbt-ci to the released 0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,21 +29,21 @@ jobs:
     continue-on-error: false
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
     - name: Install libuv
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev
     - name: Setup Scala
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v5.7.0
       with:
         distribution: corretto
         java-version: '25'
         check-latest: true
     - name: Setup SBT
-      uses: sbt/setup-sbt@v1
+      uses: sbt/setup-sbt@v1.5.7
     - name: Cache Dependencies
-      uses: coursier/cache-action@v8
+      uses: coursier/cache-action@v8.1.1
     - name: Setup Node.js
       uses: actions/setup-node@v7
       with:
@@ -264,7 +264,7 @@ jobs:
         jvm: temurin:25
         apps: sbt
     - name: Cache Dependencies
-      uses: coursier/cache-action@v8
+      uses: coursier/cache-action@v8.1.1
     - name: Release
       uses: nick-fields/retry@v4
       with:
@@ -289,21 +289,21 @@ jobs:
     if: ${{ (github.event_name == 'release' && github.event.action == 'published') || (github.event_name == 'workflow_dispatch') }}
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
     - name: Install libuv
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev
     - name: Setup Scala
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v5.7.0
       with:
         distribution: corretto
         java-version: '25'
         check-latest: true
     - name: Setup SBT
-      uses: sbt/setup-sbt@v1
+      uses: sbt/setup-sbt@v1.5.7
     - name: Cache Dependencies
-      uses: coursier/cache-action@v8
+      uses: coursier/cache-action@v8.1.1
     - name: Setup NodeJs
       uses: actions/setup-node@v7
       with:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,6 @@
 addSbtPlugin("dev.zio" % "zio-sbt-website" % "0.6.3")
 
-// zio-sbt-ci is tracked as a snapshot until the features it gained for this repository's workflow
-// land in a release. Snapshots are published from zio-sbt's main branch on every push, so the
-// version below is a specific commit and is expected to move.
-resolvers += "central-snapshots" at "https://central.sonatype.com/repository/maven-snapshots/"
-addSbtPlugin("dev.zio"            % "zio-sbt-ci"               % "0.6.3+23-a862c820-SNAPSHOT")
+addSbtPlugin("dev.zio"            % "zio-sbt-ci"               % "0.7.0")
 addSbtPlugin("com.timushev.sbt"   % "sbt-updates"              % "0.7.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                  % "0.4.8")
 addSbtPlugin("com.eed3si9n"       % "sbt-assembly"             % "2.4.1")


### PR DESCRIPTION
Replaces the snapshot pin with the released version, and drops the Sonatype snapshot resolver that
existed only to resolve it.

```diff
-resolvers += "central-snapshots" at "https://central.sonatype.com/repository/maven-snapshots/"
-addSbtPlugin("dev.zio" % "zio-sbt-ci" % "0.6.3+23-a862c820-SNAPSHOT")
+addSbtPlugin("dev.zio" % "zio-sbt-ci" % "0.7.0")
```

The snapshot was a **mutable artifact** — the registry can reap it, and it could in principle be
republished with different contents. A repository that publishes releases should not build against
one. zio/zio-sbt v0.7.0 was released for exactly this reason.

## What regenerating changes

Nine lines, all `uses:` pins on plugin-provided steps, from zio/zio-sbt#734:

```
3  coursier/cache-action@v8  -> @v8.1.1
2  sbt/setup-sbt@v1          -> @v1.5.7
2  actions/setup-java@v5     -> @v5.7.0
2  actions/checkout@v7       -> @v7.0.1
```

Nothing structural. `sbt ciCheckGithubWorkflow` passes on a clean tree.

## Worth a follow-up

This leaves `ci.yml` with **two pinning styles**:

| Step source | Pin style |
| --- | --- |
| Plugin-provided (`Checkout`, `SetupJava`, `SetupSBT`, `CacheDependencies`) | exact — `@v7.0.1` |
| Declared in `project/CiWorkflow.scala` | floating majors — `@v7`, `@v3`, `@v4` |

The floating ones are `coursier/setup-action@v3`, `actions/upload-artifact@v7`, `nick-fields/retry@v4`,
`actions/setup-node@v7`, and the `actions/checkout@v7` used by the test jobs.

A floating major is a moving reference — GitHub repoints it on each release — so the reproducibility
argument that motivated pinning the plugin's actions applies identically here. `coursier/setup-action`
is the most exposed: it provisions the JDK and sbt for every test lane.

Not folded into this PR, since that is a separate decision about this repository's own pins rather
than a consequence of the version bump.