### PR TITLE
fix(ci): move the postgres host port out of the ephemeral range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         ports:
-        - 32886:5432
+        - 15432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
     - name: Checkout current branch

--- a/project/CiWorkflow.scala
+++ b/project/CiWorkflow.scala
@@ -202,6 +202,13 @@ object CiWorkflow {
    * scala3#24183 makes it fail; docs are compiled on JDK 17 instead. Postgres
    * backs the sql modules and carries a health check so steps cannot start
    * before it accepts connections.
+   *
+   * The published host port must stay below 32768, outside Linux's ephemeral
+   * range (`net.ipv4.ip_local_port_range`, 32768-60999 on the runners). A port
+   * inside that range is intermittently stolen as the source port of an
+   * outbound connection made while the image is still being pulled, and Docker
+   * then fails the whole job with "address already in use". It must also match
+   * the `DB_URL` fallback in JdbcInstantTimezoneSpec.
    */
   lazy val testJVM: Def.Initialize[Job] = Def.setting(
     Job(
@@ -223,7 +230,7 @@ object CiWorkflow {
             "POSTGRES_PASSWORD" -> "postgres",
             "POSTGRES_DB"       -> "postgres"
           ),
-          ports = Chunk(ServicePort(32886, 5432)),
+          ports = Chunk(ServicePort(15432, 5432)),
           options = Some(
             "--health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5"
           )

--- a/sql/jvm/src/test/scala/zio/blocks/sql/JdbcInstantTimezoneSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/JdbcInstantTimezoneSpec.scala
@@ -32,7 +32,7 @@ object JdbcInstantTimezoneSpec extends ZIOSpecDefault {
   private def withPostgresConnection[A](f: java.sql.Connection => A): A = {
     Class.forName("org.postgresql.Driver")
     val url =
-      sys.env.getOrElse("DB_URL", "jdbc:postgresql://localhost:32886/postgres")
+      sys.env.getOrElse("DB_URL", "jdbc:postgresql://localhost:15432/postgres")
     val user     = sys.env.getOrElse("DB_USERNAME", "postgres")
     val password = sys.env.getOrElse("DB_PASSWORD", "postgres")
     val conn     = java.sql.DriverManager.getConnection(url, user, password)


### PR DESCRIPTION
## Problem

[`testJVM (17, JVM, 2.13.x)` on `main`](https://github.com/zio/zio-blocks/actions/runs/31581166947/job/94064333816) failed at **Initialize containers**, before checkout:

```
Error response from daemon: failed to set up container networking: driver failed
programming external connectivity on endpoint ..._postgres16_617443: failed to bind
host port for 0.0.0.0:32886:172.18.0.2:5432/tcp: address already in use
Error: failed to start containers: 76a5a2368c02...
##[error]Docker start fail with exit code 1
```

Every subsequent step was skipped, so the job reported failure without testing anything. The other eleven matrix lanes on the same commit (`04086e27`) were green.

## Cause

The service publishes postgres on host port **32886**, which is inside Linux's ephemeral port range — `net.ipv4.ip_local_port_range` is `32768 60999` on the runner image. Ports in that range are handed out as *source* ports for outbound connections, and the job makes several before Docker binds the mapping: three action downloads plus `docker pull postgres:16`, which alone takes ~9s here. If one of those is assigned 32886, the bind fails and the job dies.

That makes this a race, which is why it fires intermittently on one lane at a time rather than reproducibly.

## Fix

Publish on **15432** instead:

- below `32768`, so it is outside the ephemeral range and cannot be taken this way;
- not `5432`, which the PostgreSQL 16 pre-installed on `ubuntu-24.04` would claim if anything ever started it.

The port is spelled in two places — the workflow generator and the `DB_URL` fallback the spec uses when that variable is unset, which CI never sets — so both move together. `.github/workflows/ci.yml` is the regenerated output of `sbt ciGenerateGithubWorkflow`, not a hand edit.

The reasoning is recorded in `CiWorkflow.scala`'s scaladoc so the constraint is not rediscovered the hard way.

## Verification

- `sbt ciCheckGithubWorkflow` — clean, so the committed workflow matches the generator.
- `sbt "++2.13; check; headerCheckAll"` and `sbt "++3.8; check; headerCheckAll"` — both green, matching what the `lint` job runs.
- Ran postgres:16 locally published on `15432` with the same env and health check, then `sbt "++3.8.3; sqlJVM/testOnly zio.blocks.sql.JdbcInstantTimezoneSpec"` — `1 tests passed`, confirming the spec reaches the database on the new port rather than merely compiling.

## Note

This only removes the collision for `testJVM`. Nothing else in the workflow publishes a host port today, so there is no second instance to fix.