### PR TITLE
ci: collect failure diagnostics on the testJVM jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,32 @@ jobs:
     - name: Compile example project
       if: ${{ matrix.scala == '3.8.x' }}
       run: sbt ++${{ matrix.scala }} schema-examples/compile
+    - name: Collect failure diagnostics
+      if: failure()
+      run: |
+        kernel_log=$(sudo dmesg -T 2>/dev/null) || true
+        echo "::group::Kernel log, OOM and kill lines only"
+        if [ -n "$kernel_log" ]; then
+          echo "$kernel_log" | grep -iE 'out of memory|oom[-_ ]kill|killed process|segfault' || echo "no OOM or kill lines"
+        else
+          echo "kernel log unavailable"
+        fi
+        echo "::endgroup::"
+        echo "::group::Kernel log, last 200 lines"
+        if [ -n "$kernel_log" ]; then echo "$kernel_log" | tail -n 200; else echo "kernel log unavailable"; fi
+        echo "::endgroup::"
+        echo "::group::Memory and disk"
+        free -m || true
+        df -h . || true
+        echo "::endgroup::"
+        echo "::group::JVM crash logs"
+        crash_logs=$(find . -maxdepth 3 -name 'hs_err_pid*.log' 2>/dev/null; find . -maxdepth 3 -name 'replay_pid*.log' 2>/dev/null) || true
+        if [ -n "$crash_logs" ]; then
+          for f in $crash_logs; do echo "--- $f ---"; head -n 100 "$f"; done
+        else
+          echo "no JVM crash logs"
+        fi
+        echo "::endgroup::"
   testJS:
     name: testJS
     runs-on: ubuntu-latest

--- a/project/CiWorkflow.scala
+++ b/project/CiWorkflow.scala
@@ -274,6 +274,42 @@ object CiWorkflow {
           name = "Compile example project",
           condition = Some(expr("matrix.scala == '3.8.x'")),
           run = Some("sbt ++${{ matrix.scala }} schema-examples/compile")
+        ),
+        // sbt has repeatedly died on the JDK 25 jobs with a bare `exit code 1`, no stderr and no
+        // hs_err file, immediately after reporting that every test passed, skipping the remaining
+        // commands in the step. The build output cannot distinguish a kernel kill from a
+        // self-inflicted exit, so collect what can tell them apart the next time it happens: an
+        // OOM kill or a signal is recorded in the kernel log, and a JVM crash leaves an hs_err
+        // file behind. Runs on any job failure, ordinary test failures included; it costs seconds.
+        SingleStep(
+          name = "Collect failure diagnostics",
+          condition = Some(Condition.Function("failure()")),
+          run = Some(
+            """|kernel_log=$(sudo dmesg -T 2>/dev/null) || true
+               |echo "::group::Kernel log, OOM and kill lines only"
+               |if [ -n "$kernel_log" ]; then
+               |  echo "$kernel_log" | grep -iE 'out of memory|oom[-_ ]kill|killed process|segfault' || echo "no OOM or kill lines"
+               |else
+               |  echo "kernel log unavailable"
+               |fi
+               |echo "::endgroup::"
+               |echo "::group::Kernel log, last 200 lines"
+               |if [ -n "$kernel_log" ]; then echo "$kernel_log" | tail -n 200; else echo "kernel log unavailable"; fi
+               |echo "::endgroup::"
+               |echo "::group::Memory and disk"
+               |free -m || true
+               |df -h . || true
+               |echo "::endgroup::"
+               |echo "::group::JVM crash logs"
+               |crash_logs=$(find . -maxdepth 3 -name 'hs_err_pid*.log' 2>/dev/null; find . -maxdepth 3 -name 'replay_pid*.log' 2>/dev/null) || true
+               |if [ -n "$crash_logs" ]; then
+               |  for f in $crash_logs; do echo "--- $f ---"; head -n 100 "$f"; done
+               |else
+               |  echo "no JVM crash logs"
+               |fi
+               |echo "::endgroup::"
+               |""".stripMargin
+          )
         )
       )
     )


### PR DESCRIPTION
sbt has repeatedly died on the JDK 25 `testJVM` jobs with a bare `exit code 1` — no stderr, no `hs_err` file — immediately after reporting that every test passed, skipping the remaining commands in the step:

```
199 tests passed. 0 tests failed. 0 tests ignored.
[info] Completed tests
[success] Total time: 36 s, completed Aug 20, 2026, 12:45:17 AM
##[error]Process completed with exit code 1.
```

The build output alone cannot distinguish a kernel kill from a self-inflicted exit, which is why the cause is still unknown after #1602 and #1604 (see https://github.com/zio/zio-blocks/pull/1602#issuecomment-5360450877).

## The change

A step on `testJVM`, conditional on job failure, that captures what tells those cases apart:

- the kernel log filtered for OOM-killer and signal lines — an OOM kill or a `segfault` is recorded there and nowhere in the build output;
- the full tail of the kernel log, for context around whatever it finds;
- memory and disk state at the moment of failure;
- any `hs_err_pid*.log` / `replay_pid*.log` the JVM left in the workspace, printed inline, which is the direct evidence if the JVM crashed rather than exited.

Output is wrapped in `::group::` blocks so it stays collapsed in the log.

It runs on any job failure, ordinary test failures included, and costs a few seconds. That is deliberate: the flake is rare and moves between matrix cells, so arming only the JDK 25 cells would risk missing the next occurrence.

## Notes

- Defined in `project/CiWorkflow.scala` and rendered to `.github/workflows/ci.yml` by `ciGenerateGithubWorkflow`; both are committed, and `ciCheckGithubWorkflow` passes.
- The script was checked with `bash -n` and run under `bash -e`, matching how Actions invokes it. A `dmesg` that returns nothing degrades to `kernel log unavailable` rather than failing the step or emitting a silently empty group.