### PR TITLE
test(otel): shut down the executors the exporter specs create

### DIFF
--- a/otel/src/test/scala/zio/blocks/telemetry/otel/OtlpJsonExporterSpec.scala
+++ b/otel/src/test/scala/zio/blocks/telemetry/otel/OtlpJsonExporterSpec.scala
@@ -148,27 +148,32 @@ object OtlpJsonExporterSpec extends ZIOSpecDefault {
     suite("OtlpJsonTraceExporter")(
       test("onStart is a no-op") {
         val (sender, _) = mockHttpSender()
+        val pe          = PlatformExecutor.create()
         val exporter    = new OtlpJsonTraceExporter(
           ExporterConfig(flushIntervalMillis = 600000L),
           testResource,
           testScope,
           sender,
-          PlatformExecutor.create()
+          pe
         )
         try {
           // onStart should not throw or do anything
           // We can't easily construct a Span trait instance so we test it doesn't error
           assertTrue(true)
-        } finally exporter.shutdown()
+        } finally {
+          exporter.shutdown()
+          pe.shutdown()
+        }
       },
       test("onEnd enqueues span and forceFlush sends via HttpSender") {
         val (sender, captured) = mockHttpSender()
+        val pe                 = PlatformExecutor.create()
         val exporter           = new OtlpJsonTraceExporter(
           ExporterConfig(flushIntervalMillis = 600000L),
           testResource,
           testScope,
           sender,
-          PlatformExecutor.create()
+          pe
         )
         try {
           exporter.onEnd(sampleSpanData())
@@ -179,42 +184,54 @@ object OtlpJsonExporterSpec extends ZIOSpecDefault {
               calls.head._1.endsWith("/v1/traces") &&
               calls.head._3.nonEmpty
           )
-        } finally exporter.shutdown()
+        } finally {
+          exporter.shutdown()
+          pe.shutdown()
+        }
       },
       test("sends to correct endpoint URL") {
         val (sender, captured) = mockHttpSender()
+        val pe                 = PlatformExecutor.create()
         val exporter           = new OtlpJsonTraceExporter(
           ExporterConfig(endpoint = "http://my-collector:4318", flushIntervalMillis = 600000L),
           testResource,
           testScope,
           sender,
-          PlatformExecutor.create()
+          pe
         )
         try {
           exporter.onEnd(sampleSpanData())
           exporter.forceFlush()
           val calls = captured.get()
           assertTrue(calls.head._1 == "http://my-collector:4318/v1/traces")
-        } finally exporter.shutdown()
+        } finally {
+          exporter.shutdown()
+          pe.shutdown()
+        }
       },
       test("sends correct Content-Type header") {
         val (sender, captured) = mockHttpSender()
+        val pe                 = PlatformExecutor.create()
         val exporter           = new OtlpJsonTraceExporter(
           ExporterConfig(flushIntervalMillis = 600000L),
           testResource,
           testScope,
           sender,
-          PlatformExecutor.create()
+          pe
         )
         try {
           exporter.onEnd(sampleSpanData())
           exporter.forceFlush()
           val calls = captured.get()
           assertTrue(calls.head._2.get("Content-Type").contains("application/json"))
-        } finally exporter.shutdown()
+        } finally {
+          exporter.shutdown()
+          pe.shutdown()
+        }
       },
       test("includes custom headers from config") {
         val (sender, captured) = mockHttpSender()
+        val pe                 = PlatformExecutor.create()
         val exporter           = new OtlpJsonTraceExporter(
           ExporterConfig(
             headers = Map("Authorization" -> "Bearer secret"),
@@ -223,23 +240,27 @@ object OtlpJsonExporterSpec extends ZIOSpecDefault {
           testResource,
           testScope,
           sender,
-          PlatformExecutor.create()
+          pe
         )
         try {
           exporter.onEnd(sampleSpanData())
           exporter.forceFlush()
           val calls = captured.get()
           assertTrue(calls.head._2.get("Authorization").contains("Bearer secret"))
-        } finally exporter.shutdown()
+        } finally {
+          exporter.shutdown()
+          pe.shutdown()
+        }
       },
       test("encodes span data as valid OTLP JSON") {
         val (sender, captured) = mockHttpSender()
+        val pe                 = PlatformExecutor.create()
         val exporter           = new OtlpJsonTraceExporter(
           ExporterConfig(flushIntervalMillis = 600000L),
           testResource,
           testScope,
           sender,
-          PlatformExecutor.create()
+          pe
         )
         try {
           exporter.onEnd(sampleSpanData())
@@ -250,16 +271,20 @@ object OtlpJsonExporterSpec extends ZIOSpecDefault {
               body.contains("test-span") &&
               body.contains("0af7651916cd43dd8448eb211c80319c")
           )
-        } finally exporter.shutdown()
+        } finally {
+          exporter.shutdown()
+          pe.shutdown()
+        }
       },
       test("batches multiple spans together") {
         val (sender, captured) = mockHttpSender()
+        val pe                 = PlatformExecutor.create()
         val exporter           = new OtlpJsonTraceExporter(
           ExporterConfig(flushIntervalMillis = 600000L),
           testResource,
           testScope,
           sender,
-          PlatformExecutor.create()
+          pe
         )
         try {
           exporter.onEnd(sampleSpanData())
@@ -272,18 +297,22 @@ object OtlpJsonExporterSpec extends ZIOSpecDefault {
               body.contains("test-span") &&
               body.contains("span-2")
           )
-        } finally exporter.shutdown()
+        } finally {
+          exporter.shutdown()
+          pe.shutdown()
+        }
       }
     ),
     suite("OtlpJsonLogExporter")(
       test("onEmit enqueues log and forceFlush sends via HttpSender") {
         val (sender, captured) = mockHttpSender()
+        val pe                 = PlatformExecutor.create()
         val exporter           = new OtlpJsonLogExporter(
           ExporterConfig(flushIntervalMillis = 600000L),
           testResource,
           testScope,
           sender,
-          PlatformExecutor.create()
+          pe
         )
         try {
           exporter.onEmit(sampleLogRecord())
@@ -294,32 +323,40 @@ object OtlpJsonExporterSpec extends ZIOSpecDefault {
               calls.head._1.endsWith("/v1/logs") &&
               calls.head._3.nonEmpty
           )
-        } finally exporter.shutdown()
+        } finally {
+          exporter.shutdown()
+          pe.shutdown()
+        }
       },
       test("sends to correct endpoint URL") {
         val (sender, captured) = mockHttpSender()
+        val pe                 = PlatformExecutor.create()
         val exporter           = new OtlpJsonLogExporter(
           ExporterConfig(endpoint = "http://my-collector:4318", flushIntervalMillis = 600000L),
           testResource,
           testScope,
           sender,
-          PlatformExecutor.create()
+          pe
         )
         try {
           exporter.onEmit(sampleLogRecord())
           exporter.forceFlush()
           val calls = captured.get()
           assertTrue(calls.head._1 == "http://my-collector:4318/v1/logs")
-        } finally exporter.shutdown()
+        } finally {
+          exporter.shutdown()
+          pe.shutdown()
+        }
       },
       test("encodes log data as valid OTLP JSON") {
         val (sender, captured) = mockHttpSender()
+        val pe                 = PlatformExecutor.create()
         val exporter           = new OtlpJsonLogExporter(
           ExporterConfig(flushIntervalMillis = 600000L),
           testResource,
           testScope,
           sender,
-          PlatformExecutor.create()
+          pe
         )
         try {
           exporter.onEmit(sampleLogRecord())
@@ -330,16 +367,20 @@ object OtlpJsonExporterSpec extends ZIOSpecDefault {
               body.contains("test log message") &&
               body.contains("INFO")
           )
-        } finally exporter.shutdown()
+        } finally {
+          exporter.shutdown()
+          pe.shutdown()
+        }
       },
       test("batches multiple logs together") {
         val (sender, captured) = mockHttpSender()
+        val pe                 = PlatformExecutor.create()
         val exporter           = new OtlpJsonLogExporter(
           ExporterConfig(flushIntervalMillis = 600000L),
           testResource,
           testScope,
           sender,
-          PlatformExecutor.create()
+          pe
         )
         try {
           exporter.onEmit(sampleLogRecord())
@@ -352,7 +393,10 @@ object OtlpJsonExporterSpec extends ZIOSpecDefault {
               body.contains("test log message") &&
               body.contains("second log")
           )
-        } finally exporter.shutdown()
+        } finally {
+          exporter.shutdown()
+          pe.shutdown()
+        }
       }
     ),
     suite("OtlpJsonMetricExporter")(
@@ -481,12 +525,13 @@ object OtlpJsonExporterSpec extends ZIOSpecDefault {
     suite("Trace exporter with response mapping integration")(
       test("retryable status code triggers retry in batch processor") {
         val sender   = mockHttpSenderWithStatus(429)
+        val pe       = PlatformExecutor.create()
         val exporter = new OtlpJsonTraceExporter(
           ExporterConfig(flushIntervalMillis = 600000L),
           testResource,
           testScope,
           sender,
-          PlatformExecutor.create()
+          pe
         )
         try {
           // This will enqueue and flush — the 429 will cause retries in BatchProcessor
@@ -494,7 +539,10 @@ object OtlpJsonExporterSpec extends ZIOSpecDefault {
           exporter.onEnd(sampleSpanData())
           exporter.forceFlush()
           assertTrue(true)
-        } finally exporter.shutdown()
+        } finally {
+          exporter.shutdown()
+          pe.shutdown()
+        }
       }
     )
   ) @@ TestAspect.sequential


### PR DESCRIPTION
Every test in `OtlpJsonExporterSpec` passed a fresh `PlatformExecutor.create()` straight into the exporter constructor and then closed only the exporter:

```scala
val exporter = new OtlpJsonTraceExporter(config, testResource, testScope, sender, PlatformExecutor.create())
try   { ... }
finally exporter.shutdown()
```

`OtlpJsonTraceExporter.shutdown()` and `OtlpJsonLogExporter.shutdown()` close the batch processor and the HTTP sender, but not the executor — correctly so. The documented lifecycle in `docs/guides/telemetry-guide.md` shares a single executor across the trace and log exporters and has the caller stop it last:

```scala
val executor      = PlatformExecutor.create()
val traceExporter = new OtlpJsonTraceExporter(config, resource, scope, sender, executor)
val logExporter   = new OtlpJsonLogExporter(config, resource, scope, sender, executor)
...
// 3. Stop the scheduler last
executor.shutdown()
```

An exporter closing a scheduler it was merely handed would pull it out from under its sibling. So ownership sits with whoever called `create()` — here, the specs — and they never closed it.

## Verification

Twelve scheduled pools outlived the suite. Measured with a JSON thread dump (`jcmd Thread.dump_to_file`, which includes virtual threads) taken after the suite reported all 199 tests passing, running with `otel / Test / fork := false` so the leak is observable in sbt's own JVM:

| | live `otel-` threads | total threads |
|---|---|---|
| before | **12** — one per unbalanced `create()` | 81 |
| after | **0** | 67 |

`otel/test` passes on 3.3.6 and 2.13.18, and `scalafmtCheckAll` is clean.

## The change

Hoist the executor into a `val` and close it in the `finally` block that already exists, which is how `BatchProcessorSpec` handles the same resource (12 creates, 12 shutdowns). No behavioural or assertion changes.

## Scope

This is hygiene, not a fix for the CI flake that motivated #1602. The leaked pools sit idle — `BatchProcessor.shutdown()` cancels the scheduled flush — and their threads are daemon virtual threads, so they can neither hold the JVM open nor influence its exit code:

```
task ran on virtual=true daemon=true
main returning WITHOUT shutdown()
JVM EXIT=0
```

The root cause of that flake is still unknown; see https://github.com/zio/zio-blocks/pull/1602#issuecomment-5360450877.