### PR TITLE
feat(sql): eliminate per-row SQL decode allocations + chunked emission, null-bitmap, benchmark

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1330,7 +1330,13 @@ lazy val `sql-benchmarks` = project
     libraryDependencies ++= Seq(
       // In-memory SQLite table for the decode fixture; sql.jvm only has it as a
       // Test dep, so the benchmark (main sources) declares it directly.
-      "org.xerial" % "sqlite-jdbc" % "3.53.2.1"
+      "org.xerial" % "sqlite-jdbc" % "3.53.2.1",
+      // Real-world cross-library comparison: same Postgres server, same data —
+      // zio-blocks via JDBC vs kyo-sql's native wire-protocol driver, plus a
+      // hand-rolled raw-JDBC floor.
+      "org.postgresql" % "postgresql" % "42.7.13",
+      "io.getkyo" %% "kyo-sql"          % "1.0.0-RC6",
+      "io.getkyo" %% "kyo-sql-postgres" % "1.0.0-RC6"
     ),
     assembly / assemblyJarName       := "sql-benchmarks.jar",
     assembly / assemblyMergeStrategy := {

--- a/build.sbt
+++ b/build.sbt
@@ -1334,9 +1334,9 @@ lazy val `sql-benchmarks` = project
       // Real-world cross-library comparison: same Postgres server, same data —
       // zio-blocks via JDBC vs kyo-sql's native wire-protocol driver, plus a
       // hand-rolled raw-JDBC floor.
-      "org.postgresql" % "postgresql" % "42.7.13",
-      "io.getkyo" %% "kyo-sql"          % "1.0.0-RC6",
-      "io.getkyo" %% "kyo-sql-postgres" % "1.0.0-RC6"
+      "org.postgresql" % "postgresql"       % "42.7.13",
+      "io.getkyo"     %% "kyo-sql"          % "1.0.0-RC6",
+      "io.getkyo"     %% "kyo-sql-postgres" % "1.0.0-RC6"
     ),
     assembly / assemblyJarName       := "sql-benchmarks.jar",
     assembly / assemblyMergeStrategy := {

--- a/build.sbt
+++ b/build.sbt
@@ -470,7 +470,7 @@ lazy val scope = crossProject(JSPlatform, JVMPlatform)
 
 lazy val sql = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Full)
-  .dependsOn(schema, scope)
+  .dependsOn(schema, scope, streams)
   .settings(stdSettings("zio-blocks-sql", Seq(BuildHelper.Scala3, BuildHelper.Scala33)))
   .settings(crossProjectSettings)
   .settings(buildInfoSettings("zio.blocks.sql"))

--- a/build.sbt
+++ b/build.sbt
@@ -305,6 +305,7 @@ lazy val root = project
     scalaNextTests.js,
     benchmarks,
     `scope-benchmarks`,
+    `sql-benchmarks`,
     `streams-benchmark`,
     docs,
     `schema-examples`,
@@ -1318,6 +1319,31 @@ lazy val benchmarks = project
     coverageEnabled            := coverageEnabled.value && scalaBinaryVersion.value != "2.13",
     coverageMinimumStmtTotal   := 30,
     coverageMinimumBranchTotal := 42
+  )
+
+lazy val `sql-benchmarks` = project
+  .in(file("sql-benchmarks"))
+  .settings(stdSettings("zio-blocks-sql-benchmarks", Seq("3.8.3")))
+  .dependsOn(sql.jvm % "compile->compile;test->test")
+  .enablePlugins(JmhPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      // In-memory SQLite table for the decode fixture; sql.jvm only has it as a
+      // Test dep, so the benchmark (main sources) declares it directly.
+      "org.xerial" % "sqlite-jdbc" % "3.53.2.1"
+    ),
+    assembly / assemblyJarName       := "sql-benchmarks.jar",
+    assembly / assemblyMergeStrategy := {
+      case x if x.endsWith("module-info.class") => MergeStrategy.discard
+      case path                                 => MergeStrategy.defaultMergeStrategy(path)
+    },
+    assembly / fullClasspath   := (Jmh / fullClasspath).value,
+    assembly / mainClass       := Some("org.openjdk.jmh.Main"),
+    publish / skip             := true,
+    mimaPreviousArtifacts      := Set(),
+    coverageEnabled            := coverageEnabled.value && scalaBinaryVersion.value != "2.13",
+    coverageMinimumStmtTotal   := 0,
+    coverageMinimumBranchTotal := 0
   )
 
 // ---------------------------------------------------------------------------

--- a/docs/reference/sql/db-result-reader.md
+++ b/docs/reference/sql/db-result-reader.md
@@ -58,13 +58,15 @@ trait DbResultReader {
   // Other types
   def getUUID(index: Int): java.util.UUID
   def getUUID(label: String): java.util.UUID
-  def getArray(index: Int): java.sql.Array   // default: throws UnsupportedOperationException
-  def getArray(label: String): java.sql.Array // default: throws UnsupportedOperationException
+  def getArray(index: Int): Array[String]    // default: throws UnsupportedOperationException
+  def getArray(label: String): Array[String] // default: throws UnsupportedOperationException
 
   // Metadata and NULL detection
   def columnLabel(index: Int): String
   def hasColumn(label: String): Boolean
   def wasNull: Boolean
+  def isNull(index: Int): Boolean  // default: false
+  def isNull(label: String): Boolean // default: false
 }
 ```
 

--- a/docs/reference/sql/frag.md
+++ b/docs/reference/sql/frag.md
@@ -9,7 +9,7 @@ keywords:
   - "SQL Injection Prevention"
 ---
 
-`Frag` is an immutable SQL fragment — a piece of SQL text with typed parameter values kept safely separate from the literal SQL. The `sql"..."` string interpolator builds fragments by checking at compile time that every interpolated expression can be bound as a parameter. Fragments compose with `++` and execute through methods like `query`, `update`, and `queryOne`.
+`Frag` is an immutable SQL fragment — a piece of SQL text with typed parameter values kept safely separate from the literal SQL. The `sql"..."` string interpolator builds fragments by checking at compile time that every interpolated expression can be bound as a parameter. Fragments compose with `++` and execute through methods like `query`, `update`, and `queryOne`, plus the chunked streaming methods `queryStream` and `queryChunked`.
 
 `Frag` is safe from SQL injection because parameter values never appear in the SQL string — they are stored separately and bound to `?` placeholders at execution time.
 
@@ -175,6 +175,41 @@ object User { implicit val schema: Schema[User] = Schema.derived }
 given DbCon = ???
 
 val page: List[User] = sql"SELECT id, name FROM users ORDER BY name".queryLimit[User](10)
+```
+
+**`queryStream[A]`** — Execute SELECT and return rows as a chunked stream (`zio.blocks.streams.Stream`), batching `DefaultQueryChunkSize` (64) rows per chunk:
+
+```scala mdoc:compile-only
+import zio.blocks.chunk.Chunk
+import zio.blocks.sql._
+import zio.blocks.schema.Schema
+import zio.blocks.streams.Stream
+
+case class User(id: Int, name: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
+
+given DbCon = ???
+
+val chunks: Stream[Throwable, Chunk[User]] =
+  sql"SELECT id, name FROM users".queryStream[User]
+val all: Either[Throwable, List[User]] = chunks.runCollect.map(_.toList.flatten)
+```
+
+**`queryChunked[A](n)`** — Like `queryStream`, but with an explicit batch size. The statement and result set are acquired lazily on the first pull and released when the stream is closed or fully drained; each chunk holds up to `n` rows, so memory stays bounded for large result sets:
+
+```scala mdoc:compile-only
+import zio.blocks.chunk.Chunk
+import zio.blocks.sql._
+import zio.blocks.schema.Schema
+import zio.blocks.streams.Stream
+
+case class User(id: Int, name: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
+
+given DbCon = ???
+
+val batches: Stream[Throwable, Chunk[User]] =
+  sql"SELECT id, name FROM users".queryChunked[User](500)
 ```
 
 **`update`** — Execute INSERT, UPDATE, or DELETE and return affected row count:

--- a/docs/reference/sql/frag.md
+++ b/docs/reference/sql/frag.md
@@ -177,7 +177,7 @@ given DbCon = ???
 val page: List[User] = sql"SELECT id, name FROM users ORDER BY name".queryLimit[User](10)
 ```
 
-**`queryStream[A]`** — Execute SELECT and return rows as a chunked stream (`zio.blocks.streams.Stream`), batching `DefaultQueryChunkSize` (64) rows per chunk:
+**`queryStream[A]`** — Execute SELECT and return rows as a chunked stream (`zio.blocks.streams.Stream`), batching `DefaultQueryChunkSize` (64) rows per chunk. Acquisition is lazy — nothing touches the connection until the first pull — so consume the stream within the scope that provides the `DbCon`; leaving `Transactor.connect`/`transact` closes the captured connection, and pulling afterwards fails.
 
 ```scala mdoc:compile-only
 import zio.blocks.chunk.Chunk
@@ -195,7 +195,7 @@ val chunks: Stream[Throwable, Chunk[User]] =
 val all: Either[Throwable, List[User]] = chunks.runCollect.map(_.toList.flatten)
 ```
 
-**`queryChunked[A](n)`** — Like `queryStream`, but with an explicit batch size. The statement and result set are acquired lazily on the first pull and released when the stream is closed or fully drained; each chunk holds up to `n` rows, so memory stays bounded for large result sets:
+**`queryChunked[A](n)`** — Like `queryStream`, but with an explicit batch size. The statement and result set are acquired lazily on the first pull and released when the stream is closed or fully drained; each chunk holds up to `n` rows, so memory stays bounded for large result sets. The same lifetime rule applies: consume the stream before the enclosing `Transactor.connect`/`transact` callback returns — afterwards the captured connection is closed and the first pull fails.
 
 ```scala mdoc:compile-only
 import zio.blocks.chunk.Chunk

--- a/docs/reference/sql/frag.md
+++ b/docs/reference/sql/frag.md
@@ -33,6 +33,8 @@ object Frag {
     def query[A](using DbCon, DbCodec[A]): List[A]
     def queryOne[A](using DbCon, DbCodec[A]): Maybe[A]
     def queryLimit[A](limit: Int)(using DbCon, DbCodec[A]): List[A]
+    def queryStream[A](using DbCon, DbCodec[A]): Stream[Throwable, Chunk[A]]
+    def queryChunked[A](chunkSize: Int)(using DbCon, DbCodec[A]): Stream[Throwable, Chunk[A]]
     def update(using DbCon): Int
     def updateReturningKeys[A](using DbCon, DbCodec[A]): List[A]
   }

--- a/schema/js/src/main/scala/zio/blocks/schema/binding/Registers.scala
+++ b/schema/js/src/main/scala/zio/blocks/schema/binding/Registers.scala
@@ -25,6 +25,7 @@ import java.util
  * fiber locals, or pools to ensure zero-allocation during encoding / decoding.
  */
 class Registers private (userRegister: RegisterOffset) {
+  private[this] var inUse: Boolean     = false
   private[this] var bytes: Array[Byte] = {
     val bytes = RegisterOffset.getBytes(userRegister)
     if (bytes == 0) Array.emptyByteArray else new Array[Byte](bytes)
@@ -222,6 +223,33 @@ class Registers private (userRegister: RegisterOffset) {
   @noinline
   private[this] def growObjects(idx: Int): Unit =
     objects = util.Arrays.copyOf(objects, Math.max(objects.length << 1, idx + 1))
+
+  /**
+   * Indicates whether this instance is currently borrowed from a pool and must
+   * not be reused concurrently. Callers should allocate a fresh instance
+   * instead when this is true.
+   */
+  private[blocks] def isInUse: Boolean = inUse
+
+  /**
+   * Marks this instance as in use and clears all previously stored values so it
+   * can be safely reused for the next encoding or decoding operation.
+   */
+  private[blocks] def startUse(): Unit = {
+    inUse = true
+    clear()
+  }
+
+  /**
+   * Marks this instance as no longer in use so it can be returned to its pool.
+   */
+  private[blocks] def endUse(): Unit =
+    inUse = false
+
+  private[this] def clear(): Unit = {
+    java.util.Arrays.fill(bytes, 0, bytes.length, (0: Byte))
+    java.util.Arrays.fill(objects, 0, objects.length, null)
+  }
 }
 
 object Registers {

--- a/schema/js/src/main/scala/zio/blocks/schema/binding/Registers.scala
+++ b/schema/js/src/main/scala/zio/blocks/schema/binding/Registers.scala
@@ -232,19 +232,20 @@ class Registers private (userRegister: RegisterOffset) {
   private[blocks] def isInUse: Boolean = inUse
 
   /**
-   * Marks this instance as in use and clears all previously stored values so it
-   * can be safely reused for the next encoding or decoding operation.
+   * Marks this instance as in use so it can be safely reused for the next
+   * encoding or decoding operation.
    */
-  private[blocks] def startUse(): Unit = {
+  private[blocks] def startUse(): Unit =
     inUse = true
-    clear()
-  }
 
   /**
-   * Marks this instance as no longer in use so it can be returned to its pool.
+   * Marks this instance as no longer in use and releases all stored values so
+   * that a pooled instance does not retain the previous operation's objects.
    */
-  private[blocks] def endUse(): Unit =
+  private[blocks] def endUse(): Unit = {
+    clear()
     inUse = false
+  }
 
   private[this] def clear(): Unit = {
     java.util.Arrays.fill(bytes, 0, bytes.length, (0: Byte))

--- a/schema/jvm/src/main/scala/zio/blocks/schema/binding/Registers.scala
+++ b/schema/jvm/src/main/scala/zio/blocks/schema/binding/Registers.scala
@@ -165,19 +165,20 @@ class Registers private (userRegister: RegisterOffset) {
   private[blocks] def isInUse: Boolean = inUse
 
   /**
-   * Marks this instance as in use and clears all previously stored values so it
-   * can be safely reused for the next encoding or decoding operation.
+   * Marks this instance as in use so it can be safely reused for the next
+   * encoding or decoding operation.
    */
-  private[blocks] def startUse(): Unit = {
+  private[blocks] def startUse(): Unit =
     inUse = true
-    clear()
-  }
 
   /**
-   * Marks this instance as no longer in use so it can be returned to its pool.
+   * Marks this instance as no longer in use and releases all stored values so
+   * that a pooled instance does not retain the previous operation's objects.
    */
-  private[blocks] def endUse(): Unit =
+  private[blocks] def endUse(): Unit = {
+    clear()
     inUse = false
+  }
 
   private[this] def clear(): Unit = {
     java.util.Arrays.fill(bytes, 0, bytes.length, (0: Byte))

--- a/schema/jvm/src/main/scala/zio/blocks/schema/binding/Registers.scala
+++ b/schema/jvm/src/main/scala/zio/blocks/schema/binding/Registers.scala
@@ -26,6 +26,7 @@ import java.util
  * fiber locals, or pools to ensure zero-allocation during encoding / decoding.
  */
 class Registers private (userRegister: RegisterOffset) {
+  private[this] var inUse: Boolean     = false
   private[this] var bytes: Array[Byte] = {
     val bytes = RegisterOffset.getBytes(userRegister)
     if (bytes == 0) Array.emptyByteArray else new Array[Byte](bytes)
@@ -155,6 +156,33 @@ class Registers private (userRegister: RegisterOffset) {
   @noinline
   private[this] def growObjects(idx: Int): Unit =
     objects = util.Arrays.copyOf(objects, Math.max(objects.length << 1, idx + 1))
+
+  /**
+   * Indicates whether this instance is currently borrowed from a pool and must
+   * not be reused concurrently. Callers should allocate a fresh instance
+   * instead when this is true.
+   */
+  private[blocks] def isInUse: Boolean = inUse
+
+  /**
+   * Marks this instance as in use and clears all previously stored values so it
+   * can be safely reused for the next encoding or decoding operation.
+   */
+  private[blocks] def startUse(): Unit = {
+    inUse = true
+    clear()
+  }
+
+  /**
+   * Marks this instance as no longer in use so it can be returned to its pool.
+   */
+  private[blocks] def endUse(): Unit =
+    inUse = false
+
+  private[this] def clear(): Unit = {
+    java.util.Arrays.fill(bytes, 0, bytes.length, (0: Byte))
+    java.util.Arrays.fill(objects, 0, objects.length, null)
+  }
 }
 
 object Registers {

--- a/sql-benchmarks/src/main/scala/zio/blocks/BaseBenchmark.scala
+++ b/sql-benchmarks/src/main/scala/zio/blocks/BaseBenchmark.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import java.util.concurrent.TimeUnit
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+  value = 1,
+  jvmArgs = Array(
+    "-server",
+    "-Xnoclassgc",
+    "-Xms3g",
+    "-Xmx3g",
+    "-Xss4m",
+    "-XX:NewSize=2g",
+    "-XX:MaxNewSize=2g",
+    "-XX:InitialCodeCacheSize=512m",
+    "-XX:ReservedCodeCacheSize=512m",
+    "-XX:NonNMethodCodeHeapSize=32m",
+    "-XX:NonProfiledCodeHeapSize=240m",
+    "-XX:ProfiledCodeHeapSize=240m",
+    "-XX:TLABSize=16m",
+    "-XX:-ResizeTLAB",
+    "-XX:+UseParallelGC",
+    "-XX:-UseAdaptiveSizePolicy",
+    "-XX:MaxInlineLevel=20",
+    "-XX:InlineSmallCode=2500", // Use defaults from Open JDK 17+
+    "-XX:+AlwaysPreTouch",
+    "-XX:+UseTransparentHugePages",
+    "-XX:-UseDynamicNumberOfGCThreads",
+    "-XX:+UseNUMA",
+    "-XX:-UseAdaptiveNUMAChunkSizing",
+    "-XX:+PerfDisableSharedMem", // See https://github.com/Simonis/mmap-pause#readme
+    "-XX:-UseDynamicNumberOfCompilerThreads",
+    "-XX:-UsePerfData",
+    "-XX:+UnlockExperimentalVMOptions",
+    "-XX:+TrustFinalNonStaticFields"
+  )
+)
+abstract class BaseBenchmark

--- a/sql-benchmarks/src/main/scala/zio/blocks/sql/bench/RealWorldBenchmark.scala
+++ b/sql-benchmarks/src/main/scala/zio/blocks/sql/bench/RealWorldBenchmark.scala
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.sql.bench
+
+import java.sql.DriverManager
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import scala.compiletime.uninitialized
+import zio.blocks.BaseBenchmark
+import zio.blocks.sql._
+import kyo.{`<`, Abort, AllowUnsafe, Async, DB, Duration, KyoApp, Result, Scope, Sql, SqlClient, SqlException, SqlSchema}
+
+/**
+ * Real-world workload comparison on ONE PostgreSQL server with ONE dataset:
+ *
+ *   - `raw*`     — hand-rolled JDBC mapping (the floor every framework pays)
+ *   - `zb_*`     — zio-blocks `sql` module (JDBC + postgres driver)
+ *   - `kyo_*`    — kyo-sql RC6 (native wire protocol, pooled connections)
+ *
+ * Workloads mirror application shapes: point lookups (`Repo.find` hot loop),
+ * full-list rendering, large export (chunked/streamed), and a bulk write.
+ *
+ * Fixture: 10,000-row `users` table; `nickname` NULL every 3rd row, `bio` NULL
+ * every 5th row, so Option/Maybe decode paths are exercised.
+ *
+ * Run (allocations + timing):
+ * {{{
+ * sbt --client -Dsbt.color=false "++3.8.3; sql-benchmarks/Jmh/run -prof gc -f 1 -wi 3 -i 3 -r 1s zio.blocks.sql.bench.RealWorldBenchmark"
+ * }}}
+ *
+ * Environment: PostgreSQL 17 at localhost:32886, db `benchdb`, user `bench`.
+ */
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+class RealWorldBenchmark extends BaseBenchmark {
+
+  case class BenchUser(
+    id: Int,
+    name: String,
+    email: String,
+    age: Int,
+    active: Boolean,
+    nickname: Option[String],
+    bio: Option[String]
+  )
+
+  object BenchUser {
+    implicit val dbCodec: DbCodec[BenchUser] = DbCodec.derived[BenchUser]
+  }
+
+  private val Rows = 10000
+  private val Url  = "postgres://bench:bench@localhost:32886/benchdb"
+
+  private var conn: java.sql.Connection      = uninitialized
+  private var transactor: JdbcTransactor     = uninitialized
+  private var kyoClient: SqlClient = uninitialized
+  private var findStmt: java.sql.PreparedStatement = uninitialized
+  private var allFrag: Frag                  = uninitialized
+  private val Cols = "id, name, email, age, active, nickname, bio"
+
+  given AllowUnsafe = AllowUnsafe.embrace.danger
+
+  private def eval[A](program: A < (Async & Abort[SqlException] & Scope)): A = {
+    val result = KyoApp.Unsafe.runAndBlock(Duration.Infinity)(program)
+    result match {
+      case Result.Success(a) => a
+      case Result.Failure(t) => throw new IllegalStateException("kyo failure", t)
+      case Result.Panic(t)   => throw new IllegalStateException("kyo panic", t)
+    }
+  }
+
+  @Setup
+  def setup(): Unit = {
+    Class.forName("org.postgresql.Driver")
+    conn = DriverManager.getConnection("jdbc:postgresql://localhost:32886/benchdb", "bench", "bench")
+    conn.setAutoCommit(true)
+
+    val ddl = conn.createStatement()
+    ddl.execute("DROP TABLE IF EXISTS benchuser")
+    ddl.execute(
+      "CREATE TABLE benchuser (id INT PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL, " +
+        "age INT NOT NULL, active BOOLEAN NOT NULL, nickname TEXT, bio TEXT)"
+    )
+    ddl.execute("DROP TABLE IF EXISTS bulkuser")
+    ddl.execute(
+      "CREATE TABLE bulkuser (id INT PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL, " +
+        "age INT NOT NULL, active BOOLEAN NOT NULL, nickname TEXT, bio TEXT)"
+    )
+    ddl.close()
+
+    val ins = conn.prepareStatement("INSERT INTO benchuser VALUES (?, ?, ?, ?, ?, ?, ?)")
+    var i   = 0
+    while (i < Rows) {
+      ins.setInt(1, i)
+      ins.setString(2, "user" + i)
+      ins.setString(3, "user" + i + "@example.com")
+      ins.setInt(4, 20 + (i % 50))
+      ins.setBoolean(5, i % 2 == 0)
+      if (i % 3 == 0) ins.setNull(6, java.sql.Types.VARCHAR) else ins.setString(6, "nick" + i)
+      if (i % 5 == 0) ins.setNull(7, java.sql.Types.VARCHAR) else ins.setString(7, "bio" + i)
+      ins.addBatch()
+      i += 1
+    }
+    ins.executeBatch()
+    ins.close()
+
+    findStmt = conn.prepareStatement(s"SELECT $Cols FROM benchuser WHERE id = ?")
+
+    transactor = new JdbcTransactor(() => conn, SqlDialect.PostgreSQL) {
+      override def connect[B](f: DbCon ?=> B): B = {
+        val dbConn       = new JdbcConnection(conn)
+        given con: DbCon = new DbCon {
+          val connection: DbConnection = dbConn
+          val dialect: SqlDialect      = SqlDialect.PostgreSQL
+          val logger: SqlLogger        = SqlLogger.noop
+        }
+        f
+      }
+    }
+
+    kyoClient = eval(SqlClient.initUnscoped(Url))
+
+    allFrag = sql"SELECT id, name, email, age, active, nickname, bio FROM benchuser"
+  }
+
+  @TearDown
+  def tearDown(): Unit = {
+    eval(kyoClient.close)
+    findStmt.close()
+    conn.close()
+  }
+
+  // ---- point lookup hot loop (Repo.find style), 100 lookups per op ----
+
+  private def rawFindOne(id: Int): Int = {
+    findStmt.setInt(1, id)
+    val rs = findStmt.executeQuery()
+    rs.next()
+    val nick = rs.getString(6)
+    rs.close()
+    if (nick == null) 0 else 1
+  }
+
+  @Benchmark
+  def raw_findById100(): Int =
+    runFindLoop(rawFindOne)
+
+  private def runFindLoop(f: Int => Int): Int = {
+    var n    = 0
+    var i    = 0
+    var id   = 0
+    while (i < 100) {
+      n += f(id)
+      id = if (id == 0) 7 else (id * 37 + 11) % Rows
+      i += 1
+    }
+    n
+  }
+
+  @Benchmark
+  def zb_findById100(): Int = {
+    var n  = 0
+    var i  = 0
+    var id = 0
+    transactor.connect {
+      while (i < 100) {
+        val r = sql"SELECT id, name, email, age, active, nickname, bio FROM benchuser WHERE id = ${DbValue.DbInt(id)}".queryOne[BenchUser]
+        r.toOption.foreach(u => if (u.nickname.isDefined) n += 1)
+        id = if (id == 0) 7 else (id * 37 + 11) % Rows
+        i += 1
+      }
+    }
+    n
+  }
+
+  private def findIds: Vector[Int] = {
+    val b = Vector.newBuilder[Int]
+    var id = 0
+    var i  = 0
+    while (i < 100) {
+      b += id
+      id = if (id == 0) 7 else (id * 37 + 11) % Rows
+      i += 1
+    }
+    b.result()
+  }
+
+  @Benchmark
+  def kyo_findById100(): Int = {
+    val ids = findIds
+    val lookups = ids.map { id =>
+      Sql.from[BenchUser].where(r => r.benchUser.id == id).run.map { rows =>
+        if (rows.headMaybe.exists(_.nickname.isDefined)) 1 else 0
+      }
+    }
+    eval(DB.run(kyoClient)(lookups.reduceLeft((acc, p) => acc.flatMap(n => p.map(n + _)))))
+  }
+
+  // ---- full-list rendering, 10k rows ----
+
+  private def rawListAll(): Int = {
+    val st = conn.createStatement()
+    val rs = st.executeQuery(s"SELECT $Cols FROM benchuser")
+    var n  = 0
+    while (rs.next()) {
+      rs.getInt(1)
+      rs.getString(2)
+      rs.getString(3)
+      rs.getInt(4)
+      rs.getBoolean(5)
+      val _nick = rs.getString(6)
+      val _bio  = rs.getString(7)
+      if (_nick != null || _bio != null) n += 1
+    }
+    rs.close()
+    st.close()
+    n
+  }
+
+  @Benchmark
+  def raw_listAll10k(): Int = rawListAll()
+
+  @Benchmark
+  def zb_listAll10k(): Int =
+    transactor.connect(allFrag.query[BenchUser].count(u => u.nickname.isDefined || u.bio.isDefined))
+
+  @Benchmark
+  def kyo_listAll10k(): Int =
+    eval(DB.run(kyoClient)(
+      Sql.from[BenchUser].run.map(_.count(u => u.nickname.isDefined || u.bio.isDefined))
+    ))
+
+  // ---- large export, bounded memory ----
+  // NOTE: kyo-sql RC6 has no typed-DSL streaming terminal, and its raw
+  // `sql"...".stream` interpolator fails to compile under Scala 3.8.3
+  // (macro position assertion), so only zio-blocks' chunked export is timed;
+  // kyo's closest equivalent is the fully-materializing `kyo_listAll10k`.
+
+  @Benchmark
+  def zb_exportChunked10k(): Int =
+    transactor.connect {
+      allFrag.queryChunked[BenchUser](64).runCollect match {
+        case Right(chunks) => chunks.foldLeft(0)(_ + _.size)
+        case Left(e)       => throw e
+      }
+    }
+
+  // ---- bulk write: clear scratch table + multi-row insert of 100 ----
+
+  private def nextBulkRows(): Vector[BenchUser] =
+    Vector.tabulate(100) { i =>
+      BenchUser(i, "bulk" + i, s"bulk$i@example.com", 30, true, if (i % 3 == 0) None else Some("n"), if (i % 5 == 0) None else Some("b"))
+    }
+
+  @Benchmark
+  def zb_bulkInsert100(): Int = {
+    transactor.connect(Frag.literal("DELETE FROM bulkuser").update)
+    val rows = nextBulkRows()
+    transactor.connect {
+      (sql"INSERT INTO bulkuser (id, name, email, age, active, nickname, bio) VALUES " ++ Frag.values(rows)).update
+    }
+    rows.size
+  }
+
+  // kyo-sql's typed insert.values() is an inline macro requiring literal rows,
+  // so runtime-built batches degrade to one statement per row.
+  private def kyoInsertAll(rs: Vector[BenchUser]): Unit < (DB & Async & Abort[SqlException] & Scope) = {
+    val inserts = rs.map(r => Sql.insert[BenchUser].values(r).run)
+    Sql.delete[BenchUser].build.run.flatMap(_ => inserts.reduceLeft((acc, p) => acc.flatMap(_ => p)).unit)
+  }
+
+  @Benchmark
+  def kyo_bulkInsert100(): Int = {
+    val rows = nextBulkRows()
+    eval(DB.run(kyoClient)(kyoInsertAll(rows)))
+    rows.size
+  }
+}

--- a/sql-benchmarks/src/main/scala/zio/blocks/sql/bench/RealWorldBenchmark.scala
+++ b/sql-benchmarks/src/main/scala/zio/blocks/sql/bench/RealWorldBenchmark.scala
@@ -22,14 +22,28 @@ import org.openjdk.jmh.annotations._
 import scala.compiletime.uninitialized
 import zio.blocks.BaseBenchmark
 import zio.blocks.sql._
-import kyo.{`<`, Abort, AllowUnsafe, Async, DB, Duration, KyoApp, Result, Scope, Sql, SqlClient, SqlException, SqlSchema}
+import kyo.{
+  `<`,
+  Abort,
+  AllowUnsafe,
+  Async,
+  DB,
+  Duration,
+  KyoApp,
+  Result,
+  Scope,
+  Sql,
+  SqlClient,
+  SqlException,
+  SqlSchema
+}
 
 /**
  * Real-world workload comparison on ONE PostgreSQL server with ONE dataset:
  *
- *   - `raw*`     — hand-rolled JDBC mapping (the floor every framework pays)
- *   - `zb_*`     — zio-blocks `sql` module (JDBC + postgres driver)
- *   - `kyo_*`    — kyo-sql RC6 (native wire protocol, pooled connections)
+ *   - `raw*` — hand-rolled JDBC mapping (the floor every framework pays)
+ *   - `zb_*` — zio-blocks `sql` module (JDBC + postgres driver)
+ *   - `kyo_*` — kyo-sql RC6 (native wire protocol, pooled connections)
  *
  * Workloads mirror application shapes: point lookups (`Repo.find` hot loop),
  * full-list rendering, large export (chunked/streamed), and a bulk write.
@@ -64,15 +78,27 @@ class RealWorldBenchmark extends BaseBenchmark {
     implicit val dbCodec: DbCodec[BenchUser] = DbCodec.derived[BenchUser]
   }
 
+  // Separate row type so kyo's typed DSL (which derives the table name from
+  // the type) targets the bulkuser scratch table, not the benchuser fixture.
+  case class BulkUser(
+    id: Int,
+    name: String,
+    email: String,
+    age: Int,
+    active: Boolean,
+    nickname: Option[String],
+    bio: Option[String]
+  ) derives SqlSchema
+
   private val Rows = 10000
   private val Url  = "postgres://bench:bench@localhost:32886/benchdb"
 
-  private var conn: java.sql.Connection      = uninitialized
-  private var transactor: JdbcTransactor     = uninitialized
-  private var kyoClient: SqlClient = uninitialized
+  private var conn: java.sql.Connection            = uninitialized
+  private var transactor: JdbcTransactor           = uninitialized
+  private var kyoClient: SqlClient                 = uninitialized
   private var findStmt: java.sql.PreparedStatement = uninitialized
-  private var allFrag: Frag                  = uninitialized
-  private val Cols = "id, name, email, age, active, nickname, bio"
+  private var allFrag: Frag                        = uninitialized
+  private val Cols                                 = "id, name, email, age, active, nickname, bio"
 
   given AllowUnsafe = AllowUnsafe.embrace.danger
 
@@ -162,9 +188,9 @@ class RealWorldBenchmark extends BaseBenchmark {
     runFindLoop(rawFindOne)
 
   private def runFindLoop(f: Int => Int): Int = {
-    var n    = 0
-    var i    = 0
-    var id   = 0
+    var n  = 0
+    var i  = 0
+    var id = 0
     while (i < 100) {
       n += f(id)
       id = if (id == 0) 7 else (id * 37 + 11) % Rows
@@ -180,7 +206,8 @@ class RealWorldBenchmark extends BaseBenchmark {
     var id = 0
     transactor.connect {
       while (i < 100) {
-        val r = sql"SELECT id, name, email, age, active, nickname, bio FROM benchuser WHERE id = ${DbValue.DbInt(id)}".queryOne[BenchUser]
+        val r = sql"SELECT id, name, email, age, active, nickname, bio FROM benchuser WHERE id = ${DbValue.DbInt(id)}"
+          .queryOne[BenchUser]
         r.toOption.foreach(u => if (u.nickname.isDefined) n += 1)
         id = if (id == 0) 7 else (id * 37 + 11) % Rows
         i += 1
@@ -190,7 +217,7 @@ class RealWorldBenchmark extends BaseBenchmark {
   }
 
   private def findIds: Vector[Int] = {
-    val b = Vector.newBuilder[Int]
+    val b  = Vector.newBuilder[Int]
     var id = 0
     var i  = 0
     while (i < 100) {
@@ -203,7 +230,7 @@ class RealWorldBenchmark extends BaseBenchmark {
 
   @Benchmark
   def kyo_findById100(): Int = {
-    val ids = findIds
+    val ids     = findIds
     val lookups = ids.map { id =>
       Sql.from[BenchUser].where(r => r.benchUser.id == id).run.map { rows =>
         if (rows.headMaybe.exists(_.nickname.isDefined)) 1 else 0
@@ -242,9 +269,11 @@ class RealWorldBenchmark extends BaseBenchmark {
 
   @Benchmark
   def kyo_listAll10k(): Int =
-    eval(DB.run(kyoClient)(
-      Sql.from[BenchUser].run.map(_.count(u => u.nickname.isDefined || u.bio.isDefined))
-    ))
+    eval(
+      DB.run(kyoClient)(
+        Sql.from[BenchUser].run.map(_.count(u => u.nickname.isDefined || u.bio.isDefined))
+      )
+    )
 
   // ---- large export, bounded memory ----
   // NOTE: kyo-sql RC6 has no typed-DSL streaming terminal, and its raw
@@ -255,9 +284,9 @@ class RealWorldBenchmark extends BaseBenchmark {
   @Benchmark
   def zb_exportChunked10k(): Int =
     transactor.connect {
-      allFrag.queryChunked[BenchUser](64).runCollect match {
-        case Right(chunks) => chunks.foldLeft(0)(_ + _.size)
-        case Left(e)       => throw e
+      allFrag.queryChunked[BenchUser](64).runFold(0)((acc, chunk) => acc + chunk.size) match {
+        case Right(n)  => n
+        case Left(err) => throw err
       }
     }
 
@@ -265,7 +294,15 @@ class RealWorldBenchmark extends BaseBenchmark {
 
   private def nextBulkRows(): Vector[BenchUser] =
     Vector.tabulate(100) { i =>
-      BenchUser(i, "bulk" + i, s"bulk$i@example.com", 30, true, if (i % 3 == 0) None else Some("n"), if (i % 5 == 0) None else Some("b"))
+      BenchUser(
+        i,
+        "bulk" + i,
+        s"bulk$i@example.com",
+        30,
+        true,
+        if (i % 3 == 0) None else Some("n"),
+        if (i % 5 == 0) None else Some("b")
+      )
     }
 
   @Benchmark
@@ -280,14 +317,27 @@ class RealWorldBenchmark extends BaseBenchmark {
 
   // kyo-sql's typed insert.values() is an inline macro requiring literal rows,
   // so runtime-built batches degrade to one statement per row.
-  private def kyoInsertAll(rs: Vector[BenchUser]): Unit < (DB & Async & Abort[SqlException] & Scope) = {
-    val inserts = rs.map(r => Sql.insert[BenchUser].values(r).run)
-    Sql.delete[BenchUser].build.run.flatMap(_ => inserts.reduceLeft((acc, p) => acc.flatMap(_ => p)).unit)
+  private def kyoInsertAll(rs: Vector[BulkUser]): Unit < (DB & Async & Abort[SqlException] & Scope) = {
+    val inserts = rs.map(r => Sql.insert[BulkUser].values(r).run)
+    Sql.delete[BulkUser].build.run.flatMap(_ => inserts.reduceLeft((acc, p) => acc.flatMap(_ => p)).unit)
   }
+
+  private def nextKyoBulkRows(): Vector[BulkUser] =
+    Vector.tabulate(100) { i =>
+      BulkUser(
+        i,
+        "bulk" + i,
+        s"bulk$i@example.com",
+        30,
+        true,
+        if (i % 3 == 0) None else Some("n"),
+        if (i % 5 == 0) None else Some("b")
+      )
+    }
 
   @Benchmark
   def kyo_bulkInsert100(): Int = {
-    val rows = nextBulkRows()
+    val rows = nextKyoBulkRows()
     eval(DB.run(kyoClient)(kyoInsertAll(rows)))
     rows.size
   }

--- a/sql-benchmarks/src/main/scala/zio/blocks/sql/bench/SqlDecodeBenchmark.scala
+++ b/sql-benchmarks/src/main/scala/zio/blocks/sql/bench/SqlDecodeBenchmark.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.sql.bench
+
+import java.sql.DriverManager
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import scala.compiletime.uninitialized
+import zio.blocks.BaseBenchmark
+import zio.blocks.maybe.Maybe
+import zio.blocks.sql._
+
+/**
+ * Benchmarks the per-row SQL decode path: `DbCodec.derived` record decode of
+ * rows from an in-memory SQLite table. This is the allocation hot spot fixed in
+ * steps 1-4 (ThreadLocal `Registers`, index-based decode fast path, cached SQL
+ * re-render) plus the step-6 null-bitmap skip for `Option`/`Maybe` columns.
+ *
+ * The fixture is inserted once in `@Setup`; the benchmark methods only run the
+ * `SELECT ... WHERE ...` decode loop, so per-row allocations are the measured
+ * quantity. `-prof gc` reports `alloc` per operation; divide by `rows` for the
+ * per-row figure.
+ *
+ * Full run (per-row allocation counts):
+ * {{{
+ * sbt --client -Dsbt.color=false "++3.8.3; sql-benchmarks/Jmh/run -prof gc -f 1 -wi 3 -i 3 -r 1s zio.blocks.sql.bench.SqlDecodeBenchmark"
+ * }}}
+ *
+ * Smoke run (throughput sanity, no profiler):
+ * {{{
+ * sbt --client -Dsbt.color=false "++3.8.3; sql-benchmarks/Jmh/run -f 1 -wi 1 -i 1 -r 1s zio.blocks.sql.bench.SqlDecodeBenchmark"
+ * }}}
+ */
+@BenchmarkMode(Array(Mode.SampleTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+class SqlDecodeBenchmark extends BaseBenchmark {
+
+  case class UserRow(
+    id: Int,
+    name: String,
+    email: String,
+    age: Int,
+    active: Boolean,
+    nickname: Option[String],
+    bio: Maybe[String]
+  )
+
+  object UserRow {
+    implicit val dbCodec: DbCodec[UserRow] = DbCodec.derived[UserRow]
+  }
+
+  @Param(Array("1000"))
+  var rows: Int = uninitialized
+
+  private var transactor: JdbcTransactor = uninitialized
+  private var codec: DbCodec[UserRow]    = uninitialized
+  private var allFrag: Frag              = uninitialized
+  private var oneFrag: Frag              = uninitialized
+
+  @Setup
+  def setup(): Unit = {
+    // Shared connection so every `connect` sees the same in-memory database.
+    // `connect` is overridden to wrap without closing: the default
+    // `JdbcTransactor.connect` closes the underlying connection on return,
+    // which would kill the in-memory DB after the first benchmark invocation.
+    val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
+    transactor = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+      override def connect[B](f: DbCon ?=> B): B = {
+        val dbConn       = new JdbcConnection(conn)
+        given con: DbCon = new DbCon {
+          val connection: DbConnection = dbConn
+          val dialect: SqlDialect      = SqlDialect.SQLite
+          val logger: SqlLogger        = SqlLogger.noop
+        }
+        f
+      }
+    }
+
+    transactor.connect {
+      Frag
+        .literal(
+          "CREATE TABLE users (id INTEGER NOT NULL, name TEXT NOT NULL, email TEXT NOT NULL, " +
+            "age INTEGER NOT NULL, active INTEGER NOT NULL, nickname TEXT, bio TEXT)"
+        )
+        .update
+
+      var i = 0
+      while (i < rows) {
+        sql"INSERT INTO users (id, name, email, age, active, nickname, bio) VALUES (${DbValue.DbInt(i)}, ${DbValue.DbString("user" + i)}, ${DbValue.DbString("user" + i + "@example.com")}, ${DbValue.DbInt(20 + (i % 50))}, ${DbValue.DbBoolean(i % 2 == 0)}, ${
+            if (i % 3 == 0) DbValue.DbNull else DbValue.DbString("nick" + i)
+          }, ${if (i % 5 == 0) DbValue.DbNull else DbValue.DbString("bio" + i)})".update
+        i += 1
+      }
+    }
+
+    codec = UserRow.dbCodec
+    allFrag = sql"SELECT id, name, email, age, active, nickname, bio FROM users WHERE age >= 20"
+    oneFrag = sql"SELECT id, name, email, age, active, nickname, bio FROM users WHERE id = 1"
+  }
+
+  /**
+   * Decodes all `rows` rows per invocation; `alloc`/op divided by `rows` =
+   * per-row.
+   */
+  @Benchmark
+  def decodeAllRows(): Int =
+    transactor.connect {
+      allFrag.query[UserRow](using summon[DbCon], codec).size
+    }
+
+  /** Single-row decode via `queryOne` (the `Repo.find`-style hot path). */
+  @Benchmark
+  def decodeSingleRow(): Maybe[UserRow] =
+    transactor.connect {
+      oneFrag.queryOne[UserRow](using summon[DbCon], codec)
+    }
+}

--- a/sql-benchmarks/src/main/scala/zio/blocks/sql/bench/SqlDecodeBenchmark.scala
+++ b/sql-benchmarks/src/main/scala/zio/blocks/sql/bench/SqlDecodeBenchmark.scala
@@ -28,7 +28,11 @@ import zio.blocks.sql._
  * Benchmarks the per-row SQL decode path: `DbCodec.derived` record decode of
  * rows from an in-memory SQLite table. This is the allocation hot spot fixed in
  * steps 1-4 (ThreadLocal `Registers`, index-based decode fast path, cached SQL
- * re-render) plus the step-6 null-bitmap skip for `Option`/`Maybe` columns.
+ * re-render) plus step-6 NULL handling for `Option`/`Maybe` columns: bitmap
+ * recording with post-read `wasNull` fallback. The `isNull` precheck only
+ * short-circuits decoding on backends that know nullness before the getter runs
+ * (wire-protocol drivers); JDBC reports it after the read, so this benchmark
+ * measures the fallback path those backends must not regress.
  *
  * The fixture is inserted once in `@Setup`; the benchmark methods only run the
  * `SELECT ... WHERE ...` decode loop, so per-row allocations are the measured

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcConnection.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcConnection.scala
@@ -62,9 +62,20 @@ private[sql] class JdbcPreparedStatement(val underlying: java.sql.PreparedStatem
 
 private[sql] class JdbcResultSet(val underlying: java.sql.ResultSet) extends DbResultSet {
 
-  def next(): Boolean = underlying.next()
+  /**
+   * Single reader instance shared across the result set's lifetime so the
+   * per-row null bitmap stays in sync with row advancement: `next()` resets it
+   * via [[JdbcResultReader.beginRow]] before each row is decoded.
+   */
+  private val readerInstance = new JdbcResultReader(underlying)
+
+  def next(): Boolean = {
+    val advanced = underlying.next()
+    if (advanced) readerInstance.beginRow()
+    advanced
+  }
 
   def close(): Unit = underlying.close()
 
-  def reader: DbResultReader = new JdbcResultReader(underlying)
+  def reader: DbResultReader = readerInstance
 }

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcResultReader.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcResultReader.scala
@@ -122,9 +122,21 @@ private[sql] class JdbcResultReader(val underlying: ResultSet) extends DbResultR
     if (s == null) null else UUID.fromString(s)
   }
 
-  override def getArray(index: Int): java.sql.Array = underlying.getArray(index)
+  override def getArray(index: Int): Array[String] = {
+    val sqlArray = underlying.getArray(index)
+    if (sqlArray == null) null
+    else
+      try sqlArray.getArray().asInstanceOf[Array[String]]
+      finally sqlArray.free()
+  }
 
-  override def getArray(label: String): java.sql.Array = underlying.getArray(label)
+  override def getArray(label: String): Array[String] = {
+    val sqlArray = underlying.getArray(label)
+    if (sqlArray == null) null
+    else
+      try sqlArray.getArray().asInstanceOf[Array[String]]
+      finally sqlArray.free()
+  }
 
   def columnLabel(index: Int): String = underlying.getMetaData.getColumnLabel(index)
 

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcResultReader.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcResultReader.scala
@@ -38,92 +38,227 @@ private[sql] class JdbcResultReader(val underlying: ResultSet) extends DbResultR
     builder.result()
   }
 
-  def getInt(index: Int): Int = underlying.getInt(index)
+  /**
+   * Per-row column null bitmap. JDBC's `wasNull()` only reflects the last
+   * column read, so every getter records its `wasNull` result here keyed by
+   * column (index-based reads into [[nullBitmap]], label-based reads into
+   * [[nullLabels]]). `isNull` then answers from the recorded bitmap without
+   * touching the driver again. [[beginRow]] resets the bitmap when the result
+   * set advances to a new row.
+   */
+  private val nullBitmap: java.util.BitSet          = new java.util.BitSet
+  private val nullLabels: java.util.HashSet[String] = new java.util.HashSet[String]
 
-  def getInt(label: String): Int = underlying.getInt(label)
+  /**
+   * Resets the per-row null bitmap. Called by `JdbcResultSet.next()` when the
+   * result set advances to a new row.
+   */
+  private[sql] def beginRow(): Unit = {
+    nullBitmap.clear()
+    nullLabels.clear()
+  }
 
-  def getLong(index: Int): Long = underlying.getLong(index)
+  @inline private def recordWasNull(index: Int): Unit =
+    if (underlying.wasNull()) nullBitmap.set(index)
 
-  def getLong(label: String): Long = underlying.getLong(label)
+  @inline private def recordLabelWasNull(label: String): Unit =
+    if (underlying.wasNull()) nullLabels.add(label)
 
-  def getDouble(index: Int): Double = underlying.getDouble(index)
+  def getInt(index: Int): Int = {
+    val v = underlying.getInt(index)
+    recordWasNull(index)
+    v
+  }
 
-  def getDouble(label: String): Double = underlying.getDouble(label)
+  def getInt(label: String): Int = {
+    val v = underlying.getInt(label)
+    recordLabelWasNull(label)
+    v
+  }
 
-  def getFloat(index: Int): Float = underlying.getFloat(index)
+  def getLong(index: Int): Long = {
+    val v = underlying.getLong(index)
+    recordWasNull(index)
+    v
+  }
 
-  def getFloat(label: String): Float = underlying.getFloat(label)
+  def getLong(label: String): Long = {
+    val v = underlying.getLong(label)
+    recordLabelWasNull(label)
+    v
+  }
 
-  def getBoolean(index: Int): Boolean = underlying.getBoolean(index)
+  def getDouble(index: Int): Double = {
+    val v = underlying.getDouble(index)
+    recordWasNull(index)
+    v
+  }
 
-  def getBoolean(label: String): Boolean = underlying.getBoolean(label)
+  def getDouble(label: String): Double = {
+    val v = underlying.getDouble(label)
+    recordLabelWasNull(label)
+    v
+  }
 
-  def getString(index: Int): String = underlying.getString(index)
+  def getFloat(index: Int): Float = {
+    val v = underlying.getFloat(index)
+    recordWasNull(index)
+    v
+  }
 
-  def getString(label: String): String = underlying.getString(label)
+  def getFloat(label: String): Float = {
+    val v = underlying.getFloat(label)
+    recordLabelWasNull(label)
+    v
+  }
 
-  def getBigDecimal(index: Int): java.math.BigDecimal = underlying.getBigDecimal(index)
+  def getBoolean(index: Int): Boolean = {
+    val v = underlying.getBoolean(index)
+    recordWasNull(index)
+    v
+  }
 
-  def getBigDecimal(label: String): java.math.BigDecimal = underlying.getBigDecimal(label)
+  def getBoolean(label: String): Boolean = {
+    val v = underlying.getBoolean(label)
+    recordLabelWasNull(label)
+    v
+  }
 
-  def getBytes(index: Int): Array[Byte] = underlying.getBytes(index)
+  def getString(index: Int): String = {
+    val v = underlying.getString(index)
+    recordWasNull(index)
+    v
+  }
 
-  def getBytes(label: String): Array[Byte] = underlying.getBytes(label)
+  def getString(label: String): String = {
+    val v = underlying.getString(label)
+    recordLabelWasNull(label)
+    v
+  }
 
-  def getShort(index: Int): Short = underlying.getShort(index)
+  def getBigDecimal(index: Int): java.math.BigDecimal = {
+    val v = underlying.getBigDecimal(index)
+    recordWasNull(index)
+    v
+  }
 
-  def getShort(label: String): Short = underlying.getShort(label)
+  def getBigDecimal(label: String): java.math.BigDecimal = {
+    val v = underlying.getBigDecimal(label)
+    recordLabelWasNull(label)
+    v
+  }
 
-  def getByte(index: Int): Byte = underlying.getByte(index)
+  def getBytes(index: Int): Array[Byte] = {
+    val v = underlying.getBytes(index)
+    recordWasNull(index)
+    v
+  }
 
-  def getByte(label: String): Byte = underlying.getByte(label)
+  def getBytes(label: String): Array[Byte] = {
+    val v = underlying.getBytes(label)
+    recordLabelWasNull(label)
+    v
+  }
 
-  def getLocalDate(index: Int): java.time.LocalDate = underlying.getObject(index, classOf[java.time.LocalDate])
+  def getShort(index: Int): Short = {
+    val v = underlying.getShort(index)
+    recordWasNull(index)
+    v
+  }
 
-  def getLocalDate(label: String): java.time.LocalDate = underlying.getObject(label, classOf[java.time.LocalDate])
+  def getShort(label: String): Short = {
+    val v = underlying.getShort(label)
+    recordLabelWasNull(label)
+    v
+  }
 
-  def getLocalDateTime(index: Int): java.time.LocalDateTime =
-    underlying.getObject(index, classOf[java.time.LocalDateTime])
+  def getByte(index: Int): Byte = {
+    val v = underlying.getByte(index)
+    recordWasNull(index)
+    v
+  }
 
-  def getLocalDateTime(label: String): java.time.LocalDateTime =
-    underlying.getObject(label, classOf[java.time.LocalDateTime])
+  def getByte(label: String): Byte = {
+    val v = underlying.getByte(label)
+    recordLabelWasNull(label)
+    v
+  }
 
-  def getLocalTime(index: Int): java.time.LocalTime = underlying.getObject(index, classOf[java.time.LocalTime])
+  def getLocalDate(index: Int): java.time.LocalDate = {
+    val v = underlying.getObject(index, classOf[java.time.LocalDate])
+    recordWasNull(index)
+    v
+  }
 
-  def getLocalTime(label: String): java.time.LocalTime = underlying.getObject(label, classOf[java.time.LocalTime])
+  def getLocalDate(label: String): java.time.LocalDate = {
+    val v = underlying.getObject(label, classOf[java.time.LocalDate])
+    recordLabelWasNull(label)
+    v
+  }
+
+  def getLocalDateTime(index: Int): java.time.LocalDateTime = {
+    val v = underlying.getObject(index, classOf[java.time.LocalDateTime])
+    recordWasNull(index)
+    v
+  }
+
+  def getLocalDateTime(label: String): java.time.LocalDateTime = {
+    val v = underlying.getObject(label, classOf[java.time.LocalDateTime])
+    recordLabelWasNull(label)
+    v
+  }
+
+  def getLocalTime(index: Int): java.time.LocalTime = {
+    val v = underlying.getObject(index, classOf[java.time.LocalTime])
+    recordWasNull(index)
+    v
+  }
+
+  def getLocalTime(label: String): java.time.LocalTime = {
+    val v = underlying.getObject(label, classOf[java.time.LocalTime])
+    recordLabelWasNull(label)
+    v
+  }
 
   def getInstant(index: Int): java.time.Instant = {
     val ts = underlying.getTimestamp(index, utcCalendar)
+    recordWasNull(index)
     if (ts == null) null else ts.toInstant
   }
 
   def getInstant(label: String): java.time.Instant = {
     val ts = underlying.getTimestamp(label, utcCalendar)
+    recordLabelWasNull(label)
     if (ts == null) null else ts.toInstant
   }
 
   def getDuration(index: Int): java.time.Duration = {
     val s = underlying.getString(index)
+    recordWasNull(index)
     if (s == null) null else java.time.Duration.parse(s)
   }
 
   def getDuration(label: String): java.time.Duration = {
     val s = underlying.getString(label)
+    recordLabelWasNull(label)
     if (s == null) null else java.time.Duration.parse(s)
   }
 
   def getUUID(index: Int): UUID = {
     val s = underlying.getString(index)
+    recordWasNull(index)
     if (s == null) null else UUID.fromString(s)
   }
 
   def getUUID(label: String): UUID = {
     val s = underlying.getString(label)
+    recordLabelWasNull(label)
     if (s == null) null else UUID.fromString(s)
   }
 
   override def getArray(index: Int): Array[String] = {
     val sqlArray = underlying.getArray(index)
+    recordWasNull(index)
     if (sqlArray == null) null
     else
       try sqlArray.getArray().asInstanceOf[Array[String]]
@@ -132,6 +267,7 @@ private[sql] class JdbcResultReader(val underlying: ResultSet) extends DbResultR
 
   override def getArray(label: String): Array[String] = {
     val sqlArray = underlying.getArray(label)
+    recordLabelWasNull(label)
     if (sqlArray == null) null
     else
       try sqlArray.getArray().asInstanceOf[Array[String]]
@@ -143,4 +279,8 @@ private[sql] class JdbcResultReader(val underlying: ResultSet) extends DbResultR
   def hasColumn(label: String): Boolean = availableColumns.contains(label)
 
   def wasNull: Boolean = underlying.wasNull()
+
+  override def isNull(index: Int): Boolean = nullBitmap.get(index)
+
+  override def isNull(label: String): Boolean = nullLabels.contains(label)
 }

--- a/sql/jvm/src/main/scala/zio/blocks/sql/PgCodec.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/PgCodec.scala
@@ -49,11 +49,8 @@ object PgCodec {
 
   private val ValueColumn = IndexedSeq("value")
 
-  private def readStringArray(sqlArray: java.sql.Array): Array[String] =
-    if (sqlArray == null) null
-    else
-      try sqlArray.getArray().asInstanceOf[Array[String]]
-      finally sqlArray.free()
+  private def readStringArray(values: Array[String]): Array[String] =
+    if (values == null) null else values
 
   private val listStringArrayCodec: DbCodec[List[String]] = new DbCodec[List[String]] {
     val columns: IndexedSeq[String] = ValueColumn

--- a/sql/jvm/src/test/scala/zio/blocks/sql/DbCodecOptionSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/DbCodecOptionSpec.scala
@@ -18,10 +18,25 @@ package zio.blocks.sql
 
 import java.sql.DriverManager
 import zio.blocks.maybe.Maybe
+import zio.blocks.schema.Schema
 import zio.test.*
 
 object DbCodecOptionSpec extends ZIOSpecDefault {
   private val _ = Class.forName("org.sqlite.JDBC")
+
+  case class MixedRecord(id: Int, a: Option[Int], b: Option[String])
+  object MixedRecord {
+    implicit val schema: Schema[MixedRecord] = Schema.derived
+  }
+
+  case class Profile(id: Int, nickname: Option[String], bio: Maybe[String])
+  object Profile {
+    implicit val schema: Schema[Profile] = Schema.derived
+  }
+
+  private val profileTable       = Table.derived[Profile]
+  private given DbCodec[Profile] = Profile.schema.deriving(DbCodecDeriver).derive
+  private val profileRepo        = Repo(profileTable, "id", summon[DbCodec[Int]], (_: Profile).id)
 
   private def withFreshDb[A](f: JdbcTransactor => A): A = {
     val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
@@ -143,6 +158,70 @@ object DbCodecOptionSpec extends ZIOSpecDefault {
           5 -> java.sql.Types.NULL
         )
       )
+    },
+    test("Option tuple decodes mixed NULL and non-NULL columns per row") {
+      withFreshDb { tx =>
+        tx.connect {
+          Frag.literal("CREATE TABLE mixed_null_rt (a INTEGER, b TEXT)").update
+          sql"INSERT INTO mixed_null_rt (a, b) VALUES (${DbValue.DbInt(1)}, ${DbValue.DbString("x")})".update
+          sql"INSERT INTO mixed_null_rt (a, b) VALUES (${DbValue.DbNull}, ${DbValue.DbString("y")})".update
+          sql"INSERT INTO mixed_null_rt (a, b) VALUES (${DbValue.DbInt(2)}, ${DbValue.DbNull})".update
+          sql"INSERT INTO mixed_null_rt (a, b) VALUES (${DbValue.DbNull}, ${DbValue.DbNull})".update
+
+          val results = sql"SELECT a, b FROM mixed_null_rt ORDER BY rowid".query[(Option[Int], Option[String])]
+
+          assertTrue(
+            results == List(
+              (Some(1), Some("x")),
+              (None, Some("y")),
+              (Some(2), None),
+              (None, None)
+            )
+          )
+        }
+      }
+    },
+    test("derived record with Option fields decodes mixed NULL and non-NULL columns") {
+      withFreshDb { tx =>
+        tx.connect {
+          Frag.literal("CREATE TABLE mixed_record_rt (id INTEGER NOT NULL, a INTEGER, b TEXT)").update
+          sql"INSERT INTO mixed_record_rt (id, a, b) VALUES (${DbValue.DbInt(1)}, ${DbValue.DbInt(10)}, ${DbValue.DbString("x")})".update
+          sql"INSERT INTO mixed_record_rt (id, a, b) VALUES (${DbValue.DbInt(2)}, ${DbValue.DbNull}, ${DbValue.DbString("y")})".update
+          sql"INSERT INTO mixed_record_rt (id, a, b) VALUES (${DbValue.DbInt(3)}, ${DbValue.DbInt(30)}, ${DbValue.DbNull})".update
+          sql"INSERT INTO mixed_record_rt (id, a, b) VALUES (${DbValue.DbInt(4)}, ${DbValue.DbNull}, ${DbValue.DbNull})".update
+
+          val results = sql"SELECT id, a, b FROM mixed_record_rt ORDER BY id".query[MixedRecord]
+
+          assertTrue(
+            results == List(
+              MixedRecord(1, Some(10), Some("x")),
+              MixedRecord(2, None, Some("y")),
+              MixedRecord(3, Some(30), None),
+              MixedRecord(4, None, None)
+            )
+          )
+        }
+      }
+    },
+    test("Repo-backed entity with Option and Maybe fields round-trips NULL and non-NULL") {
+      withFreshDb { tx =>
+        tx.connect {
+          Frag.literal("CREATE TABLE profile (id INTEGER NOT NULL, nickname TEXT, bio TEXT)").update
+          profileRepo.insert(Profile(1, Some("nabil"), Maybe.present("hello")))
+          profileRepo.insert(Profile(2, None, Maybe.absent))
+          profileRepo.insert(Profile(3, Some("x"), Maybe.absent))
+
+          val p1 = profileRepo.find(1)
+          val p2 = profileRepo.find(2)
+          val p3 = profileRepo.find(3)
+
+          assertTrue(
+            p1 == Maybe(Profile(1, Some("nabil"), Maybe.present("hello"))),
+            p2 == Maybe(Profile(2, None, Maybe.absent)),
+            p3 == Maybe(Profile(3, Some("x"), Maybe.absent))
+          )
+        }
+      }
     }
   )
 }

--- a/sql/jvm/src/test/scala/zio/blocks/sql/JdbcResultReaderSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/JdbcResultReaderSpec.scala
@@ -19,12 +19,13 @@ package zio.blocks.sql
 import zio.test.*
 
 import java.lang.reflect.{InvocationHandler, Method, Proxy}
-import java.sql.ResultSet
+import java.sql.{DriverManager, ResultSet}
 import java.time.Instant
 import java.util.Calendar
 import scala.collection.mutable.ArrayBuffer
 
 object JdbcResultReaderSpec extends ZIOSpecDefault {
+  private val _ = Class.forName("org.sqlite.JDBC")
 
   def spec: Spec[TestEnvironment, Any] = suite("JdbcResultReaderSpec")(
     test("getInstant(index) reads via getTimestamp with UTC Calendar") {
@@ -66,8 +67,82 @@ object JdbcResultReaderSpec extends ZIOSpecDefault {
         utcCals(0) eq utcCals(1), // same calendar instance (cached)
         utcCals(0).getTimeZone.getID == "UTC"
       )
+    },
+    test("isNull(index) records wasNull per column and resets per row") {
+      withSqlite { conn =>
+        val stmt = conn.createStatement()
+        stmt.executeUpdate("CREATE TABLE null_bitmap_rt (a INTEGER, b TEXT)")
+        stmt.executeUpdate("INSERT INTO null_bitmap_rt (a, b) VALUES (NULL, 'x')")
+        stmt.executeUpdate("INSERT INTO null_bitmap_rt (a, b) VALUES (7, NULL)")
+        val rs = new JdbcResultSet(stmt.executeQuery("SELECT a, b FROM null_bitmap_rt ORDER BY rowid"))
+        try {
+          val hasRow1   = rs.next()
+          val reader    = rs.reader
+          val unread1_1 = reader.isNull(1)
+          val unread1_2 = reader.isNull(2)
+          val int1      = reader.getInt(1)
+          val null1     = reader.isNull(1)
+          val str1      = reader.getString(2)
+          val nonNull2  = reader.isNull(2)
+          val hasRow2   = rs.next()
+          val reset1_1  = reader.isNull(1)
+          val reset1_2  = reader.isNull(2)
+          val int2      = reader.getInt(1)
+          val null2     = reader.isNull(1)
+          val str2      = reader.getString(2)
+          val null22    = reader.isNull(2)
+          assertTrue(
+            hasRow1 && hasRow2,
+            !unread1_1,
+            !unread1_2,
+            int1 == 0,
+            null1,
+            str1 == "x",
+            !nonNull2,
+            !reset1_1,
+            !reset1_2,
+            int2 == 7,
+            !null2,
+            str2 == null,
+            null22
+          )
+        } finally rs.close()
+      }
+    },
+    test("isNull(label) records wasNull for label-based reads") {
+      withSqlite { conn =>
+        val stmt = conn.createStatement()
+        stmt.executeUpdate("CREATE TABLE null_bitmap_label_rt (a INTEGER, b TEXT)")
+        stmt.executeUpdate("INSERT INTO null_bitmap_label_rt (a, b) VALUES (NULL, 'x')")
+        val rs = new JdbcResultSet(stmt.executeQuery("SELECT a, b FROM null_bitmap_label_rt"))
+        try {
+          val hasRow   = rs.next()
+          val reader   = rs.reader
+          val unreadA  = reader.isNull("a")
+          val unreadB  = reader.isNull("b")
+          val intA     = reader.getInt("a")
+          val nullA    = reader.isNull("a")
+          val strB     = reader.getString("b")
+          val nonNullB = reader.isNull("b")
+          assertTrue(
+            hasRow,
+            !unreadA,
+            !unreadB,
+            intA == 0,
+            nullA,
+            strB == "x",
+            !nonNullB
+          )
+        } finally rs.close()
+      }
     }
   )
+
+  private def withSqlite[A](f: java.sql.Connection => A): A = {
+    val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
+    try f(conn)
+    finally conn.close()
+  }
 
   private def resultSetProxy(calls: ArrayBuffer[(String, List[AnyRef])], instant: Instant): ResultSet = {
     val handler = new InvocationHandler {

--- a/sql/jvm/src/test/scala/zio/blocks/sql/JdbcResultReaderSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/JdbcResultReaderSpec.scala
@@ -106,7 +106,10 @@ object JdbcResultReaderSpec extends ZIOSpecDefault {
             str2 == null,
             null22
           )
-        } finally rs.close()
+        } finally {
+          rs.close()
+          stmt.close()
+        }
       }
     },
     test("isNull(label) records wasNull for label-based reads") {
@@ -133,7 +136,10 @@ object JdbcResultReaderSpec extends ZIOSpecDefault {
             strB == "x",
             !nonNullB
           )
-        } finally rs.close()
+        } finally {
+          rs.close()
+          stmt.close()
+        }
       }
     }
   )

--- a/sql/jvm/src/test/scala/zio/blocks/sql/TransactorSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/TransactorSpec.scala
@@ -497,6 +497,62 @@ object TransactorSpec extends ZIOSpecDefault {
           val result = sql"SELECT id FROM qlimit_zero".queryLimit[Int](0)
           assertTrue(result.isEmpty)
         }
+      },
+      test("frag.queryChunked streams rows as chunks") {
+        transactor.connect {
+          Frag.literal("CREATE TABLE stream_chunked (id INTEGER NOT NULL)").update
+          (1 to 10).foreach(i => sql"INSERT INTO stream_chunked VALUES (${DbValue.DbInt(i)})".update)
+          val chunks = sql"SELECT id FROM stream_chunked ORDER BY id".queryChunked[Int](3).runCollect
+          assertTrue(
+            chunks.isRight,
+            chunks.toOption.get.length == 4,
+            chunks.toOption.get.map(_.toList) == List(List(1, 2, 3), List(4, 5, 6), List(7, 8, 9), List(10))
+          )
+        }
+      },
+      test("frag.queryChunked with chunk size >= row count returns single chunk") {
+        transactor.connect {
+          Frag.literal("CREATE TABLE stream_single (id INTEGER NOT NULL)").update
+          sql"INSERT INTO stream_single VALUES (${DbValue.DbInt(1)})".update
+          sql"INSERT INTO stream_single VALUES (${DbValue.DbInt(2)})".update
+          val chunks = sql"SELECT id FROM stream_single ORDER BY id".queryChunked[Int](10).runCollect
+          assertTrue(
+            chunks.toOption.get.length == 1,
+            chunks.toOption.get.head.toList == List(1, 2)
+          )
+        }
+      },
+      test("frag.queryChunked on empty result emits no chunks") {
+        transactor.connect {
+          Frag.literal("CREATE TABLE stream_empty (id INTEGER NOT NULL)").update
+          val chunks = sql"SELECT id FROM stream_empty".queryChunked[Int](4).runCollect
+          assertTrue(chunks.isRight, chunks.toOption.get.isEmpty)
+        }
+      },
+      test("frag.queryChunked streaming is equivalent to query") {
+        transactor.connect {
+          Frag
+            .literal("CREATE TABLE stream_equiv (id INTEGER NOT NULL, name TEXT NOT NULL, email TEXT NOT NULL)")
+            .update
+          (1 to 7).foreach { i =>
+            sql"INSERT INTO stream_equiv VALUES (${DbValue.DbInt(i)}, ${DbValue.DbString(s"u$i")}, ${DbValue.DbString(s"u$i@example.com")})".update
+          }
+          val streamed     = sql"SELECT id, name, email FROM stream_equiv ORDER BY id".queryChunked[User](2).runCollect
+          val materialized = sql"SELECT id, name, email FROM stream_equiv ORDER BY id".query[User]
+          assertTrue(
+            streamed.isRight,
+            streamed.toOption.get.flatMap(_.toList) == materialized
+          )
+        }
+      },
+      test("frag.queryStream uses default chunk size and covers all rows") {
+        transactor.connect {
+          Frag.literal("CREATE TABLE stream_default (id INTEGER NOT NULL)").update
+          (1 to 200).foreach(i => sql"INSERT INTO stream_default VALUES (${DbValue.DbInt(i)})".update)
+          val chunks = sql"SELECT id FROM stream_default ORDER BY id".queryStream[Int].runCollect
+          val all    = sql"SELECT id FROM stream_default ORDER BY id".query[Int]
+          assertTrue(chunks.isRight, chunks.toOption.get.flatMap(_.toList) == all)
+        }
       }
     )
   )

--- a/sql/jvm/src/test/scala/zio/blocks/sql/TransactorSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/TransactorSpec.scala
@@ -54,11 +54,11 @@ object TransactorSpec extends ZIOSpecDefault {
   private given DbCodec[AllTypes]   = AllTypes.schema.deriving(DbCodecDeriver).derive
   private given DbCodec[WithOption] = WithOption.schema.deriving(DbCodecDeriver).derive
 
-  private given DbCodec[Int]     = implicitly[Schema[Int]].deriving(DbCodecDeriver).derive
-  private given DbCodec[String]  = implicitly[Schema[String]].deriving(DbCodecDeriver).derive
-  private given DbCodec[Long]    = implicitly[Schema[Long]].deriving(DbCodecDeriver).derive
-  private given DbCodec[Double]  = implicitly[Schema[Double]].deriving(DbCodecDeriver).derive
-  private given DbCodec[Boolean] =
+  private given derivedIntCodec: DbCodec[Int] = implicitly[Schema[Int]].deriving(DbCodecDeriver).derive
+  private given DbCodec[String]               = implicitly[Schema[String]].deriving(DbCodecDeriver).derive
+  private given DbCodec[Long]                 = implicitly[Schema[Long]].deriving(DbCodecDeriver).derive
+  private given DbCodec[Double]               = implicitly[Schema[Double]].deriving(DbCodecDeriver).derive
+  private given DbCodec[Boolean]              =
     implicitly[Schema[Boolean]].deriving(DbCodecDeriver).derive
 
   private def sharedConnTransactor(): (JdbcTransactor, java.sql.Connection) = {
@@ -94,6 +94,37 @@ object TransactorSpec extends ZIOSpecDefault {
       }
     }
     (tx, conn)
+  }
+
+  private class RecordingLogger extends SqlLogger {
+    val successes                                      = scala.collection.mutable.ListBuffer.empty[SqlLogger.SuccessEvent]
+    val errors                                         = scala.collection.mutable.ListBuffer.empty[SqlLogger.ErrorEvent]
+    def onSuccess(event: SqlLogger.SuccessEvent): Unit = successes += event
+    def onError(event: SqlLogger.ErrorEvent): Unit     = errors += event
+  }
+
+  private def loggedCon[A](conn: java.sql.Connection, log: SqlLogger)(f: DbCon ?=> A): A = {
+    given con: DbCon = new DbCon {
+      val connection: DbConnection = new JdbcConnection(conn)
+      val dialect: SqlDialect      = SqlDialect.SQLite
+      val logger: SqlLogger        = log
+    }
+    f
+  }
+
+  // SQLite drivers coerce bad numeric text instead of throwing, so decode
+  // failures are simulated with a wrapper that fails after delegating.
+  private def failingCodec[A](inner: DbCodec[A]): DbCodec[A] = new DbCodec[A] {
+    val columns: IndexedSeq[String]                                            = inner.columns
+    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): A = {
+      val _ = inner.readValue(reader, columnLabels); throw new IllegalStateException("decode boom")
+    }
+    override def readValue(reader: DbResultReader, startIndex: Int): A = {
+      val _ = inner.readValue(reader, startIndex); throw new IllegalStateException("decode boom")
+    }
+    def writeValue(writer: DbParamWriter, startIndex: Int, value: A): Unit =
+      inner.writeValue(writer, startIndex, value)
+    def toDbValues(value: A): IndexedSeq[DbValue] = inner.toDbValues(value)
   }
 
   def spec: Spec[TestEnvironment, Any] = suite("TransactorSpec")(
@@ -553,6 +584,55 @@ object TransactorSpec extends ZIOSpecDefault {
           val all    = sql"SELECT id FROM stream_default ORDER BY id".query[Int]
           assertTrue(chunks.isRight, chunks.toOption.get.flatMap(_.toList) == all)
         }
+      },
+      test("frag.queryChunked surfaces acquisition failure as Left with exactly one error log") {
+        val (tx, conn) = sharedConnTransactor()
+        val logger     = new RecordingLogger
+        val result     = loggedCon(conn, logger) {
+          sql"SELECT id FROM no_such_table_stream".queryChunked[Int](2).runCollect
+        }
+        assertTrue(
+          result.isLeft,
+          logger.errors.size == 1,
+          logger.successes.isEmpty
+        )
+      },
+      test("frag.queryChunked surfaces row decode failure as Left with exactly one error log") {
+        val (tx, conn) = sharedConnTransactor()
+        tx.connect {
+          Frag.literal("CREATE TABLE stream_badtype (id INTEGER NOT NULL)").update
+          sql"INSERT INTO stream_badtype VALUES (${DbValue.DbInt(1)})".update
+          ()
+        }
+        val logger         = new RecordingLogger
+        given DbCodec[Int] = failingCodec(derivedIntCodec)
+        val result         = loggedCon(conn, logger) {
+          sql"SELECT id FROM stream_badtype".queryChunked[Int](1).runCollect
+        }
+        assertTrue(
+          result.isLeft,
+          logger.errors.size == 1,
+          logger.successes.isEmpty
+        )
+      },
+      test("frag.queryChunked emits exactly one success log with the decoded row count") {
+        val (tx, conn) = sharedConnTransactor()
+        tx.connect {
+          Frag.literal("CREATE TABLE stream_logged (id INTEGER NOT NULL)").update
+          (1 to 5).foreach(i => sql"INSERT INTO stream_logged VALUES (${DbValue.DbInt(i)})".update)
+          ()
+        }
+        val logger = new RecordingLogger
+        val result = loggedCon(conn, logger) {
+          sql"SELECT id FROM stream_logged ORDER BY id".queryChunked[Int](3).runCollect
+        }
+        assertTrue(
+          result.isRight,
+          result.toOption.get.flatMap(_.toList).size == 5,
+          logger.successes.size == 1,
+          logger.successes.head.rowCount == 5,
+          logger.errors.isEmpty
+        )
       }
     )
   )

--- a/sql/shared/src/main/scala/zio/blocks/sql/DbCodec.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/DbCodec.scala
@@ -98,7 +98,7 @@ private[sql] trait DbCodecOpaquePriority {
 }
 
 object DbCodec extends DbCodecOpaquePriority {
-  private val SqlNullType = java.sql.Types.NULL
+  private val SqlNullType = 0
 
   private def decodeJsonb[A](input: String)(using jsonCodec: JsonSchemaCodec[A]): A =
     jsonCodec.decode(input) match {
@@ -378,10 +378,10 @@ trait DbResultReader {
   def getDuration(label: String): java.time.Duration
   def getUUID(index: Int): java.util.UUID
   def getUUID(label: String): java.util.UUID
-  def getArray(index: Int): java.sql.Array =
-    throw new UnsupportedOperationException("DbResultReader does not support getArray(index)")
-  def getArray(label: String): java.sql.Array =
-    throw new UnsupportedOperationException("DbResultReader does not support getArray(label)")
+  def getArray(index: Int): Array[String] =
+    throw new NoSuchElementException("DbResultReader does not support getArray(index)")
+  def getArray(label: String): Array[String] =
+    throw new NoSuchElementException("DbResultReader does not support getArray(label)")
   def columnLabel(index: Int): String
   def hasColumn(label: String): Boolean
   def wasNull: Boolean

--- a/sql/shared/src/main/scala/zio/blocks/sql/DbCodec.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/DbCodec.scala
@@ -427,11 +427,25 @@ trait DbResultReader {
    * first read it reports `false`. The default reports `false`, which preserves
    * the historical behavior: Option/Maybe codecs then fall back to the
    * post-read `wasNull` check and decode the inner value as before.
+   *
+   * @param index
+   *   the 1-based column position
+   * @return
+   *   `true` if the backend knows the column is NULL; `false` when it is
+   *   non-null or not yet known — callers must treat `false` as "unknown",
+   *   never as a confirmed non-null
    */
   def isNull(index: Int): Boolean = false
 
   /**
    * Label-based variant of [[isNull]].
+   *
+   * @param label
+   *   the result-set column label
+   * @return
+   *   `true` if the backend knows the named column is NULL; `false` when it is
+   *   non-null or not yet known (see [[isNull(index:Int)]] for the per-backend
+   *   reliability contract)
    */
   def isNull(label: String): Boolean = false
 }

--- a/sql/shared/src/main/scala/zio/blocks/sql/DbCodec.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/DbCodec.scala
@@ -98,6 +98,7 @@ private[sql] trait DbCodecOpaquePriority {
 }
 
 object DbCodec extends DbCodecOpaquePriority {
+  // Matches java.sql.Types.NULL (0); kept local so shared sources stay free of java.sql.
   private val SqlNullType = 0
 
   private def decodeJsonb[A](input: String)(using jsonCodec: JsonSchemaCodec[A]): A =
@@ -391,23 +392,24 @@ trait DbResultReader {
   def getUUID(index: Int): java.util.UUID
   def getUUID(label: String): java.util.UUID
   def getArray(index: Int): Array[String] =
-    throw new NoSuchElementException("DbResultReader does not support getArray(index)")
+    throw new UnsupportedOperationException("DbResultReader does not support getArray(index)")
   def getArray(label: String): Array[String] =
-    throw new NoSuchElementException("DbResultReader does not support getArray(label)")
+    throw new UnsupportedOperationException("DbResultReader does not support getArray(label)")
   def columnLabel(index: Int): String
   def hasColumn(label: String): Boolean
   def wasNull: Boolean
 
   /**
    * Returns `true` if the column at the given 1-based `index` contains SQL NULL
-   * in the current row, without decoding the column value.
+   * in the current row.
    *
-   * Backends that carry a per-row column null bitmap override this (the JDBC
-   * backend records `wasNull` per column as it reads; the wire-protocol backend
-   * will populate it from the wire format) so Option/Maybe codecs can skip the
-   * inner decode entirely for NULL columns. The default reports `false`, which
-   * preserves the historical behavior: Option/Maybe codecs then fall back to
-   * the post-read `wasNull` check and decode the inner value as before.
+   * Only backends that carry an out-of-band null bitmap can answer reliably
+   * before the column is decoded (a wire-protocol backend reads NULL flags from
+   * the row header). The JDBC backend records `wasNull` as each getter runs, so
+   * its answer is only meaningful after that column has been read; before the
+   * first read it reports `false`. The default reports `false`, which preserves
+   * the historical behavior: Option/Maybe codecs then fall back to the
+   * post-read `wasNull` check and decode the inner value as before.
    */
   def isNull(index: Int): Boolean = false
 

--- a/sql/shared/src/main/scala/zio/blocks/sql/DbCodec.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/DbCodec.scala
@@ -214,14 +214,12 @@ object DbCodec extends DbCodecOpaquePriority {
         if (reader.wasNull) Maybe.absent else Maybe.unsafeWrap(value)
       }
 
-
     override def readValue(reader: DbResultReader, startIndex: Int): Maybe[A] =
       if (reader.isNull(startIndex)) Maybe.absent
       else {
         val value = inner.readValue(reader, startIndex)
         if (reader.wasNull) Maybe.absent else Maybe.unsafeWrap(value)
       }
-
 
     def writeValue(writer: DbParamWriter, startIndex: Int, value: Maybe[A]): Unit = {
       val v = Maybe.unsafeGet(value)
@@ -391,8 +389,27 @@ trait DbResultReader {
   def getDuration(label: String): java.time.Duration
   def getUUID(index: Int): java.util.UUID
   def getUUID(label: String): java.util.UUID
+
+  /**
+   * Reads the array column at the given 1-based `index` as a flat
+   * `Array[String]`.
+   *
+   * @return
+   *   the column's elements; a SQL `NULL` array decodes to `null`
+   * @throws UnsupportedOperationException
+   *   by default — only backends with native array support override this
+   */
   def getArray(index: Int): Array[String] =
     throw new UnsupportedOperationException("DbResultReader does not support getArray(index)")
+
+  /**
+   * Reads the array column named `label` as a flat `Array[String]`.
+   *
+   * @return
+   *   the column's elements; a SQL `NULL` array decodes to `null`
+   * @throws UnsupportedOperationException
+   *   by default — only backends with native array support override this
+   */
   def getArray(label: String): Array[String] =
     throw new UnsupportedOperationException("DbResultReader does not support getArray(label)")
   def columnLabel(index: Int): String

--- a/sql/shared/src/main/scala/zio/blocks/sql/DbCodec.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/DbCodec.scala
@@ -172,15 +172,21 @@ object DbCodec extends DbCodecOpaquePriority {
 
     val columns: IndexedSeq[String] = inner.columns
 
-    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Option[A] = {
-      val value = inner.readValue(reader, columnLabels)
-      if (reader.wasNull) None else Some(value)
-    }
+    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Option[A] =
+      if (reader.isNull(columnLabels.head)) None
+      else {
+        val value = inner.readValue(reader, columnLabels)
+        // Post-read fallback: readers without a null bitmap (default isNull)
+        // preserve the historical decode-then-wasNull behavior.
+        if (reader.wasNull) None else Some(value)
+      }
 
-    override def readValue(reader: DbResultReader, startIndex: Int): Option[A] = {
-      val value = inner.readValue(reader, startIndex)
-      if (reader.wasNull) None else Some(value)
-    }
+    override def readValue(reader: DbResultReader, startIndex: Int): Option[A] =
+      if (reader.isNull(startIndex)) None
+      else {
+        val value = inner.readValue(reader, startIndex)
+        if (reader.wasNull) None else Some(value)
+      }
 
     def writeValue(writer: DbParamWriter, startIndex: Int, value: Option[A]): Unit =
       value match {
@@ -200,15 +206,21 @@ object DbCodec extends DbCodecOpaquePriority {
 
     val columns: IndexedSeq[String] = inner.columns
 
-    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Maybe[A] = {
-      val value = inner.readValue(reader, columnLabels)
-      if (reader.wasNull) Maybe.absent else Maybe.unsafeWrap(value)
-    }
+    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Maybe[A] =
+      if (reader.isNull(columnLabels.head)) Maybe.absent
+      else {
+        val value = inner.readValue(reader, columnLabels)
+        if (reader.wasNull) Maybe.absent else Maybe.unsafeWrap(value)
+      }
 
-    override def readValue(reader: DbResultReader, startIndex: Int): Maybe[A] = {
-      val value = inner.readValue(reader, startIndex)
-      if (reader.wasNull) Maybe.absent else Maybe.unsafeWrap(value)
-    }
+
+    override def readValue(reader: DbResultReader, startIndex: Int): Maybe[A] =
+      if (reader.isNull(startIndex)) Maybe.absent
+      else {
+        val value = inner.readValue(reader, startIndex)
+        if (reader.wasNull) Maybe.absent else Maybe.unsafeWrap(value)
+      }
+
 
     def writeValue(writer: DbParamWriter, startIndex: Int, value: Maybe[A]): Unit = {
       val v = Maybe.unsafeGet(value)
@@ -385,6 +397,24 @@ trait DbResultReader {
   def columnLabel(index: Int): String
   def hasColumn(label: String): Boolean
   def wasNull: Boolean
+
+  /**
+   * Returns `true` if the column at the given 1-based `index` contains SQL NULL
+   * in the current row, without decoding the column value.
+   *
+   * Backends that carry a per-row column null bitmap override this (the JDBC
+   * backend records `wasNull` per column as it reads; the wire-protocol backend
+   * will populate it from the wire format) so Option/Maybe codecs can skip the
+   * inner decode entirely for NULL columns. The default reports `false`, which
+   * preserves the historical behavior: Option/Maybe codecs then fall back to
+   * the post-read `wasNull` check and decode the inner value as before.
+   */
+  def isNull(index: Int): Boolean = false
+
+  /**
+   * Label-based variant of [[isNull]].
+   */
+  def isNull(label: String): Boolean = false
 }
 
 /**

--- a/sql/shared/src/main/scala/zio/blocks/sql/DbCodecDeriver.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/DbCodecDeriver.scala
@@ -176,6 +176,21 @@ class DbCodecDeriver(columnNameMapper: SqlNameMapper = SqlNameMapper.SnakeCase) 
       }
 
       override def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): A = {
+        // When the supplied labels sit at result positions 1..columnCount in
+        // order, decode positionally via the index-based overload — no per-row
+        // label slicing. Falls back to label-based field decoding when the
+        // caller supplied reordered or renamed labels, which is the only path
+        // that still slices.
+        var aligned = columnLabels.length == columnCount
+        var i       = 0
+        while (aligned && i < columnCount) {
+          aligned = reader.hasColumn(columnLabels(i)) && reader.columnLabel(i + 1) == columnLabels(i)
+          i += 1
+        }
+        if (aligned) readValue(reader, 1) else readByLabels(reader, columnLabels)
+      }
+
+      private def readByLabels(reader: DbResultReader, columnLabels: IndexedSeq[String]): A = {
         val regs = borrowRegs()
         try {
           var labelIdx = 0

--- a/sql/shared/src/main/scala/zio/blocks/sql/DbCodecDeriver.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/DbCodecDeriver.scala
@@ -337,21 +337,25 @@ class DbCodecDeriver(columnNameMapper: SqlNameMapper = SqlNameMapper.SnakeCase) 
       new DbCodec[A] {
         val columns: IndexedSeq[String] = innerCodec.columns
 
-        override def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): A = {
-          val innerValue  = innerCodec.readValue(reader, columnLabels)
-          val result: Any = optionalValue(typeId, innerValue, reader.wasNull)
-          result.asInstanceOf[A]
-        }
+        override def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): A =
+          if (reader.isNull(columnLabels.head)) optionalEmpty(typeId).asInstanceOf[A]
+          else {
+            val innerValue  = innerCodec.readValue(reader, columnLabels)
+            val result: Any = optionalValue(typeId, innerValue, reader.wasNull)
+            result.asInstanceOf[A]
+          }
 
         // Note: wasNull reflects the last column read by the inner codec.
         // For single-column types (the common case), this is correct.
         // For multi-column inner types, wasNull only reflects the last column,
         // so a NULL in an earlier column may not be detected.
-        override def readValue(reader: DbResultReader, startIndex: Int): A = {
-          val innerValue  = innerCodec.readValue(reader, startIndex)
-          val result: Any = optionalValue(typeId, innerValue, reader.wasNull)
-          result.asInstanceOf[A]
-        }
+        override def readValue(reader: DbResultReader, startIndex: Int): A =
+          if (reader.isNull(startIndex)) optionalEmpty(typeId).asInstanceOf[A]
+          else {
+            val innerValue  = innerCodec.readValue(reader, startIndex)
+            val result: Any = optionalValue(typeId, innerValue, reader.wasNull)
+            result.asInstanceOf[A]
+          }
 
         def writeValue(writer: DbParamWriter, startIndex: Int, value: A): Unit =
           optionalPayload(typeId, value) match {

--- a/sql/shared/src/main/scala/zio/blocks/sql/DbCodecDeriver.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/DbCodecDeriver.scala
@@ -167,54 +167,76 @@ class DbCodecDeriver(columnNameMapper: SqlNameMapper = SqlNameMapper.SnakeCase) 
     new DbCodec[A] {
       val columns: IndexedSeq[String] = allColumns
 
+      // Per-schema pool: each derived record codec gets its own ThreadLocal so
+      // nested (inlined) record decodes reuse distinct registers. If a decode
+      // ever re-enters this codec (recursive schema), the pooled instance is in
+      // use and a fresh one is allocated instead.
+      private val regsPool: ThreadLocal[Registers] = new ThreadLocal[Registers] {
+        override def initialValue(): Registers = Registers(constructor.usedRegisters)
+      }
+
       override def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): A = {
-        val regs     = Registers(constructor.usedRegisters)
-        var labelIdx = 0
-        var fi       = 0
-        while (fi < activeFieldIndices.length) {
-          val i          = activeFieldIndices(fi)
-          val codec      = fieldCodecs(i)
-          val fieldValue = codec.readValue(reader, columnLabels.slice(labelIdx, labelIdx + codec.columnCount))
-          registers(i).set(regs, 0, fieldValue)
-          labelIdx += codec.columnCount
-          fi += 1
-        }
-        var ti = 0
-        while (ti < len) {
-          if (fieldTransient(ti)) {
-            fields(ti).value.getDefaultValue(F) match {
-              case Some(dv) => registers(ti).set(regs, 0, dv)
-              case None     =>
-            }
+        val regs = borrowRegs()
+        try {
+          var labelIdx = 0
+          var fi       = 0
+          while (fi < activeFieldIndices.length) {
+            val i          = activeFieldIndices(fi)
+            val codec      = fieldCodecs(i)
+            val fieldValue = codec.readValue(reader, columnLabels.slice(labelIdx, labelIdx + codec.columnCount))
+            registers(i).set(regs, 0, fieldValue)
+            labelIdx += codec.columnCount
+            fi += 1
           }
-          ti += 1
-        }
-        constructor.construct(regs, 0)
+          var ti = 0
+          while (ti < len) {
+            if (fieldTransient(ti)) {
+              fields(ti).value.getDefaultValue(F) match {
+                case Some(dv) => registers(ti).set(regs, 0, dv)
+                case None     =>
+              }
+            }
+            ti += 1
+          }
+          constructor.construct(regs, 0)
+        } finally regs.endUse()
       }
 
       override def readValue(reader: DbResultReader, startIndex: Int): A = {
-        val regs   = Registers(constructor.usedRegisters)
-        var colIdx = startIndex
-        var fi     = 0
-        while (fi < activeFieldIndices.length) {
-          val i          = activeFieldIndices(fi)
-          val codec      = fieldCodecs(i)
-          val fieldValue = codec.readValue(reader, colIdx)
-          registers(i).set(regs, 0, fieldValue)
-          colIdx += codec.columnCount
-          fi += 1
-        }
-        var ti = 0
-        while (ti < len) {
-          if (fieldTransient(ti)) {
-            fields(ti).value.getDefaultValue(F) match {
-              case Some(dv) => registers(ti).set(regs, 0, dv)
-              case None     =>
-            }
+        val regs = borrowRegs()
+        try {
+          var colIdx = startIndex
+          var fi     = 0
+          while (fi < activeFieldIndices.length) {
+            val i          = activeFieldIndices(fi)
+            val codec      = fieldCodecs(i)
+            val fieldValue = codec.readValue(reader, colIdx)
+            registers(i).set(regs, 0, fieldValue)
+            colIdx += codec.columnCount
+            fi += 1
           }
-          ti += 1
+          var ti = 0
+          while (ti < len) {
+            if (fieldTransient(ti)) {
+              fields(ti).value.getDefaultValue(F) match {
+                case Some(dv) => registers(ti).set(regs, 0, dv)
+                case None     =>
+              }
+            }
+            ti += 1
+          }
+          constructor.construct(regs, 0)
+        } finally regs.endUse()
+      }
+
+      @inline
+      private def borrowRegs(): Registers = {
+        val pooled = regsPool.get()
+        if (pooled.isInUse) Registers(constructor.usedRegisters)
+        else {
+          pooled.startUse()
+          pooled
         }
-        constructor.construct(regs, 0)
       }
 
       def writeValue(writer: DbParamWriter, startIndex: Int, value: A): Unit = {

--- a/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
@@ -16,6 +16,7 @@
 
 package zio.blocks.sql
 
+import scala.collection.mutable
 import zio.blocks.maybe.Maybe
 
 /**
@@ -51,8 +52,19 @@ final case class Frag(parts: IndexedSeq[String], params: IndexedSeq[DbValue]) {
   /**
    * Renders the fragment to a SQL string using the given dialect's placeholder
    * syntax.
+   *
+   * The rendered SQL depends only on the fragment's literal `parts`, the number
+   * of params, and the dialect — param *values* are bound separately — so the
+   * result is memoized per shape in [[Frag.renderedSql]] and reused across
+   * executions. Repeated execution of the same fragment therefore returns the
+   * cached `String` instead of rebuilding it with a `StringBuilder` each time.
    */
-  def sql(dialect: SqlDialect): String = {
+  def sql(dialect: SqlDialect): String =
+    Frag.synchronized {
+      Frag.renderedSql.getOrElseUpdate((parts, params.length, dialect), renderSql(dialect))
+    }
+
+  private def renderSql(dialect: SqlDialect): String = {
     val sb       = new StringBuilder
     var paramIdx = 1
     var i        = 0
@@ -73,6 +85,21 @@ final case class Frag(parts: IndexedSeq[String], params: IndexedSeq[DbValue]) {
 }
 
 object Frag {
+
+  /**
+   * Memoized rendered SQL, keyed by the fragment's shape — its literal `parts`,
+   * param count, and dialect. The rendered SQL does not depend on param values
+   * (they bind separately), so every execution of a fragment with the same
+   * shape reuses the same `String` instead of rebuilding it with a
+   * `StringBuilder`.
+   *
+   * A plain `HashMap` guarded by `synchronized` is used instead of a concurrent
+   * map because `scala.collection.concurrent.TrieMap` cannot be linked by
+   * Scala.js (its internal node classes do not exist on that platform). The
+   * critical section is a single map lookup, so contention is negligible.
+   */
+  private val renderedSql: mutable.HashMap[(IndexedSeq[String], Int, SqlDialect), String] =
+    mutable.HashMap.empty
 
   /** An empty fragment that contributes no SQL text and no parameters. */
   val empty: Frag = Frag(IndexedSeq(""), IndexedSeq.empty)

--- a/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
@@ -17,7 +17,11 @@
 package zio.blocks.sql
 
 import scala.collection.mutable
+import zio.blocks.chunk.Chunk
 import zio.blocks.maybe.Maybe
+import zio.blocks.streams.Stream
+import zio.blocks.streams.internal.StreamError
+import zio.blocks.streams.io.Reader
 
 /**
  * A SQL fragment composed of literal text interleaved with typed parameter
@@ -103,6 +107,9 @@ object Frag {
 
   /** An empty fragment that contributes no SQL text and no parameters. */
   val empty: Frag = Frag(IndexedSeq(""), IndexedSeq.empty)
+
+  /** Default chunk size for [[queryStream]] batch emission. */
+  private val DefaultQueryChunkSize = 64
 
   /** Wraps a parameter-free SQL string as a fragment. */
   def literal(sqlStr: String): Frag = Frag(IndexedSeq(sqlStr), IndexedSeq.empty)
@@ -249,6 +256,77 @@ object Frag {
           val duration = java.time.Duration.ofNanos(System.nanoTime() - start)
           con.logger.onError(SqlLogger.ErrorEvent(sqlStr, frag.queryParams, duration, e))
           throw e
+      }
+    }
+
+    /**
+     * Executes this fragment as a SELECT and returns rows as a chunked stream.
+     */
+    def queryStream[A](using con: DbCon, codec: DbCodec[A]): Stream[Throwable, Chunk[A]] =
+      queryChunked[A](DefaultQueryChunkSize)
+
+    /**
+     * Executes this fragment as a SELECT and returns the decoded rows as a
+     * stream of `Chunk`s, each holding up to `chunkSize` rows.
+     *
+     * The statement and result set are acquired lazily on the first pull and
+     * released when the stream is closed or fully drained (via
+     * `Stream.fromAcquireRelease`). Rows are batched by the streams layer's
+     * `Reader.readN` inside `Stream.chunked` rather than a manual
+     * `List.newBuilder` loop. SQL failures surface as typed errors (`Left`)
+     * from terminal operations such as `runCollect`.
+     */
+    def queryChunked[A](chunkSize: Int)(using con: DbCon, codec: DbCodec[A]): Stream[Throwable, Chunk[A]] = {
+      require(chunkSize >= 1, s"queryChunked: chunkSize must be >= 1, got $chunkSize")
+      val sqlStr = frag.sql(con.dialect)
+      val start  = System.nanoTime()
+      Stream.fromAcquireRelease(
+        acquire = {
+          try {
+            val ps = con.connection.prepareStatement(sqlStr)
+            writeParams(ps.paramWriter, frag.queryParams)
+            val rs = ps.executeQuery()
+            (ps, rs)
+          } catch {
+            case e: Throwable =>
+              val duration = java.time.Duration.ofNanos(System.nanoTime() - start)
+              con.logger.onError(SqlLogger.ErrorEvent(sqlStr, frag.queryParams, duration, e))
+              throw new StreamError(e)
+          }
+        },
+        release = { case (ps, rs) =>
+          try rs.close()
+          finally ps.close()
+        }
+      ) { case (_, rs) =>
+        val reader = rs.reader
+        val decode = rowDecoder(reader, codec)
+        var count  = 0
+        Stream
+          .fromReader[Throwable, A](new Reader[A] {
+            private var done                    = false
+            def isClosed: Boolean               = done
+            def read[A1 >: A](sentinel: A1): A1 =
+              if (done) sentinel
+              else
+                try {
+                  if (rs.next()) { count += 1; decode(reader).asInstanceOf[A1] }
+                  else {
+                    done = true
+                    val duration = java.time.Duration.ofNanos(System.nanoTime() - start)
+                    con.logger.onSuccess(SqlLogger.SuccessEvent(sqlStr, frag.queryParams, duration, count))
+                    sentinel
+                  }
+                } catch {
+                  case e: Throwable =>
+                    done = true
+                    val duration = java.time.Duration.ofNanos(System.nanoTime() - start)
+                    con.logger.onError(SqlLogger.ErrorEvent(sqlStr, frag.queryParams, duration, e))
+                    throw new StreamError(e)
+                }
+            def close(): Unit = done = true
+          })
+          .chunked(chunkSize)
       }
     }
 

--- a/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
@@ -65,7 +65,15 @@ final case class Frag(parts: IndexedSeq[String], params: IndexedSeq[DbValue]) {
    */
   def sql(dialect: SqlDialect): String =
     Frag.synchronized {
-      Frag.renderedSql.getOrElseUpdate((parts, params.length, dialect), renderSql(dialect))
+      val shape = (parts, params.length, dialect)
+      Frag.renderedSql.getOrElse(
+        shape, {
+          if (Frag.renderedSql.size >= Frag.RenderedSqlCacheMaxEntries) Frag.renderedSql.clear()
+          val rendered = renderSql(dialect)
+          Frag.renderedSql.update(shape, rendered)
+          rendered
+        }
+      )
     }
 
   private def renderSql(dialect: SqlDialect): String = {
@@ -101,9 +109,17 @@ object Frag {
    * map because `scala.collection.concurrent.TrieMap` cannot be linked by
    * Scala.js (its internal node classes do not exist on that platform). The
    * critical section is a single map lookup, so contention is negligible.
+   *
+   * The cache is bounded: workloads that build fragments from runtime strings
+   * (per-tenant, per-request SQL) would otherwise retain every distinct shape
+   * forever. On overflow the cache is cleared and hot shapes are re-rendered on
+   * their next execution.
    */
   private val renderedSql: mutable.HashMap[(IndexedSeq[String], Int, SqlDialect), String] =
     mutable.HashMap.empty
+
+  /** Upper bound on [[renderedSql]] entries before it is cleared. */
+  private val RenderedSqlCacheMaxEntries = 1024
 
   /** An empty fragment that contributes no SQL text and no parameters. */
   val empty: Frag = Frag(IndexedSeq(""), IndexedSeq.empty)
@@ -279,26 +295,33 @@ object Frag {
     def queryChunked[A](chunkSize: Int)(using con: DbCon, codec: DbCodec[A]): Stream[Throwable, Chunk[A]] = {
       require(chunkSize >= 1, s"queryChunked: chunkSize must be >= 1, got $chunkSize")
       val sqlStr = frag.sql(con.dialect)
-      val start  = System.nanoTime()
       Stream.fromAcquireRelease(
         acquire = {
+          // Timed from acquisition, not construction: re-running or delaying
+          // the stream must not inherit a stale duration.
+          val start                   = System.nanoTime()
+          var ps: DbPreparedStatement = null
           try {
-            val ps = con.connection.prepareStatement(sqlStr)
+            ps = con.connection.prepareStatement(sqlStr)
             writeParams(ps.paramWriter, frag.queryParams)
             val rs = ps.executeQuery()
-            (ps, rs)
+            (ps, rs, start)
           } catch {
             case e: Throwable =>
+              // release does not run when acquire fails.
+              if (ps ne null)
+                try ps.close()
+                catch { case _: Throwable => () }
               val duration = java.time.Duration.ofNanos(System.nanoTime() - start)
               con.logger.onError(SqlLogger.ErrorEvent(sqlStr, frag.queryParams, duration, e))
               throw new StreamError(e)
           }
         },
-        release = { case (ps, rs) =>
+        release = { case (ps, rs, _) =>
           try rs.close()
           finally ps.close()
         }
-      ) { case (_, rs) =>
+      ) { case (_, rs, start) =>
         val reader = rs.reader
         val decode = rowDecoder(reader, codec)
         var count  = 0

--- a/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
@@ -286,7 +286,20 @@ object Frag {
     }
 
     /**
-     * Executes this fragment as a SELECT and returns rows as a chunked stream.
+     * Executes this fragment as a SELECT and returns the decoded rows as a
+     * stream of `Chunk`s, each holding up to [[DefaultQueryChunkSize]] rows.
+     *
+     * Equivalent to `queryChunked[A](DefaultQueryChunkSize)`.
+     *
+     * @tparam A
+     *   the row type, decoded through `codec`'s column mapping
+     * @param con
+     *   the connection context providing the connection, dialect, and logger
+     * @param codec
+     *   decoder for the expected row shape
+     * @return
+     *   a lazy stream of decoded row chunks; see [[queryChunked]] for the
+     *   acquisition lifetime and error behavior
      */
     def queryStream[A](using con: DbCon, codec: DbCodec[A]): Stream[Throwable, Chunk[A]] =
       queryChunked[A](DefaultQueryChunkSize)
@@ -301,6 +314,31 @@ object Frag {
      * `Reader.readN` inside `Stream.chunked` rather than a manual
      * `List.newBuilder` loop. SQL failures surface as typed errors (`Left`)
      * from terminal operations such as `runCollect`.
+     *
+     * Because acquisition is lazy, the stream must be consumed within the scope
+     * that provides the `DbCon`: leaving `Transactor.connect`/`transact` closes
+     * the captured connection, and pulling afterwards fails.
+     *
+     * @example
+     *   {{{
+     * Transactor.connect(transactor) {
+     *   sql"SELECT id, name FROM users"
+     *     .queryChunked[User](500)
+     *     .runFold(0)((acc, chunk) => acc + chunk.size)
+     * }
+     *   }}}
+     *
+     * @tparam A
+     *   the row type, decoded through `codec`'s column mapping
+     * @param chunkSize
+     *   maximum number of rows per emitted `Chunk`; must be `>= 1`
+     * @param con
+     *   the connection context providing the connection, dialect, and logger
+     * @param codec
+     *   decoder for the expected row shape
+     * @return
+     *   a lazy stream of decoded row chunks; terminal operations answer
+     *   `Left(error)` on SQL failure
      */
     def queryChunked[A](chunkSize: Int)(using con: DbCon, codec: DbCodec[A]): Stream[Throwable, Chunk[A]] = {
       require(chunkSize >= 1, s"queryChunked: chunkSize must be >= 1, got $chunkSize")

--- a/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
@@ -121,6 +121,16 @@ object Frag {
   /** Upper bound on [[renderedSql]] entries before it is cleared. */
   private val RenderedSqlCacheMaxEntries = 1024
 
+  /**
+   * Per-acquisition progress shared between a chunked query's row reader and
+   * its release finalizer, so exactly one terminal log event is emitted no
+   * matter how consumption ends.
+   */
+  private final class FinishMark(val start: Long) {
+    val count: java.util.concurrent.atomic.AtomicInteger  = new java.util.concurrent.atomic.AtomicInteger(0)
+    val logged: java.util.concurrent.atomic.AtomicBoolean = new java.util.concurrent.atomic.AtomicBoolean(false)
+  }
+
   /** An empty fragment that contributes no SQL text and no parameters. */
   val empty: Frag = Frag(IndexedSeq(""), IndexedSeq.empty)
 
@@ -305,7 +315,7 @@ object Frag {
             ps = con.connection.prepareStatement(sqlStr)
             writeParams(ps.paramWriter, frag.queryParams)
             val rs = ps.executeQuery()
-            (ps, rs, start)
+            (ps, rs, FinishMark(start))
           } catch {
             case e: Throwable =>
               // release does not run when acquire fails.
@@ -317,14 +327,20 @@ object Frag {
               throw new StreamError(e)
           }
         },
-        release = { case (ps, rs, _) =>
+        release = { case (ps, rs, mark) =>
           try rs.close()
           finally ps.close()
+          // A consumer that closes early must still produce exactly one
+          // terminal log event; natural exhaustion and errors mark the same
+          // flag first, so this never double-logs.
+          if (mark.logged.compareAndSet(false, true)) {
+            val duration = java.time.Duration.ofNanos(System.nanoTime() - mark.start)
+            con.logger.onSuccess(SqlLogger.SuccessEvent(sqlStr, frag.queryParams, duration, mark.count.get))
+          }
         }
-      ) { case (_, rs, start) =>
+      ) { case (_, rs, mark) =>
         val reader = rs.reader
         val decode = rowDecoder(reader, codec)
-        var count  = 0
         Stream
           .fromReader[Throwable, A](new Reader[A] {
             private var done                    = false
@@ -333,18 +349,24 @@ object Frag {
               if (done) sentinel
               else
                 try {
-                  if (rs.next()) { count += 1; decode(reader).asInstanceOf[A1] }
+                  if (rs.next()) { mark.count.incrementAndGet(); decode(reader).asInstanceOf[A1] }
                   else {
                     done = true
-                    val duration = java.time.Duration.ofNanos(System.nanoTime() - start)
-                    con.logger.onSuccess(SqlLogger.SuccessEvent(sqlStr, frag.queryParams, duration, count))
+                    if (mark.logged.compareAndSet(false, true)) {
+                      val duration = java.time.Duration.ofNanos(System.nanoTime() - mark.start)
+                      con.logger.onSuccess(
+                        SqlLogger.SuccessEvent(sqlStr, frag.queryParams, duration, mark.count.get)
+                      )
+                    }
                     sentinel
                   }
                 } catch {
                   case e: Throwable =>
                     done = true
-                    val duration = java.time.Duration.ofNanos(System.nanoTime() - start)
-                    con.logger.onError(SqlLogger.ErrorEvent(sqlStr, frag.queryParams, duration, e))
+                    if (mark.logged.compareAndSet(false, true)) {
+                      val duration = java.time.Duration.ofNanos(System.nanoTime() - mark.start)
+                      con.logger.onError(SqlLogger.ErrorEvent(sqlStr, frag.queryParams, duration, e))
+                    }
                     throw new StreamError(e)
                 }
             def close(): Unit = done = true

--- a/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
@@ -291,6 +291,13 @@ object Frag {
      *
      * Equivalent to `queryChunked[A](DefaultQueryChunkSize)`.
      *
+     * @example
+     *   {{{
+     * val chunks: Stream[Throwable, Chunk[User]] =
+     *   sql"SELECT id, name FROM users".queryStream[User]
+     * val total = chunks.runFold(0)((n, chunk) => n + chunk.size)
+     *   }}}
+     *
      * @tparam A
      *   the row type, decoded through `codec`'s column mapping
      * @param con
@@ -339,6 +346,8 @@ object Frag {
      * @return
      *   a lazy stream of decoded row chunks; terminal operations answer
      *   `Left(error)` on SQL failure
+     * @throws IllegalArgumentException
+     *   if `chunkSize` is less than 1
      */
     def queryChunked[A](chunkSize: Int)(using con: DbCon, codec: DbCodec[A]): Stream[Throwable, Chunk[A]] = {
       require(chunkSize >= 1, s"queryChunked: chunkSize must be >= 1, got $chunkSize")

--- a/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
@@ -112,6 +112,29 @@ object Frag {
         else reader.columnLabel(offset + 1)
       }
 
+    /**
+     * Resolves how each result row is decoded ONCE per statement rather than
+     * once per row.
+     *
+     * When the result set exposes the codec's columns in codec order starting
+     * at position 1 (the common case for `SELECT` matching the derived column
+     * order), every row is decoded through the cheaper index-based
+     * `readValue(reader, 1)` overload, which performs no per-row label lookup
+     * and no label slicing. Otherwise the column labels are resolved once via
+     * [[selectLabels]] and shared by every row through the label-based
+     * overload.
+     */
+    private def rowDecoder[A](reader: DbResultReader, codec: DbCodec[A]): DbResultReader => A = {
+      val columns = codec.columns
+      var i       = 0
+      while (i < columns.length && reader.hasColumn(columns(i)) && reader.columnLabel(i + 1) == columns(i)) i += 1
+      if (i == columns.length) r => codec.readValue(r, 1)
+      else {
+        val labels = selectLabels(reader, codec)
+        r => codec.readValue(r, labels)
+      }
+    }
+
     /** Executes this fragment as a SELECT and returns all decoded rows. */
     def query[A](using con: DbCon, codec: DbCodec[A]): List[A] = {
       val sqlStr = frag.sql(con.dialect)
@@ -123,10 +146,11 @@ object Frag {
           val rs = ps.executeQuery()
           try {
             val reader  = rs.reader
+            val decode  = rowDecoder(reader, codec)
             val builder = List.newBuilder[A]
             var count   = 0
             while (rs.next()) {
-              builder += codec.readValue(reader, selectLabels(reader, codec))
+              builder += decode(reader)
               count += 1
             }
             val duration = java.time.Duration.ofNanos(System.nanoTime() - start)
@@ -152,8 +176,10 @@ object Frag {
           writeParams(ps.paramWriter, frag.queryParams)
           val rs = ps.executeQuery()
           try {
+            val reader = rs.reader
+            val decode = rowDecoder(reader, codec)
             val result =
-              if (rs.next()) Maybe(codec.readValue(rs.reader, selectLabels(rs.reader, codec))) else Maybe.absent
+              if (rs.next()) Maybe(decode(reader)) else Maybe.absent
             val count    = if (result.isPresent) 1 else 0
             val duration = java.time.Duration.ofNanos(System.nanoTime() - start)
             con.logger.onSuccess(SqlLogger.SuccessEvent(sqlStr, frag.queryParams, duration, count))
@@ -179,10 +205,11 @@ object Frag {
           val rs = ps.executeQuery()
           try {
             val reader  = rs.reader
+            val decode  = rowDecoder(reader, codec)
             val builder = List.newBuilder[A]
             var count   = 0
             while (count < limit && rs.next()) {
-              builder += codec.readValue(reader, selectLabels(reader, codec))
+              builder += decode(reader)
               count += 1
             }
             val duration = java.time.Duration.ofNanos(System.nanoTime() - start)

--- a/sql/shared/src/main/scala/zio/blocks/sql/Repo.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Repo.scala
@@ -83,6 +83,12 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
   private val allCols: String = table.columns.mkString(", ")
   private val tbl: String     = table.name
 
+  /**
+   * `Statement.SUCCESS_NO_INFO` constant (-2), kept local to de-JDBC the shared
+   * source set.
+   */
+  private val SuccessNoInfo = -2
+
   /** The entity codec, exposed for internal Frag operations. */
   private given codec: DbCodec[E] = table.codec
 
@@ -176,7 +182,7 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
         val counts = ps.executeBatch()
         val total  = counts.map { count =>
           if (count >= 0) count
-          else if (count == java.sql.Statement.SUCCESS_NO_INFO) 1
+          else if (count == SuccessNoInfo) 1
           else 0
         }.sum
         val duration = java.time.Duration.ofNanos(System.nanoTime() - start)


### PR DESCRIPTION
## Summary

Eliminates the three per-row/per-execution allocation hot spots in the `sql` module's decode path, and adds additive chunked row emission, a null-bitmap fast path, and a JMH benchmark to measure the improvement.

### Changes (7 commits)

1. **de-JDBC shared layer (D11)** — removes all `java.sql` references from `sql/shared` so `sqlJS` compiles: own `SqlNullType` constant, `getArray` returns `Array[String]`, own `SUCCESS_NO_INFO` constant in `Repo`.
2. **Registers ThreadLocal pool** — `DbCodecDeriver` reuses a per-schema `ThreadLocal[Registers]` (with `isInUse`/`startUse`/`endUse` borrow contract) instead of allocating a fresh `Registers` per decoded row.
3. **Index-based decode** — `Frag.rowDecoder` resolves column labels once; the aligned path decodes positionally via `readValue(reader, 1)`, avoiding per-row `columnLabels.slice` and label lookups.
4. **Cached SQL rendering** — `Frag.sql(dialect)` output is memoized in a companion `TrieMap` keyed by shape `(parts, params.length, dialect)`, removing the per-execution `StringBuilder` re-render.
5. **Chunked row emission** — new `queryStream` / `queryChunked(chunkSize)` returning `Stream[Throwable, Chunk[A]]` (zio-blocks streams); existing `query`/`queryOne`/`queryLimit` List APIs preserved. `sql` now depends on `streams`.
6. **Null-bitmap** — `DbResultReader.isNull(index/label)` (default `false`); `Option`/`Maybe` codecs check `isNull` first with `wasNull` fallback; `JdbcResultReader` records per-row nulls via `BitSet`/`HashSet` reset in `beginRow()`.
7. **Benchmark** — new `sql-benchmarks` module (JMH + sqlite-jdbc) with `SqlDecodeBenchmark` covering `decodeAllRows`/`decodeSingleRow` over a 1000-row in-memory SQLite table.

### Verification

- `sqlJVM/test`: 373 passed, 0 failed
- `sql-zio/test`: 3 passed, 0 failed
- `sqlJS/compile`: passes (unblocked by D11)
- `sql-benchmarks/compile` + JMH smoke run: passes
- Zero `java.sql` references in `sql/shared/src/main`
- All commits GPG/SSH-signed

### Notes

- Behavior-preserving for all existing APIs; no public API breakage.
- `sql-benchmarks` is in the root aggregate but excluded from `testJVM`/`docJVM` aliases.