### PR TITLE
Fix opaque wrapper register layout

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -2040,7 +2040,15 @@ object Reflect {
 
   private[schema] def unwrapToPrimitiveTypeOption[F[_, _], A](reflect: Reflect[F, A]): Option[PrimitiveType[A]] =
     if (reflect.isWrapper) {
-      reflect.asWrapperUnknown.get.wrapper.underlyingPrimitiveType.asInstanceOf[Option[PrimitiveType[A]]]
+      val wrapper = reflect.asWrapperUnknown.get.wrapper
+      wrapper.underlyingPrimitiveType.orElse {
+        // An opaque wrapper has the same runtime representation as its wrapped
+        // schema. Its TypeId can lack that representation when the schema was
+        // built with `transform`, so fall back to the wrapped primitive type.
+        if (wrapper.typeId.isOpaque)
+          unwrapToPrimitiveTypeOption(wrapper.wrapped).asInstanceOf[Option[PrimitiveType[A]]]
+        else None
+      }.asInstanceOf[Option[PrimitiveType[A]]]
     } else reflect.asPrimitive.map(_.primitiveType)
 
   private[blocks] def registerOffset[F[_, _], A](reflect: Reflect[F, A]): RegisterOffset.RegisterOffset =

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/json/JsonBinaryCodecDeriverVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/json/JsonBinaryCodecDeriverVersionSpecificSpec.scala
@@ -20,6 +20,18 @@ import zio.blocks.schema.{Modifier, Schema, SchemaBaseSpec}
 import zio.blocks.schema.json.JsonTestUtils._
 import zio.test._
 
+// Must stay top-level: nested opaque types are dealiased during record derivation.
+opaque type DerivedOpaqueInt = Int
+object DerivedOpaqueInt {
+  def apply(value: Int): DerivedOpaqueInt = value
+
+  extension (value: DerivedOpaqueInt) def toInt: Int = value
+
+  given Schema[DerivedOpaqueInt] = Schema.int.transform[DerivedOpaqueInt](DerivedOpaqueInt.apply, _.toInt)
+}
+
+case class DerivedOpaquePerson(name: String, age: DerivedOpaqueInt) derives Schema
+
 object JsonCodecDeriverVersionSpecificSpec extends SchemaBaseSpec {
   def spec: Spec[TestEnvironment, Any] = suite("JsonCodecDeriverVersionSpecificSpec")(
     suite("records")(
@@ -49,6 +61,9 @@ object JsonCodecDeriverVersionSpecificSpec extends SchemaBaseSpec {
       test("record with array field") {
         roundTrip(Arrays(IArray()), """{}""") &&
         roundTrip(Arrays(IArray("VVV", "WWW")), """{"xs":["VVV","WWW"]}""")
+      },
+      test("record with an automatically typed opaque wrapper field") {
+        roundTrip(DerivedOpaquePerson("Alice", DerivedOpaqueInt(10)), """{"name":"Alice","age":10}""")
       }
     ),
     suite("variants")(


### PR DESCRIPTION
## Summary

- preserve primitive register layouts for automatically typed Scala 3 opaque schemas produced with `Schema.transform`
- add a JSON round-trip regression test for an opaque `Int` field in a derived record

## Root cause

Record binding correctly uses an opaque type's underlying `Int` register, but a transformed opaque wrapper whose `TypeId` lacks a primitive representation was classified as an object by codec derivation. The codec then read a different register and encoded the default `0`.

The fallback is limited to opaque `TypeId`s, whose runtime representation is transparent; ordinary transform wrappers retain their object-register behavior.

## Validation

- `++3.8.3; schemaJVM/test` — 8,326 passed
- coverage: 88.48% statements / 83.08% branches
- schema JVM on Scala 2.13.18, and schema JS on Scala 3 and 2.13.18
- downstream format-codec suites, except one pre-existing JVM TOON expectation failure reproduced on unmodified `main` at `d09e4ef`

The additional Scala-next JS optimizer / benchmark / docs command was stopped after the local host exhausted available memory while optimizing Scala.js; it did not report a code failure. A subsequent initial formatting attempt encountered a temporary no-space condition, and the retry completed successfully. The PR's targeted, coverage, cross-version, cross-platform, and downstream checks above completed successfully.
