### PR TITLE
Fix Incorrect parsing of nested lists by Markdown parser

### DIFF
--- a/markdown/shared/src/main/scala/zio/blocks/docs/Parser.scala
+++ b/markdown/shared/src/main/scala/zio/blocks/docs/Parser.scala
@@ -216,6 +216,9 @@ object Parser {
       innerState.parseBlocks().map(blocks => BlockQuote(blocks))
     }
 
+    private def indentation(line: String): Int =
+      line.takeWhile(_ == ' ').length
+
     private def isBulletListItem(line: String): Boolean = {
       val trimmed = line.dropWhile(_ == ' ')
       if (trimmed.isEmpty) return false
@@ -234,12 +237,18 @@ object Parser {
     }
 
     private def parseBulletList(): Either[ParseError, BulletList] = {
-      val items = Chunk.newBuilder[ListItem]
+      val items             = Chunk.newBuilder[ListItem]
+      val listContentIndent = indentation(currentLine) + 2
 
-      while (lineIndex < lines.length && isBulletListItem(currentLine)) {
-        val line    = currentLine
-        val trimmed = line.dropWhile(_ == ' ')
-        val content = trimmed.drop(2)
+      while (
+        lineIndex < lines.length &&
+        indentation(currentLine) < listContentIndent &&
+        isBulletListItem(currentLine)
+      ) {
+        val line              = currentLine
+        val itemContentIndent = indentation(line) + 2
+        val trimmed           = line.dropWhile(_ == ' ')
+        val content           = trimmed.drop(2)
 
         val (checked, itemContent) = parseTaskListMarker(content)
 
@@ -248,8 +257,8 @@ object Parser {
         val continuationLines = Chunk.newBuilder[String]
         continuationLines += itemContent
 
-        while (lineIndex < lines.length && isListContinuation(currentLine)) {
-          continuationLines += currentLine.dropWhile(_ == ' ')
+        while (lineIndex < lines.length && isListContinuation(currentLine, itemContentIndent)) {
+          continuationLines += normalizeListContinuation(currentLine, itemContentIndent)
           lineIndex += 1
         }
 
@@ -276,24 +285,36 @@ object Parser {
         (None, content)
       }
 
-    private def isListContinuation(line: String): Boolean = {
+    private def isListContinuation(line: String, contentIndent: Int): Boolean = {
       val trimmed = line.dropWhile(_ == ' ')
-      trimmed.nonEmpty &&
-      !isBulletListItem(line) &&
-      !isOrderedListItem(line) &&
-      line.startsWith("  ")
+      trimmed.nonEmpty && indentation(line) >= contentIndent
     }
 
+    // Remove the indentation up to the parent item's content column while
+    // retaining any additional indentation for blocks nested more deeply.
+    private def normalizeListContinuation(line: String, contentIndent: Int): String =
+      line.drop(contentIndent.min(line.length))
+
     private def parseOrderedList(): Either[ParseError, OrderedList] = {
-      val items = Chunk.newBuilder[ListItem]
-      var start = 1
+      val items            = Chunk.newBuilder[ListItem]
+      val firstMarkerWidth = {
+        val trimmed = currentLine.dropWhile(_ == ' ')
+        trimmed.takeWhile(_.isDigit).length + 2
+      }
+      val listContentIndent = indentation(currentLine) + firstMarkerWidth
+      var start             = 1
 
       var first = true
-      while (lineIndex < lines.length && isOrderedListItem(currentLine)) {
-        val line    = currentLine
-        val trimmed = line.dropWhile(_ == ' ')
-        val digits  = trimmed.takeWhile(_.isDigit)
-        val num     = digits.toInt
+      while (
+        lineIndex < lines.length &&
+        indentation(currentLine) < listContentIndent &&
+        isOrderedListItem(currentLine)
+      ) {
+        val line              = currentLine
+        val trimmed           = line.dropWhile(_ == ' ')
+        val digits            = trimmed.takeWhile(_.isDigit)
+        val itemContentIndent = indentation(line) + digits.length + 2
+        val num               = digits.toInt
 
         if (first) {
           start = num
@@ -306,8 +327,8 @@ object Parser {
         val continuationLines = Chunk.newBuilder[String]
         continuationLines += content
 
-        while (lineIndex < lines.length && isListContinuation(currentLine)) {
-          continuationLines += currentLine.dropWhile(_ == ' ')
+        while (lineIndex < lines.length && isListContinuation(currentLine, itemContentIndent)) {
+          continuationLines += normalizeListContinuation(currentLine, itemContentIndent)
           lineIndex += 1
         }
 

--- a/markdown/shared/src/test/scala/zio/blocks/docs/ParserSpec.scala
+++ b/markdown/shared/src/test/scala/zio/blocks/docs/ParserSpec.scala
@@ -228,6 +228,76 @@ object ParserSpec extends MarkdownBaseSpec {
           )
         )
       },
+      test("distinguishes sibling and nested bullet items at the content indentation boundary") {
+        val sibling = Parser.parse("- parent\n * sibling")
+        val nested  = Parser.parse("- parent\n  * child")
+        assertTrue(
+          sibling == Right(
+            Doc(
+              Chunk(
+                BulletList(
+                  Chunk(
+                    ListItem(Chunk(Paragraph(Chunk(Text("parent")))), None),
+                    ListItem(Chunk(Paragraph(Chunk(Text("sibling")))), None)
+                  ),
+                  tight = true
+                )
+              )
+            )
+          ),
+          nested == Right(
+            Doc(
+              Chunk(
+                BulletList(
+                  Chunk(
+                    ListItem(
+                      Chunk(
+                        Paragraph(Chunk(Text("parent"))),
+                        BulletList(
+                          Chunk(ListItem(Chunk(Paragraph(Chunk(Text("child")))), None)),
+                          tight = true
+                        )
+                      ),
+                      None
+                    )
+                  ),
+                  tight = true
+                )
+              )
+            )
+          )
+        )
+      },
+      test("parses indented nested bullet list") {
+        val input  = "- First item\n- Second item\n- Third item\n   * Indented item\n- Fourth item"
+        val result = Parser.parse(input)
+        assertTrue(
+          result == Right(
+            Doc(
+              Chunk(
+                BulletList(
+                  Chunk(
+                    ListItem(Chunk(Paragraph(Chunk(Text("First item")))), None),
+                    ListItem(Chunk(Paragraph(Chunk(Text("Second item")))), None),
+                    ListItem(
+                      Chunk(
+                        Paragraph(Chunk(Text("Third item"))),
+                        BulletList(
+                          Chunk(ListItem(Chunk(Paragraph(Chunk(Text("Indented item")))), None)),
+                          tight = true
+                        )
+                      ),
+                      None
+                    ),
+                    ListItem(Chunk(Paragraph(Chunk(Text("Fourth item")))), None)
+                  ),
+                  tight = true
+                )
+              )
+            )
+          )
+        )
+      },
       test("parses bullet list with asterisk") {
         val input  = "* item 1\n* item 2"
         val result = Parser.parse(input)
@@ -323,6 +393,48 @@ object ParserSpec extends MarkdownBaseSpec {
       }
     ),
     suite("Ordered lists")(
+      test("distinguishes sibling and nested items using the ordered marker width") {
+        val sibling = Parser.parse("10. parent\n   11. sibling")
+        val nested  = Parser.parse("10. parent\n    * child")
+        assertTrue(
+          sibling == Right(
+            Doc(
+              Chunk(
+                OrderedList(
+                  10,
+                  Chunk(
+                    ListItem(Chunk(Paragraph(Chunk(Text("parent")))), None),
+                    ListItem(Chunk(Paragraph(Chunk(Text("sibling")))), None)
+                  ),
+                  tight = true
+                )
+              )
+            )
+          ),
+          nested == Right(
+            Doc(
+              Chunk(
+                OrderedList(
+                  10,
+                  Chunk(
+                    ListItem(
+                      Chunk(
+                        Paragraph(Chunk(Text("parent"))),
+                        BulletList(
+                          Chunk(ListItem(Chunk(Paragraph(Chunk(Text("child")))), None)),
+                          tight = true
+                        )
+                      ),
+                      None
+                    )
+                  ),
+                  tight = true
+                )
+              )
+            )
+          )
+        )
+      },
       test("parses ordered list") {
         val input  = "1. first\n2. second"
         val result = Parser.parse(input)


### PR DESCRIPTION
/closes #1377

 ### Error
Parser.parseBulletList() incorrectly flattened nested bullet-list items into siblings.

Previously, isListContinuation() explicitly rejected lines recognized by isBulletListItem() or isOrderedListItem(). parseBulletList() saw the indented marker as another top-level item because isBulletListItem() ignores leading
spaces. This lost the nesting.

### Fix
The PR changes list parsing to use indentation boundaries:

 - Added indentation() to count leading spaces.
 - Updated parseBulletList() to calculate:
     - listContentIndent for the list
     - itemContentIndent for each item
 - Changed isListContinuation() to accept any non-empty line at or beyond the parent item’s content indentation, including nested list markers.
 - Added normalizeListContinuation() to remove only the parent indentation while preserving deeper indentation.
 - The normalized item text is passed to ParserState.parseBlocks(), allowing it to create a nested BulletList or OrderedList.
 - Applied equivalent marker-width-aware handling in parseOrderedList(), including multi-digit markers such as 10..
 
 ### Tests
 ParserSpec now verifies:

 - Nested bullet lists remain nested.
 - Slightly indented sibling bullet items remain siblings.
 - Ordered-list boundaries account for marker width.
 - Nested bullet lists inside ordered-list items are parsed correctly.
 