### PR TITLE
Fix native serialization of nested Json values

### DIFF
--- a/chunk/shared/src/test/scala/zio/blocks/chunk/ChunkSpec.scala
+++ b/chunk/shared/src/test/scala/zio/blocks/chunk/ChunkSpec.scala
@@ -198,6 +198,21 @@ object ChunkSpec extends ChunkBaseSpec {
         assert(as.corresponds(bs)(f))(equalTo(as.toList.corresponds(bs.toList)(f)))
       }
     },
+    test("ChunkIterator.fromArray") {
+      assertTrue(
+        Chunk.ChunkIterator.fromArray(Array.empty[Int]).length == 0,
+        Chunk.ChunkIterator.fromArray(Array(1)).nextAt(0) == 1,
+        Chunk.ChunkIterator.fromArray(Array("a", "b")).nextAt(1) == "b",
+        Chunk.ChunkIterator.fromArray(Array(true, false)).nextAt(1) == false,
+        Chunk.ChunkIterator.fromArray(Array[Byte](1, 2)).nextAt(1) == 2,
+        Chunk.ChunkIterator.fromArray(Array('a', 'b')).nextAt(1) == 'b',
+        Chunk.ChunkIterator.fromArray(Array(1.0, 2.0)).nextAt(1) == 2.0,
+        Chunk.ChunkIterator.fromArray(Array(1.0f, 2.0f)).nextAt(1) == 2.0f,
+        Chunk.ChunkIterator.fromArray(Array(1, 2)).nextAt(1) == 2,
+        Chunk.ChunkIterator.fromArray(Array(1L, 2L)).nextAt(1) == 2L,
+        Chunk.ChunkIterator.fromArray(Array[Short](1, 2)).nextAt(1) == 2
+      )
+    },
     test("chunkIterator") {
       def roundTrip[A](c: Chunk[A]): Chunk[A] = {
         val ci      = c.chunkIterator

--- a/schema/shared/src/main/scala/zio/blocks/schema/json/JsonCodecDeriver.scala
+++ b/schema/shared/src/main/scala/zio/blocks/schema/json/JsonCodecDeriver.scala
@@ -925,7 +925,9 @@ class JsonCodecDeriver private[json] (
     defaultValue: Option[A],
     examples: Seq[A]
   )(implicit F: HasBinding[F], D: HasInstance[F]): Lazy[JsonCodec[A]] = {
-    if (binding.isInstanceOf[Binding[?, ?]]) {
+    if (binding.isInstanceOf[Binding[?, ?]] && typeId == TypeId.of[Json]) {
+      Lazy(Json.jsonCodec.asInstanceOf[JsonCodec[A]])
+    } else if (binding.isInstanceOf[Binding[?, ?]]) {
       val isOption = typeId.isOption
       if (isOption || typeId.isMaybe) {
         D.instance(cases(1).value.asRecord.get.fields(0).value.metadata).map { codec =>

--- a/schema/shared/src/test/scala/zio/blocks/schema/SyntaxSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/SyntaxSpec.scala
@@ -32,6 +32,11 @@ object SyntaxSpec extends SchemaBaseSpec {
     implicit val schema: Schema[Address] = Schema.derived
   }
 
+  case class JsonField(a: Int, b: String, c: Json)
+  object JsonField {
+    implicit val schema: Schema[JsonField] = Schema.derived
+  }
+
   override def spec: Spec[TestEnvironment, Any] = suite("SyntaxSpec")(
     suite("diff")(
       test("computes difference between two values") {
@@ -80,6 +85,16 @@ object SyntaxSpec extends SchemaBaseSpec {
           json.get("street").as[String] == Right("456 Oak Ave"),
           json.get("city").as[String] == Right("Metropolis")
         )
+      },
+      test("embeds Json fields without structural ADT tags") {
+        val value = JsonField(2, "test", Json.Object("f" -> Json.Number(36)))
+        assertTrue(
+          value.toJson == Json.Object(
+            "a" -> Json.Number(2),
+            "b" -> Json.String("test"),
+            "c" -> Json.Object("f" -> Json.Number(36))
+          )
+        )
       }
     ),
     suite("toJsonString")(
@@ -97,6 +112,14 @@ object SyntaxSpec extends SchemaBaseSpec {
         val p      = Person("Eve", 35)
         val result = p.toJsonString
         assertTrue(Json.parse(result).isRight)
+      },
+      test("round-trips embedded Json fields in their native representation") {
+        val value   = JsonField(2, "test", Json.Object("f" -> Json.Number(36)))
+        val encoded = value.toJsonString
+        assertTrue(
+          encoded == """{"a":2,"b":"test","c":{"f":36}}""",
+          encoded.fromJson[JsonField] == Right(value)
+        )
       }
     ),
     suite("toJsonBytes")(

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/JsonSpec.scala
@@ -2301,13 +2301,13 @@ object JsonSpec extends SchemaBaseSpec {
           JsonTestUtils.roundTrip(Json.String("hello"), """{"value":"hello"}""")
         },
         test("Json.Array serializes to JSON") {
-          JsonTestUtils.roundTrip(Json.Array(Json.Number(1)), """{"value":[{"Number":{"value":1}}]}""")
+          JsonTestUtils.roundTrip(Json.Array(Json.Number(1)), """{"value":[1]}""")
         },
         test("Json (variant) serializes to JSON") {
-          JsonTestUtils.roundTrip(Json.Null: Json, """{"Null":{}}""") &&
-          JsonTestUtils.roundTrip(Json.Boolean(true): Json, """{"Boolean":{"value":true}}""") &&
-          JsonTestUtils.roundTrip(Json.Number(1): Json, """{"Number":{"value":1}}""") &&
-          JsonTestUtils.roundTrip(Json.String("x"): Json, """{"String":{"value":"x"}}""")
+          JsonTestUtils.roundTrip(Json.Null: Json, "null") &&
+          JsonTestUtils.roundTrip(Json.Boolean(true): Json, "true") &&
+          JsonTestUtils.roundTrip(Json.Number(1): Json, "1") &&
+          JsonTestUtils.roundTrip(Json.String("x"): Json, """"x"""")
         }
       ),
       suite("Schema roundtrip")(

--- a/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonPatchSerializationSpec.scala
+++ b/schema/shared/src/test/scala/zio/blocks/schema/json/patch/JsonPatchSerializationSpec.scala
@@ -121,13 +121,13 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
     test("ArrayOp.Insert serializes") {
       roundTrip(
         ArrayOp.Insert(1, Chunk(Json.Number(42), Json.String("test"))): ArrayOp,
-        """{"Insert":{"index":1,"values":[{"Number":{"value":42}},{"String":{"value":"test"}}]}}"""
+        """{"Insert":{"index":1,"values":[42,"test"]}}"""
       )
     },
     test("ArrayOp.Append serializes") {
       roundTrip(
         ArrayOp.Append(Chunk(Json.Boolean(true), Json.Null)): ArrayOp,
-        """{"Append":{"values":[{"Boolean":{"value":true}},{"Null":{}}]}}"""
+        """{"Append":{"values":[true,null]}}"""
       )
     },
     test("ArrayOp.Delete serializes") {
@@ -139,7 +139,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
     test("ArrayOp.Modify with Set operation") {
       roundTrip(
         ArrayOp.Modify(0, Op.Set(Json.Number(100))): ArrayOp,
-        """{"Modify":{"index":0,"op":{"Set":{"value":{"Number":{"value":100}}}}}}"""
+        """{"Modify":{"index":0,"op":{"Set":{"value":100}}}}"""
       )
     },
     test("ArrayOp.Modify with nested PrimitiveDelta") {
@@ -156,7 +156,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
     test("ObjectOp.Add serializes") {
       roundTrip(
         ObjectOp.Add("name", Json.String("Alice")): ObjectOp,
-        """{"Add":{"key":"name","value":{"String":{"value":"Alice"}}}}"""
+        """{"Add":{"key":"name","value":"Alice"}}"""
       )
     },
     test("ObjectOp.Remove serializes") {
@@ -170,13 +170,13 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
       roundTrip(
         ObjectOp.Modify("counter", innerPatch): ObjectOp,
         // Empty path serializes as empty object
-        """{"Modify":{"key":"counter","patch":{"ops":[{"path":{},"operation":{"Set":{"value":{"Number":{"value":42}}}}}]}}}"""
+        """{"Modify":{"key":"counter","patch":{"ops":[{"path":{},"operation":{"Set":{"value":42}}}]}}}"""
       )
     },
     test("ObjectOp with unicode keys") {
       roundTrip(
         ObjectOp.Add("名前", Json.String("太郎")): ObjectOp,
-        """{"Add":{"key":"名前","value":{"String":{"value":"太郎"}}}}"""
+        """{"Add":{"key":"名前","value":"太郎"}}"""
       )
     }
   )
@@ -187,13 +187,13 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
     test("Op.Set with simple value") {
       roundTrip(
         Op.Set(Json.String("hello")): Op,
-        """{"Set":{"value":{"String":{"value":"hello"}}}}"""
+        """{"Set":{"value":"hello"}}"""
       )
     },
     test("Op.Set with complex object") {
       roundTrip(
         Op.Set(Json.Object("a" -> Json.Number(1), "b" -> Json.Array(Json.Boolean(true)))): Op,
-        """{"Set":{"value":{"Object":{"value":[["a",{"Number":{"value":1}}],["b",{"Array":{"value":[{"Boolean":{"value":true}}]}}]]}}}}"""
+        """{"Set":{"value":{"a":1,"b":[true]}}}"""
       )
     },
     test("Op.PrimitiveDelta with NumberDelta") {
@@ -216,7 +216,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
             ArrayOp.Delete(0, 1)
           )
         ): Op,
-        """{"ArrayEdit":{"ops":[{"Append":{"values":[{"Number":{"value":1}}]}},{"Delete":{"index":0,"count":1}}]}}"""
+        """{"ArrayEdit":{"ops":[{"Append":{"values":[1]}},{"Delete":{"index":0,"count":1}}]}}"""
       )
     },
     test("Op.ObjectEdit serializes") {
@@ -227,7 +227,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
             ObjectOp.Remove("y")
           )
         ): Op,
-        """{"ObjectEdit":{"ops":[{"Add":{"key":"x","value":{"Number":{"value":10}}}},{"Remove":{"key":"y"}}]}}"""
+        """{"ObjectEdit":{"ops":[{"Add":{"key":"x","value":10}},{"Remove":{"key":"y"}}]}}"""
       )
     },
     test("Op.Nested serializes") {
@@ -235,7 +235,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
       roundTrip(
         Op.Nested(innerPatch): Op,
         // Empty path serializes as empty object
-        """{"Nested":{"patch":{"ops":[{"path":{},"operation":{"Set":{"value":{"Boolean":{"value":true}}}}}]}}}"""
+        """{"Nested":{"patch":{"ops":[{"path":{},"operation":{"Set":{"value":true}}}]}}}"""
       )
     }
   )
@@ -247,7 +247,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
       roundTrip(
         JsonPatchOp(DynamicOptic.root, Op.Set(Json.Number(42))),
         // Empty path serializes as empty object
-        """{"path":{},"operation":{"Set":{"value":{"Number":{"value":42}}}}}"""
+        """{"path":{},"operation":{"Set":{"value":42}}}"""
       )
     },
     test("JsonPatchOp with single field path") {
@@ -257,7 +257,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
           Op.Set(Json.String("Bob"))
         ),
         // Path is serialized as DynamicOptic record with nodes field
-        """{"path":{"nodes":[{"Field":{"name":"name"}}]},"operation":{"Set":{"value":{"String":{"value":"Bob"}}}}}"""
+        """{"path":{"nodes":[{"Field":{"name":"name"}}]},"operation":{"Set":{"value":"Bob"}}}"""
       )
     },
     test("JsonPatchOp with nested path") {
@@ -266,7 +266,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
           DynamicOptic.root.field("user").field("address").field("city"),
           Op.Set(Json.String("NYC"))
         ),
-        """{"path":{"nodes":[{"Field":{"name":"user"}},{"Field":{"name":"address"}},{"Field":{"name":"city"}}]},"operation":{"Set":{"value":{"String":{"value":"NYC"}}}}}"""
+        """{"path":{"nodes":[{"Field":{"name":"user"}},{"Field":{"name":"address"}},{"Field":{"name":"city"}}]},"operation":{"Set":{"value":"NYC"}}}"""
       )
     },
     test("JsonPatchOp with array index in path") {
@@ -293,7 +293,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
       roundTrip(
         JsonPatch.root(Op.Set(Json.String("hello"))),
         // Empty path serializes as empty object
-        """{"ops":[{"path":{},"operation":{"Set":{"value":{"String":{"value":"hello"}}}}}]}"""
+        """{"ops":[{"path":{},"operation":{"Set":{"value":"hello"}}}]}"""
       )
     },
     test("JsonPatch with multiple operations") {
@@ -311,7 +311,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
           )
         ),
         // Path is serialized as DynamicOptic record with nodes field
-        """{"ops":[{"path":{"nodes":[{"Field":{"name":"name"}}]},"operation":{"Set":{"value":{"String":{"value":"Alice"}}}}},{"path":{"nodes":[{"Field":{"name":"age"}}]},"operation":{"PrimitiveDelta":{"op":{"NumberDelta":{"delta":1}}}}}]}"""
+        """{"ops":[{"path":{"nodes":[{"Field":{"name":"name"}}]},"operation":{"Set":{"value":"Alice"}}},{"path":{"nodes":[{"Field":{"name":"age"}}]},"operation":{"PrimitiveDelta":{"op":{"NumberDelta":{"delta":1}}}}}]}"""
       )
     }
   )
@@ -327,7 +327,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
       // Empty paths serialize as empty objects
       roundTrip(
         level1,
-        """{"ops":[{"path":{},"operation":{"Nested":{"patch":{"ops":[{"path":{},"operation":{"Nested":{"patch":{"ops":[{"path":{},"operation":{"Set":{"value":{"Number":{"value":42}}}}}]}}}}]}}}}]}"""
+        """{"ops":[{"path":{},"operation":{"Nested":{"patch":{"ops":[{"path":{},"operation":{"Nested":{"patch":{"ops":[{"path":{},"operation":{"Set":{"value":42}}}]}}}}]}}}}]}"""
       )
     },
     test("ObjectOp.Modify with deeply nested patches") {
@@ -345,7 +345,7 @@ object JsonPatchSerializationSpec extends SchemaBaseSpec {
       // Empty paths serialize as empty objects
       roundTrip(
         ObjectOp.Modify("outer", innerPatch): ObjectOp,
-        """{"Modify":{"key":"outer","patch":{"ops":[{"path":{},"operation":{"ObjectEdit":{"ops":[{"Add":{"key":"nested","value":{"Object":{"value":[["a",{"Number":{"value":1}}]]}}}},{"Modify":{"key":"other","patch":{"ops":[{"path":{},"operation":{"Set":{"value":{"String":{"value":"deep"}}}}}]}}}]}}}]}}}"""
+        """{"Modify":{"key":"outer","patch":{"ops":[{"path":{},"operation":{"ObjectEdit":{"ops":[{"Add":{"key":"nested","value":{"a":1}}},{"Modify":{"key":"other","patch":{"ops":[{"path":{},"operation":{"Set":{"value":"deep"}}}]}}}]}}}]}}}"""
       )
     },
     test("ArrayOp.Modify containing ObjectEdit containing ArrayEdit") {


### PR DESCRIPTION
/closes #1370 

Fix

 - Use Json.jsonCodec when deriving codecs for nested Json fields.
 - Fix - nested JSON from being serialized as the structural Json ADT.
 - Updated affected serialization expectations and add regression tests.
 - Added deterministic ChunkIterator.fromArray coverage for all array variants. (so I could hit coverage target)

 Result

 Nested values now serialize natively:

 ```json
   {"a":2,"b":"test","c":{"f":36}}
 ```