### PR TITLE
build: run the config specs sequentially

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -821,7 +821,13 @@ lazy val config = crossProject(JSPlatform, JVMPlatform)
   .settings(crossProjectSettings)
   .settings(buildInfoSettings("zio.blocks.config"))
   .enablePlugins(BuildInfoPlugin)
-  .jvmSettings(mimaSettings(failOnProblem = false))
+  .jvmSettings(
+    mimaSettings(failOnProblem = false),
+    // Specs share FlagSource.Registry (mutable singleton); parallel specs cause race
+    // conditions. TestAspect.sequential only orders tests within a spec, so it does not
+    // help here. jsSettings already sets this; the JVM inherits `true` from stdSettings.
+    Test / parallelExecution := false
+  )
   .jsSettings(jsSettings)
   .settings(
     libraryDependencies ++= Seq(


### PR DESCRIPTION
Fixes an intermittent `configJVM` failure that has reddened `main` three times.

## The race

`FlagSource.Registry` ([FlagSource.scala:61](https://github.com/zio/zio-blocks/blob/main/config/shared/src/main/scala/zio/blocks/config/FlagSource.scala#L61)) is an `object`, so one instance exists per JVM. Four specs mutate it — `FlagSourceSpec`, `StaticFlagSpec`, `DynamicFlagSpec`, `FlagDumpSpec` — and `stdSettings` leaves `Test / parallelExecution := true` ([BuildHelper.scala:243](https://github.com/zio/zio-blocks/blob/main/project/BuildHelper.scala#L243)), so they run concurrently against that single registry. Each spec's `clear()` is visible to the others.

The failing test registers two sources and reads them straight back:

```scala
// FlagSourceSpec.scala:80
FlagSource.Registry.clear()
FlagSource.Registry.register(p1)                            // write
FlagSource.Registry.register(p2)                            // write
val ids = FlagSource.Registry.all.map(_.sourceId).toSet     // read
assertTrue(ids.contains("all-1"), ids.contains("all-2"))
```

| time | thread A — `FlagSourceSpec` | thread B — `StaticFlagSpec` | registry |
|---|---|---|---|
| t1 | `clear()` | | `{}` |
| t2 | `register(p1)` | | `{all-1}` |
| t3 | `register(p2)` | | `{all-1, all-2}` |
| t4 | | **`clear()`** | `{}` |
| t5 | reads `all` → `Set()` | | `{}` |
| t6 | assertion fails | | |

## Evidence

Three occurrences, two different specs, three different matrix cells — the victim moves, which is what distinguishes a race from a flaky assertion:

| run | cell | test |
|---|---|---|
| [32234167683](https://github.com/zio/zio-blocks/actions/runs/32234167683) | 25 / 3.8 | `StaticFlagSpec / … / FlagSource takes priority over system property` |
| [32378081293](https://github.com/zio/zio-blocks/actions/runs/32378081293) | 17 / 2.13 | `FlagSourceSpec / Registry / all returns registered sources` |
| [32462601972](https://github.com/zio/zio-blocks/actions/runs/32462601972) | 17 / 3.3 | `FlagSourceSpec / Registry / all returns registered sources` |

`ids = Set()` is the diagnostic. The test registers two sources immediately before reading, so an *empty* registry means another spec's `clear()` landed between the writes and the read — a lost write would have left one entry, and a missing setup `clear()` would have left extra ones.

Worth noting the blast radius: on run 32462601972 this one ~4-second suite was the sole reason a 13-job pipeline reported red, which also left the `release` job skipped. Re-running the failed job turned the whole run green with no code change, and let `release` through.

## Why the collections don't already cover it

`byId` is a `ConcurrentHashMap` and `ordered` is a `CopyOnWriteArrayList`, so every *individual* operation is atomic. What is unprotected is the write-write-read *sequence* — a check-then-act pattern that no thread-safe collection can guard.

Each spec does carry `@@ TestAspect.sequential`, but that orders tests *within* one spec and says nothing about two specs running side by side. That is why the aspect never prevented this.

## The change

```scala
.jvmSettings(
  mimaSettings(failOnProblem = false),
  // Specs share FlagSource.Registry (mutable singleton); parallel specs cause race
  // conditions. TestAspect.sequential only orders tests within a spec, so it does not
  // help here. jsSettings already sets this; the JVM inherits `true` from stdSettings.
  Test / parallelExecution := false
)
```

Serialising the module's specs removes the second thread, so nothing is alive to interpose a `clear()`. No test logic changes — each test is already correct in isolation; the defect is the execution environment meeting global state.

This is the established pattern in this build for exactly this situation:

- `build.sbt:656` — *"Tests share GlobalLogState (mutable singleton); parallel specs cause race conditions."*
- `build.sbt:736` — streams specs, serialised to avoid cross-spec CPU starvation.

`jsSettings` already sets the flag, so only the JVM side needed it.

## Verification

- `show configJVM/Test/parallelExecution` → `false` (JS already `false`).
- `configJVM/test` passes three consecutive times, 308 tests, and the suite runs in 3–4s serially — immaterial next to a 12–40 minute job.
- `scalafmtSbtCheck` passes.

## Scope

This contains the symptom rather than making the registry safe for concurrent use. `clear()` is effectively a test-only affordance — production registers sources at startup and does not wipe them — so serialising the specs is proportionate. Making the registry an injectable instance so each test owns its own would fix the design, at the cost of changing a public API; that is deliberately not attempted here.