### PR TITLE
fix: restore Maven Central / Sonatype Snapshot badges on a valid artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Modular, zero-dependency building blocks for modern Scala applications.**
 
-[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-blocks/workflows/CI/badge.svg) [![ZIO Blocks](https://img.shields.io/github/stars/zio/zio-blocks?style=social)](https://github.com/zio/zio-blocks)
+[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-blocks/workflows/CI/badge.svg) [![Maven Central](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fdev%2Fzio%2Fzio-blocks-config_3%2Fmaven-metadata.xml&label=Maven%20Central)](https://central.sonatype.com/artifact/dev.zio/zio-blocks-config_3) [![Sonatype Snapshot](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fdev%2Fzio%2Fzio-blocks-config_3%2Fmaven-metadata.xml&label=Sonatype%20Snapshot)](https://central.sonatype.com/repository/maven-snapshots/dev/zio/zio-blocks-config_3/) [![ZIO Blocks](https://img.shields.io/github/stars/zio/zio-blocks?style=social)](https://github.com/zio/zio-blocks)
 
 ## What Is ZIO Blocks?
 

--- a/build.sbt
+++ b/build.sbt
@@ -1681,11 +1681,20 @@ lazy val docs = project
       "dev.zio"   %% "zio-sbt-source" % "0.6.3",
       "org.xerial" % "sqlite-jdbc"    % "3.53.2.0"
     ),
-    // Override @PROJECT_BADGES@ to exclude Sonatype Release, Snapshot, and javadoc badges
+    // Override @PROJECT_BADGES@ to exclude the javadoc badge and to anchor the Maven Central /
+    // Sonatype Snapshot badges on the "zio-blocks-config" artifact instead of "zio-blocks-schema".
+    // A malformed "0.017" version was once published for zio-blocks-schema_3 (and several other
+    // modules); Maven Central is immutable, and Maven's version comparator ranks "0.017" (=[0,17])
+    // above every real "0.0.x" release (=[0,0,x]), so any badge keyed off zio-blocks-schema_3 would
+    // show "v0.017" forever. zio-blocks-config_3 was added after that bad publish and was never
+    // poisoned, so it accurately reflects the project's real version (all modules in this monorepo
+    // are released together under one version). Do not repoint these badges back at zio-blocks-schema_3.
     mdocVariables ++= Map(
       "PROJECT_BADGES" -> (
         "[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) " +
           "![CI Badge](https://github.com/zio/zio-blocks/workflows/CI/badge.svg) " +
+          "[![Maven Central](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fdev%2Fzio%2Fzio-blocks-config_3%2Fmaven-metadata.xml&label=Maven%20Central)](https://central.sonatype.com/artifact/dev.zio/zio-blocks-config_3) " +
+          "[![Sonatype Snapshot](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fdev%2Fzio%2Fzio-blocks-config_3%2Fmaven-metadata.xml&label=Sonatype%20Snapshot)](https://central.sonatype.com/repository/maven-snapshots/dev/zio/zio-blocks-config_3/) " +
           "[![ZIO Blocks](https://img.shields.io/github/stars/zio/zio-blocks?style=social)](https://github.com/zio/zio-blocks)"
       )
     ),
@@ -1729,9 +1738,12 @@ lazy val docs = project
       val docsIndex   = baseDirectory.value / "docs" / "index.md"
       val readmeFile  = baseDirectory.value / "README.md"
       val versionText = version.value
-      val badges      =
+      // Keep in sync with the PROJECT_BADGES mdocVariable above.
+      val badges =
         "[![Development](https://img.shields.io/badge/Project%20Stage-Development-green.svg)](https://github.com/zio/zio/wiki/Project-Stages) " +
           "![CI Badge](https://github.com/zio/zio-blocks/workflows/CI/badge.svg) " +
+          "[![Maven Central](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fdev%2Fzio%2Fzio-blocks-config_3%2Fmaven-metadata.xml&label=Maven%20Central)](https://central.sonatype.com/artifact/dev.zio/zio-blocks-config_3) " +
+          "[![Sonatype Snapshot](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fdev%2Fzio%2Fzio-blocks-config_3%2Fmaven-metadata.xml&label=Sonatype%20Snapshot)](https://central.sonatype.com/repository/maven-snapshots/dev/zio/zio-blocks-config_3/) " +
           "[![ZIO Blocks](https://img.shields.io/github/stars/zio/zio-blocks?style=social)](https://github.com/zio/zio-blocks)"
 
       val rendered = IO


### PR DESCRIPTION
## Summary
- Root cause: a malformed `0.017` version was once published for `zio-blocks-schema_3` (and `chunk_3`, `docs_3`, `scope_3`, `context_3`, `typeid_3`). Maven Central is immutable, and Maven's version comparator ranks `0.017` (`[0,17]`) above every real `0.0.x` release (`[0,0,x]`), so any badge keyed off those modules would show `v0.017` forever — that's why the badges were removed entirely in 4a1d168e instead of being fixed.
- `zio-blocks-config_3` was added after that bad publish and was never poisoned, so the restored Maven Central / Sonatype Snapshot badges are anchored there instead (all modules in this monorepo release together under one version, so it accurately reflects the real project version).
- Also switched from shields' `nexus/r`/`nexus/s` badge types (which only speak the old, now-decommissioned OSSRH Nexus API — confirmed `oss.sonatype.org` 404s) to the generic `maven-metadata/v` dynamic badge, which works against both `repo1.maven.org` and the new Central Portal snapshot repo.
- Verified both new badge URLs live: Maven Central renders `v0.0.51`, Sonatype Snapshot renders `v0.0.51+11-...-SNAPSHOT`.

## Test plan
- [x] `sbt scalafmtAll` / `sbt scalafmtSbt`
- [x] `sbt "++2.13; check"` passes
- [x] Rendered both new badge SVGs directly and confirmed correct version text (not `0.017`, not "artifact not found")
- [ ] Visual check of badges rendering on the PR's README preview on GitHub