### PR TITLE
ci: drop the libuv step and raise the docs and testJVM timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,13 @@ jobs:
   buildDocs:
     name: Build Docs
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
-    - name: Install libuv
-      run: sudo apt-get update && sudo apt-get install -y libuv1-dev
     - name: Setup Scala
       uses: actions/setup-java@v5.7.0
       with:
@@ -108,7 +106,7 @@ jobs:
   testJVM:
     name: testJVM
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 40
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -292,8 +290,6 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
-    - name: Install libuv
-      run: sudo apt-get update && sudo apt-get install -y libuv1-dev
     - name: Setup Scala
       uses: actions/setup-java@v5.7.0
       with:

--- a/project/CiWorkflow.scala
+++ b/project/CiWorkflow.scala
@@ -90,15 +90,20 @@ object CiWorkflow {
    * existing. The closing `find` is not, matching the workflow this replaces -
    * it would fail in a checkout with no website. Left as-is to keep the port
    * faithful; worth guarding separately.
+   *
+   * `SetupLibuv`, which zio-sbt-ci puts in every job template, is deliberately
+   * omitted: libuv1-dev is only needed to link Scala Native binaries and this
+   * build cross-compiles to JVM and JS only. It made the job depend on an apt
+   * mirror, which stalled for eight minutes and consumed the whole timeout in
+   * run 32234167683.
    */
   lazy val buildDocs: Def.Initialize[Job] = Def.setting(
     Job(
       id = "buildDocs",
       name = "Build Docs",
-      jobTimeout = Some(10),
+      jobTimeout = Some(20),
       steps = Seq(
         Checkout.value,
-        SetupLibuv,
         SetupJava("25"),
         SetupSBT,
         CacheDependencies,
@@ -202,12 +207,19 @@ object CiWorkflow {
    * scala3#24183 makes it fail; docs are compiled on JDK 17 instead. Postgres
    * backs the sql modules and carries a health check so steps cannot start
    * before it accepts connections.
+   *
+   * The timeout is sized for the JDK 25 / 3.8.x cell, the only one that runs
+   * instrumented tests, the Scala Next suite and the example compile in
+   * sequence. The coverage step alone has measured anywhere from 10 to 20
+   * minutes on unchanged sources, because only dependencies are cached and
+   * every run recompiles from scratch on whatever runner it draws, so the cap
+   * has to clear the slow end of that spread rather than its median.
    */
   lazy val testJVM: Def.Initialize[Job] = Def.setting(
     Job(
       id = "testJVM",
       name = "testJVM",
-      jobTimeout = Some(25),
+      jobTimeout = Some(40),
       strategy = Some(
         Strategy(
           matrix = Map("java" -> List("17", "25"), "platform" -> List("JVM"), "scala" -> Scalas),
@@ -395,7 +407,6 @@ object CiWorkflow {
       ),
       steps = Seq(
         Checkout.value,
-        SetupLibuv,
         SetupJava("25"),
         SetupSBT,
         CacheDependencies,


### PR DESCRIPTION
Run [32234167683](https://github.com/zio/zio-blocks/actions/runs/32234167683) went red without a single test failing. Two jobs were killed by their own `timeout-minutes`, which GitHub reports as `cancelled`, and the `ci` gate job then failed on its cancelled needs.

## Build Docs — remove `SetupLibuv`

The job died in `Install libuv`, two steps in. The Azure Ubuntu mirror was unreachable, apt fell back to `archive.ubuntu.com` and then stalled for eight minutes with no output and no exit, consuming the whole ten minute budget before Scala was even installed:

```
08:47:39  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
   ...8 minutes of nothing...
08:55:46  ##[error]The operation was canceled.
```

`SetupLibuv` comes from zio-sbt-ci, which puts it in all eight of its job templates for the repos in the org that publish Scala Native artifacts. zio-blocks is not one of them — there is no `sbt-scala-native` plugin and no `NativePlatform` in any `crossProject`, so nothing here links against libuv, and the docs job compiles no C at all. Removing the step deletes the only network dependency that job had outside of actions and coursier, so there is nothing left to retry or to time out.

A retry loop would not have helped: apt hung rather than exiting non-zero, and a retry only engages on a non-zero exit.

## testJVM — raise the cap from 25 to 40

`testJVM (25, JVM, 3.8.x)` ran 25m14s against a 25 minute cap. It is the heaviest cell in the matrix, and the only one where three `if:` conditions all match, so it runs:

| step | duration |
|---|---|
| scoverage-instrumented `test` + `coverageReport` | 20.1m |
| `scalaNextTests/test benchmarks/test` | 4.3m (killed mid-step) |
| `schema-examples/compile` | never reached (~1.2m) |

The coverage step has measured **9.6, 12.1, 17.7 and 20.1 minutes** across the last four runs on unchanged sources: only dependencies are cached, so every run recompiles from scratch on whatever shared runner it draws, and instrumentation roughly doubles the compile. The cap sat inside that spread, which made the job a coin flip on every push. 40 clears the slow end.

## Build Docs — raise the cap from 10 to 20

Even with libuv gone the job needs 7 to 9 minutes of a 10 minute cap, and its cost is about to grow: 659fccc added 1190 lines to `docs/reference/async.md`, whose snippets `sbt docs/mdoc` has to compile. A re-run of that commit with libuv still in place has since completed the job in 8.1m, so the margin is real but thin.

## Notes

- Regenerated with `sbt ciGenerateGithubWorkflow`; `sbt ciCheckGithubWorkflow` and `sbt scalafmtSbtCheck` both pass.
- The rationale is recorded in the scaladoc of both jobs, so that a later sync with a newer zio-sbt-ci does not silently re-add `SetupLibuv` from the plugin's own templates.
- Worth knowing for the future: once a job's conclusion is `cancelled`, **"Re-run failed jobs" is a permanent no-op on that run** — GitHub only re-executes `failure` jobs and copies `cancelled` ones forward with their original timestamps. Attempts 2 and 3 of that run each lasted 9 seconds and re-ran nothing but the gate job. A full `gh run rerun` is the only recovery.