### PR TITLE
build: fork the otel test JVM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -684,7 +684,12 @@ lazy val otel = project
         Seq()
     }),
     coverageMinimumStmtTotal   := 0,
-    coverageMinimumBranchTotal := 0
+    coverageMinimumBranchTotal := 0,
+    // The exporter specs create scheduled executors backed by virtual threads and leave retry
+    // workers running past the end of a test. In-process those outlive the suite and have taken
+    // sbt itself down on JDK 25 (silent exit 1 right after "tests passed"). Fork so that any
+    // such crash is confined to the test JVM, and reported instead of killing the build.
+    Test / fork := true
   )
   .settings(
     mimaSettings(failOnProblem = false),


### PR DESCRIPTION
The `otel` exporter specs create scheduled executors backed by virtual threads and leave retry workers running past the end of a test. Running in-process (the build defaults to `Test / fork := false`), those outlive the suite inside sbt's own JVM, and on JDK 25 they have taken sbt down with them: the build exits 1 with no output at all, immediately after reporting that every test passed, and skips the remaining commands in the step.

```
199 tests passed. 0 tests failed. 0 tests ignored.
Executed in 31 s 694 ms
[info] Completed tests
[success] Total time: 36 s, completed Aug 20, 2026, 12:45:17 AM
##[error]Process completed with exit code 1.
```

In the 3.3.x job above, `coverageReport` never ran; in the 2.13.x job, `docJVM` never ran.

## Why this is flaky, not a test failure

- Seen in `testJVM (25, JVM, 2.13.x)` and `testJVM (25, JVM, 3.3.x)` of run [32317629755](https://github.com/zio/zio-blocks/actions/runs/32317629755), and in `testJVM (25, JVM, 3.8.x)` of run [32234167683](https://github.com/zio/zio-blocks/actions/runs/32234167683) on `main`.
- The affected matrix cell moves between runs; other cells run the identical command list and reach `coverageReport` fine.
- Rerunning the failed jobs on the same commit, with no code change, passes.
- Every case dies at the same point: the end of the `otel` suite (199 tests, ~31s), which is the last suite in `testJVM`.

The exit is silent — no stack trace, no `hs_err`, no OOM marker — which is the signature of the reporting process itself being the casualty.

## The change

`Test / fork := true` for the `otel` project, following the existing use of the same setting for `zioGolemIntegrationTests`. Forking confines a teardown crash to the test JVM, where sbt survives to report it rather than dying with it. Cost is one extra JVM start per `otel/test`.

This is a containment and diagnosability fix. It does not clean up the leaked executors themselves — if the crash recurs inside the forked JVM, we will now get an actual error message to work from.

## Verification

- `otel/test` on 3.3.6 and 2.13.18: 199 tests pass, forked (`show otel/Test/fork` → `true`).
- `coverage; otel/test; otel/coverageReport`: scoverage still collects from the forked JVM — stmt 87.45%, branch 86.93%.
- `scalafmtSbtCheck` passes.