### PR TITLE
Fix opaque wrapper register layout

### DIFF
--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -2040,7 +2040,15 @@ object Reflect {
 
   private[schema] def unwrapToPrimitiveTypeOption[F[_, _], A](reflect: Reflect[F, A]): Option[PrimitiveType[A]] =
     if (reflect.isWrapper) {
-      reflect.asWrapperUnknown.get.wrapper.underlyingPrimitiveType.asInstanceOf[Option[PrimitiveType[A]]]
+      val wrapper = reflect.asWrapperUnknown.get.wrapper
+      wrapper.underlyingPrimitiveType.orElse {
+        // An opaque wrapper has the same runtime representation as its wrapped
+        // schema. Its TypeId can lack that representation when the schema was
+        // built with `transform`, so fall back to the wrapped primitive type.
+        if (wrapper.typeId.isOpaque)
+          unwrapToPrimitiveTypeOption(wrapper.wrapped).asInstanceOf[Option[PrimitiveType[A]]]
+        else None
+      }.asInstanceOf[Option[PrimitiveType[A]]]
     } else reflect.asPrimitive.map(_.primitiveType)
 
   private[blocks] def registerOffset[F[_, _], A](reflect: Reflect[F, A]): RegisterOffset.RegisterOffset =

--- a/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/Reflect.scala
@@ -2039,17 +2039,19 @@ object Reflect {
   }
 
   private[schema] def unwrapToPrimitiveTypeOption[F[_, _], A](reflect: Reflect[F, A]): Option[PrimitiveType[A]] =
-    if (reflect.isWrapper) {
-      val wrapper = reflect.asWrapperUnknown.get.wrapper
-      wrapper.underlyingPrimitiveType.orElse {
-        // An opaque wrapper has the same runtime representation as its wrapped
-        // schema. Its TypeId can lack that representation when the schema was
-        // built with `transform`, so fall back to the wrapped primitive type.
-        if (wrapper.typeId.isOpaque)
-          unwrapToPrimitiveTypeOption(wrapper.wrapped).asInstanceOf[Option[PrimitiveType[A]]]
-        else None
-      }.asInstanceOf[Option[PrimitiveType[A]]]
-    } else reflect.asPrimitive.map(_.primitiveType)
+    reflect.asWrapperUnknown match {
+      case Some(unknown) =>
+        val wrapper = unknown.wrapper
+        wrapper.underlyingPrimitiveType.orElse {
+          // An opaque wrapper has the same runtime representation as its wrapped
+          // schema. Its TypeId can lack that representation when the schema was
+          // built with `transform`, so fall back to the wrapped primitive type.
+          if (wrapper.typeId.isOpaque)
+            unwrapToPrimitiveTypeOption(wrapper.wrapped).asInstanceOf[Option[PrimitiveType[A]]]
+          else None
+        }.asInstanceOf[Option[PrimitiveType[A]]]
+      case None => reflect.asPrimitive.map(_.primitiveType)
+    }
 
   private[blocks] def registerOffset[F[_, _], A](reflect: Reflect[F, A]): RegisterOffset.RegisterOffset =
     unwrapToPrimitiveTypeOption(reflect) match {

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/json/ExternalOpaqueInt.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/json/ExternalOpaqueInt.scala
@@ -26,8 +26,8 @@ object ExternalOpaqueInt {
 
   extension (value: ExternalOpaqueInt) def toInt: Int = value
 
-  // Models opaque types such as Iron's `:|`: its TypeId representation does
-  // not directly identify the primitive runtime representation.
+  // Models an opaque wrapper whose TypeId representation does not directly
+  // identify its primitive runtime representation.
   given TypeId[ExternalOpaqueInt] = TypeId.opaque(
     "ExternalOpaqueInt",
     Owner.Root,

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/json/ExternalOpaqueInt.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/json/ExternalOpaqueInt.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.json.opaque
+
+import zio.blocks.schema.Schema
+import zio.blocks.typeid.{Owner, TypeId, TypeRepr}
+
+opaque type ExternalOpaqueInt = Int
+
+object ExternalOpaqueInt {
+  def apply(value: Int): ExternalOpaqueInt = value
+
+  extension (value: ExternalOpaqueInt) def toInt: Int = value
+
+  // Models opaque types such as Iron's `:|`: its TypeId representation does
+  // not directly identify the primitive runtime representation.
+  given TypeId[ExternalOpaqueInt] = TypeId.opaque(
+    "ExternalOpaqueInt",
+    Owner.Root,
+    representation = TypeRepr.Applied(TypeRepr.Ref(TypeId.option), List(TypeRepr.Ref(TypeId.int)))
+  )
+
+  given Schema[ExternalOpaqueInt] = Schema.int.transform[ExternalOpaqueInt](ExternalOpaqueInt.apply, _.toInt)
+}

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/json/ExternalOpaqueInt.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/json/ExternalOpaqueInt.scala
@@ -16,13 +16,18 @@
 
 package zio.blocks.schema.json.opaque
 
-import zio.blocks.schema.Schema
+import zio.blocks.schema.{Schema, SchemaError}
 import zio.blocks.typeid.{Owner, TypeId, TypeRepr}
 
 opaque type ExternalOpaqueInt = Int
 
 object ExternalOpaqueInt {
-  def apply(value: Int): ExternalOpaqueInt = value
+  def apply(value: Int): Either[String, ExternalOpaqueInt] =
+    if (value > 0) Right(value)
+    else Left("value must be strictly positive")
+
+  def unsafe(value: Int): ExternalOpaqueInt =
+    apply(value).fold(message => throw new IllegalArgumentException(message), identity)
 
   extension (value: ExternalOpaqueInt) def toInt: Int = value
 
@@ -34,5 +39,8 @@ object ExternalOpaqueInt {
     representation = TypeRepr.Applied(TypeRepr.Ref(TypeId.option), List(TypeRepr.Ref(TypeId.int)))
   )
 
-  given Schema[ExternalOpaqueInt] = Schema.int.transform[ExternalOpaqueInt](ExternalOpaqueInt.apply, _.toInt)
+  given Schema[ExternalOpaqueInt] = Schema.int.transform[ExternalOpaqueInt](
+    apply(_).fold(message => throw SchemaError.validationFailed(message), identity),
+    _.toInt
+  )
 }

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/json/JsonBinaryCodecDeriverVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/json/JsonBinaryCodecDeriverVersionSpecificSpec.scala
@@ -18,19 +18,10 @@ package zio.blocks.schema.json
 
 import zio.blocks.schema.{Modifier, Schema, SchemaBaseSpec}
 import zio.blocks.schema.json.JsonTestUtils._
+import zio.blocks.schema.json.opaque.ExternalOpaqueInt
 import zio.test._
 
-// Must stay top-level: nested opaque types are dealiased during record derivation.
-opaque type DerivedOpaqueInt = Int
-object DerivedOpaqueInt {
-  def apply(value: Int): DerivedOpaqueInt = value
-
-  extension (value: DerivedOpaqueInt) def toInt: Int = value
-
-  given Schema[DerivedOpaqueInt] = Schema.int.transform[DerivedOpaqueInt](DerivedOpaqueInt.apply, _.toInt)
-}
-
-case class DerivedOpaquePerson(name: String, age: DerivedOpaqueInt) derives Schema
+case class ExternalOpaquePerson(name: String, age: ExternalOpaqueInt) derives Schema
 
 object JsonCodecDeriverVersionSpecificSpec extends SchemaBaseSpec {
   def spec: Spec[TestEnvironment, Any] = suite("JsonCodecDeriverVersionSpecificSpec")(
@@ -62,8 +53,8 @@ object JsonCodecDeriverVersionSpecificSpec extends SchemaBaseSpec {
         roundTrip(Arrays(IArray()), """{}""") &&
         roundTrip(Arrays(IArray("VVV", "WWW")), """{"xs":["VVV","WWW"]}""")
       },
-      test("record with an automatically typed opaque wrapper field") {
-        roundTrip(DerivedOpaquePerson("Alice", DerivedOpaqueInt(10)), """{"name":"Alice","age":10}""")
+      test("record with an opaque wrapper whose type representation is not primitive") {
+        roundTrip(ExternalOpaquePerson("Alice", ExternalOpaqueInt(10)), """{"name":"Alice","age":10}""")
       }
     ),
     suite("variants")(

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/json/JsonBinaryCodecDeriverVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/json/JsonBinaryCodecDeriverVersionSpecificSpec.scala
@@ -53,8 +53,18 @@ object JsonCodecDeriverVersionSpecificSpec extends SchemaBaseSpec {
         roundTrip(Arrays(IArray()), """{}""") &&
         roundTrip(Arrays(IArray("VVV", "WWW")), """{"xs":["VVV","WWW"]}""")
       },
-      test("record with an opaque wrapper whose type representation is not primitive") {
-        roundTrip(ExternalOpaquePerson("Alice", ExternalOpaqueInt(10)), """{"name":"Alice","age":10}""")
+      test("record with a constrained opaque wrapper whose type representation is not primitive") {
+        val schema = Schema[ExternalOpaquePerson]
+
+        roundTrip(ExternalOpaquePerson("Alice", ExternalOpaqueInt.unsafe(10)), """{"name":"Alice","age":10}""") &&
+        assertTrue(
+          ExternalOpaqueInt(0) == Left("value must be strictly positive")
+        ) &&
+        decodeError(
+          """{"name":"Alice","age":0}""",
+          "value must be strictly positive at: .age.wrapped",
+          schema.jsonCodec
+        )
       }
     ),
     suite("variants")(

--- a/schema/shared/src/test/scala-3/zio/blocks/schema/json/JsonBinaryCodecDeriverVersionSpecificSpec.scala
+++ b/schema/shared/src/test/scala-3/zio/blocks/schema/json/JsonBinaryCodecDeriverVersionSpecificSpec.scala
@@ -20,6 +20,18 @@ import zio.blocks.schema.{Modifier, Schema, SchemaBaseSpec}
 import zio.blocks.schema.json.JsonTestUtils._
 import zio.test._
 
+// Must stay top-level: nested opaque types are dealiased during record derivation.
+opaque type DerivedOpaqueInt = Int
+object DerivedOpaqueInt {
+  def apply(value: Int): DerivedOpaqueInt = value
+
+  extension (value: DerivedOpaqueInt) def toInt: Int = value
+
+  given Schema[DerivedOpaqueInt] = Schema.int.transform[DerivedOpaqueInt](DerivedOpaqueInt.apply, _.toInt)
+}
+
+case class DerivedOpaquePerson(name: String, age: DerivedOpaqueInt) derives Schema
+
 object JsonCodecDeriverVersionSpecificSpec extends SchemaBaseSpec {
   def spec: Spec[TestEnvironment, Any] = suite("JsonCodecDeriverVersionSpecificSpec")(
     suite("records")(
@@ -49,6 +61,9 @@ object JsonCodecDeriverVersionSpecificSpec extends SchemaBaseSpec {
       test("record with array field") {
         roundTrip(Arrays(IArray()), """{}""") &&
         roundTrip(Arrays(IArray("VVV", "WWW")), """{"xs":["VVV","WWW"]}""")
+      },
+      test("record with an automatically typed opaque wrapper field") {
+        roundTrip(DerivedOpaquePerson("Alice", DerivedOpaqueInt(10)), """{"name":"Alice","age":10}""")
       }
     ),
     suite("variants")(


### PR DESCRIPTION
## Summary

- preserve primitive register layouts for opaque wrappers whose `TypeId` representation is not primitive
- add a JSON regression fixture that models a constrained opaque integer and verifies the validation message and field path

## Root cause

Record binding uses an opaque wrapper's underlying primitive register, but codec derivation previously classified an opaque wrapper with a non-primitive `TypeId` representation as an object. The codec then read a different register, causing incorrect serialized values or object-register bounds errors.

The fallback is limited to opaque `TypeId`s, whose runtime representation is transparent. It resolves the wrapped primitive only during codec derivation; ordinary transform wrappers retain object-register behavior and hot encode/decode paths gain no work.

## Validation

- `++3.8.3; schemaJVM/testOnly zio.blocks.schema.json.JsonCodecDeriverVersionSpecificSpec` — 12 passed
- `++3.3.7; schemaJS/testOnly zio.blocks.schema.json.JsonCodecDeriverVersionSpecificSpec` — 12 passed
- `++3.8.3; project schemaJVM; coverage; test; coverageReport` — 8,326 passed; 88.48% statements / 83.08% branches
- `++2.13.18; schemaJVM/test` — 7,632 passed
- `++3.8.3; coverageOff; schemaJS/test; ++2.13.18; schemaJS/test` — 6,991 and 6,398 passed
- `++3.8.3; project schemaJVM; fmtDirty`

The regression fixture fails on clean `main` and passes with this change.