### PR TITLE
build: stop enforcing license headers in *-examples projects

### DIFF
--- a/async-examples/src/main/scala/async/AsyncShowcaseExample.scala
+++ b/async-examples/src/main/scala/async/AsyncShowcaseExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package async
 
 import zio.blocks.async._

--- a/async-examples/src/main/scala/zio/blocks/async/gettingstarted/AttemptExample.scala
+++ b/async-examples/src/main/scala/zio/blocks/async/gettingstarted/AttemptExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package zio.blocks.async.gettingstarted
 
 import zio.blocks.async._

--- a/async-examples/src/main/scala/zio/blocks/async/gettingstarted/CallbackBridgeExample.scala
+++ b/async-examples/src/main/scala/zio/blocks/async/gettingstarted/CallbackBridgeExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package zio.blocks.async.gettingstarted
 
 import zio.blocks.async._

--- a/async-examples/src/main/scala/zio/blocks/async/gettingstarted/CompleteExample.scala
+++ b/async-examples/src/main/scala/zio/blocks/async/gettingstarted/CompleteExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package zio.blocks.async.gettingstarted
 
 import zio.blocks.async._

--- a/async-examples/src/main/scala/zio/blocks/async/gettingstarted/DirectStyleExample.scala
+++ b/async-examples/src/main/scala/zio/blocks/async/gettingstarted/DirectStyleExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package zio.blocks.async.gettingstarted
 
 import zio.blocks.async._

--- a/async-examples/src/main/scala/zio/blocks/async/gettingstarted/ErrorHandlingExample.scala
+++ b/async-examples/src/main/scala/zio/blocks/async/gettingstarted/ErrorHandlingExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package zio.blocks.async.gettingstarted
 
 import zio.blocks.async._

--- a/async-examples/src/main/scala/zio/blocks/async/gettingstarted/ForkingExample.scala
+++ b/async-examples/src/main/scala/zio/blocks/async/gettingstarted/ForkingExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package zio.blocks.async.gettingstarted
 
 import zio.blocks.async._

--- a/async-examples/src/main/scala/zio/blocks/async/gettingstarted/ReadyValuesExample.scala
+++ b/async-examples/src/main/scala/zio/blocks/async/gettingstarted/ReadyValuesExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package zio.blocks.async.gettingstarted
 
 import zio.blocks.async._

--- a/endpoint-examples/src/main/scala/endpointexamples/AuthTypePatterns.scala
+++ b/endpoint-examples/src/main/scala/endpointexamples/AuthTypePatterns.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package endpointexamples
 
 import scala.language.implicitConversions

--- a/endpoint-examples/src/main/scala/endpointexamples/BasicEndpointDefinition.scala
+++ b/endpoint-examples/src/main/scala/endpointexamples/BasicEndpointDefinition.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package endpointexamples
 
 import scala.language.implicitConversions

--- a/endpoint-examples/src/main/scala/endpointexamples/CompleteApiDefinition.scala
+++ b/endpoint-examples/src/main/scala/endpointexamples/CompleteApiDefinition.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package endpointexamples
 
 import scala.language.implicitConversions

--- a/endpoint-examples/src/main/scala/endpointexamples/HttpCodecConstruction.scala
+++ b/endpoint-examples/src/main/scala/endpointexamples/HttpCodecConstruction.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package endpointexamples
 
 import zio.blocks.chunk.Chunk

--- a/endpoint-examples/src/main/scala/endpointexamples/PathAndSegmentCodecs.scala
+++ b/endpoint-examples/src/main/scala/endpointexamples/PathAndSegmentCodecs.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package endpointexamples
 
 import scala.language.implicitConversions

--- a/http-model-examples/src/main/scala/httpmodel/BasicHttpRequest.scala
+++ b/http-model-examples/src/main/scala/httpmodel/BasicHttpRequest.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package httpmodel
 
 import zio.http._

--- a/http-model-examples/src/main/scala/httpmodel/CompleteHttpExchange.scala
+++ b/http-model-examples/src/main/scala/httpmodel/CompleteHttpExchange.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package httpmodel
 
 import zio.http._

--- a/http-model-examples/src/main/scala/httpmodel/FormAndCookies.scala
+++ b/http-model-examples/src/main/scala/httpmodel/FormAndCookies.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package httpmodel
 
 import zio.http._

--- a/http-model-examples/src/main/scala/httpmodel/HeadersAndQueryParams.scala
+++ b/http-model-examples/src/main/scala/httpmodel/HeadersAndQueryParams.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package httpmodel
 
 import zio.http._

--- a/mux-examples/src/main/scala/mux/CompleteExample.scala
+++ b/mux-examples/src/main/scala/mux/CompleteExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package mux
 
 import zio.blocks.mux._

--- a/mux-examples/src/main/scala/mux/Example1CreatingAMux.scala
+++ b/mux-examples/src/main/scala/mux/Example1CreatingAMux.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package mux
 
 import zio.blocks.mux._

--- a/mux-examples/src/main/scala/mux/Example2UnderstandingStreamsAndMessageQueues.scala
+++ b/mux-examples/src/main/scala/mux/Example2UnderstandingStreamsAndMessageQueues.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package mux
 
 import zio.blocks.mux._

--- a/mux-examples/src/main/scala/mux/Example3StreamLifecycle.scala
+++ b/mux-examples/src/main/scala/mux/Example3StreamLifecycle.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package mux
 
 import zio.blocks.mux._

--- a/mux-examples/src/main/scala/mux/Example4WorkingWithMultipleStreams.scala
+++ b/mux-examples/src/main/scala/mux/Example4WorkingWithMultipleStreams.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package mux
 
 import zio.blocks.mux._

--- a/mux-examples/src/main/scala/mux/Example5ManagingCapacity.scala
+++ b/mux-examples/src/main/scala/mux/Example5ManagingCapacity.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package mux
 
 import zio.blocks.mux._

--- a/mux-examples/src/main/scala/mux/Example6ThreadSafety.scala
+++ b/mux-examples/src/main/scala/mux/Example6ThreadSafety.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package mux
 
 import zio.blocks.mux._

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -1,3 +1,4 @@
+import sbtheader.HeaderPlugin.autoImport.*
 import sbt.Keys.*
 import sbt.{Def, *}
 import sbtbuildinfo.*
@@ -252,7 +253,13 @@ object BuildHelper {
       coverageMinimumStmtTotal   := 95,
       coverageMinimumBranchTotal := 90,
       coverageExcludedFiles      := ".*BuildInfo.*"
-    )
+    ) ++ {
+      // Example projects are embedded verbatim into the documentation via `mdoc:embed`, so they carry
+      // no license header. An empty mapping leaves sbt-header with no file types to process, which
+      // makes both `headerCreate` and `headerCheck` no-ops for these projects.
+      if (prjName.endsWith("-examples")) Seq(headerMappings := Map.empty)
+      else Seq.empty
+    }
 
   def jsSettings: Seq[Def.Setting[?]] = Seq(
     crossScalaVersions       := crossScalaVersions.value.filterNot(_ == Scala3),

--- a/schema-examples/src/main/scala/ChunkExample.scala
+++ b/schema-examples/src/main/scala/ChunkExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import zio.blocks.chunk.Chunk
 
 /** Minimal runnable example demonstrating basic `Chunk` operations. */

--- a/schema-examples/src/main/scala/as/AsManualConstructionExample.scala
+++ b/schema-examples/src/main/scala/as/AsManualConstructionExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package as
 
 import zio.blocks.schema.{As, Into, SchemaError}

--- a/schema-examples/src/main/scala/as/AsNumericRoundTripExample.scala
+++ b/schema-examples/src/main/scala/as/AsNumericRoundTripExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package as
 
 import zio.blocks.schema.As

--- a/schema-examples/src/main/scala/as/AsReverseExample.scala
+++ b/schema-examples/src/main/scala/as/AsReverseExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package as
 
 import zio.blocks.schema.{As, Into}

--- a/schema-examples/src/main/scala/as/AsSchemaEvolutionExample.scala
+++ b/schema-examples/src/main/scala/as/AsSchemaEvolutionExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package as
 
 import zio.blocks.schema.As

--- a/schema-examples/src/main/scala/bindingresolvers/BindingResolverBasicExample.scala
+++ b/schema-examples/src/main/scala/bindingresolvers/BindingResolverBasicExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package bindingresolvers
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/bindingresolvers/BindingResolverChainExample.scala
+++ b/schema-examples/src/main/scala/bindingresolvers/BindingResolverChainExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package bindingresolvers
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/bindingresolvers/BindingResolverSchemaRegistryExample.scala
+++ b/schema-examples/src/main/scala/bindingresolvers/BindingResolverSchemaRegistryExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package bindingresolvers
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/comptime/AllowsCsvExample.scala
+++ b/schema-examples/src/main/scala/comptime/AllowsCsvExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package comptime
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/comptime/AllowsEventBusExample.scala
+++ b/schema-examples/src/main/scala/comptime/AllowsEventBusExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package comptime
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/comptime/AllowsGraphQLTreeExample.scala
+++ b/schema-examples/src/main/scala/comptime/AllowsGraphQLTreeExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package comptime
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/comptime/AllowsSealedTraitExample.scala
+++ b/schema-examples/src/main/scala/comptime/AllowsSealedTraitExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package comptime
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/comptime/DocumentStoreExample.scala
+++ b/schema-examples/src/main/scala/comptime/DocumentStoreExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package comptime
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/comptime/RdbmsExample.scala
+++ b/schema-examples/src/main/scala/comptime/RdbmsExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package comptime
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/context/ContextConstructionExample.scala
+++ b/schema-examples/src/main/scala/context/ContextConstructionExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package context
 
 import zio.blocks.context._

--- a/schema-examples/src/main/scala/context/ContextModificationExample.scala
+++ b/schema-examples/src/main/scala/context/ContextModificationExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package context
 
 import zio.blocks.context._

--- a/schema-examples/src/main/scala/context/ContextRetrievalExample.scala
+++ b/schema-examples/src/main/scala/context/ContextRetrievalExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package context
 
 import zio.blocks.context._

--- a/schema-examples/src/main/scala/customcodec/CustomCodecOverrideExample.scala
+++ b/schema-examples/src/main/scala/customcodec/CustomCodecOverrideExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package customcodec
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/deriveroverrides/CompleteExample.scala
+++ b/schema-examples/src/main/scala/deriveroverrides/CompleteExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package deriveroverrides
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/dynamicschema/DynamicSchemaRebindExample.scala
+++ b/schema-examples/src/main/scala/dynamicschema/DynamicSchemaRebindExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package dynamicschema
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/dynamicschema/DynamicSchemaRegistryExample.scala
+++ b/schema-examples/src/main/scala/dynamicschema/DynamicSchemaRegistryExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package dynamicschema
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/dynamicschema/DynamicSchemaSerializationExample.scala
+++ b/schema-examples/src/main/scala/dynamicschema/DynamicSchemaSerializationExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package dynamicschema
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/dynamicschema/DynamicSchemaValidationExample.scala
+++ b/schema-examples/src/main/scala/dynamicschema/DynamicSchemaValidationExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package dynamicschema
 
 import zio.blocks.chunk.Chunk

--- a/schema-examples/src/main/scala/into/IntoCollectionsExample.scala
+++ b/schema-examples/src/main/scala/into/IntoCollectionsExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package into
 
 import zio.blocks.schema.Into

--- a/schema-examples/src/main/scala/into/IntoDomainBoundaryExample.scala
+++ b/schema-examples/src/main/scala/into/IntoDomainBoundaryExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package into
 
 import zio.blocks.schema.{Into, SchemaError}

--- a/schema-examples/src/main/scala/into/IntoErrorAccumulationExample.scala
+++ b/schema-examples/src/main/scala/into/IntoErrorAccumulationExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package into
 
 import zio.blocks.schema.{Into, SchemaError}

--- a/schema-examples/src/main/scala/into/IntoNumericExample.scala
+++ b/schema-examples/src/main/scala/into/IntoNumericExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package into
 
 import zio.blocks.schema.Into

--- a/schema-examples/src/main/scala/into/IntoSchemaEvolutionExample.scala
+++ b/schema-examples/src/main/scala/into/IntoSchemaEvolutionExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package into
 
 import zio.blocks.schema.Into

--- a/schema-examples/src/main/scala/into/IntoSealedTraitExample.scala
+++ b/schema-examples/src/main/scala/into/IntoSealedTraitExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package into
 
 import zio.blocks.schema.Into

--- a/schema-examples/src/main/scala/jsonpatch/CompleteJsonPatchExample.scala
+++ b/schema-examples/src/main/scala/jsonpatch/CompleteJsonPatchExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package jsonpatch
 
 import zio.blocks.chunk.Chunk

--- a/schema-examples/src/main/scala/jsonpatch/JsonPatchCompositionExample.scala
+++ b/schema-examples/src/main/scala/jsonpatch/JsonPatchCompositionExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package jsonpatch
 
 import zio.blocks.chunk.Chunk

--- a/schema-examples/src/main/scala/jsonpatch/JsonPatchDiffAndApplyExample.scala
+++ b/schema-examples/src/main/scala/jsonpatch/JsonPatchDiffAndApplyExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package jsonpatch
 
 import zio.blocks.schema.json.{Json, JsonPatch}

--- a/schema-examples/src/main/scala/jsonpatch/JsonPatchManualBuildExample.scala
+++ b/schema-examples/src/main/scala/jsonpatch/JsonPatchManualBuildExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package jsonpatch
 
 import zio.blocks.chunk.Chunk

--- a/schema-examples/src/main/scala/jsonpatch/JsonPatchOperationsExample.scala
+++ b/schema-examples/src/main/scala/jsonpatch/JsonPatchOperationsExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package jsonpatch
 
 import zio.blocks.chunk.Chunk

--- a/schema-examples/src/main/scala/querydslbuilder/Common.scala
+++ b/schema-examples/src/main/scala/querydslbuilder/Common.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslbuilder
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/querydslbuilder/CompleteFluentBuilder.scala
+++ b/schema-examples/src/main/scala/querydslbuilder/CompleteFluentBuilder.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslbuilder
 
 /**

--- a/schema-examples/src/main/scala/querydslbuilder/Step1SeamlessConditions.scala
+++ b/schema-examples/src/main/scala/querydslbuilder/Step1SeamlessConditions.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslbuilder
 
 /**

--- a/schema-examples/src/main/scala/querydslbuilder/Step2SelectBuilder.scala
+++ b/schema-examples/src/main/scala/querydslbuilder/Step2SelectBuilder.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslbuilder
 
 /**

--- a/schema-examples/src/main/scala/querydslbuilder/Step3UpdateInsertDelete.scala
+++ b/schema-examples/src/main/scala/querydslbuilder/Step3UpdateInsertDelete.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslbuilder
 
 /**

--- a/schema-examples/src/main/scala/querydslbuilder/Step4SchemaTableName.scala
+++ b/schema-examples/src/main/scala/querydslbuilder/Step4SchemaTableName.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslbuilder
 
 /**

--- a/schema-examples/src/main/scala/querydslbuilder/package.scala
+++ b/schema-examples/src/main/scala/querydslbuilder/package.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package object querydslbuilder {
 
   import zio.blocks.schema._

--- a/schema-examples/src/main/scala/querydslexpressions/CompleteQueryDSL.scala
+++ b/schema-examples/src/main/scala/querydslexpressions/CompleteQueryDSL.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslexpressions
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/querydslexpressions/Step1BasicQueries.scala
+++ b/schema-examples/src/main/scala/querydslexpressions/Step1BasicQueries.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslexpressions
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/querydslexpressions/Step2BooleanLogic.scala
+++ b/schema-examples/src/main/scala/querydslexpressions/Step2BooleanLogic.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslexpressions
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/querydslexpressions/Step3ArithmeticAndStrings.scala
+++ b/schema-examples/src/main/scala/querydslexpressions/Step3ArithmeticAndStrings.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslexpressions
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/querydslexpressions/Step4NestedAndCollections.scala
+++ b/schema-examples/src/main/scala/querydslexpressions/Step4NestedAndCollections.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslexpressions
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/querydslextended/Common.scala
+++ b/schema-examples/src/main/scala/querydslextended/Common.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslextended
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/querydslextended/CompleteExtendedDSL.scala
+++ b/schema-examples/src/main/scala/querydslextended/CompleteExtendedDSL.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslextended
 
 /**

--- a/schema-examples/src/main/scala/querydslextended/Step1ExtendedAST.scala
+++ b/schema-examples/src/main/scala/querydslextended/Step1ExtendedAST.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslextended
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/querydslextended/Step2SqlPredicates.scala
+++ b/schema-examples/src/main/scala/querydslextended/Step2SqlPredicates.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslextended
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/querydslextended/Step3AggregatesAndCaseWhen.scala
+++ b/schema-examples/src/main/scala/querydslextended/Step3AggregatesAndCaseWhen.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslextended
 
 /**

--- a/schema-examples/src/main/scala/querydslextended/package.scala
+++ b/schema-examples/src/main/scala/querydslextended/package.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package object querydslextended {
 
   import zio.blocks.schema._

--- a/schema-examples/src/main/scala/querydslsql/Common.scala
+++ b/schema-examples/src/main/scala/querydslsql/Common.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslsql
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/querydslsql/CompleteSqlGenerator.scala
+++ b/schema-examples/src/main/scala/querydslsql/CompleteSqlGenerator.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslsql
 
 /**

--- a/schema-examples/src/main/scala/querydslsql/Step1SqlBasics.scala
+++ b/schema-examples/src/main/scala/querydslsql/Step1SqlBasics.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslsql
 
 /**

--- a/schema-examples/src/main/scala/querydslsql/Step2CompoundAndOperations.scala
+++ b/schema-examples/src/main/scala/querydslsql/Step2CompoundAndOperations.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslsql
 
 /**

--- a/schema-examples/src/main/scala/querydslsql/Step3SelectAndParameterized.scala
+++ b/schema-examples/src/main/scala/querydslsql/Step3SelectAndParameterized.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslsql
 
 /**

--- a/schema-examples/src/main/scala/querydslsql/Step4NestedSql.scala
+++ b/schema-examples/src/main/scala/querydslsql/Step4NestedSql.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package querydslsql
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/querydslsql/package.scala
+++ b/schema-examples/src/main/scala/querydslsql/package.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package object querydslsql {
 
   import zio.blocks.schema._

--- a/schema-examples/src/main/scala/schemaerror/SchemaErrorExample.scala
+++ b/schema-examples/src/main/scala/schemaerror/SchemaErrorExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package schemaerror
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/structural/StructuralIntegrationExample.scala
+++ b/schema-examples/src/main/scala/structural/StructuralIntegrationExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package structural
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/structural/StructuralProductExample.scala
+++ b/schema-examples/src/main/scala/structural/StructuralProductExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package structural
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/structural/StructuralSumTypeExample.scala
+++ b/schema-examples/src/main/scala/structural/StructuralSumTypeExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package structural
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/structural/StructuralTupleExample.scala
+++ b/schema-examples/src/main/scala/structural/StructuralTupleExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package structural
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/typeclassderivation/DeriveGenExample.scala
+++ b/schema-examples/src/main/scala/typeclassderivation/DeriveGenExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package typeclassderivation
 
 import zio.blocks.chunk.Chunk

--- a/schema-examples/src/main/scala/typeclassderivation/DeriveShowExample.scala
+++ b/schema-examples/src/main/scala/typeclassderivation/DeriveShowExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package typeclassderivation
 
 import zio.blocks.chunk.Chunk

--- a/schema-examples/src/main/scala/typeid/OpaqueTypesExample.scala
+++ b/schema-examples/src/main/scala/typeid/OpaqueTypesExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package typeid
 
 import zio.blocks.typeid._

--- a/schema-examples/src/main/scala/typeid/SingletonTypeTest.scala
+++ b/schema-examples/src/main/scala/typeid/SingletonTypeTest.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package typeid
 
 import zio.blocks.typeid._

--- a/schema-examples/src/main/scala/typeid/TypeIdBasicExample.scala
+++ b/schema-examples/src/main/scala/typeid/TypeIdBasicExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package typeid
 
 import zio.blocks.typeid.*

--- a/schema-examples/src/main/scala/typeid/TypeIdNormalizationExample.scala
+++ b/schema-examples/src/main/scala/typeid/TypeIdNormalizationExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package typeid
 
 import zio.blocks.typeid._

--- a/schema-examples/src/main/scala/typeid/TypeIdSubtypingExample.scala
+++ b/schema-examples/src/main/scala/typeid/TypeIdSubtypingExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package typeid
 
 import zio.blocks.typeid._

--- a/schema-examples/src/main/scala/ziosschemamigration/CompleteMigrationExample.scala
+++ b/schema-examples/src/main/scala/ziosschemamigration/CompleteMigrationExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ziosschemamigration
 
 import zio.blocks.chunk.Chunk

--- a/schema-examples/src/main/scala/ziosschemamigration/Step1SchemaDerivedAndPrimitives.scala
+++ b/schema-examples/src/main/scala/ziosschemamigration/Step1SchemaDerivedAndPrimitives.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ziosschemamigration
 
 import zio.blocks.chunk.Chunk

--- a/schema-examples/src/main/scala/ziosschemamigration/Step2ModifiersAndTransform.scala
+++ b/schema-examples/src/main/scala/ziosschemamigration/Step2ModifiersAndTransform.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ziosschemamigration
 
 import zio.blocks.schema._

--- a/schema-examples/src/main/scala/ziosschemamigration/Step3OpticsAndDynamicSchema.scala
+++ b/schema-examples/src/main/scala/ziosschemamigration/Step3OpticsAndDynamicSchema.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ziosschemamigration
 
 import zio.blocks.chunk.Chunk

--- a/schema-examples/src/main/scala/ziosschemamigration/Step4DiffAndPatch.scala
+++ b/schema-examples/src/main/scala/ziosschemamigration/Step4DiffAndPatch.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ziosschemamigration
 
 import zio.blocks.schema._

--- a/scope-examples/src/main/scala/com/example/external/LeakFromExternalPackageTest.scala
+++ b/scope-examples/src/main/scala/com/example/external/LeakFromExternalPackageTest.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.example.external
 
 import scala.annotation.nowarn

--- a/scope-examples/src/main/scala/scope/examples/CachingSharedLoggerExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/CachingSharedLoggerExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/scope/examples/CircularDependencyDemoExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/CircularDependencyDemoExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/scope/examples/ConfigReaderExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/ConfigReaderExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/scope/examples/ConnectionPoolExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/ConnectionPoolExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/scope/examples/DatabaseConnectionExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/DatabaseConnectionExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/scope/examples/HttpClientPipelineExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/HttpClientPipelineExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/scope/examples/IntegrationTestHarnessExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/IntegrationTestHarnessExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/scope/examples/LayeredWebServiceExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/LayeredWebServiceExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/scope/examples/LegacyLibraryInteropExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/LegacyLibraryInteropExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/scope/examples/PluginArchitectureExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/PluginArchitectureExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/scope/examples/ScopedForComprehensionExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/ScopedForComprehensionExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/scope/examples/TempFileHandlingExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/TempFileHandlingExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/scope/examples/ThreadOwnershipExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/ThreadOwnershipExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/scope/examples/TransactionBoundaryExample.scala
+++ b/scope-examples/src/main/scala/scope/examples/TransactionBoundaryExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package scope.examples
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/wire/WireBasicExample.scala
+++ b/scope-examples/src/main/scala/wire/WireBasicExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package wire
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/wire/WireFromFunctionExample.scala
+++ b/scope-examples/src/main/scala/wire/WireFromFunctionExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package wire
 
 import zio.blocks.scope._

--- a/scope-examples/src/main/scala/wire/WireSharedUniqueExample.scala
+++ b/scope-examples/src/main/scala/wire/WireSharedUniqueExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package wire
 
 import zio.blocks.scope._

--- a/smithy-examples/src/main/scala/smithyexample/BasicParsingAndQuerying.scala
+++ b/smithy-examples/src/main/scala/smithyexample/BasicParsingAndQuerying.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package smithyexample
 
 import zio.blocks.smithy._

--- a/smithy-examples/src/main/scala/smithyexample/BookStoreAPI.scala
+++ b/smithy-examples/src/main/scala/smithyexample/BookStoreAPI.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package smithyexample
 
 import zio.blocks.smithy._

--- a/smithy-examples/src/main/scala/smithyexample/BuildingModelsAndTraits.scala
+++ b/smithy-examples/src/main/scala/smithyexample/BuildingModelsAndTraits.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package smithyexample
 
 import zio.blocks.smithy._

--- a/smithy-examples/src/main/scala/smithyexample/ValidationAndAnalysis.scala
+++ b/smithy-examples/src/main/scala/smithyexample/ValidationAndAnalysis.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package smithyexample
 
 import zio.blocks.smithy._

--- a/streams-examples/src/main/scala/nio/NioBinaryTelemetryWalkthrough.scala
+++ b/streams-examples/src/main/scala/nio/NioBinaryTelemetryWalkthrough.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package nio
 
 import zio.blocks.chunk.Chunk

--- a/streams-examples/src/main/scala/pipeline/PipelineBasicUsageExample.scala
+++ b/streams-examples/src/main/scala/pipeline/PipelineBasicUsageExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package pipeline
 
 import zio.blocks.streams.*

--- a/streams-examples/src/main/scala/pipeline/PipelineCompositionExample.scala
+++ b/streams-examples/src/main/scala/pipeline/PipelineCompositionExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package pipeline
 
 import zio.blocks.streams.*

--- a/streams-examples/src/main/scala/pipeline/PipelineSinkIntegrationExample.scala
+++ b/streams-examples/src/main/scala/pipeline/PipelineSinkIntegrationExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package pipeline
 
 import zio.blocks.streams.*

--- a/streams-examples/src/main/scala/reader/ReaderBasicConstructionExample.scala
+++ b/streams-examples/src/main/scala/reader/ReaderBasicConstructionExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package reader
 
 import zio.blocks.chunk.Chunk

--- a/streams-examples/src/main/scala/reader/ReaderCompositionExample.scala
+++ b/streams-examples/src/main/scala/reader/ReaderCompositionExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package reader
 
 import zio.blocks.chunk.Chunk

--- a/streams-examples/src/main/scala/reader/ReaderPrimitiveSpecializationExample.scala
+++ b/streams-examples/src/main/scala/reader/ReaderPrimitiveSpecializationExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package reader
 
 import zio.blocks.chunk.Chunk

--- a/streams-examples/src/main/scala/sink/SinkAggregationExample.scala
+++ b/streams-examples/src/main/scala/sink/SinkAggregationExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package sink
 
 import zio.blocks.streams.*

--- a/streams-examples/src/main/scala/sink/SinkBasicUsageExample.scala
+++ b/streams-examples/src/main/scala/sink/SinkBasicUsageExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package sink
 
 import zio.blocks.streams.*

--- a/streams-examples/src/main/scala/sink/SinkScientificComputingExample.scala
+++ b/streams-examples/src/main/scala/sink/SinkScientificComputingExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package sink
 
 import zio.blocks.streams.*

--- a/streams-examples/src/main/scala/sink/SinkSentinelGuardExample.scala
+++ b/streams-examples/src/main/scala/sink/SinkSentinelGuardExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package sink
 
 import zio.blocks.streams.*

--- a/streams-examples/src/main/scala/sink/SinkTelemetryExample.scala
+++ b/streams-examples/src/main/scala/sink/SinkTelemetryExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package sink
 
 import zio.blocks.streams.*

--- a/streams-examples/src/main/scala/sink/SinkTransformationExample.scala
+++ b/streams-examples/src/main/scala/sink/SinkTransformationExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package sink
 
 import zio.blocks.streams.*

--- a/streams-examples/src/main/scala/stream/DeepTelemetryRecoveryWalkthrough.scala
+++ b/streams-examples/src/main/scala/stream/DeepTelemetryRecoveryWalkthrough.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package stream
 
 import zio.blocks.chunk.Chunk

--- a/streams-examples/src/main/scala/stream/ManualPullUsingStart.scala
+++ b/streams-examples/src/main/scala/stream/ManualPullUsingStart.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package stream
 
 import zio.blocks.streams.*

--- a/streams-examples/src/main/scala/stream/MixedFeedAuditWalkthrough.scala
+++ b/streams-examples/src/main/scala/stream/MixedFeedAuditWalkthrough.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package stream
 
 import zio.blocks.chunk.Chunk

--- a/streams-examples/src/main/scala/stream/SegmentedLedgerIngestWalkthrough.scala
+++ b/streams-examples/src/main/scala/stream/SegmentedLedgerIngestWalkthrough.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package stream
 
 import zio.blocks.chunk.Chunk

--- a/streams-examples/src/main/scala/stream/StreamBasicUsageExample.scala
+++ b/streams-examples/src/main/scala/stream/StreamBasicUsageExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package stream
 
 import zio.blocks.streams.Stream

--- a/streams-examples/src/main/scala/stream/StreamErrorHandlingExample.scala
+++ b/streams-examples/src/main/scala/stream/StreamErrorHandlingExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package stream
 
 import zio.blocks.streams.Stream

--- a/streams-examples/src/main/scala/stream/StreamFlatMapExample.scala
+++ b/streams-examples/src/main/scala/stream/StreamFlatMapExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package stream
 
 import zio.blocks.streams.Stream

--- a/streams-examples/src/main/scala/stream/StreamResourceExample.scala
+++ b/streams-examples/src/main/scala/stream/StreamResourceExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package stream
 
 import zio.blocks.streams.Stream

--- a/streams-examples/src/main/scala/stream/StreamWindowingExample.scala
+++ b/streams-examples/src/main/scala/stream/StreamWindowingExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package stream
 
 import zio.blocks.streams.Stream

--- a/streams-examples/src/main/scala/writer/WriterBasicConstructionExample.scala
+++ b/streams-examples/src/main/scala/writer/WriterBasicConstructionExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package writer
 
 import zio.blocks.streams.io.Writer

--- a/streams-examples/src/main/scala/writer/WriterBoundedImplementationExample.scala
+++ b/streams-examples/src/main/scala/writer/WriterBoundedImplementationExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package writer
 
 import zio.blocks.streams.io.Writer

--- a/streams-examples/src/main/scala/writer/WriterCompositionExample.scala
+++ b/streams-examples/src/main/scala/writer/WriterCompositionExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package writer
 
 import zio.blocks.streams.io.Writer

--- a/streams-examples/src/main/scala/writer/WriterIOAdapterExample.scala
+++ b/streams-examples/src/main/scala/writer/WriterIOAdapterExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package writer
 
 import zio.blocks.streams.io.Writer

--- a/zio-blocks-htmx-examples/src/main/scala/zioBlocksHtmx/AdvancedPatterns.scala
+++ b/zio-blocks-htmx-examples/src/main/scala/zioBlocksHtmx/AdvancedPatterns.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package zioBlocksHtmx
 
 import zio.blocks.html._

--- a/zio-blocks-htmx-examples/src/main/scala/zioBlocksHtmx/BasicUsage.scala
+++ b/zio-blocks-htmx-examples/src/main/scala/zioBlocksHtmx/BasicUsage.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package zioBlocksHtmx
 
 import zio.blocks.html._

--- a/zio-blocks-htmx-examples/src/main/scala/zioBlocksHtmx/CompleteExample.scala
+++ b/zio-blocks-htmx-examples/src/main/scala/zioBlocksHtmx/CompleteExample.scala
@@ -1,19 +1,3 @@
-/*
- * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package zioBlocksHtmx
 
 import zio.blocks.html._


### PR DESCRIPTION
## What

Example projects no longer carry (or require) the Apache-2.0 license header.

Their sources are embedded verbatim into the documentation through `mdoc:embed`, so every documented snippet started with 16 lines of license boilerplate before the first line of actual example code.

## How

`BuildHelper.stdSettings` clears `headerMappings` for any project whose name ends with `-examples`:

```scala
if (prjName.endsWith("-examples")) Seq(headerMappings := Map.empty)
else Seq.empty
```

With no file types mapped, sbt-header has nothing to group, so `headerCreate` and `headerCheck` are no-ops for those projects. Every other project keeps the header exactly as before, and future example projects are covered automatically by the name rule.

`headerLicense := None` is deliberately *not* used: sbt-header resolves it via `headerLicense.value.getOrElse(sys.error("Unable to auto detect project license"))` eagerly, so it fails the build rather than relaxing the check. Clearing `ThisBuild / headerLicense` would not work either — the plugin default re-derives the license from `licenses` and `organizationName`.

The second commit removes the existing header from 151 sources across the nine `*-examples` projects: `scope-examples`, `mux-examples`, `http-model-examples`, `zio-blocks-htmx-examples`, `endpoint-examples`, `smithy-examples`, `schema-examples`, `streams-examples`, `async-examples`.

`golem/test-agents` (artifact `zio-golem-examples-js`) does not match the rule and keeps its headers — it holds test agents, not documentation examples.

## Verification

- `sbt "++2.13; headerCheckAll; ++3.8; headerCheckAll"` — success
- `scalafmtCheckAll` on all nine example projects — success
- `scope-examples/headerCreate` — success, zero files touched (headers are not re-added)
- `scope-examples`/`async-examples` `Compile/headerMappings` → `Map()`; `ringbufferJVM/Compile/headerMappings` → scala + java mappings unchanged
- Enforcement is still real elsewhere: stripping the header from `ringbuffer/shared/src/test/scala/zio/blocks/ringbuffer/MpscRingBufferSpec.scala` made `headerCheck` fail as expected (file restored afterwards)