### PR TITLE
feat(endpoint): bulk endpoint creation DSL — endpoints { ... } macro with static NamedTuple groups

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,13 +13,7 @@ inThisBuild(
     name         := "ZIO Blocks",
     organization := "dev.zio",
     homepage     := Some(url("https://zio.dev")),
-    scmInfo      := Some(
-      ScmInfo(
-        url("https://github.com/zio/zio-blocks"),
-        "scm:git:git@github.com:zio/zio-blocks.git"
-      )
-    ),
-    licenses := List(
+    licenses     := List(
       "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")
     ),
     startYear     := Some(2024),
@@ -102,61 +96,28 @@ addCommandAlias(
   "golemTestAll",
   "golemTest3; golemTest2"
 )
-lazy val testJVMScala2Command =
-  "typeidJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
-    "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; mediatypeJVM/test; " +
-    "openapiJVM/test; smithy/test; codegen/test; htmlJVM/test"
-
-lazy val testJVMScala3Command =
+addCommandAlias(
+  "testJVM",
   "typeidJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
     "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; mediatypeJVM/test; http-modelJVM/test; " +
     "http-model-schemaJVM/test; openapiJVM/test; smithy/test; codegen/test; htmlJVM/test"
+)
 
-lazy val testJSScala2Command =
-  "typeidJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
-    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; htmlJS/test"
-
-lazy val testJSScala3Command =
+addCommandAlias(
+  "testJS",
   "typeidJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
     "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; mediatypeJS/test; http-modelJS/test; http-model-schemaJS/test; htmlJS/test"
-
-lazy val docJVMScala2Command =
-  "typeidJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
-    "schema-thrift/doc; schema-bson/doc; schema-xmlJVM/doc; schema-yamlJVM/doc; schema-csvJVM/doc; contextJVM/doc; scopeJVM/doc; mediatypeJVM/doc; " +
-    "openapiJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc"
-
-lazy val docJVMScala3Command =
+)
+addCommandAlias(
+  "docJVM",
   "typeidJVM/doc; chunkJVM/doc; combinatorsJVM/doc; ringbufferJVM/doc; schemaJVM/doc; streamsJVM/doc; schema-toonJVM/doc; schema-messagepackJVM/doc; schema-avro/doc; " +
     "schema-thrift/doc; schema-bson/doc; schema-xmlJVM/doc; schema-yamlJVM/doc; schema-csvJVM/doc; contextJVM/doc; scopeJVM/doc; mediatypeJVM/doc; http-modelJVM/doc; " +
     "http-model-schemaJVM/doc; openapiJVM/doc; smithy/doc; codegen/doc; htmlJVM/doc"
-
-lazy val docJSScala2Command =
-  "typeidJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
-    "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; htmlJS/doc"
-
-lazy val docJSScala3Command =
+)
+addCommandAlias(
+  "docJS",
   "typeidJS/doc; chunkJS/doc; combinatorsJS/doc; ringbufferJS/doc; schemaJS/doc; streamsJS/doc; schema-toonJS/doc; schema-messagepackJS/doc; openapiJS/doc; " +
     "schema-xmlJS/doc; schema-yamlJS/doc; schema-csvJS/doc; contextJS/doc; scopeJS/doc; mediatypeJS/doc; http-modelJS/doc; http-model-schemaJS/doc; htmlJS/doc"
-
-def commandForScalaVersion(name: String, scala2Command: String, scala3Command: String): Command =
-  Command.command(name) { state =>
-    val extracted = Project.extract(state)
-    val version   = extracted.get(LocalProject("schemaJVM") / scalaVersion)
-    val selected  = CrossVersion.partialVersion(version) match {
-      case Some((2, _)) => scala2Command
-      case _            => scala3Command
-    }
-
-    selected.split(';').foldLeft(state) { case (current, command) =>
-      Command.process(command.trim, current)
-    }
-  }
-
-commands ++= Seq(
-  commandForScalaVersion("testJVM", testJVMScala2Command, testJVMScala3Command),
-  commandForScalaVersion("testJS", testJSScala2Command, testJSScala3Command),
-  commandForScalaVersion("docJVM", docJVMScala2Command, docJVMScala3Command),
-  commandForScalaVersion("docJS", docJSScala2Command, docJSScala3Command)
 )
 
 lazy val root = project
@@ -425,13 +386,32 @@ lazy val streams = crossProject(JSPlatform, JVMPlatform)
   .settings(crossProjectSettings)
   .settings(buildInfoSettings("zio.blocks.streams"))
   .enablePlugins(BuildInfoPlugin)
+  .settings(
+    // Streams source requires Scala 3 (inline, summonFrom, etc.).
+    // Under 2.13 CI runs, skip compilation entirely.
+    Compile / sources := {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) => Nil
+        case _            => (Compile / sources).value
+      }
+    },
+    Test / sources := {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) => Nil
+        case _            => (Test / sources).value
+      }
+    }
+  )
   .jvmSettings(
     mimaSettings(failOnProblem = false),
     // Streams requires JDK 21+ (Project Loom virtual threads).
     // Override the default -release flag so Thread.ofVirtual() is available.
     // Only set -release 21 when running on JDK 21+; on JDK 17 CI, skip
     // compilation of streams (tests will be skipped due to compilation failure).
-    scalacOptions ~= (opts => removeOptionWithValue(opts, "-release")),
+    scalacOptions ~= { opts =>
+      opts.zipWithIndex.flatMap { case (o, i) => if (o == "-release") None else Some((o, i)) }
+        .map(_._1)
+    },
     scalacOptions ++= {
       val jdkVersion = System.getProperty("java.specification.version", "17").toInt
       if (jdkVersion >= 21) Seq("-release", "21") else Seq("-release", jdkVersion.toString)
@@ -445,12 +425,6 @@ lazy val streams = crossProject(JSPlatform, JVMPlatform)
       // Alphanumeric infix in tests (andThen, etc.)
       "-Wconf:msg=Alphanumeric method.*infix:s"
     ),
-    Compile / doc / scalacOptions ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) => Seq("-no-link-warnings")
-        case _            => Seq.empty
-      }
-    },
     javacOptions ++= {
       val jdkVersion = System.getProperty("java.specification.version", "17").toInt
       if (jdkVersion >= 21) Seq("--release", "21") else Seq("--release", jdkVersion.toString)
@@ -463,13 +437,7 @@ lazy val streams = crossProject(JSPlatform, JVMPlatform)
       "-Wconf:msg=being leaked from scope:s",
       // Alphanumeric infix in tests (andThen, etc.)
       "-Wconf:msg=Alphanumeric method.*infix:s"
-    ),
-    Compile / doc / scalacOptions ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) => Seq("-no-link-warnings")
-        case _            => Seq.empty
-      }
-    }
+    )
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -520,7 +488,7 @@ lazy val mediatype = crossProject(JSPlatform, JVMPlatform)
 
 lazy val `http-model` = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Full)
-  .settings(stdSettings("zio-http-model", Seq(Scala3, Scala33)))
+  .settings(stdSettings("zio-http-model"))
   .settings(crossProjectSettings)
   .settings(buildInfoSettings("zio.http"))
   .enablePlugins(BuildInfoPlugin)
@@ -533,12 +501,25 @@ lazy val `http-model` = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test-sbt" % "2.1.25" % Test
     ),
     coverageMinimumStmtTotal   := 95,
-    coverageMinimumBranchTotal := 94
+    coverageMinimumBranchTotal := 94,
+    // HTTP model requires streams, which is Scala 3 only.
+    Compile / sources := {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) => Nil
+        case _            => (Compile / sources).value
+      }
+    },
+    Test / sources := {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) => Nil
+        case _            => (Test / sources).value
+      }
+    }
   )
 
 lazy val `http-model-schema` = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Full)
-  .settings(stdSettings("zio-http-model-schema", Seq(Scala3, Scala33)))
+  .settings(stdSettings("zio-http-model-schema"))
   .settings(crossProjectSettings)
   .settings(buildInfoSettings("zio.http.schema"))
   .enablePlugins(BuildInfoPlugin)
@@ -551,7 +532,20 @@ lazy val `http-model-schema` = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test-sbt" % "2.1.25" % Test
     ),
     coverageMinimumStmtTotal   := 67,
-    coverageMinimumBranchTotal := 51
+    coverageMinimumBranchTotal := 51,
+    // Depends on http-model which is Scala 3 only.
+    Compile / sources := {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) => Nil
+        case _            => (Compile / sources).value
+      }
+    },
+    Test / sources := {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) => Nil
+        case _            => (Test / sources).value
+      }
+    }
   )
 
 lazy val `http-model-examples` = project
@@ -564,6 +558,37 @@ lazy val `http-model-examples` = project
     coverageMinimumBranchTotal := 0
   )
   .dependsOn(`http-model`.jvm)
+
+lazy val endpoint = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Full)
+  .settings(stdSettings("zio-blocks-endpoint"))
+  .settings(crossProjectSettings)
+  .settings(buildInfoSettings("zio.blocks.endpoint"))
+  .enablePlugins(BuildInfoPlugin)
+  .jvmSettings(mimaSettings(failOnProblem = false))
+  .jsSettings(jsSettings)
+  .dependsOn(`http-model`, schema, combinators, mediatype, markdown)
+  .settings(
+    libraryDependencies ++= Seq(
+      "dev.zio" %%% "zio-test"     % "2.1.25" % Test,
+      "dev.zio" %%% "zio-test-sbt" % "2.1.25" % Test
+    ),
+    coverageMinimumStmtTotal   := 0,
+    coverageMinimumBranchTotal := 0,
+    // Endpoint depends on http-model, which requires streams (Scala 3 only).
+    Compile / sources := {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) => Nil
+        case _            => (Compile / sources).value
+      }
+    },
+    Test / sources := {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) => Nil
+        case _            => (Test / sources).value
+      }
+    }
+  )
 
 lazy val markdown = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Full)
@@ -645,7 +670,7 @@ lazy val `schema-bson` = project
   .enablePlugins(BuildInfoPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "org.mongodb" % "bson"         % "5.7.0",
+      "org.mongodb" % "bson"         % "5.6.5",
       "dev.zio"    %% "zio-test"     % "2.1.25" % Test,
       "dev.zio"    %% "zio-test-sbt" % "2.1.25" % Test
     ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
@@ -847,8 +872,8 @@ lazy val benchmarks = project
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.38.9",
       "com.sksamuel.avro4s"                   %% "avro4s-core"           % "5.0.15",
       "dev.zio"                               %% "zio-json"              % "0.9.2",
-      "dev.zio"                               %% "zio-schema-avro"       % "1.8.5",
-      "dev.zio"                               %% "zio-schema-json"       % "1.8.5",
+      "dev.zio"                               %% "zio-schema-avro"       % "1.8.2",
+      "dev.zio"                               %% "zio-schema-json"       % "1.8.2",
       "io.github.arainko"                     %% "chanterelle"           % "0.1.2", // the last version that depends on Scala 3.7.x
       "com.softwaremill.quicklens"            %% "quicklens"             % "1.9.12",
       "dev.optics"                            %% "monocle-core"          % "3.3.0",
@@ -906,7 +931,7 @@ lazy val zioGolemModel = crossProject(JSPlatform, JVMPlatform)
   .jvmSettings(
     libraryDependencies ++= Seq(
       "com.lihaoyi" %% "ujson"                 % "3.1.0",
-      "dev.zio"     %% "zio-schema-derivation" % "1.8.5" % Test
+      "dev.zio"     %% "zio-schema-derivation" % "1.8.3" % Test
     )
   )
   .jsSettings(jsSettings)
@@ -977,7 +1002,7 @@ lazy val zioGolemMacros = project
       "dev.zio"     %% "zio-test"              % "2.1.25" % Test,
       "dev.zio"     %% "zio-test-sbt"          % "2.1.25" % Test,
       "com.lihaoyi" %% "ujson"                 % "3.1.0"  % Test,
-      "dev.zio"     %% "zio-schema-derivation" % "1.8.5"  % Test
+      "dev.zio"     %% "zio-schema-derivation" % "1.8.3"  % Test
     )
   )
   .dependsOn(zioGolemModel.jvm)
@@ -1119,7 +1144,10 @@ lazy val `streams-benchmark` = project
   .enablePlugins(JmhPlugin)
   .settings(
     // Requires JDK 21+ for Thread.ofVirtual() (Project Loom)
-    scalacOptions ~= (opts => removeOptionWithValue(opts, "-release")),
+    scalacOptions ~= { opts =>
+      opts.zipWithIndex.flatMap { case (o, i) => if (o == "-release") None else Some((o, i)) }
+        .map(_._1)
+    },
     scalacOptions ++= {
       val jdkVersion = System.getProperty("java.specification.version", "17").toInt
       if (jdkVersion >= 21) Seq("-release", "21") else Seq("-release", jdkVersion.toString)
@@ -1137,7 +1165,7 @@ lazy val `streams-benchmark` = project
       "co.fs2"        %% "fs2-core"    % "3.13.0",
       "org.typelevel" %% "cats-effect" % "3.7.0",
       // Apache Pekko Streams (Apache-2.0 fork of Akka Streams)
-      "org.apache.pekko" %% "pekko-stream" % "1.6.0",
+      "org.apache.pekko" %% "pekko-stream" % "1.5.0",
       // Kyo — algebraic effect streams (Scala 3 only)
       "io.getkyo" %% "kyo-prelude" % "0.19.0",
       "io.getkyo" %% "kyo-core"    % "0.19.0",
@@ -1251,6 +1279,7 @@ lazy val docs = project
     `schema-bson`,
     `schema-xml`.jvm,
     mediatype.jvm,
+    endpoint.jvm,
     `http-model`.jvm,
     `http-model-schema`.jvm,
     openapi.jvm

--- a/build.sbt
+++ b/build.sbt
@@ -164,6 +164,7 @@ lazy val root = project
     `http-model-schema`.jvm,
     `http-model-schema`.js,
     `http-model-examples`,
+    `endpoint-examples`,
     markdown.jvm,
     markdown.js,
     html.jvm,
@@ -589,6 +590,20 @@ lazy val endpoint = crossProject(JSPlatform, JVMPlatform)
       }
     }
   )
+
+lazy val `endpoint-examples` = project
+  .in(file("endpoint-examples"))
+  .settings(stdSettings("zio-blocks-endpoint-examples", Seq(BuildHelper.Scala3)))
+  .settings(
+    publish / skip             := true,
+    mimaPreviousArtifacts      := Set(),
+    coverageMinimumStmtTotal   := 0,
+    coverageMinimumBranchTotal := 0,
+    // endpoints { val name = Endpoint(...) } re-splices RHS trees, so named vals
+    // look "unused" to the compiler in main sources (test-only Wconf doesn't apply)
+    scalacOptions -= "-Werror"
+  )
+  .dependsOn(endpoint.jvm)
 
 lazy val markdown = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Full)

--- a/docs/reference/endpoint.md
+++ b/docs/reference/endpoint.md
@@ -1,0 +1,107 @@
+---
+id: endpoint
+title: "Endpoint"
+---
+
+`Endpoint[PathInput, Input, Err, Output, Auth]` is a pure descriptor for HTTP endpoints. It combines a route pattern with typed request input, typed error output, typed success output, authentication requirements, and documentation metadata.
+
+At a high level, the DSL is designed to stay close to zio-http where that improves ergonomics:
+
+```scala
+final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
+  route: RoutePattern[PathInput],
+  input: HttpCodec[CodecKind.Request, Input],
+  error: HttpCodec[CodecKind.Response, Err],
+  output: HttpCodec[CodecKind.Response, Output],
+  auth: Auth,
+  doc: Doc
+)
+```
+
+## Overview
+
+Endpoints are pure data. They describe an HTTP surface without committing to server or client interpretation up front.
+
+```scala mdoc:compile-only
+import zio.blocks.endpoint._
+import zio.blocks.endpoint.RoutePattern.*
+import zio.blocks.schema.Schema
+import zio.http.{Method, Status}
+
+val getUser = Endpoint(Method.GET / "users" / PathCodec.int("userId"))
+  .query("verbose", Schema.boolean)
+  .out(Schema.string)
+  .outError(Status.NotFound, Schema.string)
+  .auth(AuthType.Bearer)
+```
+
+## Route DSL
+
+The primary route syntax is method-first:
+
+```scala mdoc:compile-only
+import zio.blocks.endpoint._
+import zio.blocks.endpoint.RoutePattern.*
+import zio.http.Method
+
+val route = Method.GET / "users" / PathCodec.uuid("userId")
+```
+
+This keeps the route readable and matches the shape users already expect from zio-http.
+
+## Additive request and response builders
+
+Request inputs, outputs, and error outputs are additive. Calling a builder adds another part instead of replacing the previous one.
+
+```scala mdoc:compile-only
+import zio.blocks.endpoint._
+import zio.blocks.endpoint.RoutePattern.*
+import zio.blocks.schema.Schema
+import zio.http.{Method, Status}
+
+val endpoint = Endpoint(Method.POST / "users")
+  .in(Schema.string)
+  .header("X-Trace", Schema.string)
+  .out(Status.Created, Schema.int)
+  .outError(Status.BadRequest, Schema.string)
+```
+
+## Scala 3 union errors with `orOutError`
+
+On Scala 3, `orOutError` lets you accumulate error outputs into a real union type instead of nested `Either`s.
+
+```scala mdoc:compile-only
+import zio.blocks.endpoint._
+import zio.blocks.endpoint.RoutePattern.*
+import zio.blocks.schema.Schema
+import zio.http.{Method, Status}
+
+val endpoint = Endpoint(Method.GET / "users")
+  .orOutError(Status.BadRequest, Schema.string)
+  .orOutError(Status.Conflict, Schema.int)
+
+val typed: Endpoint[Unit, Unit, String | Int, Unit, AuthType.None.type] = endpoint
+```
+
+This improves on zio-http's current Scala 3-only error DSL by making the fallback combinator itself union-aware internally instead of only relying on type inference at the call site.
+
+Two constraints are intentional:
+
+- `outError(...)` remains the cross-version additive API
+- `orOutError(...)` rejects overlapping union members such as `String | String`
+
+## Typed authentication
+
+Authentication is part of the endpoint type. Built-in auth constructors keep the request requirement precise:
+
+```scala mdoc:compile-only
+import zio.blocks.endpoint._
+import zio.blocks.endpoint.RoutePattern.*
+import zio.http.Method
+
+val secured = Endpoint(Method.GET / "me").auth(AuthType.Bearer)
+
+val authCodec = secured.auth.codec
+```
+
+This makes it possible to require bearer, basic, or digest auth without dropping down to raw string headers.

--- a/docs/reference/endpoint.md
+++ b/docs/reference/endpoint.md
@@ -105,3 +105,50 @@ val authCodec = secured.auth.codec
 ```
 
 This makes it possible to require bearer, basic, or digest auth without dropping down to raw string headers.
+
+## Bulk endpoint creation with `endpoints { ... }`
+
+The `endpoints` macro (Scala 3.7+) lets you define multiple `Endpoint` values in a block and access them by name on the returned `NamedTuple`. Member names are either explicit `val` names or auto-generated from the `RoutePattern.render` string (method prefix + path template).
+
+```scala mdoc:compile-only
+import zio.blocks.endpoint._
+import zio.blocks.endpoint.RoutePattern.*
+import zio.http.Method
+import zio.blocks.schema.Schema
+import zio.http.Status
+
+val api = "api" / endpoints {
+  val customer = Endpoint(Method.GET / "customers")
+  Endpoint(Method.GET / "health")
+}
+```
+
+Member access is static (zero runtime cost):
+
+```scala mdoc:compile-only
+val c: Endpoint[Unit, Unit, Unit, Unit, AuthType.None.type] = api.customer
+val h: Endpoint[Unit, Unit, Unit, Unit, AuthType.None.type] = api.`GET /health`
+```
+
+Auto-naming follows `RoutePattern.render` exactly:
+
+- `GET /user/{userId}` for path variables (RFC 6570 `{var}`)
+- `GET#|POST /orders` for multi-method
+- `v{major}` for `~` concat segments
+- `...` for trailing segments
+- `.unused` renders as `{name}`
+
+Constant-prefix nesting bakes the prefix into each child's `RoutePattern` at the description level; grouping nodes have no path themselves:
+
+```scala mdoc:compile-only
+val v1 = "api" / endpoints {
+  "v1" / endpoints {
+    val users = Endpoint(Method.GET / "users")
+  }
+}
+val u = v1.v1.users  // route.render == "GET /api/v1/users"
+```
+
+Path-variable prefixes (`int("id") / endpoints { ... }`) are DESIGNED but not yet implemented (M4 deferred).
+
+The returned type is a Scala 3 `NamedTuple` — static member access, erased at runtime. The DSL is Scala 3 only (3.7+ named tuples). All examples above compile against the `endpoint` module on Scala 3.8.3.

--- a/docs/reference/endpoint.md
+++ b/docs/reference/endpoint.md
@@ -149,6 +149,37 @@ val v1 = "api" / endpoints {
 val u = v1.v1.users  // route.render == "GET /api/v1/users"
 ```
 
-Path-variable prefixes (`int("id") / endpoints { ... }`) are DESIGNED but not yet implemented (M4 deferred).
+Path-variable prefixes are implemented the same way. A capturing prefix contributes its segment to every child's path, while children keep their relative auto-names:
+
+```scala mdoc:compile-only
+import zio.blocks.endpoint._
+import zio.blocks.endpoint.RoutePattern.*
+import zio.http.Method
+
+val byId = PathCodec.int("id") / endpoints {
+  val get = Endpoint(Method.GET / "orders")
+  Endpoint(Method.DELETE / "orders") // auto-named `DELETE /orders`
+}
+
+val getOrder: Endpoint[Int, Unit, Unit, Unit, AuthType.None.type] = byId.get
+val delOrder = byId.`DELETE /orders`
+```
+
+Both children carry the captured segment: `byId.get.route.render == "GET /{id}/orders"` and the auto-named member renders `"DELETE /{id}/orders"`. Static types are preserved — `byId.get` is an `Endpoint[Int, Unit, Unit, Unit, AuthType.None.type]`, so the captured `id` will be delivered to handlers when routes are created on the zio-http side. A child with its own path variables composes positionally: under `int("id")`, `Endpoint(Method.GET / "orders" / PathCodec.int("orderId"))` renders as `GET /{id}/orders/{orderId}` and carries `(Int, Int)`:
+
+```scala mdoc:compile-only
+import zio.blocks.endpoint._
+import zio.blocks.endpoint.RoutePattern.*
+import zio.http.Method
+
+val ordersById = PathCodec.int("id") / endpoints {
+  val o = Endpoint(Method.GET / "orders" / PathCodec.int("orderId"))
+}
+
+val lookup: Endpoint[(Int, Int), Unit, Unit, Unit, AuthType.None.type] = ordersById.o
+// lookup.route.render == "GET /{id}/orders/{orderId}"
+```
+
+Variable prefixes should be bound to an explicit `val` — the val names the subgroup whose members you access through it (`byId.get`, `ordersById.o`). One known limitation: a constant-prefix subgroup directly inside a path-variable-prefixed block aborts compilation with guidance to use a flat block instead.
 
 The returned type is a Scala 3 `NamedTuple` — static member access, erased at runtime. The DSL is Scala 3 only (3.7+ named tuples). All examples above compile against the `endpoint` module on Scala 3.8.3.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -117,34 +117,33 @@ const sidebars = {
          "reference/combinators",
          "reference/docs",
          "reference/media-type",
-         {
-           type: "category",
-           label: "HTTP Model",
-           link: { type: "doc", id: "reference/http-model/index" },
-           items: [
-             "reference/http-model/model",
-             "reference/http-model/schema",
-           ]
-         },
-         "reference/openapi",
-         "reference/chunk",
-         "path-interpolator",
-         "reference/ringbuffer",
-         "reference/html",
           {
             type: "category",
-            label: "Streams",
-            link: { type: "doc", id: "reference/streams/index" },
+            label: "HTTP Model",
+            link: { type: "doc", id: "reference/http-model/index" },
             items: [
-              "reference/streams/stream",
-              "reference/streams/pipeline",
-              "reference/streams/sink",
-              "reference/streams/reader",
-              "reference/streams/writer",
-              "reference/streams/zero-boxing",
-              "reference/streams/scala-2-compatibility",
+              "reference/http-model/model",
+              "reference/http-model/schema",
             ]
           },
+          "reference/endpoint",
+          "reference/chunk",
+          "path-interpolator",
+          "reference/ringbuffer",
+         "reference/html",
+         {
+           type: "category",
+           label: "Streams",
+           link: { type: "doc", id: "reference/streams/index" },
+           items: [
+             "reference/streams/stream",
+             "reference/streams/pipeline",
+             "reference/streams/sink",
+             "reference/streams/reader",
+             "reference/streams/writer",
+             "reference/streams/zero-boxing",
+           ]
+         },
       ]
     },
     {

--- a/endpoint-examples/src/main/scala/endpointexamples/BulkEndpointsExample.scala
+++ b/endpoint-examples/src/main/scala/endpointexamples/BulkEndpointsExample.scala
@@ -3,10 +3,9 @@ package endpointexamples
 import zio.blocks.endpoint._
 import zio.blocks.endpoint.RoutePattern.*
 import zio.http.Method
-import zio.blocks.schema.Schema
-import zio.http.Status
+import scala.language.implicitConversions
 
-@main def runBulkEndpointsExample(): Unit =
+@main def runBulkEndpointsExample(): Unit = {
   val api = "api" / endpoints {
     val customer = Endpoint(Method.GET / "customers")
     Endpoint(Method.GET / "health")
@@ -20,3 +19,4 @@ import zio.http.Status
   assert(h.route.render == "GET /health")
 
   println("BulkEndpointsExample OK")
+}

--- a/endpoint-examples/src/main/scala/endpointexamples/BulkEndpointsExample.scala
+++ b/endpoint-examples/src/main/scala/endpointexamples/BulkEndpointsExample.scala
@@ -1,0 +1,22 @@
+package endpointexamples
+
+import zio.blocks.endpoint._
+import zio.blocks.endpoint.RoutePattern.*
+import zio.http.Method
+import zio.blocks.schema.Schema
+import zio.http.Status
+
+@main def runBulkEndpointsExample(): Unit =
+  val api = "api" / endpoints {
+    val customer = Endpoint(Method.GET / "customers")
+    Endpoint(Method.GET / "health")
+  }
+
+  // val-named and auto-named access
+  val c = api.customer
+  val h = api.`GET /health`
+
+  assert(c.route.render == "GET /customers")
+  assert(h.route.render == "GET /health")
+
+  println("BulkEndpointsExample OK")

--- a/endpoint/shared/src/main/scala-2/zio/blocks/endpoint/AlternatorPlatformSpecific.scala
+++ b/endpoint/shared/src/main/scala-2/zio/blocks/endpoint/AlternatorPlatformSpecific.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+private[endpoint] trait AlternatorPlatformSpecific

--- a/endpoint/shared/src/main/scala-2/zio/blocks/endpoint/EndpointUnionErrorBuilder.scala
+++ b/endpoint/shared/src/main/scala-2/zio/blocks/endpoint/EndpointUnionErrorBuilder.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+object EndpointUnionErrorBuilder {
+  trait ErrorBuilder[Err, E2] {
+    type Out
+
+    def add(existing: HttpCodec[CodecKind.Response, Err], next: HttpCodec[CodecKind.Response, E2]): HttpCodec[CodecKind.Response, Out]
+  }
+
+  object ErrorBuilder {
+    type WithOut[Err, E2, O] = ErrorBuilder[Err, E2] { type Out = O }
+  }
+}

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/AlternatorPlatformSpecific.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/AlternatorPlatformSpecific.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import zio.blocks.combinators.Unions
+
+private[endpoint] trait AlternatorPlatformSpecific {
+  self: Alternator.type =>
+
+  def fromUnions[L, R, O](unions: Unions.Unions.WithOut[L, R, O]): WithOut[L, R, O] =
+    new Alternator[L, R] {
+      type Out = O
+
+      def combine(either: Either[L, R]): O = unions.combine(either)
+
+      def separate(out: O): Either[L, R] = unions.separate(out)
+    }
+
+  given fromUnionsGiven[L, R, O](using unions: Unions.Unions.WithOut[L, R, O]): WithOut[L, R, O] =
+    fromUnions(unions)
+}

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupMacro.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupMacro.scala
@@ -25,7 +25,6 @@ object EndpointGroupMacro {
     def unwrap(term: Term): Term = term match {
       case Inlined(_, _, inner) => unwrap(inner)
       case Typed(inner, _)      => unwrap(inner)
-      case Block(List(single), _) if single.isInstanceOf[Inlined @unchecked | Typed @unchecked] => unwrap(single.asInstanceOf[Term])
       case _ => term
     }
 
@@ -34,36 +33,164 @@ object EndpointGroupMacro {
     def isEndpoint(tpe: TypeRepr): Boolean =
       tpe <:< TypeRepr.of[Endpoint[?, ?, ?, ?, ?]]
 
-    def collectMembers(stats: List[Statement]): List[(String, Term)] = stats.collect {
-      case vd: ValDef if vd.rhs.nonEmpty =>
-        val rhsTerm = vd.rhs.get
-        if (isEndpoint(rhsTerm.tpe)) {
-          (vd.name, rhsTerm)
-        } else {
-          report.errorAndAbort(s"endpoints { ... } only accepts `val name = Endpoint(...)` statements; found non-Endpoint val ${vd.name}")
+    def collectMembers(stats: List[Statement]): List[(String, Term)] = {
+      val raw = stats.flatMap {
+        case vd: ValDef if vd.rhs.nonEmpty =>
+          val rhsTerm = vd.rhs.get
+          if (isEndpoint(rhsTerm.tpe)) {
+            Some((vd.name, rhsTerm))
+          } else {
+            report.errorAndAbort(s"endpoints { ... } only accepts `val name = Endpoint(...)` statements; found non-Endpoint val ${vd.name}")
+          }
+        case app: Term if isEndpoint(app.tpe) =>
+          val name = autoName(app)
+          Some((name, app))
+        case other if !other.isInstanceOf[ValDef @unchecked] && !other.toString.trim.isEmpty =>
+          report.errorAndAbort("endpoints { ... } only accepts `val name = Endpoint(...)` statements or bare `Endpoint(...)` expressions")
+        case _ => None
+      }
+      val nameToTerms = raw.groupBy(_._1)
+      nameToTerms.foreach { case (n, list) =>
+        if (list.size > 1) {
+          val locs = list.map { case (_, t) => s"${t.pos.sourceFile.name}:${t.pos.startLine}" }.mkString(", ")
+          report.error(s"duplicate endpoint name `$n` from: $locs")
         }
-      case other if !other.isInstanceOf[ValDef @unchecked] && !other.toString.trim.isEmpty =>
-        report.errorAndAbort("endpoints { ... } only accepts `val name = Endpoint(...)` statements; bare expressions are not allowed in M1")
-      case _ => null
-    }.filter(_ != null).asInstanceOf[List[(String, Term)]]
+      }
+      raw
+    }
+
+    def autoName(endpointTerm: Term): String = {
+      import quotes.reflect.*
+      def stripWrappers(t: Term): Term = t match {
+        case TypeApply(inner, _) => stripWrappers(inner)
+        case Inlined(_, _, inner) => stripWrappers(inner)
+        case Typed(inner, _) => stripWrappers(inner)
+        case Apply(x, List(TypeApply(Ident("leftUnit"), _))) => stripWrappers(x)
+        case Apply(x, args) if args.exists { case TypeApply(Ident("leftUnit"), _) => true; case _ => false } => stripWrappers(x)
+        case _ => t
+      }
+      def peelToRoutePattern(t: Term): Term = t match {
+        case Apply(Select(qual, _), args) if Set("apply", "in", "out", "query", "header", "auth", "doc", "unauthorizedStatus", "orOutError", "outError", "outHeader").contains(qual.symbol.name) || qual.tpe <:< TypeRepr.of[Endpoint[?, ?, ?, ?, ?]] =>
+          args.headOption match {
+            case Some(rp) if rp.tpe <:< TypeRepr.of[RoutePattern[?]] => rp
+            case _ => peelToRoutePattern(qual)
+          }
+        case Apply(Select(Select(_, "Endpoint"), "apply"), List(rp)) => rp
+        case Apply(Select(Ident("Endpoint"), "apply"), List(rp)) => rp
+        case Apply(Select(qual, "apply"), List(rp)) if qual.tpe.typeSymbol.name == "Endpoint" => rp
+        case Apply(TypeApply(Select(Select(_, "Endpoint"), "apply"), _), List(rp)) => rp
+        case Apply(TypeApply(Select(Ident("Endpoint"), "apply"), _), List(rp)) => rp
+        case Apply(TypeApply(Apply(Ident("/"), _), _), List(rp)) => rp
+        case Apply(TypeApply(Apply(Select(_, "/"), _), _), List(rp)) => rp
+        case Apply(conversion, List(lit)) if conversion.tpe.toString.contains("Conversion") => lit
+        case Apply(Select(Ident(givenName), "apply"), List(lit)) if givenName.startsWith("given_Conversion") => lit
+        case _ => t
+      }
+      val rpTerm = peelToRoutePattern(stripWrappers(endpointTerm))
+      renderRoutePatternName(rpTerm)
+    }
+
+    def renderRoutePatternName(rpTerm0: Term): String = {
+      import quotes.reflect.*
+      def stripWrappers(t: Term): Term = t match {
+        case TypeApply(inner, _) => stripWrappers(inner)
+        case Inlined(_, _, inner) => stripWrappers(inner)
+        case Typed(inner, _) => stripWrappers(inner)
+        case Apply(x, List(TypeApply(Ident("leftUnit"), _))) => stripWrappers(x)
+        case Apply(x, args) if args.exists { case TypeApply(Ident("leftUnit"), _) => true; case _ => false } => stripWrappers(x)
+        case _ => t
+      }
+      val rpTerm = stripWrappers(rpTerm0)
+      def methodRender(m: Term): String = m match {
+        case Select(_, name) if Set("GET","POST","PUT","DELETE","PATCH","HEAD","OPTIONS","TRACE","CONNECT").contains(name) => name
+        case Select(_, "ANY") => "*"
+        case Apply(Select(left, "#|"), List(right)) =>
+          val ms = collectMethods(left) ++ collectMethods(right)
+          ms.toList.sortBy(identity).mkString("#|")
+        case _ => report.errorAndAbort(s"cannot auto-name: unsupported method tree ${Printer.TreeStructure.show(m)}")
+      }
+      def collectMethods(m: Term): Set[String] = m match {
+        case Select(_, name) if Set("GET","POST","PUT","DELETE","PATCH","HEAD","OPTIONS","TRACE","CONNECT").contains(name) => Set(name)
+        case Select(_, "ANY") => Set("*")
+        case Apply(Select(l, "#|"), List(r)) => collectMethods(l) ++ collectMethods(r)
+        case _ => Set()
+      }
+      def pathRender(p: Term): String = pathRender0(stripWrappers(p))
+      def pathRender0(p: Term): String = p match {
+        case Apply(Select(conv, "apply"), List(inner)) if conv.symbol.name.contains("Conversion") => pathRender0(inner)
+        case Apply(Select(Ident(givenName), "apply"), List(lit)) if givenName.startsWith("given_Conversion") => pathRender0(lit)
+        case Apply(conversion, List(lit)) if conversion.tpe.toString.contains("Conversion") => pathRender0(lit)
+        case Literal(StringConstant(s)) => s
+        case Apply(TypeApply(Select(Select(_, "PathCodec"), ctor), _), List(Literal(StringConstant(n)))) if Set("int","long","string","bool","uuid").contains(ctor) => s"{$n}"
+        case Apply(Select(Select(_, "PathCodec"), ctor), List(Literal(StringConstant(n)))) if Set("int","long","string","bool","uuid").contains(ctor) => s"{$n}"
+        case Apply(Select(qual, ctor), List(Literal(StringConstant(n)))) if Set("int","long","string","bool","uuid").contains(ctor) && qual.symbol.name == "PathCodec" => s"{$n}"
+        case Apply(Select(Select(_, "SegmentCodec"), ctor), List(Literal(StringConstant(n)))) if Set("int","long","string","bool","uuid").contains(ctor) => s"{$n}"
+        case Apply(Select(left, "/"), List(right)) => pathRender0(left) + "/" + pathRender0(right)
+        case Apply(TypeApply(Select(left, "/"), _), List(right)) => pathRender0(left) + "/" + pathRender0(right)
+        case Apply(Select(left, "~"), List(right)) => pathRender0(left) + pathRender0(right)
+        case Apply(Select(_, "trailing"), _) => "..."
+        case Apply(TypeApply(Ident("leftUnit"), _), List(inner)) => pathRender0(inner)
+        case Apply(Select(qual, "apply"), args) if qual.symbol.name == "PathCodec" => pathRender0(args.headOption.getOrElse(qual))
+        case _ => report.errorAndAbort(s"cannot auto-name: unsupported path tree ${Printer.TreeStructure.show(p)} ; assign to val instead")
+      }
+      def decompose(t0: Term): (String, List[String]) = {
+        val t = stripWrappers(t0)
+        t match {
+          case Apply(Select(left, "/"), List(right)) =>
+            val (m, segs) = decompose(left)
+            (m, segs :+ pathRender(right))
+          case Apply(TypeApply(Select(left, "/"), _), List(right)) =>
+            val (m, segs) = decompose(left)
+            (m, segs :+ pathRender(right))
+          case Apply(TypeApply(Apply(Ident("/"), List(method)), _), List(seg)) =>
+            (methodRender(method), List(pathRender(seg)))
+          case Apply(Apply(Ident("/"), List(method)), List(seg)) =>
+            (methodRender(method), List(pathRender(seg)))
+          case Apply(Ident("/"), List(method)) =>
+            (methodRender(method), Nil)
+          case m if m.tpe <:< TypeRepr.of[zio.http.Method] =>
+            (methodRender(m), Nil)
+          case Select(Ident("Method"), name) =>
+            (methodRender(t), Nil)
+          case _ =>
+            report.errorAndAbort(s"cannot auto-name this endpoint; assign it to a val. Tree: ${Printer.TreeStructure.show(t)}")
+        }
+      }
+      val (method, segments) = decompose(rpTerm)
+      val rendered = if (segments.isEmpty) "" else segments.mkString("/", "/", "")
+      if (segments.isEmpty) method else s"$method $rendered"
+    }
+
+    def isEndpointTerm(t: Term): Boolean = t match {
+      case vd: ValDef => vd.rhs.exists(rhs => isEndpoint(rhs.tpe))
+      case other      => isEndpoint(other.tpe)
+    }
 
     unwrapped match {
-      case Block(stats, _) =>
-        val members = collectMembers(stats)
-        if (members.isEmpty) {
+      case Block(stats, expr) =>
+        val memberStats: List[Statement] =
+          if (isEndpointTerm(expr) || expr.isInstanceOf[ValDef @unchecked]) stats :+ expr
+          else if (expr match { case Literal(UnitConstant()) => true; case _ => false }) stats
+          else stats
+        if (memberStats.isEmpty) {
           '{ NamedTuple(EmptyTuple) }
         } else {
-          val (names, terms) = members.unzip
-          val exprs = terms.map(_.asExprOf[Endpoint[?, ?, ?, ?, ?]])
-          val namesTupleExpr: Expr[Tuple] = Expr.ofTupleFromSeq(names.map(Expr(_)))
-          val namesTypeRepr: TypeRepr = namesTupleExpr.asTerm.tpe
-          val valuesTuple: Expr[Tuple] = Expr.ofTupleFromSeq(exprs)
-          val valuesTypeRepr: TypeRepr = valuesTuple.asTerm.tpe   // fallback; switch to terms.map(_.tpe) fold if needed for concrete
-          val ntType: TypeRepr =
-            AppliedType(TypeRepr.of[scala.NamedTuple.NamedTuple], List(namesTypeRepr, valuesTypeRepr))
-          ntType.asType match {
-            case '[nt] =>
-              '{ $valuesTuple.asInstanceOf[nt] }
+          val members = collectMembers(memberStats)
+          if (members.isEmpty) {
+            '{ NamedTuple(EmptyTuple) }
+          } else {
+            val (names, terms) = members.unzip
+            val exprs = terms.map(_.asExprOf[Endpoint[?, ?, ?, ?, ?]])
+            val namesTupleExpr: Expr[Tuple] = Expr.ofTupleFromSeq(names.map(Expr(_)))
+            val namesTypeRepr: TypeRepr = namesTupleExpr.asTerm.tpe
+            val valuesTuple: Expr[Tuple] = Expr.ofTupleFromSeq(exprs)
+            val valuesTypeRepr: TypeRepr = valuesTuple.asTerm.tpe
+            val ntType: TypeRepr =
+              AppliedType(TypeRepr.of[scala.NamedTuple.NamedTuple], List(namesTypeRepr, valuesTypeRepr))
+            ntType.asType match {
+              case '[nt] =>
+                '{ $valuesTuple.asInstanceOf[nt] }
+            }
           }
         }
 

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupMacro.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupMacro.scala
@@ -23,8 +23,12 @@ object EndpointGroupMacro {
     import quotes.reflect.*
 
     def unwrap(term: Term): Term = term match {
+      case Inlined(Some(Apply(Ident("endpoints"), List(b))), _, _)     => unwrap(b)
+      case Inlined(Some(Apply(Select(_, "endpoints"), List(b))), _, _) => unwrap(b)
       case Inlined(_, _, inner) => unwrap(inner)
       case Typed(inner, _)      => unwrap(inner)
+      case Apply(Ident("endpoints"), List(b))     => unwrap(b)
+      case Apply(Select(_, "endpoints"), List(b)) => unwrap(b)
       case _ => term
     }
 
@@ -33,26 +37,58 @@ object EndpointGroupMacro {
     def isEndpoint(tpe: TypeRepr): Boolean =
       tpe <:< TypeRepr.of[Endpoint[?, ?, ?, ?, ?]]
 
-    def collectMembers(stats: List[Statement]): List[(String, Term)] = {
+    def isNestedSubgroupStmt(t: Term): Option[(String, Term)] = t match {
+      case Inlined(Some(call: Term), _, _) =>
+        slashPrefix(call) match {
+          case Some(p) => Some((p, t))
+          case None    => isNestedSubgroupStmt(call)
+        }
+      case Inlined(_, _, inner) => isNestedSubgroupStmt(inner)
+      case Typed(inner, _)      => isNestedSubgroupStmt(inner)
+      case Apply(Apply(TypeApply(Apply(Ident("/"), List(Literal(StringConstant(p)))), _), _), List(_)) => Some((p, t))
+      case Apply(TypeApply(Apply(Ident("/"), List(Literal(StringConstant(p)))), _), List(_)) => Some((p, t))
+      case Apply(Apply(Ident("/"), List(Literal(StringConstant(p)))), List(_)) => Some((p, t))
+      case Apply(Select(Literal(StringConstant(p)), "/"), List(_)) => Some((p, t))
+      case Apply(TypeApply(Select(Literal(StringConstant(p)), "/"), _), List(_)) => Some((p, t))
+      case _ => None
+    }
+
+    def slashPrefix(t: Term): Option[String] = t match {
+      case Apply(Apply(TypeApply(Apply(Ident("/"), List(Literal(StringConstant(p)))), _), _), List(_)) => Some(p)
+      case Apply(TypeApply(Apply(Ident("/"), List(Literal(StringConstant(p)))), _), List(_)) => Some(p)
+      case Apply(Apply(Ident("/"), List(Literal(StringConstant(p)))), List(_)) => Some(p)
+      case Apply(Ident("/"), List(Literal(StringConstant(p)))) => Some(p)
+      case Apply(Select(Literal(StringConstant(p)), "/"), List(_)) => Some(p)
+      case Apply(TypeApply(Select(Literal(StringConstant(p)), "/"), _), List(_)) => Some(p)
+      case _ => None
+    }
+
+    def collectMembers(stats: List[Statement]): List[(String, Term, Boolean)] = {
       val raw = stats.flatMap {
         case vd: ValDef if vd.rhs.nonEmpty =>
-          val rhsTerm = vd.rhs.get
-          if (isEndpoint(rhsTerm.tpe)) {
-            Some((vd.name, rhsTerm))
+          val rhs = vd.rhs.get
+          if (isEndpoint(rhs.tpe)) {
+            Some((vd.name, rhs, false))
           } else {
             report.errorAndAbort(s"endpoints { ... } only accepts `val name = Endpoint(...)` statements; found non-Endpoint val ${vd.name}")
           }
         case app: Term if isEndpoint(app.tpe) =>
           val name = autoName(app)
-          Some((name, app))
-        case other if !other.isInstanceOf[ValDef @unchecked] && !other.toString.trim.isEmpty =>
-          report.errorAndAbort("endpoints { ... } only accepts `val name = Endpoint(...)` statements or bare `Endpoint(...)` expressions")
+          Some((name, app, false))
+        case other: Term =>
+          isNestedSubgroupStmt(other) match {
+            case Some((name, wholeSlashTerm)) =>
+              Some((name, wholeSlashTerm, true))
+            case None if !other.isInstanceOf[ValDef @unchecked] && !other.toString.trim.isEmpty =>
+              report.errorAndAbort("endpoints { ... } only accepts `val name = Endpoint(...)` statements, bare `Endpoint(...)` or `prefix / endpoints { ... }`")
+            case _ => None
+          }
         case _ => None
       }
       val nameToTerms = raw.groupBy(_._1)
       nameToTerms.foreach { case (n, list) =>
         if (list.size > 1) {
-          val locs = list.map { case (_, t) => s"${t.pos.sourceFile.name}:${t.pos.startLine}" }.mkString(", ")
+          val locs = list.map { case (_, t, _) => s"${t.pos.sourceFile.name}:${t.pos.startLine}" }.mkString(", ")
           report.error(s"duplicate endpoint name `$n` from: $locs")
         }
       }
@@ -169,7 +205,7 @@ object EndpointGroupMacro {
     unwrapped match {
       case Block(stats, expr) =>
         val memberStats: List[Statement] =
-          if (isEndpointTerm(expr) || expr.isInstanceOf[ValDef @unchecked]) stats :+ expr
+          if (isEndpointTerm(expr) || expr.isInstanceOf[ValDef @unchecked] || isNestedSubgroupStmt(expr).isDefined) stats :+ expr
           else if (expr match { case Literal(UnitConstant()) => true; case _ => false }) stats
           else stats
         if (memberStats.isEmpty) {
@@ -179,8 +215,10 @@ object EndpointGroupMacro {
           if (members.isEmpty) {
             '{ NamedTuple(EmptyTuple) }
           } else {
-            val (names, terms) = members.unzip
-            val exprs = terms.map(_.asExprOf[Endpoint[?, ?, ?, ?, ?]])
+            val (names, terms, isSubgroups) = members.unzip3
+            val exprs: List[Expr[Any]] = terms.zip(isSubgroups).map { case (t, isSub) =>
+              if (isSub) t.asExpr else t.asExprOf[Endpoint[?, ?, ?, ?, ?]]
+            }
             val namesTupleExpr: Expr[Tuple] = Expr.ofTupleFromSeq(names.map(Expr(_)))
             val namesTypeRepr: TypeRepr = namesTupleExpr.asTerm.tpe
             val valuesTuple: Expr[Tuple] = Expr.ofTupleFromSeq(exprs)
@@ -190,11 +228,13 @@ object EndpointGroupMacro {
             ntType.asType match {
               case '[nt] =>
                 '{ $valuesTuple.asInstanceOf[nt] }
+              case _ =>
+                report.errorAndAbort("failed to construct NamedTuple type for group")
             }
           }
         }
 
-      case vd: ValDef if vd.rhs.nonEmpty => // single-val no outer Block
+      case vd: ValDef if vd.rhs.nonEmpty =>
         val rhsTerm = vd.rhs.get
         if (isEndpoint(rhsTerm.tpe)) {
           val expr = rhsTerm.asExprOf[Endpoint[?, ?, ?, ?, ?]]
@@ -207,12 +247,31 @@ object EndpointGroupMacro {
           ntType.asType match {
             case '[nt] =>
               '{ $valuesTuple.asInstanceOf[nt] }
+            case _ =>
+              report.errorAndAbort("failed to construct NamedTuple type for group")
           }
         } else {
           report.errorAndAbort("endpoints { ... } only accepts `val name = Endpoint(...)` statements")
         }
 
-      case Block(Nil, _) | _ => '{ NamedTuple(EmptyTuple) }
+      case t: Term =>
+        isNestedSubgroupStmt(t) match {
+          case Some((name, whole)) =>
+            val members = List((name, whole, true))
+            val (names, terms, isSubgroups) = members.unzip3
+            val exprs: List[Expr[Any]] = terms.zip(isSubgroups).map { case (tt, isSub) => if (isSub) tt.asExpr else tt.asExprOf[Endpoint[?, ?, ?, ?, ?]] }
+            val namesTupleExpr: Expr[Tuple] = Expr.ofTupleFromSeq(names.map(Expr(_)))
+            val namesTypeRepr: TypeRepr = namesTupleExpr.asTerm.tpe
+            val valuesTuple: Expr[Tuple] = Expr.ofTupleFromSeq(exprs)
+            val valuesTypeRepr: TypeRepr = valuesTuple.asTerm.tpe
+            val ntType: TypeRepr = AppliedType(TypeRepr.of[scala.NamedTuple.NamedTuple], List(namesTypeRepr, valuesTypeRepr))
+            ntType.asType match {
+              case '[nt] => '{ $valuesTuple.asInstanceOf[nt] }
+              case _ => report.errorAndAbort("failed to construct NamedTuple type for single-subgroup group")
+            }
+          case None =>
+            '{ NamedTuple(EmptyTuple) }
+        }
     }
   }
 }

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupMacro.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupMacro.scala
@@ -17,10 +17,36 @@
 package zio.blocks.endpoint
 
 import scala.quoted.* // used for Expr/Quotes in build
+import zio.blocks.endpoint.{Endpoint, PathCodec, RoutePattern}
 
 object EndpointGroupMacro {
-  def build(body: Expr[Any])(using Quotes): Expr[Any] = {
+  def build(body: Expr[Any])(using Quotes): Expr[Any] = buildGroup(body, None)
+
+  def prefixGroup(codecExpr: Expr[PathCodec[?]], ntExpr: Expr[Any])(using Quotes): Expr[Any] = {
     import quotes.reflect.*
+
+    def recoverBlock(t: Term): Term = t match {
+      case Inlined(Some(Apply(Ident("endpoints"), List(b))), _, _)     => b
+      case Inlined(Some(Apply(Select(_, "endpoints"), List(b))), _, _) => b
+      case Inlined(_, _, inner) => recoverBlock(inner)
+      case Typed(inner, _)      => recoverBlock(inner)
+      case Apply(Select(Ident("NamedTuple"), "toTuple"), List(inner)) => recoverBlock(inner)
+      case Apply(Select(_, "toTuple"), List(inner)) => recoverBlock(inner)
+      case Apply(TypeApply(Select(Ident("NamedTuple"), "toTuple"), _), List(inner)) => recoverBlock(inner)
+      case Apply(TypeApply(Select(_, "toTuple"), _), List(inner)) => recoverBlock(inner)
+      case Apply(Ident("endpoints"), List(b))     => b
+      case Apply(Select(_, "endpoints"), List(b)) => b
+      case other => other
+    }
+    val block = recoverBlock(ntExpr.asTerm)
+    buildGroup(block.asExpr, Some(codecExpr))
+  }
+
+  private def buildGroup(bodyExpr: Expr[Any], captureCodecExpr: Option[Expr[Any]])(using Quotes): Expr[Any] = {
+    import quotes.reflect.*
+
+    val bodyTerm: Term = bodyExpr.asTerm
+    val captureCodec: Option[Term] = captureCodecExpr.map(_.asTerm)
 
     def unwrap(term: Term): Term = term match {
       case Inlined(Some(Apply(Ident("endpoints"), List(b))), _, _)     => unwrap(b)
@@ -32,7 +58,7 @@ object EndpointGroupMacro {
       case _ => term
     }
 
-    val unwrapped = unwrap(body.asTerm)
+    val unwrapped = unwrap(bodyTerm)
 
     def isEndpoint(tpe: TypeRepr): Boolean =
       tpe <:< TypeRepr.of[Endpoint[?, ?, ?, ?, ?]]
@@ -202,6 +228,36 @@ object EndpointGroupMacro {
       case other      => isEndpoint(other.tpe)
     }
 
+    def wrapLeaf(term: Term): Expr[Any] = captureCodec match {
+      case Some(codecTerm) =>
+        val codec = codecTerm.asExprOf[PathCodec[?]]
+        val epTpe = term.tpe
+        val (pi, i, e, o, a) = epTpe match {
+          case AppliedType(_, List(pi, i, e, o, a)) => (pi, i, e, o, a)
+          case _ => report.errorAndAbort(s"cannot read Endpoint type: ${epTpe.show}")
+        }
+        val codecA = codecTerm.tpe.dealias.widen match {
+          case AppliedType(_, List(a)) => a
+          case _ => report.errorAndAbort(s"cannot read PathCodec type: ${codecTerm.tpe.dealias.widen.show}")
+        }
+        val composedPI: TypeRepr =
+          if (pi =:= TypeRepr.of[Unit]) codecA
+          else if (pi <:< TypeRepr.of[Tuple]) TypeRepr.of[*:].appliedTo(List(codecA, pi))
+          else TypeRepr.of[*:].appliedTo(List(codecA, TypeRepr.of[*:].appliedTo(List(pi, TypeRepr.of[EmptyTuple]))))
+        val composedEndpoint: TypeRepr =
+          TypeRepr.of[Endpoint].appliedTo(List(composedPI, i, e, o, a))
+        (codecA.asType, pi.asType, composedEndpoint.asType) match {
+          case ('[ca], '[cp], '[ce]) =>
+            val ep = term.asExprOf[Endpoint[?, ?, ?, ?, ?]]
+            '{ $ep.copy(route = $ep.route.copy(pathCodec = $codec.asInstanceOf[PathCodec[ca]] ++ $ep.route.pathCodec.asInstanceOf[PathCodec[cp]])).asInstanceOf[ce] }
+        }
+      case None => term.asExprOf[Endpoint[?, ?, ?, ?, ?]]
+    }
+
+    def wrapSubgroupError(): Nothing =
+      if (captureCodec.isDefined) report.errorAndAbort("nested constant groups under a path-variable prefix are not yet supported; use a flat block")
+      else sys.error("internal: subgroup under capture without error")
+
     unwrapped match {
       case Block(stats, expr) =>
         val memberStats: List[Statement] =
@@ -217,7 +273,11 @@ object EndpointGroupMacro {
           } else {
             val (names, terms, isSubgroups) = members.unzip3
             val exprs: List[Expr[Any]] = terms.zip(isSubgroups).map { case (t, isSub) =>
-              if (isSub) t.asExpr else t.asExprOf[Endpoint[?, ?, ?, ?, ?]]
+              if (isSub) {
+                if (captureCodec.isDefined) wrapSubgroupError() else t.asExpr
+              } else {
+                wrapLeaf(t)
+              }
             }
             val namesTupleExpr: Expr[Tuple] = Expr.ofTupleFromSeq(names.map(Expr(_)))
             val namesTypeRepr: TypeRepr = namesTupleExpr.asTerm.tpe
@@ -237,7 +297,7 @@ object EndpointGroupMacro {
       case vd: ValDef if vd.rhs.nonEmpty =>
         val rhsTerm = vd.rhs.get
         if (isEndpoint(rhsTerm.tpe)) {
-          val expr = rhsTerm.asExprOf[Endpoint[?, ?, ?, ?, ?]]
+          val expr = wrapLeaf(rhsTerm)
           val namesTupleExpr: Expr[Tuple] = Expr.ofTupleFromSeq(List(Expr(vd.name)))
           val namesTypeRepr: TypeRepr = namesTupleExpr.asTerm.tpe
           val valuesTuple: Expr[Tuple] = Expr.ofTupleFromSeq(Seq(expr))
@@ -257,9 +317,10 @@ object EndpointGroupMacro {
       case t: Term =>
         isNestedSubgroupStmt(t) match {
           case Some((name, whole)) =>
+            if (captureCodec.isDefined) wrapSubgroupError()
             val members = List((name, whole, true))
             val (names, terms, isSubgroups) = members.unzip3
-            val exprs: List[Expr[Any]] = terms.zip(isSubgroups).map { case (tt, isSub) => if (isSub) tt.asExpr else tt.asExprOf[Endpoint[?, ?, ?, ?, ?]] }
+            val exprs: List[Expr[Any]] = terms.zip(isSubgroups).map { case (tt, isSub) => if (isSub) tt.asExpr else wrapLeaf(tt) }
             val namesTupleExpr: Expr[Tuple] = Expr.ofTupleFromSeq(names.map(Expr(_)))
             val namesTypeRepr: TypeRepr = namesTupleExpr.asTerm.tpe
             val valuesTuple: Expr[Tuple] = Expr.ofTupleFromSeq(exprs)

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupMacro.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupMacro.scala
@@ -70,7 +70,7 @@ object EndpointGroupMacro {
           if (isEndpoint(rhs.tpe)) {
             Some((vd.name, rhs, false))
           } else {
-            report.errorAndAbort(s"endpoints { ... } only accepts `val name = Endpoint(...)` statements; found non-Endpoint val ${vd.name}")
+            report.errorAndAbort(s"endpoints { ... } only accepts `val name = Endpoint(...)` statements; found non-Endpoint val ${vd.name} of type ${rhs.tpe.show}")
           }
         case app: Term if isEndpoint(app.tpe) =>
           val name = autoName(app)
@@ -89,7 +89,7 @@ object EndpointGroupMacro {
       nameToTerms.foreach { case (n, list) =>
         if (list.size > 1) {
           val locs = list.map { case (_, t, _) => s"${t.pos.sourceFile.name}:${t.pos.startLine}" }.mkString(", ")
-          report.error(s"duplicate endpoint name `$n` from: $locs")
+          report.error(s"duplicate endpoint name `$n` from: $locs; rename one or assign to an explicit `val`")
         }
       }
       raw
@@ -143,7 +143,7 @@ object EndpointGroupMacro {
         case Apply(Select(left, "#|"), List(right)) =>
           val ms = collectMethods(left) ++ collectMethods(right)
           ms.toList.sortBy(identity).mkString("#|")
-        case _ => report.errorAndAbort(s"cannot auto-name: unsupported method tree ${Printer.TreeStructure.show(m)}")
+        case _ => report.errorAndAbort(s"cannot auto-name: unsupported method tree ${Printer.TreeStructure.show(m)} ; assign to val instead")
       }
       def collectMethods(m: Term): Set[String] = m match {
         case Select(_, name) if Set("GET","POST","PUT","DELETE","PATCH","HEAD","OPTIONS","TRACE","CONNECT").contains(name) => Set(name)

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupMacro.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupMacro.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import scala.quoted.* // used for Expr/Quotes in build
+
+object EndpointGroupMacro {
+  def build(body: Expr[Any])(using Quotes): Expr[Any] = {
+    import quotes.reflect.*
+
+    def unwrap(term: Term): Term = term match {
+      case Inlined(_, _, inner) => unwrap(inner)
+      case Typed(inner, _)      => unwrap(inner)
+      case Block(List(single), _) if single.isInstanceOf[Inlined @unchecked | Typed @unchecked] => unwrap(single.asInstanceOf[Term])
+      case _ => term
+    }
+
+    val unwrapped = unwrap(body.asTerm)
+
+    def isEndpoint(tpe: TypeRepr): Boolean =
+      tpe <:< TypeRepr.of[Endpoint[?, ?, ?, ?, ?]]
+
+    def collectMembers(stats: List[Statement]): List[(String, Term)] = stats.collect {
+      case vd: ValDef if vd.rhs.nonEmpty =>
+        val rhsTerm = vd.rhs.get
+        if (isEndpoint(rhsTerm.tpe)) {
+          (vd.name, rhsTerm)
+        } else {
+          report.errorAndAbort(s"endpoints { ... } only accepts `val name = Endpoint(...)` statements; found non-Endpoint val ${vd.name}")
+        }
+      case other if !other.isInstanceOf[ValDef @unchecked] && !other.toString.trim.isEmpty =>
+        report.errorAndAbort("endpoints { ... } only accepts `val name = Endpoint(...)` statements; bare expressions are not allowed in M1")
+      case _ => null
+    }.filter(_ != null).asInstanceOf[List[(String, Term)]]
+
+    unwrapped match {
+      case Block(stats, _) =>
+        val members = collectMembers(stats)
+        if (members.isEmpty) {
+          '{ NamedTuple(EmptyTuple) }
+        } else {
+          val (names, terms) = members.unzip
+          val exprs = terms.map(_.asExprOf[Endpoint[?, ?, ?, ?, ?]])
+          val namesTupleExpr: Expr[Tuple] = Expr.ofTupleFromSeq(names.map(Expr(_)))
+          val namesTypeRepr: TypeRepr = namesTupleExpr.asTerm.tpe
+          val valuesTuple: Expr[Tuple] = Expr.ofTupleFromSeq(exprs)
+          val valuesTypeRepr: TypeRepr = valuesTuple.asTerm.tpe   // fallback; switch to terms.map(_.tpe) fold if needed for concrete
+          val ntType: TypeRepr =
+            AppliedType(TypeRepr.of[scala.NamedTuple.NamedTuple], List(namesTypeRepr, valuesTypeRepr))
+          ntType.asType match {
+            case '[nt] =>
+              '{ $valuesTuple.asInstanceOf[nt] }
+          }
+        }
+
+      case vd: ValDef if vd.rhs.nonEmpty => // single-val no outer Block
+        val rhsTerm = vd.rhs.get
+        if (isEndpoint(rhsTerm.tpe)) {
+          val expr = rhsTerm.asExprOf[Endpoint[?, ?, ?, ?, ?]]
+          val namesTupleExpr: Expr[Tuple] = Expr.ofTupleFromSeq(List(Expr(vd.name)))
+          val namesTypeRepr: TypeRepr = namesTupleExpr.asTerm.tpe
+          val valuesTuple: Expr[Tuple] = Expr.ofTupleFromSeq(Seq(expr))
+          val valuesTypeRepr: TypeRepr = valuesTuple.asTerm.tpe
+          val ntType: TypeRepr =
+            AppliedType(TypeRepr.of[scala.NamedTuple.NamedTuple], List(namesTypeRepr, valuesTypeRepr))
+          ntType.asType match {
+            case '[nt] =>
+              '{ $valuesTuple.asInstanceOf[nt] }
+          }
+        } else {
+          report.errorAndAbort("endpoints { ... } only accepts `val name = Endpoint(...)` statements")
+        }
+
+      case Block(Nil, _) | _ => '{ NamedTuple(EmptyTuple) }
+    }
+  }
+}

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupSyntax.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupSyntax.scala
@@ -18,3 +18,8 @@ package zio.blocks.endpoint
 
 transparent inline def endpoints(inline body: Any): Any =
   ${ EndpointGroupMacro.build('body) }
+
+extension (prefix: String) {
+  transparent inline def /[N <: Tuple, V <: Tuple](inline nt: NamedTuple.NamedTuple[N, V])(using nv: NestPrefix[V]): NamedTuple.NamedTuple[N, V] =
+    nv.nest(nt.asInstanceOf[V], prefix).asInstanceOf[NamedTuple.NamedTuple[N, V]]
+}

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupSyntax.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupSyntax.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+transparent inline def endpoints(inline body: Any): Any =
+  ${ EndpointGroupMacro.build('body) }

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupSyntax.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointGroupSyntax.scala
@@ -16,10 +16,17 @@
 
 package zio.blocks.endpoint
 
+import zio.blocks.endpoint.PathCodec
+
 transparent inline def endpoints(inline body: Any): Any =
   ${ EndpointGroupMacro.build('body) }
 
 extension (prefix: String) {
   transparent inline def /[N <: Tuple, V <: Tuple](inline nt: NamedTuple.NamedTuple[N, V])(using nv: NestPrefix[V]): NamedTuple.NamedTuple[N, V] =
     nv.nest(nt.asInstanceOf[V], prefix).asInstanceOf[NamedTuple.NamedTuple[N, V]]
+}
+
+extension [A](codec: PathCodec[A]) {
+  transparent inline def /[NT <: Tuple](inline nt: NT): Any =
+    ${ EndpointGroupMacro.prefixGroup('codec, 'nt) }
 }

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointUnionErrorBuilder.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/EndpointUnionErrorBuilder.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import zio.blocks.combinators.Unions
+
+object EndpointUnionErrorBuilder {
+  trait ErrorBuilder[Err, E2] {
+    type Out
+
+    def add(existing: HttpCodec[CodecKind.Response, Err], next: HttpCodec[CodecKind.Response, E2]): HttpCodec[CodecKind.Response, Out]
+  }
+
+  object ErrorBuilder {
+    type WithOut[Err, E2, O] = ErrorBuilder[Err, E2] { type Out = O }
+
+    given initialError[E2]: ErrorBuilder[Unit, E2] with {
+      type Out = E2
+
+      def add(
+        existing: HttpCodec[CodecKind.Response, Unit],
+        next: HttpCodec[CodecKind.Response, E2]
+      ): HttpCodec[CodecKind.Response, E2] = next
+    }
+
+    given unionError[Err, E2, E3](using alternator: Unions.Unions.WithOut[Err, E2, E3]): ErrorBuilder[Err, E2] with {
+      type Out = E3
+
+      def add(
+        existing: HttpCodec[CodecKind.Response, Err],
+        next: HttpCodec[CodecKind.Response, E2]
+      ): HttpCodec[CodecKind.Response, E3] =
+        HttpCodec.Fallback(existing, next, Alternator.fromUnions(alternator))
+    }
+  }
+}

--- a/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/NestPrefix.scala
+++ b/endpoint/shared/src/main/scala-3/zio/blocks/endpoint/NestPrefix.scala
@@ -1,0 +1,35 @@
+package zio.blocks.endpoint
+
+import scala.NamedTuple
+import zio.blocks.endpoint.Endpoint
+import zio.blocks.endpoint.AuthType
+import zio.blocks.endpoint.PathCodec
+
+/** Runtime type-class: nest a constant path prefix into every Endpoint leaf of a group. */
+trait NestPrefix[NT] {
+  def nest(nt: NT, prefix: String): NT
+}
+
+object NestPrefix {
+  // Endpoint leaf: copy with route.nest(PathCodec(prefix)) — preserves PathVars (prefix PathVars = EmptyTuple)
+  given endpointNest[PathInput, Input, Err, Output, Auth <: AuthType]: NestPrefix[Endpoint[PathInput, Input, Err, Output, Auth]] with {
+    def nest(ep: Endpoint[PathInput, Input, Err, Output, Auth], prefix: String): Endpoint[PathInput, Input, Err, Output, Auth] =
+      ep.copy(route = ep.route.nest(PathCodec(prefix)))
+  }
+
+  given emptyNest: NestPrefix[EmptyTuple] with {
+    def nest(t: EmptyTuple, prefix: String): EmptyTuple = t
+  }
+
+  // Tuple cons: recurse head + tail (element can be Endpoint or a nested NamedTuple)
+  given consNest[H, T <: Tuple](using nh: NestPrefix[H], nt: NestPrefix[T]): NestPrefix[H *: T] with {
+    def nest(t: H *: T, prefix: String): H *: T =
+      nh.nest(t.head, prefix) *: nt.nest(t.tail, prefix)
+  }
+
+  // NamedTuple: the runtime value IS the values-tuple; recurse into it and re-wrap preserving names
+  given namedTupleNest[N <: Tuple, V <: Tuple](using nv: NestPrefix[V]): NestPrefix[NamedTuple.NamedTuple[N, V]] with {
+    def nest(nt: NamedTuple.NamedTuple[N, V], prefix: String): NamedTuple.NamedTuple[N, V] =
+      nv.nest(nt.asInstanceOf[V], prefix).asInstanceOf[NamedTuple.NamedTuple[N, V]]
+  }
+}

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/Alternator.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/Alternator.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import zio.blocks.combinators.Eithers
+
+trait Alternator[L, R] {
+  type Out
+
+  def combine(either: Either[L, R]): Out
+
+  def separate(out: Out): Either[L, R]
+}
+
+object Alternator extends AlternatorPlatformSpecific {
+  type WithOut[L, R, O] = Alternator[L, R] { type Out = O }
+
+  def fromEithers[L, R, O](eithers: Eithers.Eithers.WithOut[L, R, O]): WithOut[L, R, O] =
+    new Alternator[L, R] {
+      type Out = O
+
+      def combine(either: Either[L, R]): O = eithers.combine(either)
+
+      def separate(out: O): Either[L, R] = eithers.separate(out)
+    }
+
+  implicit def fromEithersImplicit[L, R, O](implicit eithers: Eithers.Eithers.WithOut[L, R, O]): WithOut[L, R, O] =
+    fromEithers(eithers)
+}

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/AuthType.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/AuthType.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import zio.blocks.combinators.Eithers
+import zio.http.{Status, headers}
+
+/** Authentication scheme descriptor aligned with zio-http's typed auth model. */
+sealed trait AuthType { self =>
+  type ClientRequirement
+
+  def codec: HttpCodec[CodecKind.Request, ClientRequirement]
+
+  def unauthorizedStatus: Status = Status.NotFound
+
+  def withUnauthorizedStatus(status: Status): AuthType { type ClientRequirement = self.ClientRequirement } =
+    AuthType.WithStatus(
+      self.asInstanceOf[AuthType { type ClientRequirement = self.ClientRequirement }],
+      status
+    )
+
+  def |[ClientReq2, ClientReq](that: AuthType { type ClientRequirement = ClientReq2 })(using
+    alternator: Eithers.Eithers.WithOut[ClientRequirement, ClientReq2, ClientReq]
+  ): AuthType { type ClientRequirement = ClientReq } =
+    AuthType.Or(
+      self.asInstanceOf[AuthType { type ClientRequirement = self.ClientRequirement }],
+      that,
+      alternator
+    )
+}
+
+object AuthType {
+  type None   = None.type
+  type Basic  = Basic.type
+  type Bearer = Bearer.type
+
+  case object None extends AuthType {
+    type ClientRequirement = Unit
+    override val codec: HttpCodec[CodecKind.Request, Unit] = HttpCodec.empty
+  }
+
+  case object Basic extends AuthType {
+    type ClientRequirement = headers.Authorization.Basic
+    override val codec: HttpCodec[CodecKind.Request, headers.Authorization.Basic] =
+      HttpCodec.basicAuth
+  }
+
+  case object Bearer extends AuthType {
+    type ClientRequirement = headers.Authorization.Bearer
+    override val codec: HttpCodec[CodecKind.Request, headers.Authorization.Bearer] =
+      HttpCodec.bearerAuth
+  }
+
+  case object Digest extends AuthType {
+    type ClientRequirement = headers.Authorization.Digest
+    override val codec: HttpCodec[CodecKind.Request, headers.Authorization.Digest] =
+      HttpCodec.digestAuth
+  }
+
+  final case class Custom[ClientReq](override val codec: HttpCodec[CodecKind.Request, ClientReq]) extends AuthType {
+    type ClientRequirement = ClientReq
+  }
+
+  final case class Or[ClientReq1, ClientReq2, ClientReq](
+    left: AuthType { type ClientRequirement = ClientReq1 },
+    right: AuthType { type ClientRequirement = ClientReq2 },
+    alternator: Eithers.Eithers.WithOut[ClientReq1, ClientReq2, ClientReq]
+  ) extends AuthType {
+    type ClientRequirement = ClientReq
+    override val codec: HttpCodec[CodecKind.Request, ClientReq] =
+      HttpCodec.Fallback(left.codec, right.codec, Alternator.fromEithers(alternator))
+    override def unauthorizedStatus: Status                     = left.unauthorizedStatus
+  }
+
+  final case class WithStatus[ClientReq](
+    authType: AuthType { type ClientRequirement = ClientReq },
+    override val unauthorizedStatus: Status
+  ) extends AuthType {
+    type ClientRequirement = ClientReq
+    override val codec: HttpCodec[CodecKind.Request, ClientReq] = authType.codec
+  }
+
+  final case class Scoped[ClientReq](
+    inner: AuthType { type ClientRequirement = ClientReq },
+    scopes: List[String]
+  ) extends AuthType {
+    type ClientRequirement = ClientReq
+    override val codec: HttpCodec[CodecKind.Request, ClientReq] = inner.codec
+    override def unauthorizedStatus: Status                     = inner.unauthorizedStatus
+  }
+}

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/Endpoint.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/Endpoint.scala
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import zio.blocks.docs.Doc
+import zio.blocks.combinators.Eithers
+import zio.blocks.combinators.Tuples
+import zio.blocks.mediatype.MediaType
+import zio.blocks.schema.Schema
+import zio.http.Status
+
+/**
+ * Top-level endpoint descriptor. Combines a route pattern with
+ * input/output/error HTTP codecs, authentication, and documentation.
+ *
+ * Pure data — no `implement*` methods, no `Invocation`, no codec errors.
+ */
+final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
+  route: RoutePattern[PathInput],
+  input: HttpCodec[CodecKind.Request, Input],
+  error: HttpCodec[CodecKind.Response, Err],
+  output: HttpCodec[CodecKind.Response, Output],
+  auth: Auth,
+  doc: Doc
+) {
+  def in[I2, I3](codec: HttpCodec[CodecKind.Request, I2])(using
+    combiner: Tuples.Tuples.WithOut[Input, I2, I3]
+  ): Endpoint[PathInput, I3, Err, Output, Auth] =
+    copy(input = input ++ codec)
+
+  def in[I2, I3](schema: Schema[I2])(using
+    combiner: Tuples.Tuples.WithOut[Input, I2, I3]
+  ): Endpoint[PathInput, I3, Err, Output, Auth] =
+    copy(input = input ++ HttpCodec.requestBody(schema))
+
+  def in[I2, I3](schema: Schema[I2], doc: Doc)(using
+    combiner: Tuples.Tuples.WithOut[Input, I2, I3]
+  ): Endpoint[PathInput, I3, Err, Output, Auth] =
+    copy(input = input ++ HttpCodec.requestBody(schema, doc = doc))
+
+  def in[I2, I3](mediaType: MediaType, schema: Schema[I2])(using
+    combiner: Tuples.Tuples.WithOut[Input, I2, I3]
+  ): Endpoint[PathInput, I3, Err, Output, Auth] =
+    copy(input = input ++ HttpCodec.requestBody(schema, zio.blocks.chunk.Chunk.single(mediaType)))
+
+  def in[I2, I3](mediaType: MediaType, schema: Schema[I2], doc: Doc)(using
+    combiner: Tuples.Tuples.WithOut[Input, I2, I3]
+  ): Endpoint[PathInput, I3, Err, Output, Auth] =
+    copy(input = input ++ HttpCodec.requestBody(schema, zio.blocks.chunk.Chunk.single(mediaType), doc = doc))
+
+  def query[I2, I3](codec: HttpCodec.Query[I2])(using
+    combiner: Tuples.Tuples.WithOut[Input, I2, I3]
+  ): Endpoint[PathInput, I3, Err, Output, Auth] =
+    copy(input = input ++ codec)
+
+  def header[I2, I3](codec: HttpCodec.Header[CodecKind.Request, I2])(using
+    combiner: Tuples.Tuples.WithOut[Input, I2, I3]
+  ): Endpoint[PathInput, I3, Err, Output, Auth] =
+    copy(input = input ++ codec)
+
+  def header[A, I2](name: String, schema: Schema[A])(using
+    combiner: Tuples.Tuples.WithOut[Input, A, I2]
+  ): Endpoint[PathInput, I2, Err, Output, Auth] =
+    header(HttpCodec.requestHeader(name, schema))
+
+  def header[A, I2](name: String, schema: Schema[A], doc: Doc)(using
+    combiner: Tuples.Tuples.WithOut[Input, A, I2]
+  ): Endpoint[PathInput, I2, Err, Output, Auth] =
+    header(HttpCodec.requestHeader(name, schema, doc = doc))
+
+  def out[O2, O3](codec: HttpCodec[CodecKind.Response, O2])(using
+    alternator: Eithers.Eithers.WithOut[O2, Output, O3]
+  ): Endpoint[PathInput, Input, Err, O3, Auth] =
+    copy(output = codec | output)
+
+  def out[O2, O3](schema: Schema[O2])(using
+    alternator: Eithers.Eithers.WithOut[O2, Output, O3]
+  ): Endpoint[PathInput, Input, Err, O3, Auth] =
+    copy(output = (HttpCodec.responseBody(schema) ++ HttpCodec.Ok) | output)
+
+  def out[O2, O3](schema: Schema[O2], doc: Doc)(using
+    alternator: Eithers.Eithers.WithOut[O2, Output, O3]
+  ): Endpoint[PathInput, Input, Err, O3, Auth] =
+    copy(output = (HttpCodec.responseBody(schema, doc = doc) ++ HttpCodec.Ok) | output)
+
+  def out[O2, O3](status: Status, schema: Schema[O2])(using
+    alternator: Eithers.Eithers.WithOut[O2, Output, O3]
+  ): Endpoint[PathInput, Input, Err, O3, Auth] =
+    copy(output = (HttpCodec.responseBody(schema) ++ HttpCodec.status(status)) | output)
+
+  def out[O2, O3](mediaType: MediaType, schema: Schema[O2])(using
+    alternator: Eithers.Eithers.WithOut[O2, Output, O3]
+  ): Endpoint[PathInput, Input, Err, O3, Auth] =
+    copy(output =
+      (HttpCodec.responseBody(schema, mediaTypes = zio.blocks.chunk.Chunk.single(mediaType)) ++ HttpCodec.Ok) | output
+    )
+
+  def out[O2, O3](status: Status, schema: Schema[O2], doc: Doc)(using
+    alternator: Eithers.Eithers.WithOut[O2, Output, O3]
+  ): Endpoint[PathInput, Input, Err, O3, Auth] =
+    copy(output = (HttpCodec.responseBody(schema, doc = doc) ++ HttpCodec.status(status, doc)) | output)
+
+  def out[O2, O3](mediaType: MediaType, schema: Schema[O2], doc: Doc)(using
+    alternator: Eithers.Eithers.WithOut[O2, Output, O3]
+  ): Endpoint[PathInput, Input, Err, O3, Auth] =
+    copy(
+      output = (HttpCodec.responseBody(
+        schema,
+        mediaTypes = zio.blocks.chunk.Chunk.single(mediaType),
+        doc = doc
+      ) ++ HttpCodec.Ok) | output
+    )
+
+  def out[O2, O3](status: Status, mediaType: MediaType, schema: Schema[O2])(using
+    alternator: Eithers.Eithers.WithOut[O2, Output, O3]
+  ): Endpoint[PathInput, Input, Err, O3, Auth] =
+    copy(
+      output =
+        (HttpCodec.responseBody(schema, mediaTypes = zio.blocks.chunk.Chunk.single(mediaType)) ++ HttpCodec.status(
+          status
+        )) | output
+    )
+
+  def out[O2, O3](status: Status, mediaType: MediaType, schema: Schema[O2], doc: Doc)(using
+    alternator: Eithers.Eithers.WithOut[O2, Output, O3]
+  ): Endpoint[PathInput, Input, Err, O3, Auth] =
+    copy(
+      output =
+        (HttpCodec.responseBody(schema, mediaTypes = zio.blocks.chunk.Chunk.single(mediaType), doc = doc) ++ HttpCodec
+          .status(status, doc)) | output
+    )
+
+  def outError[E2, E3](codec: HttpCodec[CodecKind.Response, E2])(using
+    alternator: Eithers.Eithers.WithOut[E2, Err, E3]
+  ): Endpoint[PathInput, Input, E3, Output, Auth] =
+    copy(error = codec | error)
+
+  def orOutError[E2, E3](codec: HttpCodec[CodecKind.Response, E2])(using
+    builder: EndpointUnionErrorBuilder.ErrorBuilder.WithOut[Err, E2, E3]
+  ): Endpoint[PathInput, Input, E3, Output, Auth] =
+    copy(error = builder.add(error, codec))
+
+  def outError[E2, E3](status: Status, schema: Schema[E2])(using
+    alternator: Eithers.Eithers.WithOut[E2, Err, E3]
+  ): Endpoint[PathInput, Input, E3, Output, Auth] =
+    copy(error = (HttpCodec.responseBody(schema, name = Some("error-response")) ++ HttpCodec.status(status)) | error)
+
+  def orOutError[E2, E3](status: Status, schema: Schema[E2])(using
+    builder: EndpointUnionErrorBuilder.ErrorBuilder.WithOut[Err, E2, E3]
+  ): Endpoint[PathInput, Input, E3, Output, Auth] =
+    orOutError(HttpCodec.responseBody(schema, name = Some("error-response")) ++ HttpCodec.status(status))
+
+  def outError[E2, E3](status: Status, schema: Schema[E2], doc: Doc)(using
+    alternator: Eithers.Eithers.WithOut[E2, Err, E3]
+  ): Endpoint[PathInput, Input, E3, Output, Auth] =
+    copy(error =
+      ((HttpCodec.responseBody(schema, name = Some("error-response"), doc = doc) ++ HttpCodec
+        .status(status, doc))) | error
+    )
+
+  def orOutError[E2, E3](status: Status, schema: Schema[E2], doc: Doc)(using
+    builder: EndpointUnionErrorBuilder.ErrorBuilder.WithOut[Err, E2, E3]
+  ): Endpoint[PathInput, Input, E3, Output, Auth] =
+    orOutError(
+      HttpCodec.responseBody(schema, name = Some("error-response"), doc = doc) ++ HttpCodec.status(status, doc)
+    )
+
+  def outError[E2, E3](status: Status, mediaType: MediaType, schema: Schema[E2])(using
+    alternator: Eithers.Eithers.WithOut[E2, Err, E3]
+  ): Endpoint[PathInput, Input, E3, Output, Auth] =
+    copy(
+      error = ((HttpCodec.responseBody(
+        schema,
+        mediaTypes = zio.blocks.chunk.Chunk.single(mediaType),
+        name = Some("error-response")
+      ) ++ HttpCodec.status(status))) | error
+    )
+
+  def orOutError[E2, E3](status: Status, mediaType: MediaType, schema: Schema[E2])(using
+    builder: EndpointUnionErrorBuilder.ErrorBuilder.WithOut[Err, E2, E3]
+  ): Endpoint[PathInput, Input, E3, Output, Auth] =
+    orOutError(
+      HttpCodec.responseBody(
+        schema,
+        mediaTypes = zio.blocks.chunk.Chunk.single(mediaType),
+        name = Some("error-response")
+      ) ++ HttpCodec.status(status)
+    )
+
+  def outError[E2, E3](status: Status, mediaType: MediaType, schema: Schema[E2], doc: Doc)(using
+    alternator: Eithers.Eithers.WithOut[E2, Err, E3]
+  ): Endpoint[PathInput, Input, E3, Output, Auth] =
+    copy(
+      error = ((HttpCodec.responseBody(
+        schema,
+        mediaTypes = zio.blocks.chunk.Chunk.single(mediaType),
+        name = Some("error-response"),
+        doc = doc
+      ) ++ HttpCodec.status(status, doc))) | error
+    )
+
+  def orOutError[E2, E3](status: Status, mediaType: MediaType, schema: Schema[E2], doc: Doc)(using
+    builder: EndpointUnionErrorBuilder.ErrorBuilder.WithOut[Err, E2, E3]
+  ): Endpoint[PathInput, Input, E3, Output, Auth] =
+    orOutError(
+      HttpCodec.responseBody(
+        schema,
+        mediaTypes = zio.blocks.chunk.Chunk.single(mediaType),
+        name = Some("error-response"),
+        doc = doc
+      ) ++ HttpCodec.status(status, doc)
+    )
+
+  def outHeader[O2, O3](codec: HttpCodec.Header[CodecKind.Response, O2])(using
+    combiner: Tuples.Tuples.WithOut[Output, O2, O3]
+  ): Endpoint[PathInput, Input, Err, O3, Auth] =
+    copy(output = output ++ codec)
+
+  def outHeader[A, O2](name: String, schema: Schema[A])(using
+    combiner: Tuples.Tuples.WithOut[Output, A, O2]
+  ): Endpoint[PathInput, Input, Err, O2, Auth] =
+    outHeader(HttpCodec.responseHeader(name, schema))
+
+  def outHeader[A, O2](name: String, schema: Schema[A], doc: Doc)(using
+    combiner: Tuples.Tuples.WithOut[Output, A, O2]
+  ): Endpoint[PathInput, Input, Err, O2, Auth] =
+    outHeader(HttpCodec.responseHeader(name, schema, doc = doc))
+
+  def auth[Auth0 <: AuthType](authType: Auth0): Endpoint[PathInput, Input, Err, Output, Auth0] =
+    copy(auth = authType)
+
+  def unauthorizedStatus(
+    status: Status
+  ): Endpoint[PathInput, Input, Err, Output, AuthType { type ClientRequirement = auth.ClientRequirement }] =
+    copy(auth = auth.withUnauthorizedStatus(status))
+
+  def doc(documentation: Doc): Endpoint[PathInput, Input, Err, Output, Auth] =
+    copy(doc = documentation)
+
+  def query[A, I2](name: String, schema: Schema[A])(using
+    combiner: Tuples.Tuples.WithOut[Input, A, I2]
+  ): Endpoint[PathInput, I2, Err, Output, Auth] =
+    copy(input = input ++ HttpCodec.query(name, schema))
+
+}
+
+object Endpoint {
+
+  def apply[PathInput](route: RoutePattern[PathInput]): Endpoint[PathInput, Unit, Unit, Unit, AuthType.None] =
+    Endpoint(
+      route = route,
+      input = HttpCodec.Empty,
+      error = HttpCodec.Empty,
+      output = HttpCodec.Empty,
+      auth = AuthType.None,
+      doc = Doc.empty
+    )
+}

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/HttpCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/HttpCodec.scala
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import scala.annotation.unchecked.uncheckedVariance
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.combinators.{Eithers, Tuples}
+import zio.blocks.docs.Doc
+import zio.blocks.mediatype.MediaType
+import zio.blocks.schema.{Schema, SchemaError}
+import zio.http.Status
+import zio.http.{Header => HttpHeader, headers}
+
+/** Phantom type for codec direction. */
+sealed trait CodecKind
+
+object CodecKind {
+
+  /**
+   * Codec that describes request parts (query, request header, request body).
+   */
+  sealed trait Request extends CodecKind
+
+  /**
+   * Codec that describes response parts (status, response header, response
+   * body).
+   */
+  sealed trait Response extends CodecKind
+}
+
+/**
+ * Composable typed descriptor for HTTP request/response parts.
+ *
+ * Most nodes are plain data carrying schemas plus endpoint metadata directly on
+ * the atom (`doc`, `examples`, `deprecated`) instead of wrapping in extra
+ * annotation layers. Typed header and auth helpers reuse `Schema.transform` so
+ * the descriptor can keep exposing `Schema[A]` for parsed header values without
+ * introducing dedicated interpreter-only AST nodes.
+ */
+sealed trait HttpCodec[+K <: CodecKind, A] { self =>
+  def ++[B, C](that: HttpCodec[K @uncheckedVariance, B])(using
+    combiner: Tuples.Tuples.WithOut[A, B, C]
+  ): HttpCodec[K, C] =
+    HttpCodec.Combine(self, that, combiner)
+
+  def |[B, C](that: HttpCodec[K @uncheckedVariance, B])(using
+    alternator: Eithers.Eithers.WithOut[A, B, C]
+  ): HttpCodec[K, C] =
+    HttpCodec.Fallback(self, that, Alternator.fromEithers(alternator))
+}
+
+object HttpCodec {
+
+  private def validationFailure(message: String): Nothing =
+    throw SchemaError.validationFailed(message)
+
+  private def headerSchema[A <: zio.http.Header](headerType: HttpHeader.Typed[A]): Schema[A] =
+    Schema[String].transform[A](
+      value => headerType.parse(value).fold(validationFailure, identity),
+      value => headerType.render(value)
+    )
+
+  private def authorizationSchema[A <: headers.Authorization](
+    expectedScheme: String,
+    extract: PartialFunction[headers.Authorization, A]
+  ): Schema[A] =
+    Schema[String].transform[A](
+      value =>
+        headers.Authorization.parse(value) match {
+          case Right(auth) if extract.isDefinedAt(auth) => extract(auth)
+          case Right(other) =>
+            validationFailure(s"Expected $expectedScheme authorization header but found ${other.getClass.getSimpleName}")
+          case Left(error) => validationFailure(error)
+        },
+      value => headers.Authorization.render(value)
+    )
+
+  // === Combinators ===
+
+  /** No additional data. */
+  case object Empty extends HttpCodec[Nothing, Unit]
+
+  /** Sequential combination of two codecs. */
+  final case class Combine[K <: CodecKind, A, B, C](
+    left: HttpCodec[K, A],
+    right: HttpCodec[K, B],
+    combiner: Tuples.Tuples.WithOut[A, B, C]
+  ) extends HttpCodec[K, C]
+
+  /** Alternative between two codecs. */
+  final case class Fallback[K <: CodecKind, A, B, C](
+    left: HttpCodec[K, A],
+    right: HttpCodec[K, B],
+    alternator: Alternator.WithOut[A, B, C]
+  ) extends HttpCodec[K, C]
+
+  // === Atom types (with metadata as direct fields) ===
+
+  /** Query parameter descriptor. */
+  final case class Query[A](
+    name: String,
+    schema: Schema[A],
+    default: Option[A] = None,
+    doc: Doc = Doc.empty,
+    examples: Chunk[(String, A)] = Chunk.empty,
+    deprecated: Option[Doc] = None
+  ) extends HttpCodec[CodecKind.Request, A]
+
+  /** HTTP header descriptor. */
+  final case class Header[K <: CodecKind, A](
+    name: String,
+    schema: Schema[A],
+    default: Option[A] = None,
+    doc: Doc = Doc.empty,
+    examples: Chunk[(String, A)] = Chunk.empty,
+    deprecated: Option[Doc] = None
+  ) extends HttpCodec[K, A]
+
+  /** Request/response body descriptor. */
+  final case class Body[K <: CodecKind, A](
+    schema: Schema[A],
+    mediaTypes: Chunk[MediaType] = Chunk.empty,
+    name: Option[String] = None,
+    doc: Doc = Doc.empty,
+    examples: Chunk[(String, A)] = Chunk.empty,
+    deprecated: Option[Doc] = None
+  ) extends HttpCodec[K, A]
+
+  /** HTTP status code descriptor. */
+  final case class StatusCodec(
+    status: Option[Status] = None,
+    doc: Doc = Doc.empty,
+    examples: Chunk[Status] = Chunk.empty,
+    deprecated: Option[Doc] = None
+  ) extends HttpCodec[CodecKind.Response, Unit]
+
+  def empty[K <: CodecKind]: HttpCodec[K, Unit] = Empty
+
+  def query[A](
+    name: String,
+    schema: Schema[A],
+    default: Option[A] = None,
+    doc: Doc = Doc.empty,
+    examples: Chunk[(String, A)] = Chunk.empty,
+    deprecated: Option[Doc] = None
+  ): HttpCodec.Query[A] =
+    Query(name, schema, default, doc, examples, deprecated)
+
+  def requestHeader[A](
+    name: String,
+    schema: Schema[A],
+    default: Option[A] = None,
+    doc: Doc = Doc.empty,
+    examples: Chunk[(String, A)] = Chunk.empty,
+    deprecated: Option[Doc] = None
+  ): HttpCodec.Header[CodecKind.Request, A] =
+    Header[CodecKind.Request, A](name, schema, default, doc, examples, deprecated)
+
+  def requestHeader[A <: zio.http.Header](headerType: HttpHeader.Typed[A]): HttpCodec.Header[CodecKind.Request, A] =
+    Header[CodecKind.Request, A](headerType.name, headerSchema(headerType))
+
+  def responseHeader[A](
+    name: String,
+    schema: Schema[A],
+    default: Option[A] = None,
+    doc: Doc = Doc.empty,
+    examples: Chunk[(String, A)] = Chunk.empty,
+    deprecated: Option[Doc] = None
+  ): HttpCodec.Header[CodecKind.Response, A] =
+    Header[CodecKind.Response, A](name, schema, default, doc, examples, deprecated)
+
+  def responseHeader[A <: zio.http.Header](headerType: HttpHeader.Typed[A]): HttpCodec.Header[CodecKind.Response, A] =
+    Header[CodecKind.Response, A](headerType.name, headerSchema(headerType))
+
+  def requestBody[A](
+    schema: Schema[A],
+    mediaTypes: Chunk[MediaType] = Chunk.empty,
+    name: Option[String] = None,
+    doc: Doc = Doc.empty,
+    examples: Chunk[(String, A)] = Chunk.empty,
+    deprecated: Option[Doc] = None
+  ): HttpCodec[CodecKind.Request, A] =
+    Body[CodecKind.Request, A](schema, mediaTypes, name, doc, examples, deprecated)
+
+  def responseBody[A](
+    schema: Schema[A],
+    mediaTypes: Chunk[MediaType] = Chunk.empty,
+    name: Option[String] = None,
+    doc: Doc = Doc.empty,
+    examples: Chunk[(String, A)] = Chunk.empty,
+    deprecated: Option[Doc] = None
+  ): HttpCodec[CodecKind.Response, A] =
+    Body[CodecKind.Response, A](schema, mediaTypes, name, doc, examples, deprecated)
+
+  def status(
+    status: Status,
+    doc: Doc = Doc.empty,
+    examples: Chunk[Status] = Chunk.empty,
+    deprecated: Option[Doc] = None
+  ): HttpCodec[CodecKind.Response, Unit] =
+    StatusCodec(Some(status), doc, examples, deprecated)
+
+  val authorization: HttpCodec[CodecKind.Request, headers.Authorization]          = requestHeader(headers.Authorization)
+  val basicAuth: HttpCodec[CodecKind.Request, headers.Authorization.Basic] =
+    requestHeader("authorization", authorizationSchema("Basic", { case basic: headers.Authorization.Basic => basic }))
+  val bearerAuth: HttpCodec[CodecKind.Request, headers.Authorization.Bearer] =
+    requestHeader("authorization", authorizationSchema("Bearer", { case bearer: headers.Authorization.Bearer => bearer }))
+  val digestAuth: HttpCodec[CodecKind.Request, headers.Authorization.Digest] =
+    requestHeader("authorization", authorizationSchema("Digest", { case digest: headers.Authorization.Digest => digest }))
+  val proxyAuthorization: HttpCodec[CodecKind.Request, headers.ProxyAuthorization] = requestHeader(headers.ProxyAuthorization)
+
+  val Continue: HttpCodec[CodecKind.Response, Unit]                      = status(Status.Continue)
+  val SwitchingProtocols: HttpCodec[CodecKind.Response, Unit]            = status(Status.SwitchingProtocols)
+  val Processing: HttpCodec[CodecKind.Response, Unit]                    = status(Status.Processing)
+  val Ok: HttpCodec[CodecKind.Response, Unit]                            = status(Status.Ok)
+  val Created: HttpCodec[CodecKind.Response, Unit]                       = status(Status.Created)
+  val Accepted: HttpCodec[CodecKind.Response, Unit]                      = status(Status.Accepted)
+  val NoContent: HttpCodec[CodecKind.Response, Unit]                     = status(Status.NoContent)
+  val BadRequest: HttpCodec[CodecKind.Response, Unit]                    = status(Status.BadRequest)
+  val Unauthorized: HttpCodec[CodecKind.Response, Unit]                  = status(Status.Unauthorized)
+  val Forbidden: HttpCodec[CodecKind.Response, Unit]                     = status(Status.Forbidden)
+  val NotFound: HttpCodec[CodecKind.Response, Unit]                      = status(Status.NotFound)
+  val InternalServerError: HttpCodec[CodecKind.Response, Unit]           = status(Status.InternalServerError)
+  def CustomStatus(code: Int): HttpCodec[CodecKind.Response, Unit] = status(Status.fromInt(code))
+}

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/PathCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/PathCodec.scala
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import scala.language.implicitConversions
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.combinators.Tuples
+import zio.http.Path
+
+/**
+ * Composable path descriptor. Segments are combined with `/` or `++`, literal alternatives with `orElse`.
+ * Use [[PathCodec.decode decode]] / [[PathCodec.format format]] for bidirectional path conversion,
+ * and [[PathCodec.alternatives alternatives]] to expand `orElse` branches for routing-trie insertion.
+ */
+sealed trait PathCodec[A]
+
+object PathCodec {
+
+  private type AnyCombiner = Tuples.Tuples.WithOut[Any, Any, Any]
+
+  given unitUnit: Tuples.Tuples.WithOut[Unit, Unit, Unit] = Tuples.Tuples.leftUnit[Unit]
+
+  extension [A](self: PathCodec[A]) {
+    def ++[B, C](that: PathCodec[B])(using
+      combiner: Tuples.Tuples.WithOut[A, B, C]
+    ): PathCodec[C] =
+      if (self == empty) that.asInstanceOf[PathCodec[C]]
+      else if (that == empty) self.asInstanceOf[PathCodec[C]]
+      else Concat(self, that, combiner)
+
+    def /[B, C](that: PathCodec[B])(using
+      combiner: Tuples.Tuples.WithOut[A, B, C]
+    ): PathCodec[C] =
+      self ++ that
+
+    def orElse(that: PathCodec[Unit])(using ev: A =:= Unit): PathCodec[Unit] =
+      Fallback(self.asInstanceOf[PathCodec[Unit]], that)
+
+    def alternatives: List[PathCodec[A]] =
+      expand(self).asInstanceOf[List[PathCodec[A]]]
+
+    def decode(path: Path): Either[String, A] =
+      decodeCodec(self, path.segments, 0).collectFirst {
+        case (value, end) if end == path.segments.length => value.asInstanceOf[A]
+      }
+        .toRight(s"Path ${path.encode} did not match ${PathCodec.render(self)}")
+
+    def format(value: A): Either[String, Path] =
+      formatCodec(self, value.asInstanceOf[Any]).map(_.addLeadingSlash)
+
+    def matches(path: Path): Boolean =
+      decode(path).isRight
+
+    def render: String = PathCodec.render(codec = self)
+  }
+
+  def apply(value: String): PathCodec[Unit] = {
+    val path = Path(value)
+    if (path.segments.isEmpty) empty
+    else path.segments.foldLeft(empty: PathCodec[Unit])((acc, segment) => acc / literal(segment))
+  }
+
+  def apply[A](segment: SegmentCodec[A]): PathCodec[A] =
+    Segment(segment)
+
+  given Conversion[String, PathCodec[Unit]]            = apply(_)
+  given [A]: Conversion[SegmentCodec[A], PathCodec[A]] = Segment(_)
+
+  final case class Segment[A](segment: SegmentCodec[A]) extends PathCodec[A]
+  final case class Concat[A, B, C](
+    left: PathCodec[A],
+    right: PathCodec[B],
+    combiner: Tuples.Tuples.WithOut[A, B, C]
+  ) extends PathCodec[C]
+  final case class Fallback(left: PathCodec[Unit], right: PathCodec[Unit]) extends PathCodec[Unit]
+
+  val empty: PathCodec[Unit] = Segment(SegmentCodec.Empty)
+
+  def literal(value: String): PathCodec[Unit]       = Segment(SegmentCodec.literal(value))
+  def bool(name: String): PathCodec[Boolean]        = Segment(SegmentCodec.bool(name))
+  def int(name: String): PathCodec[Int]             = Segment(SegmentCodec.int(name))
+  def long(name: String): PathCodec[Long]           = Segment(SegmentCodec.long(name))
+  def string(name: String): PathCodec[String]       = Segment(SegmentCodec.string(name))
+  def uuid(name: String): PathCodec[java.util.UUID] = Segment(SegmentCodec.uuid(name))
+  val trailing: PathCodec[Path]                     = Segment(SegmentCodec.Trailing)
+
+  def render(codec: PathCodec[_], prefix: String = "{", suffix: String = "}"): String = {
+    def loop(current: PathCodec[_]): String =
+      current match {
+        case Segment(segment)       => segment.render(prefix, suffix)
+        case Concat(left, right, _) => loop(left) + loop(right)
+        case Fallback(left, right)  => loop(left) + " | " + loop(right)
+      }
+    val rendered = loop(codec)
+    if (rendered.isEmpty) "/" else rendered
+  }
+
+  private def expand(codec: PathCodec[_]): List[PathCodec[_]] =
+    codec match {
+      case fallback: Fallback =>
+        def loop(codecs: List[PathCodec[_]], result: List[PathCodec[_]]): List[PathCodec[_]] =
+          codecs match {
+            case Nil          => result
+            case head :: tail =>
+              head match {
+                case Segment(SegmentCodec.Empty)            => loop(tail, result)
+                case Fallback(left, right)                  => loop(left :: right :: tail, result)
+                case Segment(SegmentCodec.Literal(_, _, _)) => loop(tail, result :+ head)
+                case other                                  =>
+                  throw new IllegalStateException(
+                    s"Alternative path segments should only contain literals, found: $other"
+                  )
+              }
+          }
+        loop(List(fallback.left, fallback.right), Nil)
+      case Concat(left, right, combiner) =>
+        for {
+          l <- expand(left)
+          r <- expand(right)
+        } yield Concat(
+          l.asInstanceOf[PathCodec[Any]],
+          r.asInstanceOf[PathCodec[Any]],
+          combiner.asInstanceOf[AnyCombiner]
+        )
+      case Segment(SegmentCodec.Empty) => Nil
+      case other                       => List(other)
+    }
+
+  private def decodeCodec(codec: PathCodec[_], segments: Chunk[String], index: Int): List[(Any, Int)] =
+    codec match {
+      case Segment(segment)              => decodeSegment(segment, segments, index)
+      case Concat(left, right, combiner) =>
+        decodeCodec(left, segments, index).flatMap { case (leftValue, next) =>
+          decodeCodec(right, segments, next).map { case (rightValue, end) =>
+            val typed = combiner.asInstanceOf[AnyCombiner]
+            (typed.combine(leftValue, rightValue), end)
+          }
+        }
+      case Fallback(left, right) => decodeCodec(left, segments, index) ++ decodeCodec(right, segments, index)
+    }
+
+  private def decodeSegment(codec: SegmentCodec[_], segments: Chunk[String], index: Int): List[(Any, Int)] =
+    codec match {
+      case SegmentCodec.Empty                => List(((), index))
+      case SegmentCodec.Literal(value, _, _) =>
+        if (index < segments.length && segments(index) == value) List(((), index + 1)) else Nil
+      case SegmentCodec.BoolSeg(_, _, _) =>
+        if (index >= segments.length) Nil
+        else
+          segments(index) match {
+            case "true"  => List((true, index + 1))
+            case "false" => List((false, index + 1))
+            case _       => Nil
+          }
+      case SegmentCodec.IntSeg(_, _, _) =>
+        segments.lift(index).flatMap(_.toIntOption).map(v => List((v, index + 1))).getOrElse(Nil)
+      case SegmentCodec.LongSeg(_, _, _) =>
+        segments.lift(index).flatMap(_.toLongOption).map(v => List((v, index + 1))).getOrElse(Nil)
+      case SegmentCodec.StringSeg(_, _, _) => segments.lift(index).map(v => List((v, index + 1))).getOrElse(Nil)
+      case SegmentCodec.UUIDSeg(_, _, _)   =>
+        segments
+          .lift(index)
+          .flatMap { segment =>
+            try Some(java.util.UUID.fromString(segment))
+            catch { case _: IllegalArgumentException => None }
+          }
+          .map(v => List((v, index + 1)))
+          .getOrElse(Nil)
+      case SegmentCodec.Trailing =>
+        val path =
+          if (index >= segments.length) Path.root
+          else Path(segments.drop(index), hasLeadingSlash = true, trailingSlash = false)
+        List((path, segments.length))
+      case combined: SegmentCodec.Combined[?, ?, ?] =>
+        if (index >= segments.length) Nil
+        else {
+          val segment = segments(index)
+          SegmentCodec.decodeCombined(combined, segment, 0).collect {
+            case (value, end) if end == segment.length => (value, index + 1)
+          }
+        }
+    }
+
+  private def formatCodec(codec: PathCodec[_], value: Any): Either[String, Path] =
+    codec match {
+      case Segment(segment)              => Right(segment.asInstanceOf[SegmentCodec[Any]].format(value))
+      case Concat(left, right, combiner) =>
+        val typed                   = combiner.asInstanceOf[AnyCombiner]
+        val (leftValue, rightValue) = typed.separate(value)
+        for {
+          leftPath  <- formatCodec(left, leftValue)
+          rightPath <- formatCodec(right, rightValue)
+        } yield leftPath ++ rightPath.dropLeadingSlash
+      case Fallback(left, _) => formatCodec(left, value)
+    }
+}

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/RoutePattern.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/RoutePattern.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import zio.blocks.docs.Doc
+import zio.blocks.combinators.Tuples
+import zio.http.{Method, Path}
+
+/**
+ * HTTP method paired with a typed path pattern. The primary constructor is `Method.GET / "users" / PathCodec.int("id")`.
+ * Use [[RoutePattern.alternatives alternatives]] to expand `orElse` branches, [[RoutePattern.any any]] for
+ * catch-all trailing routes, and [[RoutePattern.nest nest]] to prepend a path prefix.
+ */
+final case class RoutePattern[A](
+  method: Method,
+  pathCodec: PathCodec[A],
+  doc: Doc = Doc.empty
+) {
+  def /[B, C](that: PathCodec[B])(using combiner: Tuples.Tuples.WithOut[A, B, C]): RoutePattern[C] =
+    if (that == PathCodec.empty) this.asInstanceOf[RoutePattern[C]]
+    else if (pathCodec == PathCodec.empty) copy(pathCodec = that.asInstanceOf[PathCodec[C]])
+    else copy(pathCodec = pathCodec ++ that)
+
+  def alternatives: List[RoutePattern[A]] =
+    pathCodec.alternatives.flatMap { codec =>
+      method match {
+        case Method.ANY         => Method.standardMethods.toList.map(single => copy(method = single, pathCodec = codec))
+        case Method.Methods(ms) => ms.toList.map(single => copy(method = single, pathCodec = codec))
+        case _                  => List(copy(pathCodec = codec))
+      }
+    }
+
+  def decode(actual: Method, path: Path): Either[String, A] =
+    if (!method.matches(actual) && !(method == Method.GET && actual == Method.HEAD))
+      Left(s"Expected HTTP method ${Method.render(method)} but found ${Method.render(actual)}")
+    else pathCodec.decode(path)
+
+  def encode(value: A): Either[String, (Method, Path)] =
+    format(value).map(method -> _)
+
+  def format(value: A): Either[String, Path] =
+    pathCodec.format(value)
+
+  def matches(actual: Method, path: Path): Boolean =
+    decode(actual, path).isRight
+
+  def nest(prefix: PathCodec[Unit]): RoutePattern[A] =
+    copy(pathCodec = prefix / pathCodec)
+
+  def render: String =
+    s"${Method.render(method)} ${pathCodec.render}"
+}
+
+object RoutePattern {
+  val CONNECT: RoutePattern[Unit] = fromMethod(Method.CONNECT)
+  val DELETE: RoutePattern[Unit]  = fromMethod(Method.DELETE)
+  val GET: RoutePattern[Unit]     = fromMethod(Method.GET)
+  val HEAD: RoutePattern[Unit]    = fromMethod(Method.HEAD)
+  val OPTIONS: RoutePattern[Unit] = fromMethod(Method.OPTIONS)
+  val PATCH: RoutePattern[Unit]   = fromMethod(Method.PATCH)
+  val POST: RoutePattern[Unit]    = fromMethod(Method.POST)
+  val PUT: RoutePattern[Unit]     = fromMethod(Method.PUT)
+  val TRACE: RoutePattern[Unit]   = fromMethod(Method.TRACE)
+
+  def apply(method: Method): RoutePattern[Unit] =
+    RoutePattern(method, PathCodec.empty)
+
+  def apply(method: Method, path: Path): RoutePattern[Unit] =
+    path.segments.foldLeft(fromMethod(method))((acc, segment) =>
+      acc./[Unit, Unit](PathCodec.literal(segment))(using Tuples.Tuples.leftUnit[Unit])
+    )
+
+  def apply(method: Method, pathString: String): RoutePattern[Unit] =
+    apply(method, Path(pathString))
+
+  def fromMethod(method: Method): RoutePattern[Unit] =
+    RoutePattern(method, PathCodec.empty)
+
+  def any: RoutePattern[Path] =
+    RoutePattern(Method.ANY, PathCodec.trailing)
+
+  def any(method: Method): RoutePattern[Path] =
+    RoutePattern(method, PathCodec.trailing)
+
+  extension (method: Method) {
+    def /[A](path: PathCodec[A]): RoutePattern[A] =
+      RoutePattern(method, path)
+  }
+}

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/RouteTree.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/RouteTree.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import scala.collection.immutable.ListMap
+
+import zio.blocks.chunk.Chunk
+import zio.http.{Method, Path}
+
+/**
+ * Routing trie keyed by HTTP method, then by path segments. Literals are matched first, then dynamic
+ * segments in priority order (int > long > uuid > bool > string > combined > trailing).
+ * HEAD requests fall back to GET handlers. Merge prefers right-hand-side values on conflict.
+ */
+final case class RouteTree[A](
+  roots: Map[Method, SegmentSubtree[A]]
+) { self =>
+
+  def add[A1 >: A](pattern: RoutePattern[_], value: A1): RouteTree[A1] =
+    pattern.alternatives.foldLeft(this.asInstanceOf[RouteTree[A1]]) { (tree, alternative) =>
+      tree.addSingle(alternative, value)
+    }
+
+  private def addSingle[A1 >: A](pattern: RoutePattern[_], value: A1): RouteTree[A1] = {
+    val widened  = roots.asInstanceOf[Map[Method, SegmentSubtree[A1]]]
+    val segments = RouteTree.flattenPathCodec(pattern.pathCodec)
+    val subtree  = SegmentSubtree.single(segments, value)
+    val existing = widened.getOrElse(pattern.method, SegmentSubtree.empty[A1])
+    RouteTree(widened.updated(pattern.method, existing.merge(subtree)))
+  }
+
+  def get(method: Method, path: Path): Option[A] =
+    roots.get(method).flatMap(_.get(path.segments, 0)).orElse {
+      if (method == Method.HEAD) roots.get(Method.GET).flatMap(_.get(path.segments, 0)) else None
+    }
+
+  def merge[A1 >: A](that: RouteTree[A1]): RouteTree[A1] = {
+    val mergedRoots = (self.roots.keySet ++ that.roots.keySet).iterator.map { method =>
+      val left  = self.roots.getOrElse(method, SegmentSubtree.empty[A1])
+      val right = that.roots.getOrElse(method, SegmentSubtree.empty[A1])
+      method -> left.merge(right)
+    }.toMap
+    RouteTree(mergedRoots)
+  }
+
+  def map[B](f: A => B): RouteTree[B] =
+    RouteTree(roots.map { case (method, subtree) => method -> subtree.map(f) })
+}
+
+object RouteTree {
+  def empty[A]: RouteTree[A] = RouteTree(Map.empty)
+
+  private[endpoint] def flattenPathCodec(codec: PathCodec[_]): Chunk[SegmentCodec[_]] =
+    codec match {
+      case PathCodec.Segment(seg)           => Chunk(seg)
+      case PathCodec.Concat(left, right, _) => flattenPathCodec(left) ++ flattenPathCodec(right)
+      case PathCodec.Fallback(_, _)         =>
+        throw new IllegalStateException("Fallback paths must be expanded before flattening")
+    }
+}
+
+/**
+ * A single level of the routing trie. `literals` holds exact-match branches, `others` holds
+ * dynamic segment branches keyed by [[SegmentCodec.Key]] and ordered by match priority.
+ */
+final case class SegmentSubtree[A](
+  literals: Map[String, SegmentSubtree[A]],
+  others: ListMap[SegmentCodec.Key, (SegmentCodec[_], SegmentSubtree[A])],
+  value: Option[A]
+) { self =>
+
+  def get(segments: Chunk[String], index: Int): Option[A] =
+    if (index >= segments.length) {
+      value.orElse(others.get(SegmentCodec.Key.Trailing).flatMap(_._2.value))
+    } else {
+      val segment = segments(index)
+      literals.get(segment).flatMap(_.get(segments, index + 1)).orElse {
+        others.iterator.flatMap { case (_, (codec, subtree)) =>
+          val consumed = SegmentCodec.matches(codec, segments, index)
+          if (consumed > 0) subtree.get(segments, index + consumed) else None
+        }.nextOption()
+      }
+    }
+
+  def merge[A1 >: A](that: SegmentSubtree[A1]): SegmentSubtree[A1] = {
+    val mergedLiterals = (self.literals.keySet ++ that.literals.keySet).iterator.map { key =>
+      val left  = self.literals.getOrElse(key, SegmentSubtree.empty[A1])
+      val right = that.literals.getOrElse(key, SegmentSubtree.empty[A1])
+      key -> left.merge(right)
+    }.toMap
+
+    val mergedOthers = {
+      val keys = (self.others.keySet ++ that.others.keySet).toList.distinct.sorted
+      ListMap.from(keys.map { key =>
+        val leftEntry =
+          self.others.get(key).map { case (codec, subtree) => codec -> subtree.asInstanceOf[SegmentSubtree[A1]] }
+        val rightEntry = that.others.get(key)
+        val merged     = (leftEntry, rightEntry) match {
+          case (Some((leftCodec, leftSubtree)), Some((_, rightSubtree))) =>
+            leftCodec -> leftSubtree.merge(rightSubtree)
+          case (Some(entry), None) => entry
+          case (None, Some(entry)) => entry
+          case (None, None)        => throw new IllegalStateException(s"Missing route subtree for key: $key")
+        }
+        key -> merged
+      })
+    }
+
+    SegmentSubtree(mergedLiterals, mergedOthers, that.value.orElse(self.value))
+  }
+
+  def map[B](f: A => B): SegmentSubtree[B] =
+    SegmentSubtree(
+      literals = literals.map { case (key, subtree) => key -> subtree.map(f) },
+      others = ListMap.from(others.map { case (key, entries) =>
+        key -> (entries._1 -> entries._2.map(f))
+      }),
+      value = value.map(f)
+    )
+}
+
+object SegmentSubtree {
+  def empty[A]: SegmentSubtree[A] = SegmentSubtree(Map.empty, ListMap.empty, None)
+
+  def single[A](segments: Chunk[SegmentCodec[_]], value: A): SegmentSubtree[A] = {
+    val filtered = segments.filter(_ != SegmentCodec.Empty)
+    filtered.foldRight(SegmentSubtree[A](Map.empty, ListMap.empty, Some(value))) { case (codec, child) =>
+      codec match {
+        case SegmentCodec.Literal(value, _, _) =>
+          SegmentSubtree(Map(value -> child), ListMap.empty, None)
+        case other =>
+          SegmentSubtree(Map.empty, ListMap(SegmentCodec.key(other) -> (other -> child)), None)
+      }
+    }
+  }
+}

--- a/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
+++ b/endpoint/shared/src/main/scala/zio/blocks/endpoint/SegmentCodec.scala
@@ -1,0 +1,462 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import scala.quoted.*
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.combinators.Tuples
+import zio.blocks.docs.Doc
+import zio.http.Path
+
+/**
+ * Typed descriptor for a single URL path segment. Subtypes include [[SegmentCodec.Literal Literal]],
+ * [[SegmentCodec.IntSeg Int]], [[SegmentCodec.StringSeg String]], [[SegmentCodec.Combined Combined]] (intra-segment
+ * composition via `~`), and [[SegmentCodec.Trailing Trailing]] (captures remaining path).
+ */
+sealed trait SegmentCodec[A] { self =>
+  def doc: Doc
+  def examples: Chunk[(String, A)]
+
+  final def format(value: A): Path =
+    Path(s"/${SegmentCodec.formatSegment(self, value)}")
+
+  final def render(prefix: String = "{", suffix: String = "}"): String =
+    SegmentCodec.render(self, prefix, suffix)
+}
+
+object SegmentCodec {
+
+  enum Kind {
+    case Empty
+    case Literal
+    case Bool
+    case Int
+    case Long
+    case String
+    case UUID
+    case Combined
+    case Trailing
+  }
+
+  sealed trait Key
+  object Key {
+    case object Empty                            extends Key
+    final case class Literal(value: String)      extends Key
+    case object Bool                             extends Key
+    case object Int                              extends Key
+    case object Long                             extends Key
+    case object String                           extends Key
+    case object UUID                             extends Key
+    final case class Combined(parts: Chunk[Key]) extends Key
+    case object Trailing                         extends Key
+  }
+
+  extension [A](self: SegmentCodec[A]) {
+    inline def ~[B, C](that: SegmentCodec[B])(using
+      combiner: Tuples.Tuples.WithOut[A, B, C]
+    ): SegmentCodec[C] =
+      ${ SegmentCodecMacros.combineImpl[A, B, C]('self, 'that, 'combiner) }
+
+    inline def ~[C](that: String)(using combiner: Tuples.Tuples.WithOut[A, Unit, C]): SegmentCodec[C] =
+      ${ SegmentCodecMacros.combineImpl[A, Unit, C]('self, '{ literal(that) }, 'combiner) }
+  }
+
+  def literal(value: String): Literal       = Literal(value)
+  def bool(name: String): BoolSeg           = BoolSeg(name)
+  def int(name: String): IntSeg             = IntSeg(name)
+  def long(name: String): LongSeg           = LongSeg(name)
+  def string(name: String): StringSeg       = StringSeg(name)
+  def uuid(name: String): UUIDSeg           = UUIDSeg(name)
+
+  private[endpoint] def combineValidated[A, B, C](
+    left: SegmentCodec[A],
+    right: SegmentCodec[B],
+    combiner: Tuples.Tuples.WithOut[A, B, C]
+  ): SegmentCodec[C] =
+    (left, right) match {
+      case (Empty, _)          => right.asInstanceOf[SegmentCodec[C]]
+      case (_, Empty)          => left.asInstanceOf[SegmentCodec[C]]
+      case (Literal(lv, ld, le), Literal(rv, rd, _)) =>
+        Literal(lv + rv, ld ++ rd, le).asInstanceOf[SegmentCodec[C]]
+      case (Combined(l, r, existing), Literal(rv, rd, _)) if r.isInstanceOf[Literal] =>
+        Combined(
+          l.asInstanceOf[SegmentCodec[Any]],
+          Literal(r.asInstanceOf[Literal].value + rv, r.asInstanceOf[Literal].doc ++ rd)
+            .asInstanceOf[SegmentCodec[Any]],
+          existing.asInstanceOf[Tuples.Tuples.WithOut[Any, Any, Any]]
+        ).asInstanceOf[SegmentCodec[C]]
+      case (_, StringSeg(name, _, _)) =>
+        rejectTrailingString(left, name)
+        Combined(left, right, combiner)
+      case (_, IntSeg(name, _, _)) =>
+        rejectTrailingNumeric(left, name)
+        Combined(left, right, combiner)
+      case (_, LongSeg(name, _, _)) =>
+        rejectTrailingNumeric(left, name)
+        Combined(left, right, combiner)
+      case _ => Combined(left, right, combiner)
+    }
+
+  private[endpoint] def kind(codec: SegmentCodec[_]): Kind =
+    codec match {
+      case Empty              => Kind.Empty
+      case Literal(_, _, _)   => Kind.Literal
+      case BoolSeg(_, _, _)   => Kind.Bool
+      case IntSeg(_, _, _)    => Kind.Int
+      case LongSeg(_, _, _)   => Kind.Long
+      case StringSeg(_, _, _) => Kind.String
+      case UUIDSeg(_, _, _)   => Kind.UUID
+      case Combined(_, _, _)  => Kind.Combined
+      case Trailing           => Kind.Trailing
+    }
+
+  private[endpoint] def key(codec: SegmentCodec[_]): Key =
+    codec match {
+      case Empty                => Key.Empty
+      case Literal(value, _, _) => Key.Literal(value)
+      case BoolSeg(_, _, _)     => Key.Bool
+      case IntSeg(_, _, _)      => Key.Int
+      case LongSeg(_, _, _)     => Key.Long
+      case StringSeg(_, _, _)   => Key.String
+      case UUIDSeg(_, _, _)     => Key.UUID
+      case Combined(_, _, _)    => Key.Combined(flatten(codec).map(key))
+      case Trailing             => Key.Trailing
+    }
+
+  implicit val segmentCodecOrdering: Ordering[Kind] = Ordering.by {
+    case Kind.Literal  => -1
+    case Kind.Int      => 0
+    case Kind.Long     => 1
+    case Kind.UUID     => 2
+    case Kind.Bool     => 3
+    case Kind.String   => 4
+    case Kind.Combined => 5
+    case Kind.Trailing => 6
+    case Kind.Empty    => 7
+  }
+
+  given keyOrdering: Ordering[Key] = (a: Key, b: Key) => {
+    def rank(k: Key): Int = k match {
+      case Key.Literal(_)  => 0
+      case Key.Int         => 1
+      case Key.Long        => 2
+      case Key.UUID        => 3
+      case Key.Bool        => 4
+      case Key.String      => 5
+      case Key.Combined(_) => 6
+      case Key.Trailing    => 7
+      case Key.Empty       => 8
+    }
+    val cmp = rank(a) - rank(b)
+    if (cmp != 0) cmp
+    else
+      (a, b) match {
+        case (Key.Literal(x), Key.Literal(y))   => x.compareTo(y)
+        case (Key.Combined(x), Key.Combined(y)) =>
+          val len = x.length.compareTo(y.length)
+          if (len != 0) len
+          else x.iterator.zip(y.iterator).map { case (l, r) => keyOrdering.compare(l, r) }.find(_ != 0).getOrElse(0)
+        case _ => 0
+      }
+  }
+
+  case object Empty extends SegmentCodec[Unit] {
+    val doc: Doc                        = Doc.empty
+    val examples: Chunk[(String, Unit)] = Chunk.empty
+  }
+
+  final case class Literal(value: String, doc: Doc = Doc.empty, examples: Chunk[(String, Unit)] = Chunk.empty)
+      extends SegmentCodec[Unit]
+
+  final case class BoolSeg(name: String, doc: Doc = Doc.empty, examples: Chunk[(String, Boolean)] = Chunk.empty)
+      extends SegmentCodec[Boolean]
+
+  final case class IntSeg(name: String, doc: Doc = Doc.empty, examples: Chunk[(String, Int)] = Chunk.empty)
+      extends SegmentCodec[Int]
+
+  final case class LongSeg(name: String, doc: Doc = Doc.empty, examples: Chunk[(String, Long)] = Chunk.empty)
+      extends SegmentCodec[Long]
+
+  final case class StringSeg(name: String, doc: Doc = Doc.empty, examples: Chunk[(String, String)] = Chunk.empty)
+      extends SegmentCodec[String]
+
+  final case class UUIDSeg(
+    name: String,
+    doc: Doc = Doc.empty,
+    examples: Chunk[(String, java.util.UUID)] = Chunk.empty
+  ) extends SegmentCodec[java.util.UUID]
+
+  final case class Combined[A, B, C](
+    left: SegmentCodec[A],
+    right: SegmentCodec[B],
+    combiner: Tuples.Tuples.WithOut[A, B, C]
+  ) extends SegmentCodec[C] {
+    val doc: Doc                     = left.doc ++ right.doc
+    val examples: Chunk[(String, C)] = Chunk.empty
+  }
+
+  case object Trailing extends SegmentCodec[Path] {
+    val doc: Doc                        = Doc.empty
+    val examples: Chunk[(String, Path)] = Chunk.empty
+  }
+
+  def render(codec: SegmentCodec[_], prefix: String = "{", suffix: String = "}"): String = {
+    val out                                  = new StringBuilder
+    def loop(current: SegmentCodec[_]): Unit =
+      current match {
+        case Empty                    => ()
+        case Literal(value, _, _)     => out.append(value)
+        case BoolSeg(name, _, _)      => out.append(prefix).append(name).append(suffix)
+        case IntSeg(name, _, _)       => out.append(prefix).append(name).append(suffix)
+        case LongSeg(name, _, _)      => out.append(prefix).append(name).append(suffix)
+        case StringSeg(name, _, _)    => out.append(prefix).append(name).append(suffix)
+        case UUIDSeg(name, _, _)      => out.append(prefix).append(name).append(suffix)
+        case Combined(left, right, _) =>
+          loop(left)
+          loop(right)
+        case Trailing => out.append("...")
+      }
+    loop(codec)
+    if (out.isEmpty) "/" else s"/${out.result()}"
+  }
+
+  def matches(codec: SegmentCodec[_], segments: Chunk[String], index: Int): Int =
+    if (index < 0 || index > segments.length) -1
+    else
+      codec match {
+        case Empty                => 0
+        case Literal(value, _, _) => if (index < segments.length && segments(index) == value) 1 else -1
+        case BoolSeg(_, _, _)     =>
+          if (index < segments.length && (segments(index) == "true" || segments(index) == "false")) 1 else -1
+        case IntSeg(_, _, _)    => if (index < segments.length && segments(index).toIntOption.isDefined) 1 else -1
+        case LongSeg(_, _, _)   => if (index < segments.length && segments(index).toLongOption.isDefined) 1 else -1
+        case StringSeg(_, _, _) => if (index < segments.length) 1 else -1
+        case UUIDSeg(_, _, _)   =>
+          if (index >= segments.length) -1
+          else {
+            try {
+              java.util.UUID.fromString(segments(index))
+              1
+            } catch {
+              case _: IllegalArgumentException => -1
+            }
+          }
+        case Trailing                    => (segments.length - index).max(0)
+        case combined: Combined[?, ?, ?] =>
+          if (index >= segments.length) -1
+          else if (decodeCombined(combined, segments(index), 0).exists(_._2 == segments(index).length)) 1
+          else -1
+      }
+
+  def decodeCombined(codec: SegmentCodec[_], segment: String, from: Int): List[(Any, Int)] =
+    codec match {
+      case Empty                => List(((), from))
+      case Literal(value, _, _) => if (segment.startsWith(value, from)) List(((), from + value.length)) else Nil
+      case BoolSeg(_, _, _)     =>
+        List("true" -> true, "false" -> false).collect {
+          case (text, value) if segment.startsWith(text, from) => (value, from + text.length)
+        }
+      case IntSeg(_, _, _)    => numericCandidates(segment, from, _.toIntOption)
+      case LongSeg(_, _, _)   => numericCandidates(segment, from, _.toLongOption)
+      case StringSeg(_, _, _) =>
+        if (from > segment.length) Nil
+        else {
+          val results = List.newBuilder[(Any, Int)]
+          var end     = segment.length
+          while (end >= from) {
+            results += ((segment.substring(from, end), end))
+            end -= 1
+          }
+          results.result()
+        }
+      case UUIDSeg(_, _, _) =>
+        if (segment.length - from < 36) Nil
+        else {
+          val candidate = segment.substring(from, from + 36)
+          try List((java.util.UUID.fromString(candidate), from + 36))
+          catch { case _: IllegalArgumentException => Nil }
+        }
+      case Trailing                    => List((Path(segment.substring(from)).addLeadingSlash, segment.length))
+      case combined: Combined[?, ?, ?] =>
+        decodeCombined(combined.left, segment, from).flatMap { case (leftValue, next) =>
+          decodeCombined(combined.right, segment, next).map { case (rightValue, end) =>
+            val typed = combined.combiner.asInstanceOf[Tuples.Tuples.WithOut[Any, Any, Any]]
+            (typed.combine(leftValue, rightValue), end)
+          }
+        }
+    }
+
+  def formatSegment(codec: SegmentCodec[_], value: Any): String =
+    codec match {
+      case Empty                       => ""
+      case Literal(value, _, _)        => value
+      case BoolSeg(_, _, _)            => value.toString
+      case IntSeg(_, _, _)             => value.toString
+      case LongSeg(_, _, _)            => value.toString
+      case StringSeg(_, _, _)          => value.asInstanceOf[String]
+      case UUIDSeg(_, _, _)            => value.toString
+      case Trailing                    => value.asInstanceOf[Path].render.stripPrefix("/")
+      case combined: Combined[?, ?, ?] =>
+        val typed                   = combined.combiner.asInstanceOf[Tuples.Tuples.WithOut[Any, Any, Any]]
+        val (leftValue, rightValue) = typed.separate(value)
+        formatSegment(combined.left, leftValue) + formatSegment(combined.right, rightValue)
+    }
+
+  def flatten(codec: SegmentCodec[_]): Chunk[SegmentCodec[_]] =
+    codec match {
+      case Combined(left, right, _) => flatten(left) ++ flatten(right)
+      case other                    => Chunk(other)
+    }
+
+  private def numericCandidates[A](segment: String, from: Int, parse: String => Option[A]): List[(A, Int)] =
+    if (from >= segment.length) Nil
+    else {
+      val start = if (segment.charAt(from) == '-') from + 1 else from
+      if (start >= segment.length || !segment.charAt(start).isDigit) Nil
+      else {
+        var end     = start + 1
+        val results = List.newBuilder[(A, Int)]
+        while (end <= segment.length && (end == start + 1 || segment.charAt(end - 1).isDigit)) {
+          parse(segment.substring(from, end)).foreach(v => results += (v -> end))
+          end += 1
+        }
+        results.result()
+      }
+    }
+
+  private def rejectTrailingString(codec: SegmentCodec[_], newName: String): Unit =
+    trailingLeaf(codec) match {
+      case Some(StringSeg(name, _, _)) =>
+        throw new IllegalArgumentException(s"Cannot combine two string segments. Their names are $name and $newName")
+      case _ => ()
+    }
+
+  private def rejectTrailingNumeric(codec: SegmentCodec[_], newName: String): Unit =
+    trailingLeaf(codec) match {
+      case Some(IntSeg(name, _, _)) =>
+        throw new IllegalArgumentException(s"Cannot combine two numeric segments. Their names are $name and $newName")
+      case Some(LongSeg(name, _, _)) =>
+        throw new IllegalArgumentException(s"Cannot combine two numeric segments. Their names are $name and $newName")
+      case _ => ()
+    }
+
+  private def trailingLeaf(codec: SegmentCodec[_]): Option[SegmentCodec[_]] =
+    codec match {
+      case Combined(_, right, _) => trailingLeaf(right)
+      case Empty                 => None
+      case other                 => Some(other)
+    }
+
+  private object SegmentCodecMacros {
+    private sealed trait SegmentInfoKind
+    private object SegmentInfoKind {
+      case object Empty   extends SegmentInfoKind
+      case object Literal extends SegmentInfoKind
+      case object String  extends SegmentInfoKind
+      case object Int     extends SegmentInfoKind
+      case object Long    extends SegmentInfoKind
+      case object Bool    extends SegmentInfoKind
+      case object UUID    extends SegmentInfoKind
+      case object Unknown extends SegmentInfoKind
+    }
+
+    private final case class SegmentInfo(kind: SegmentInfoKind, name: String)
+
+    def combineImpl[A: Type, B: Type, C: Type](
+      leftExpr: Expr[SegmentCodec[A]],
+      rightExpr: Expr[SegmentCodec[B]],
+      combinerExpr: Expr[Tuples.Tuples.WithOut[A, B, C]]
+    )(using Quotes): Expr[SegmentCodec[C]] = {
+      import quotes.reflect.*
+
+      val leftInfo  = segmentInfo(leftExpr.asTerm)
+      val rightInfo = segmentInfo(rightExpr.asTerm)
+
+      (leftInfo, rightInfo) match {
+        case (Some(SegmentInfo(SegmentInfoKind.String, leftName)), Some(SegmentInfo(SegmentInfoKind.String, rightName))) =>
+          report.errorAndAbort(s"Cannot combine two string segments. Their names are $leftName and $rightName")
+        case (Some(SegmentInfo(SegmentInfoKind.Int | SegmentInfoKind.Long, leftName)),
+              Some(SegmentInfo(SegmentInfoKind.Int | SegmentInfoKind.Long, rightName))) =>
+          report.errorAndAbort(s"Cannot combine two numeric segments. Their names are $leftName and $rightName")
+        case _ =>
+          '{ SegmentCodec.combineValidated($leftExpr, $rightExpr, $combinerExpr) }
+      }
+    }
+
+    private def segmentInfo(using Quotes)(term: quotes.reflect.Term): Option[SegmentInfo] = {
+      import quotes.reflect.*
+
+      def stringArg(args: List[Term], default: String): String =
+        args.collectFirst { case quotes.reflect.Literal(StringConstant(value)) => value }.getOrElse(default)
+
+      def applyInfo(name: String, args: List[Term]): Option[SegmentInfo] = name match {
+        case "literal" | "Literal" => Some(SegmentInfo(SegmentInfoKind.Literal, stringArg(args, "literal")))
+        case "string" | "StringSeg" => Some(SegmentInfo(SegmentInfoKind.String, stringArg(args, "string")))
+        case "int" | "IntSeg"       => Some(SegmentInfo(SegmentInfoKind.Int, stringArg(args, "int")))
+        case "long" | "LongSeg"     => Some(SegmentInfo(SegmentInfoKind.Long, stringArg(args, "long")))
+        case "bool" | "BoolSeg"     => Some(SegmentInfo(SegmentInfoKind.Bool, stringArg(args, "bool")))
+        case "uuid" | "UUIDSeg"     => Some(SegmentInfo(SegmentInfoKind.UUID, stringArg(args, "uuid")))
+        case "Empty"                 => Some(SegmentInfo(SegmentInfoKind.Empty, "empty"))
+        case _                       => None
+      }
+
+      def combineInfo(left: SegmentInfo, right: SegmentInfo): SegmentInfo =
+        (left.kind, right.kind) match {
+          case (SegmentInfoKind.Empty, _)    => right
+          case (_, SegmentInfoKind.Empty)    => left
+          case (_, SegmentInfoKind.Literal)  => right
+          case (_, SegmentInfoKind.Unknown)  => right
+          case _                             => right
+        }
+
+      term match {
+        case Inlined(_, _, inner) => segmentInfo(inner)
+        case Typed(inner, _)      => segmentInfo(inner)
+        case Block(_, expr)       => segmentInfo(expr)
+        case Ident(_)             =>
+          term.symbol.tree match {
+            case valDef: ValDef => valDef.rhs.flatMap(segmentInfo)
+            case _              => None
+          }
+        case Apply(TypeApply(Select(_, "combineValidated"), _), List(left, right, _)) =>
+          for {
+            leftInfo  <- segmentInfo(left)
+            rightInfo <- segmentInfo(right)
+          } yield combineInfo(leftInfo, rightInfo)
+        case Apply(Select(_, "combineValidated"), List(left, right, _)) =>
+          for {
+            leftInfo  <- segmentInfo(left)
+            rightInfo <- segmentInfo(right)
+          } yield combineInfo(leftInfo, rightInfo)
+        case Apply(fun, args) =>
+          val fullName = fun.symbol.fullName
+          if (fullName == "zio.blocks.endpoint.SegmentCodec.literal" || fullName == "zio.blocks.endpoint.SegmentCodec.string" ||
+            fullName == "zio.blocks.endpoint.SegmentCodec.int" || fullName == "zio.blocks.endpoint.SegmentCodec.long" ||
+            fullName == "zio.blocks.endpoint.SegmentCodec.bool" || fullName == "zio.blocks.endpoint.SegmentCodec.uuid")
+            applyInfo(fun.symbol.name, args)
+          else if (fullName.endsWith("SegmentCodec.Literal.apply") || fullName.endsWith("SegmentCodec.StringSeg.apply") ||
+            fullName.endsWith("SegmentCodec.IntSeg.apply") || fullName.endsWith("SegmentCodec.LongSeg.apply") ||
+            fullName.endsWith("SegmentCodec.BoolSeg.apply") || fullName.endsWith("SegmentCodec.UUIDSeg.apply"))
+            applyInfo(fun.symbol.owner.name, args)
+          else None
+        case Select(_, "Empty") => Some(SegmentInfo(SegmentInfoKind.Empty, "empty"))
+        case _                   => None
+      }
+    }
+  }
+}

--- a/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointGroupSpec.scala
+++ b/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointGroupSpec.scala
@@ -20,6 +20,7 @@ import zio.blocks.endpoint.RoutePattern.*
 import zio.http.Method
 import zio.test.*
 import scala.language.implicitConversions
+import scala.compiletime.testing.typeCheckErrors
 
 object EndpointGroupSpec extends ZIOSpecDefault {
 
@@ -44,6 +45,52 @@ object EndpointGroupSpec extends ZIOSpecDefault {
           val only = Endpoint(Method.GET / "only")
         }
         assertTrue(group.only.route.render == "GET /only")
+      }
+    ),
+    suite("endpoints macro M2 auto-naming")(
+      test("bare Endpoint(Method.GET / \"health\") auto-names to `GET /health`") {
+        val group = endpoints {
+          Endpoint(Method.GET / "health")
+        }
+        assertTrue(group.`GET /health`.route.render == "GET /health")
+      },
+      test("path var Endpoint(Method.GET / \"user\" / PathCodec.int(\"userId\")) names `GET /user/{userId}`") {
+        val group = endpoints {
+          Endpoint(Method.GET / "user" / PathCodec.int("userId"))
+        }
+        assertTrue(group.`GET /user/{userId}`.route.render == "GET /user/{userId}")
+      },
+      test("multi-method Endpoint(Method.GET #| Method.POST / \"orders\") names `GET#|POST /orders`") {
+        val group = endpoints {
+          Endpoint(Method.GET #| Method.POST / "orders")
+        }
+        assertTrue(group.`GET#|POST /orders`.route.render == "GET#|POST /orders")
+      },
+      test("same path different method coexist: GET /users and POST /users") {
+        val group = endpoints {
+          Endpoint(Method.GET / "users")
+          Endpoint(Method.POST / "users")
+        }
+        assertTrue(
+          group.`GET /users`.route.render == "GET /users",
+          group.`POST /users`.route.render == "POST /users"
+        )
+      },
+      test("mixed val-named + bare auto-named in one block") {
+        val group = endpoints {
+          val mine = Endpoint(Method.GET / "mine")
+          Endpoint(Method.GET / "auto")
+        }
+        assertTrue(
+          group.mine.route.render == "GET /mine",
+          group.`GET /auto`.route.render == "GET /auto"
+        )
+      },
+      test("collision on identical bare endpoints reports error") {
+        val errors = typeCheckErrors(
+          "endpoints { Endpoint(Method.GET / \"dup\"); Endpoint(Method.GET / \"dup\") }"
+        )
+        assertTrue(errors.nonEmpty)
       }
     )
   )

--- a/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointGroupSpec.scala
+++ b/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointGroupSpec.scala
@@ -163,6 +163,26 @@ object EndpointGroupSpec extends ZIOSpecDefault {
         }
         assertTrue(group.`type`.route.render == "GET /t")
       }
+    ),
+    suite("endpoints macro M4 path-variable prefixes")(
+      test("int(\"id\") / endpoints { val get = Endpoint(Method.GET / \"orders\") }") {
+        val byId = PathCodec.int("id") / endpoints { val get = Endpoint(Method.GET / "orders") }
+        assertTrue(byId.get.route.render == "GET /{id}/orders")
+      },
+      test("bare Endpoint under path-var prefix") {
+        val byId2 = PathCodec.int("id") / endpoints { Endpoint(Method.GET / "orders") }
+        assertTrue(byId2.`GET /orders`.route.render == "GET /{id}/orders")
+      },
+      test("child endpoint with own var composes PathVars") {
+        val byId3 = PathCodec.int("id") / endpoints { val o = Endpoint(Method.GET / "orders" / PathCodec.int("orderId")) }
+        assertTrue(byId3.o.route.render == "GET /{id}/orders/{orderId}")
+      },
+      test("path-var prefix preserves static PathInput type") {
+        val byId = PathCodec.int("id") / endpoints { val get = Endpoint(Method.GET / "orders") }
+        val get = byId.get
+        val _: RoutePattern[Int] = get.route   // compile-time: PathInput must be Int
+        assertTrue(byId.get.route.render == "GET /{id}/orders")
+      }
     )
   )
 }

--- a/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointGroupSpec.scala
+++ b/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointGroupSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import zio.blocks.endpoint.RoutePattern.*
+import zio.http.Method
+import zio.test.*
+import scala.language.implicitConversions
+
+object EndpointGroupSpec extends ZIOSpecDefault {
+
+  def spec: Spec[Any, Nothing] = suite("EndpointGroupSpec")(
+    suite("endpoints macro M1")(
+      test("two-val block returns NamedTuple with static .a .b access") {
+        val group = endpoints {
+          val a = Endpoint(Method.GET / "a")
+          val b = Endpoint(Method.GET / "b")
+        }
+        assertTrue(
+          group.a.route.render == "GET /a",
+          group.b.route.render == "GET /b"
+        )
+      },
+      test("empty block returns NamedTuple[EmptyTuple, EmptyTuple]") {
+        val group = endpoints {}
+        assertTrue(group.isInstanceOf[scala.NamedTuple.NamedTuple[EmptyTuple, EmptyTuple]])
+      },
+      test("single val block returns 1-member NamedTuple") {
+        val group = endpoints {
+          val only = Endpoint(Method.GET / "only")
+        }
+        assertTrue(group.only.route.render == "GET /only")
+      }
+    )
+  )
+}

--- a/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointGroupSpec.scala
+++ b/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointGroupSpec.scala
@@ -16,6 +16,7 @@
 
 package zio.blocks.endpoint
 
+import zio.blocks.endpoint.*
 import zio.blocks.endpoint.RoutePattern.*
 import zio.http.Method
 import zio.test.*
@@ -91,6 +92,40 @@ object EndpointGroupSpec extends ZIOSpecDefault {
           "endpoints { Endpoint(Method.GET / \"dup\"); Endpoint(Method.GET / \"dup\") }"
         )
         assertTrue(errors.nonEmpty)
+      }
+    ),
+    suite("endpoints macro M3 nesting")(
+      test("\"api\" / endpoints { val a = Endpoint(Method.GET / \"a\") }") {
+        val group = "api" / endpoints {
+          val a = Endpoint(Method.GET / "a")
+        }
+        assertTrue(group.a.route.render == "GET /api/a")
+      },
+      test("nested \"api\" / endpoints { \"v1\" / endpoints { val users = Endpoint(Method.GET / \"users\") } }") {
+        val group = "api" / endpoints {
+          "v1" / endpoints {
+            val users = Endpoint(Method.GET / "users")
+          }
+        }
+        assertTrue(group.v1.users.route.render == "GET /api/v1/users")
+      },
+      test("nested + auto-named inner Endpoint(Method.POST / \"users\")") {
+        val group = "api" / endpoints {
+          "v1" / endpoints {
+            Endpoint(Method.POST / "users")
+          }
+        }
+        assertTrue(group.v1.`POST /users`.route.render == "POST /api/v1/users")
+      },
+      test("deep 3-level nesting") {
+        val group = "a" / endpoints {
+          "b" / endpoints {
+            "c" / endpoints {
+              val x = Endpoint(Method.GET / "x")
+            }
+          }
+        }
+        assertTrue(group.b.c.x.route.render == "GET /a/b/c/x")
       }
     )
   )

--- a/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointGroupSpec.scala
+++ b/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointGroupSpec.scala
@@ -127,6 +127,42 @@ object EndpointGroupSpec extends ZIOSpecDefault {
         }
         assertTrue(group.b.c.x.route.render == "GET /a/b/c/x")
       }
+    ),
+    suite("endpoints macro M6 error handling")(
+      test("duplicate name reports error listing both locations and actionable advice") {
+        val errors = typeCheckErrors(
+          "endpoints { Endpoint(Method.GET / \"dup\"); Endpoint(Method.GET / \"dup\") }"
+        )
+        assertTrue(errors.nonEmpty && errors.exists(_.message.contains("duplicate")))
+      },
+      test("non-Endpoint val error message contains the val name and its actual type") {
+        val errors = typeCheckErrors(
+          "endpoints { val x = 42 }"
+        )
+        assertTrue(errors.nonEmpty && errors.exists(_.message.contains("val x")) && errors.exists(_.message.contains("of type")))
+      },
+      test("bare non-Endpoint expression reports error") {
+        val errors = typeCheckErrors(
+          "endpoints { \"not an endpoint\" }"
+        )
+        assertTrue(errors.nonEmpty)
+      },
+      test("23-member block compiles and .e22 access works (proves >22 arity via ofTupleFromSeq)") {
+        val group = endpoints {
+          val e0 = Endpoint(Method.GET / "e0"); val e1 = Endpoint(Method.GET / "e1"); val e2 = Endpoint(Method.GET / "e2"); val e3 = Endpoint(Method.GET / "e3"); val e4 = Endpoint(Method.GET / "e4")
+          val e5 = Endpoint(Method.GET / "e5"); val e6 = Endpoint(Method.GET / "e6"); val e7 = Endpoint(Method.GET / "e7"); val e8 = Endpoint(Method.GET / "e8"); val e9 = Endpoint(Method.GET / "e9")
+          val e10 = Endpoint(Method.GET / "e10"); val e11 = Endpoint(Method.GET / "e11"); val e12 = Endpoint(Method.GET / "e12"); val e13 = Endpoint(Method.GET / "e13"); val e14 = Endpoint(Method.GET / "e14")
+          val e15 = Endpoint(Method.GET / "e15"); val e16 = Endpoint(Method.GET / "e16"); val e17 = Endpoint(Method.GET / "e17"); val e18 = Endpoint(Method.GET / "e18"); val e19 = Endpoint(Method.GET / "e19")
+          val e20 = Endpoint(Method.GET / "e20"); val e21 = Endpoint(Method.GET / "e21"); val e22 = Endpoint(Method.GET / "e22")
+        }
+        assertTrue(group.e22.route.render == "GET /e22")
+      },
+      test("backticked reserved-word member name works (val `type`)") {
+        val group = endpoints {
+          val `type` = Endpoint(Method.GET / "t")
+        }
+        assertTrue(group.`type`.route.render == "GET /t")
+      }
     )
   )
 }

--- a/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
+++ b/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/EndpointSpec.scala
@@ -1,0 +1,641 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import scala.language.implicitConversions
+
+import java.util.UUID
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.docs.Doc
+import zio.blocks.endpoint.RoutePattern.*
+import zio.blocks.schema.Schema
+import zio.http.{Method, Status}
+import zio.test._
+import zio.test.Assertion.{isLeft, isRight}
+
+object EndpointSpec extends ZIOSpecDefault {
+
+  def spec: Spec[Any, Nothing] = suite("EndpointSpec")(
+    suite("SegmentCodec")(
+      test("literal segment") {
+        val seg = SegmentCodec.Literal("users")
+        assertTrue(seg.value == "users")
+      },
+      test("int segment") {
+        val seg = SegmentCodec.IntSeg("id")
+        assertTrue(seg.name == "id")
+      },
+      test("rejects combining two string segments") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+
+            val invalid = SegmentCodec.string("a") ~ SegmentCodec.string("b")
+          """)
+        )(isLeft)
+      },
+      test("rejects combining two numeric segments (int ~ int)") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+
+            val invalid = SegmentCodec.int("a") ~ SegmentCodec.int("b")
+          """)
+        )(isLeft)
+      },
+      test("rejects combining int after long") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+
+            val invalid = SegmentCodec.long("a") ~ SegmentCodec.int("b")
+          """)
+        )(isLeft)
+      },
+      test("rejects combining long after int") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+
+            val invalid = SegmentCodec.int("a") ~ SegmentCodec.long("b")
+          """)
+        )(isLeft)
+      },
+      test("rejects invalid nested combinations at compile time") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+
+            val invalid = SegmentCodec.uuid("id") ~ SegmentCodec.int("a") ~ SegmentCodec.int("b")
+          """)
+        )(isLeft)
+      },
+      test("allows valid mixed combinations") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+
+            val valid: SegmentCodec[(Int, String)] =
+              SegmentCodec.literal("v") ~ SegmentCodec.int("major") ~ SegmentCodec.string("suffix")
+          """)
+        )(isRight)
+      },
+      test("runtime validation still rejects opaque invalid combinations") {
+        val left: SegmentCodec[Any]  = SegmentCodec.string("a").asInstanceOf[SegmentCodec[Any]]
+        val right: SegmentCodec[Any] = SegmentCodec.string("b").asInstanceOf[SegmentCodec[Any]]
+
+        val result = scala.util.Try {
+          SegmentCodec.combineValidated(
+            left,
+            right,
+            summon[zio.blocks.combinators.Tuples.Tuples.WithOut[Any, Any, (Any, Any)]]
+          )
+        }
+
+        assertTrue(result.failed.toOption.exists(_.getMessage.contains("Cannot combine two string segments")))
+      }
+    ),
+    suite("PathCodec")(
+      test("path string parses slash-separated segments") {
+        val path = PathCodec("/users/posts")
+        val tree = RouteTree.empty[String].add(RoutePattern(Method.GET, path), "handler")
+        assertTrue(tree.get(Method.GET, zio.http.Path("/users/posts")) == Some("handler"))
+      },
+      test("literal path") {
+        val path = PathCodec.literal("users")
+        assertTrue(path.isInstanceOf[PathCodec.Segment[?]])
+      },
+      test("int path") {
+        val path = PathCodec.int("id")
+        assertTrue(path.isInstanceOf[PathCodec.Segment[?]])
+      },
+      test("literal path alternatives decode both branches") {
+        val path = PathCodec.literal("users").orElse(PathCodec.literal("posts"))
+        assertTrue(
+          path.decode(zio.http.Path("/users")) == Right(()),
+          path.decode(zio.http.Path("/posts")) == Right(())
+        )
+      },
+      test("combined segment path decodes and formats") {
+        val path = PathCodec(SegmentCodec.literal("v") ~ SegmentCodec.int("version"))
+        assertTrue(
+          path.decode(zio.http.Path("/v42")) == Right(42),
+          path.format(42).map(_.render) == Right("/v42")
+        )
+      },
+      test("bool path decodes and formats") {
+        val path = PathCodec.bool("flag")
+        assertTrue(
+          path.decode(zio.http.Path("/true")) == Right(true),
+          path.format(false).map(_.render) == Right("/false")
+        )
+      },
+      test("long path decodes and formats") {
+        val path = PathCodec.long("id")
+        assertTrue(
+          path.decode(zio.http.Path("/922337203685477580")) == Right(922337203685477580L),
+          path.format(42L).map(_.render) == Right("/42")
+        )
+      },
+      test("string path decodes and formats") {
+        val path = PathCodec.string("slug")
+        assertTrue(
+          path.decode(zio.http.Path("/hello-world")) == Right("hello-world"),
+          path.format("zio-http").map(_.render) == Right("/zio-http")
+        )
+      },
+      test("uuid path decodes and formats") {
+        val value = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+        val path  = PathCodec.uuid("id")
+        assertTrue(
+          path.decode(zio.http.Path(s"/$value")) == Right(value),
+          path.format(value).map(_.render) == Right(s"/$value")
+        )
+      }
+    ),
+    suite("RoutePattern")(
+      test("method syntax is the primary constructor") {
+        val getRoute  = Method.GET / "users"
+        val postRoute = Method.POST / "users"
+        assertTrue(
+          getRoute.method == Method.GET,
+          RouteTree.empty[String].add(getRoute, "handler").get(Method.GET, zio.http.Path("/users")) == Some("handler"),
+          postRoute.method == Method.POST
+        )
+      },
+      test("method + path") {
+        val rp = Method.GET / "users"
+        assertTrue(rp.method == Method.GET)
+      },
+      test("route pattern supports chained path composition") {
+        val route = Method.GET / "users" / PathCodec.int("id")
+        val tree  = RouteTree.empty[String].add(route, "handler")
+
+        assertTrue(tree.get(Method.GET, zio.http.Path("/users/42")) == Some("handler"))
+      },
+      test("method only") {
+        val rp = RoutePattern(Method.POST)
+        assertTrue(rp.method == Method.POST)
+      },
+      test("route pattern any captures trailing path") {
+        val route = RoutePattern.any(Method.GET)
+        assertTrue(route.decode(Method.GET, zio.http.Path("/users/42")).isRight)
+      },
+      test("route pattern any matches any method and any path") {
+        val route = RoutePattern.any
+        assertTrue(
+          route.decode(Method.GET, zio.http.Path("/users/42")).isRight,
+          route.decode(Method.POST, zio.http.Path("/users/42")).isRight
+        )
+      },
+      test("route pattern alternatives expand ANY into standard methods") {
+        val route = RoutePattern.any
+        assertTrue(route.alternatives.map(_.method).toSet == Method.standardMethods)
+      },
+      test("route pattern alternatives expand combined methods") {
+        val route = RoutePattern(Method.GET #| Method.POST, PathCodec.literal("users"))
+        assertTrue(route.alternatives.map(_.method).toSet == Set(Method.GET, Method.POST))
+      },
+      test("nest prepends path prefix") {
+        val route  = RoutePattern(Method.GET, PathCodec.literal("users") / PathCodec.int("id"))
+        val nested = route.nest(PathCodec("/api/v1"))
+        val tree   = RouteTree.empty[String].add(nested, "handler")
+        assertTrue(
+          tree.get(Method.GET, zio.http.Path("/api/v1/users/42")) == Some("handler"),
+          tree.get(Method.GET, zio.http.Path("/users/42")).isEmpty
+        )
+      },
+      test("combined method route pattern decodes matching methods") {
+        val route = RoutePattern(Method.GET #| Method.POST, PathCodec.literal("users"))
+        assertTrue(
+          route.decode(Method.GET, zio.http.Path("/users")) == Right(()),
+          route.decode(Method.POST, zio.http.Path("/users")) == Right(()),
+          route.decode(Method.DELETE, zio.http.Path("/users")).isLeft
+        )
+      }
+    ),
+    suite("HttpCodec")(
+      test("smart constructors") {
+        val q = HttpCodec.query("limit", Schema.int)
+        val h = HttpCodec.requestHeader("Authorization", Schema.string)
+        val b = HttpCodec.responseBody(Schema.string)
+        val s = HttpCodec.status(Status.Created)
+        val a = HttpCodec.bearerAuth
+
+        assertTrue(
+          q == HttpCodec.Query("limit", Schema.int),
+          h == HttpCodec.Header[CodecKind.Request, String]("Authorization", Schema.string),
+          b == HttpCodec.Body[CodecKind.Response, String](Schema.string),
+          s == HttpCodec.StatusCodec(Some(Status.Created)),
+          a.isInstanceOf[HttpCodec[CodecKind.Request, zio.http.headers.Authorization.Bearer]]
+        )
+      },
+      test("query codec") {
+        val q = HttpCodec.Query("limit", Schema.int)
+        assertTrue(q.name == "limit")
+      },
+      test("header codec") {
+        val h = HttpCodec.Header[CodecKind.Request, String]("Authorization", Schema.string)
+        assertTrue(h.name == "Authorization")
+      },
+      test("body codec") {
+        val b = HttpCodec.Body[CodecKind.Request, String](Schema.string)
+        assertTrue(b.name.isEmpty)
+      },
+      test("status codec") {
+        val s = HttpCodec.StatusCodec(Some(Status.Ok))
+        assertTrue(s.status.isDefined)
+      },
+      test("status codec stores metadata") {
+        val s = HttpCodec.status(
+          Status.Created,
+          Doc.empty,
+          examples = Chunk(Status.Created, Status.Accepted),
+          deprecated = Some(Doc.empty)
+        )
+
+        assertTrue(
+          s == HttpCodec.StatusCodec(
+            Some(Status.Created),
+            Doc.empty,
+            Chunk(Status.Created, Status.Accepted),
+            Some(Doc.empty)
+          )
+        )
+      },
+      test("typed authorization schema failures surface SchemaError") {
+        val codec = HttpCodec.bearerAuth.asInstanceOf[
+          HttpCodec.Header[CodecKind.Request, zio.http.headers.Authorization.Bearer]
+        ]
+        val result = codec.schema.fromDynamicValue(Schema.string.toDynamicValue("Basic Zm9vOmJhcg=="))
+
+        assertTrue(
+          result.isLeft,
+          result.swap.exists(_.message.contains("Expected Bearer authorization header"))
+        )
+      },
+      test("empty codec") {
+        assertTrue(HttpCodec.Empty.isInstanceOf[HttpCodec[?, ?]])
+      }
+    ),
+    suite("AuthType")(
+      test("none") {
+        assertTrue(AuthType.None.isInstanceOf[AuthType])
+      },
+      test("bearer") {
+        assertTrue(AuthType.Bearer.isInstanceOf[AuthType])
+      },
+      test("or composition") {
+        val auth = AuthType.Basic | AuthType.Bearer
+        assertTrue(auth.isInstanceOf[AuthType.Or[?, ?, ?]])
+      },
+      test("scoped") {
+        val auth = AuthType.Scoped(AuthType.Bearer, List("read", "write"))
+        assertTrue(auth.scopes == List("read", "write"))
+      },
+      test("typed auth is preserved on endpoint") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+
+            val endpoint = Endpoint(Method.GET / "users").auth(AuthType.Bearer)
+            val codec = endpoint.auth.codec
+          """)
+        )(isRight)
+      },
+      test("unauthorizedStatus returns wrapped auth type") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+            import zio.http.Status
+            import zio.http.headers
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .auth(AuthType.Bearer)
+              .unauthorizedStatus(Status.Unauthorized)
+
+            val auth = endpoint.auth
+            val status = auth.unauthorizedStatus
+            val codec: HttpCodec[CodecKind.Request, headers.Authorization.Bearer] = auth.codec
+          """)
+        )(isRight)
+      }
+    ),
+    suite("Endpoint")(
+      test("create from route pattern") {
+        val ep = Endpoint(Method.GET / "users")
+        assertTrue(ep.route.method == Method.GET, ep.auth == AuthType.None)
+      }
+    ),
+    suite("HttpCodec phantom type")(
+      test("rejects mixing request and response") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+            import zio.http.Status
+
+            val bad = HttpCodec.Query("name", Schema.string) ++ HttpCodec.StatusCodec(Some(Status.Ok))
+          """)
+        )(isLeft)
+      },
+      test("accepts valid request combination") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+
+            val good = HttpCodec.Query("name", Schema.string) ++ HttpCodec.Query("age", Schema.int)
+          """)
+        )(isRight)
+      },
+      test("combines request codecs") {
+        val input = HttpCodec.Query("name", Schema.string) ++ HttpCodec.Query("age", Schema.int)
+        assertTrue(input.isInstanceOf[HttpCodec[CodecKind.Request, ?]])
+      },
+      test("combines response codecs") {
+        val output = HttpCodec.StatusCodec(Some(Status.Ok)) ++
+          HttpCodec.Body[CodecKind.Response, String](Schema.string)
+        assertTrue(output.isInstanceOf[HttpCodec[CodecKind.Response, ?]])
+      }
+    ),
+    suite("Endpoint builders")(
+      test("query and header builders compose request input") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .query(HttpCodec.query("q", Schema.string))
+              .header(HttpCodec.requestHeader("X-Trace", Schema.string))
+          """)
+        )(isRight)
+      },
+      test("header builder has schema overload") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .header("X-Trace", Schema.string)
+          """)
+        )(isRight)
+      },
+      test("header builder has documented schema overload") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.docs.Doc
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .header("X-Trace", Schema.string, Doc.empty)
+          """)
+        )(isRight)
+      },
+      test("in builder is additive") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .in(HttpCodec.query("q", Schema.string))
+              .in(HttpCodec.requestHeader("X-Trace", Schema.string))
+          """)
+        )(isRight)
+      },
+      test("query builder rejects non-query codecs") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+
+            Endpoint(Method.GET / "users").query(HttpCodec.requestBody(Schema.string))
+          """)
+        )(isLeft)
+      },
+      test("header builder rejects non-header codecs") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+
+            Endpoint(Method.GET / "users").header(HttpCodec.query("q", Schema.string))
+          """)
+        )(isLeft)
+      },
+      test("out builder keeps previous alternatives") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+            import zio.http.Status
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .out(Schema.string)
+              .out(Status.Created, Schema.int)
+          """)
+        )(isRight)
+      },
+      test("out supports documented schema overload") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.docs.Doc
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .out(Schema.string, Doc.empty)
+          """)
+        )(isRight)
+      },
+      test("out supports media-type overloads") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.docs.Doc
+            import zio.blocks.endpoint._
+            import zio.blocks.mediatype.MediaTypes
+            import zio.blocks.schema.Schema
+            import zio.http.Status
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .out(MediaTypes.application.`json`, Schema.string)
+              .out(Status.Created, MediaTypes.text.`plain`, Schema.int, Doc.empty)
+          """)
+        )(isRight)
+      },
+      test("outHeader has schema overloads") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.docs.Doc
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .outHeader("X-Trace", Schema.string)
+              .outHeader("X-Other", Schema.int, Doc.empty)
+          """)
+        )(isRight)
+      },
+      test("outError helper adds status-tagged error alternative") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+            import zio.http.Status
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .outError(Status.BadRequest, Schema.string)
+          """)
+        )(isRight)
+      },
+      test("outError supports documented schema overload") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.docs.Doc
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+            import zio.http.Status
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .outError(Status.BadRequest, Schema.string, Doc.empty)
+          """)
+        )(isRight)
+      },
+      test("outError supports media-type overloads") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.docs.Doc
+            import zio.blocks.endpoint._
+            import zio.blocks.mediatype.MediaTypes
+            import zio.blocks.schema.Schema
+            import zio.http.Status
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .outError(Status.BadRequest, MediaTypes.application.`json`, Schema.string)
+              .outError(Status.Conflict, MediaTypes.text.`plain`, Schema.int, Doc.empty)
+          """)
+        )(isRight)
+      },
+      test("orOutError introduces Scala 3 union error types") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+            import zio.http.Status
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .orOutError(Status.BadRequest, Schema.string)
+              .orOutError(Status.Conflict, Schema.int)
+
+            val _: Endpoint[Unit, Unit, String | Int, Unit, AuthType.None] = endpoint
+          """)
+        )(isRight)
+      },
+      test("orOutError supports documented and media-type overloads") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.docs.Doc
+            import zio.blocks.endpoint._
+            import zio.blocks.mediatype.MediaTypes
+            import zio.blocks.schema.Schema
+            import zio.http.Status
+
+            val endpoint = Endpoint(Method.GET / "users")
+              .orOutError(Status.BadRequest, Schema.string, Doc.empty)
+              .orOutError(Status.Conflict, MediaTypes.text.`plain`, Schema.int, Doc.empty)
+
+            val _: Endpoint[Unit, Unit, String | Int, Unit, AuthType.None] = endpoint
+          """)
+        )(isRight)
+      },
+      test("orOutError builds union-aware fallback codec") {
+        val first: HttpCodec[CodecKind.Response, String] =
+          HttpCodec.responseBody(Schema.string, name = Some("error-response")) ++ HttpCodec.status(Status.BadRequest)
+        val second: HttpCodec[CodecKind.Response, Int] =
+          HttpCodec.responseBody(Schema.int, name = Some("error-response")) ++ HttpCodec.status(Status.Conflict)
+        val builder = summon[EndpointUnionErrorBuilder.ErrorBuilder.WithOut[String, Int, String | Int]]
+        val codec   = builder.add(first, second)
+
+        codec match {
+          case fallback: HttpCodec.Fallback[CodecKind.Response, String, Int, String | Int] @unchecked =>
+            assertTrue(
+              fallback.left == first,
+              fallback.right == second,
+              fallback.alternator.separate("bad request") == Left("bad request"),
+              fallback.alternator.separate(409) == Right(409)
+            )
+          case _ =>
+            assertTrue(false)
+        }
+      },
+      test("orOutError rejects overlapping union types") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+            import zio.http.Status
+
+            Endpoint(Method.GET / "users")
+              .orOutError(Status.BadRequest, Schema.string)
+              .orOutError(Status.Conflict, Schema.string)
+          """)
+        )(isLeft)
+      },
+      test("in schema overload adds request body") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+
+            val endpoint = Endpoint(Method.POST / "users")
+              .in(Schema.string)
+          """)
+        )(isRight)
+      },
+      test("in supports documented schema overload") {
+        assertZIO(
+          typeCheck("""
+            import zio.blocks.docs.Doc
+            import zio.blocks.endpoint._
+            import zio.blocks.schema.Schema
+
+            val endpoint = Endpoint(Method.POST / "users")
+              .in(Schema.string, Doc.empty)
+          """)
+        )(isRight)
+      },
+      test("in/out/error/auth/doc") {
+        val endpoint = Endpoint(Method.GET / "users")
+          .in(HttpCodec.Query("q", Schema.string))
+          .out(Schema.string)
+          .outError(HttpCodec.StatusCodec())
+          .auth(AuthType.Bearer)
+          .doc(zio.blocks.docs.Doc.empty)
+
+        assertTrue(
+          endpoint.auth == AuthType.Bearer,
+          endpoint.route.method == Method.GET
+        )
+      }
+    )
+  )
+}

--- a/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/RouteTreeSpec.scala
+++ b/endpoint/shared/src/test/scala-3/zio/blocks/endpoint/RouteTreeSpec.scala
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.endpoint
+
+import scala.language.implicitConversions
+
+import zio.blocks.endpoint.RoutePattern.*
+import zio.http.{Method, Path}
+import zio.test._
+
+object RouteTreeSpec extends ZIOSpecDefault {
+
+  def spec: Spec[Any, Nothing] = suite("RouteTreeSpec")(
+    test("empty tree") {
+      val tree = RouteTree.empty[String]
+      assertTrue(tree.get(Method.GET, Path("/")).isEmpty)
+    },
+    test("single literal route") {
+      val tree = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, PathCodec.literal("users")), "handler")
+
+      assertTrue(tree.get(Method.GET, Path("/users")) == Some("handler"))
+    },
+    test("single typed route") {
+      val usersWithId = PathCodec.literal("users") / PathCodec.int("id")
+      val tree        = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, usersWithId), "handler")
+
+      assertTrue(tree.get(Method.GET, Path("/users/42")) == Some("handler"))
+    },
+    test("multiple methods") {
+      val tree = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, PathCodec.literal("users")), "get-users")
+        .add(RoutePattern(Method.POST, PathCodec.literal("users")), "post-users")
+
+      assertTrue(
+        tree.get(Method.GET, Path("/users")) == Some("get-users"),
+        tree.get(Method.POST, Path("/users")) == Some("post-users")
+      )
+    },
+    test("multiple paths") {
+      val tree = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, PathCodec.literal("users")), "users")
+        .add(RoutePattern(Method.GET, PathCodec.literal("posts")), "posts")
+
+      assertTrue(
+        tree.get(Method.GET, Path("/users")) == Some("users"),
+        tree.get(Method.GET, Path("/posts")) == Some("posts")
+      )
+    },
+    test("path with multiple segments") {
+      val usersWithPosts =
+        PathCodec.literal("users") /
+          PathCodec.int("user-id") /
+          PathCodec.literal("posts") /
+          PathCodec.int("post-id")
+      val tree = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, usersWithPosts), "handler")
+
+      assertTrue(tree.get(Method.GET, Path("/users/42/posts/7")) == Some("handler"))
+    },
+    test("no match") {
+      val tree = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, PathCodec.literal("users")), "handler")
+
+      assertTrue(tree.get(Method.GET, Path("/posts")).isEmpty)
+    },
+    test("trailing matches suffix") {
+      val assets = PathCodec.literal("assets") / PathCodec.trailing
+      val tree   = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, assets), "handler")
+
+      assertTrue(
+        tree.get(Method.GET, Path("/assets")) == Some("handler"),
+        tree.get(Method.GET, Path("/assets/js/app.js")) == Some("handler")
+      )
+    },
+    test("trailing does not shadow more specific dynamic routes after merge") {
+      val trailingTree = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, PathCodec.trailing), "trailing")
+
+      val intTree = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, PathCodec.int("id")), "int")
+
+      val merged = trailingTree.merge(intTree)
+
+      assertTrue(
+        merged.get(Method.GET, Path("/42")) == Some("int"),
+        merged.get(Method.GET, Path("/foo/bar")) == Some("trailing")
+      )
+    },
+    test("overlapping dynamic routes prefer more specific kinds before string") {
+      val stringFirst = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, PathCodec.string("value")), "string")
+        .add(RoutePattern(Method.GET, PathCodec.int("id")), "int")
+
+      val intFirst = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, PathCodec.int("id")), "int")
+        .add(RoutePattern(Method.GET, PathCodec.string("value")), "string")
+
+      assertTrue(
+        stringFirst.get(Method.GET, Path("/42")) == Some("int"),
+        intFirst.get(Method.GET, Path("/42")) == Some("int")
+      )
+    },
+    test("dynamic routes with different metadata share the same branch kind") {
+      val first = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, PathCodec.int("id")), "first")
+        .add(RoutePattern(Method.GET, PathCodec.int("userId")), "second")
+
+      val second = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, PathCodec.int("userId")), "second")
+        .add(RoutePattern(Method.GET, PathCodec.int("id")), "first")
+
+      assertTrue(
+        first.get(Method.GET, Path("/42")) == Some("second"),
+        second.get(Method.GET, Path("/42")) == Some("first")
+      )
+    },
+    test("merge prefers right-hand side") {
+      val tree1 = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, PathCodec.literal("users")), "left")
+
+      val tree2 = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, PathCodec.literal("users")), "right")
+        .add(RoutePattern(Method.GET, PathCodec.literal("posts")), "posts")
+
+      val merged = tree1.merge(tree2)
+
+      assertTrue(
+        merged.get(Method.GET, Path("/users")) == Some("right"),
+        merged.get(Method.GET, Path("/posts")) == Some("posts")
+      )
+    },
+    test("map transforms values") {
+      val tree = RouteTree
+        .empty[Int]
+        .add(RoutePattern(Method.GET, PathCodec.literal("users")), 1)
+      val mapped = tree.map(_ + 1)
+
+      assertTrue(mapped.get(Method.GET, Path("/users")) == Some(2))
+    },
+    test("collision between literal and int segment") {
+      val literalRoute = PathCodec("users/42")
+      val intRoute     = PathCodec.literal("users") / PathCodec.int("id")
+      val tree         = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, intRoute), "int")
+        .add(RoutePattern(Method.GET, literalRoute), "literal")
+
+      assertTrue(
+        tree.get(Method.GET, Path("/users/42")) == Some("literal"),
+        tree.get(Method.GET, Path("/users/99")) == Some("int")
+      )
+    },
+    test("head falls back to get routes") {
+      val tree = RouteTree.empty[String].add(Method.GET / "users", "handler")
+      assertTrue(tree.get(Method.HEAD, Path("/users")) == Some("handler"))
+    },
+    test("path alternatives add both routes") {
+      val tree = RouteTree
+        .empty[String]
+        .add(RoutePattern(Method.GET, PathCodec.literal("users").orElse(PathCodec.literal("posts"))), "handler")
+
+      assertTrue(
+        tree.get(Method.GET, Path("/users")) == Some("handler"),
+        tree.get(Method.GET, Path("/posts")) == Some("handler")
+      )
+    },
+    test("any route expands to all methods when inserted into route tree") {
+      val tree = RouteTree.empty[String].add(RoutePattern.any, "handler")
+
+      assertTrue(
+        tree.get(Method.GET, Path("/users")) == Some("handler"),
+        tree.get(Method.POST, Path("/users")) == Some("handler"),
+        tree.get(Method.DELETE, Path("/users")) == Some("handler")
+      )
+    },
+    test("multi-method route expands each method when inserted into route tree") {
+      val tree = RouteTree.empty[String].add(RoutePattern(Method.GET #| Method.POST, PathCodec.literal("users")), "handler")
+
+      assertTrue(
+        tree.get(Method.GET, Path("/users")) == Some("handler"),
+        tree.get(Method.POST, Path("/users")) == Some("handler"),
+        tree.get(Method.DELETE, Path("/users")).isEmpty
+      )
+    },
+    test("combined segments match within one path segment") {
+      val route = Method.GET / PathCodec(SegmentCodec.literal("v") ~ SegmentCodec.int("version"))
+      val tree  = RouteTree.empty[String].add(route, "handler")
+
+      assertTrue(
+        tree.get(Method.GET, Path("/v42")) == Some("handler"),
+        tree.get(Method.GET, Path("/vfoo")).isEmpty
+      )
+    }
+  )
+}

--- a/http-model/shared/src/main/scala/zio/http/Method.scala
+++ b/http-model/shared/src/main/scala/zio/http/Method.scala
@@ -24,7 +24,30 @@ import zio.blocks.chunk.Chunk
  * Each method has a unique `ordinal` for efficient array-based dispatch.
  */
 sealed abstract class Method(val name: String, val ordinal: Int) {
-  override def toString: String = name
+  def #|(that: Method): Method =
+    if (this == Method.ANY || that == Method.ANY) Method.ANY
+    else
+      (this, that) match {
+        case (Method.Methods(a), Method.Methods(b)) => Method.Methods(a ++ b)
+        case (Method.Methods(a), _)                 => Method.Methods(a + that)
+        case (_, Method.Methods(b))                 => Method.Methods(b + this)
+        case _ if this == that                      => this
+        case _                                      => Method.Methods(Set(this, that))
+      }
+
+  def matches(that: Method): Boolean =
+    if (this == Method.ANY || that == Method.ANY) true
+    else
+      this match {
+        case Method.Methods(methods) => methods.exists(_.matches(that))
+        case _                       =>
+          that match {
+            case Method.Methods(methods) => methods.exists(_.matches(this))
+            case _                       => this == that
+          }
+      }
+
+  override def toString: String = Method.render(this)
 }
 
 object Method {
@@ -37,12 +60,21 @@ object Method {
   case object OPTIONS extends Method("OPTIONS", 6)
   case object TRACE   extends Method("TRACE", 7)
   case object CONNECT extends Method("CONNECT", 8)
+  case object ANY     extends Method("GET", -1)
+
+  final case class Methods(methods: Set[Method])
+      extends Method(methods.toList.sortBy(Method.render).map(Method.render).mkString("#|"), -1)
 
   val values: Chunk[Method] = Chunk(GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE, CONNECT)
+
+  val standardMethods: Set[Method] = values.iterator.toSet
 
   private val byName: Map[String, Method] = values.iterator.map(m => m.name -> m).toMap
 
   def fromString(s: String): Option[Method] = byName.get(s)
 
-  def render(method: Method): String = method.name
+  def render(method: Method): String = method match {
+    case ANY => "*"
+    case _   => method.name
+  }
 }

--- a/http-model/shared/src/test/scala/zio/http/MethodSpec.scala
+++ b/http-model/shared/src/test/scala/zio/http/MethodSpec.scala
@@ -106,6 +106,46 @@ object MethodSpec extends HttpModelBaseSpec {
           Method.DELETE.toString == "DELETE"
         )
       }
+    ),
+    suite("matches")(
+      test("ANY matches every standard method") {
+        assertTrue(
+          Method.ANY.matches(Method.GET),
+          Method.GET.matches(Method.ANY),
+          Method.ANY.matches(Method.POST)
+        )
+      },
+      test("combined methods match any constituent method") {
+        val combined = Method.GET #| Method.POST
+        assertTrue(
+          combined.matches(Method.GET),
+          combined.matches(Method.POST),
+          !combined.matches(Method.DELETE)
+        )
+      }
+    ),
+    suite("#|")(
+      test("combines distinct methods into Methods") {
+        val combined = Method.GET #| Method.POST
+        assertTrue(combined == Method.Methods(Set(Method.GET, Method.POST)))
+      },
+      test("returns ANY when either side is ANY") {
+        assertTrue(
+          (Method.ANY #| Method.GET) == Method.ANY,
+          (Method.GET #| Method.ANY) == Method.ANY
+        )
+      },
+      test("deduplicates repeated methods") {
+        assertTrue((Method.GET #| Method.GET) == Method.GET)
+      }
+    ),
+    suite("special methods")(
+      test("render formats ANY as wildcard") {
+        assertTrue(Method.render(Method.ANY) == "*")
+      },
+      test("standardMethods contains all 9 standard methods") {
+        assertTrue(Method.standardMethods == Method.values.iterator.toSet)
+      }
     )
   )
 }


### PR DESCRIPTION
## Summary

Adds a Scala 3-only bulk endpoint creation DSL to the `endpoint` module:

```scala
val api = "api" / endpoints {
  val customer = Endpoint(Method.GET / "customers")   // member .customer
  Endpoint(Method.GET / "health")                     // auto-named `GET /health`
  "v1" / endpoints {                                  // nested constant prefix
    val users = Endpoint(Method.GET / "users")
    Endpoint(Method.POST / "users")                   // auto-named `POST /users`
  }
}

val byId = PathCodec.int("id") / endpoints {          // capturing path-variable prefix
  val get = Endpoint(Method.GET / "orders")
}
// byId.get : Endpoint[Int, Unit, Unit, Unit, AuthType.None] — PathVars preserved statically
```

### Features
- **Bulk creation**: a block of `val name = Endpoint(...)` / bare `Endpoint(...)` statements returns a Scala 3 `NamedTuple` with statically-typed members (`.customer`, `` .`GET /health` ``) — zero runtime cost, compile-time duplicate-name detection, no 22-member cap.
- **Auto-naming mirrors `RoutePattern.render` exactly** (RFC 6570 `{var}` style): literals as-is, named vars `{name}`, intra-segment `~` concatenation (`v{major}`), trailing `...`, multi-method `GET#|POST /orders`. Same path + different method = distinct legal members; true duplicates fail compilation.
- **Constant-prefix nesting**: `"api" / endpoints { "v1" / endpoints { ... } }` composes prefixes into every leaf at description level via a runtime `NestPrefix` type-class (avoids the runtime-prefix codec breakage class of bugs); grouping nodes carry no path.
- **Path-variable prefixes**: `int("id") / endpoints { ... }` composes the capturing codec into each child and reconstructs each leaf's precise composed type — PathInput/PathVars flow statically so handlers will receive typed ids.
- **Error hardening**: actionable messages for duplicates (with both locations), non-Endpoint vals, unsupported trees ("assign to val"); >22-member blocks proven; backticked reserved-word members work.

### Architecture note
`endpoints { ... }` is a transparent-inline macro; `/` prefixing is deliberately NOT macro-based for constants (plain extension + runtime `NestPrefix`) because dotty's inliner collapses nested transparent-inline chains — outer macros never execute. Capturing prefixes use a focused macro that recovers the inner block via the preserved `Inlined.call` field. Details in the module docs added here.

### Scope note
The first commit (`fix(endpoint): rebase branch and preserve route parity`) establishes the `endpoint` module baseline this DSL builds on — nothing of it exists on `main` yet, so it necessarily rides in this PR.

## Testing
- `endpointJVM/test` (Scala 3.8.3): **108 tests green**, incl. new suites for M1 groups, auto-naming, constant nesting, path-variable prefixes (with a compile-time `RoutePattern[Int]` static-type assertion), and error handling (23-member blocks, duplicate detection via `typeCheckErrors`).
- Existing `EndpointSpec` / `RouteTreeSpec` regression-green.
- New `endpoint-examples` module wired (compile-checked) with a runnable example.

## Follow-ups
- Route creation convenience (`toRoutes`) lives in zio-http (RouteTree stays internal here) — separate change.
- Known limitation: constant-prefix subgroups directly inside a var-prefixed block abort with "use a flat block" guidance.