### PR TITLE
Document the typed header model in http-model

### DIFF
--- a/docs/reference/http-model/headers.md
+++ b/docs/reference/http-model/headers.md
@@ -1,0 +1,660 @@
+---
+id: headers
+title: "Header"
+sidebar_label: "Header"
+---
+
+`Header` is the typed model of a single HTTP header field. Each of the 75 built-in headers is a case class or sealed ADT paired with a companion that knows the header's wire name and how to parse and render it. `Header.Codec[A]` is the type class carrying that knowledge, and `Headers` uses it to decode raw strings on demand and cache the result. The lead-in to every typed read:
+
+```scala
+trait Header {
+  def headerName: String
+  def renderedValue: String
+}
+
+object Header {
+  trait Codec[A] {
+    def name: String
+    def parse(value: String): Either[String, A]
+    def render(value: A): String
+  }
+
+  trait Typed[H <: Header] extends Codec[H]
+
+  case class Custom(headerName: String, rawValue: String) extends Header
+}
+```
+
+## Motivation
+
+An HTTP message is a bag of strings, and treating it that way pushes the same three mistakes into every handler. `headers.rawGet("content-length").map(_.toInt)` throws on a malformed value. `headers.rawGet("Content-Length")` works only because someone remembered the casing rules. `cache-control: max-age=600, no-store` has to be split, trimmed, and matched by hand at each call site.
+
+A typed header replaces all three with one lookup. `Header.ContentLength` knows its wire name is `content-length`, that the value is a `Long`, and that a non-numeric value is a parse failure rather than an exception. Reading it is `headers.get(Header.ContentLength)`, and the result is an `Option[ContentLength]` with a `length: Long` inside.
+
+Parsing stays lazy because most handlers read two or three headers out of fifteen. `Headers` keeps the raw strings and only parses an entry when a typed read asks for it, caching the parsed value per entry so a header read twice is parsed once.
+
+## Quick Showcase
+
+Setting a typed header renders it; reading it back parses it:
+
+```scala mdoc:silent
+import zio.http.{Header, Headers}
+
+val headers = Headers.empty
+  .add(Header.ContentLength(1024))
+  .add(Header.CacheControl.MaxAge(600))
+  .add("x-request-id", "abc-123")
+```
+
+Rendering happened at `Headers#add`, so the collection holds wire-format strings:
+
+```scala mdoc
+headers.toList
+```
+
+Typed reads give back the domain value, and untyped reads give back the string:
+
+```scala mdoc
+headers.get(Header.ContentLength)
+headers.get(Header.CacheControl)
+headers.rawGet("x-request-id")
+```
+
+Lookups are case-insensitive in both directions, because names are lowercased on the way in:
+
+```scala mdoc
+headers.rawGet("X-Request-ID")
+headers.has("Content-Length")
+```
+
+## The Codec Type Class
+
+`Header.Codec[A]` is what every typed read and write goes through. It pairs a wire name with a parse and a render:
+
+```scala
+trait Codec[A] {
+  def name: String
+  def parse(value: String): Either[String, A]
+  def render(value: A): String
+}
+```
+
+`Header.Typed[H <: Header]` narrows that to codecs whose domain value is itself a `Header`, which is what all 75 built-ins are. Each header's companion object *is* its codec — `Header.ContentLength` refers to the companion when used as a codec and to the case class when used as a type:
+
+```scala mdoc:silent:reset
+import zio.http.Header
+```
+
+The codec's name is the canonical lowercase wire name, and parsing reports a message rather than throwing:
+
+```scala mdoc
+Header.ContentLength.name
+Header.ContentLength.parse("1024")
+Header.ContentLength.parse("not-a-number")
+```
+
+Rendering is the inverse, and every built-in round-trips:
+
+```scala mdoc
+Header.ContentLength.render(Header.ContentLength(1024))
+```
+
+Because `Header` itself carries `headerName` and `renderedValue`, an instance knows how to write itself without the codec being named again:
+
+```scala mdoc
+Header.CacheControl.MaxAge(600).headerName
+Header.CacheControl.MaxAge(600).renderedValue
+```
+
+## Reading Headers
+
+Six methods read from a `Headers` collection: three typed, three raw. Which you want depends on whether you need the domain value or the exact bytes.
+
+### `Headers#get` — first parseable match
+
+`Headers#get` scans for the first entry whose name matches the codec and returns the parsed value:
+
+```scala
+final class Headers {
+  def get[A](headerCodec: Header.Codec[A]): Option[A]
+}
+```
+
+A present, well-formed header parses; an absent one is `None`:
+
+```scala mdoc:silent:reset
+import zio.http.{Header, Headers}
+
+val headers = Headers("content-length" -> "2048", "accept" -> "application/json")
+```
+
+The typed result carries the domain value, not the string:
+
+```scala mdoc
+headers.get(Header.ContentLength)
+headers.get(Header.ETag)
+```
+
+:::warning[Unparseable headers are skipped, not reported]
+`Headers#get` treats a parse failure exactly like a name mismatch: it discards the error and keeps scanning. A malformed header therefore reads as `None` — or as the *next* entry with the same name that does parse. There is no method that surfaces the parse error from a collection read.
+:::
+
+That behaviour is worth seeing, because it is the one place a typed read can mislead you:
+
+```scala mdoc:silent:reset
+import zio.http.{Header, Headers}
+
+val malformed = Headers("content-length" -> "huge")
+val shadowing = Headers("content-length" -> "huge", "content-length" -> "512")
+```
+
+A single bad value is indistinguishable from an absent header, and a bad value followed by a good one silently yields the good one:
+
+```scala mdoc
+malformed.get(Header.ContentLength)
+shadowing.get(Header.ContentLength)
+```
+
+To tell "missing" from "malformed", read the raw value and parse it explicitly:
+
+```scala mdoc
+malformed.rawGet("content-length").map(Header.ContentLength.parse)
+```
+
+### `Headers#getAll` — every parseable match
+
+`Headers#getAll` returns all matching entries in header order, skipping the ones that fail to parse:
+
+```scala
+final class Headers {
+  def getAll[A](headerCodec: Header.Codec[A]): Chunk[A]
+}
+```
+
+Multi-value headers are the normal case for `accept-encoding`, `via`, and `set-cookie`:
+
+```scala mdoc:silent:reset
+import zio.http.{Header, Headers}
+
+val multi = Headers(
+  "content-length" -> "100",
+  "content-length" -> "oops",
+  "content-length" -> "300"
+)
+```
+
+Two entries parse and the middle one is dropped, so the typed result is shorter than the raw one:
+
+```scala mdoc
+multi.getAll(Header.ContentLength)
+multi.rawGetAll("content-length").length
+```
+
+How many entries survive depends on how strict the individual codec is, and they vary. `Header.ContentLength` rejects anything non-numeric, while some codecs accept almost any input:
+
+```scala mdoc
+Header.AcceptEncoding.parse("gzip")
+Header.AcceptEncoding.parse("!!!")
+```
+
+:::warning[`AcceptEncoding` falls back to `GZip` on unknown values]
+`Header.AcceptEncoding` matches a fixed set of encoding names and returns `GZip` for anything it does not recognize, rather than reporting a parse failure. A request with `accept-encoding: bogus` — or a typo like `identityy` — reads as if the client asked for gzip. Its `parse` fails only on an empty value, so a server choosing a response encoding from this header should compare against `Header.AcceptEncoding.render` output or read the raw value instead.
+:::
+
+### `Headers#getLast` — last parseable match
+
+`Headers#getLast` is `Headers#getAll` keeping only the final element, which is what you want when a later header is meant to override an earlier one:
+
+```scala
+final class Headers {
+  def getLast[H <: Header](headerType: Header.Typed[H]): Option[H]
+}
+```
+
+Note the tighter bound: `Headers#getLast` takes a `Header.Typed[H]`, so it works with the built-ins but not with a bare `Header.Codec[A]` over a non-`Header` type:
+
+```scala mdoc:silent:reset
+import zio.http.{Header, Headers}
+
+val overridden = Headers("content-length" -> "100", "content-length" -> "200")
+```
+
+First and last differ, and each method says which it takes:
+
+```scala mdoc
+overridden.get(Header.ContentLength)
+overridden.getLast(Header.ContentLength)
+```
+
+### Raw Access
+
+Three methods bypass parsing entirely and hand back the stored string. Use them for headers with no typed model, for pass-through proxying, and for telling a malformed value from an absent one:
+
+| Method                    | Returns             | Picks                        |
+| ------------------------- | ------------------- | ---------------------------- |
+| `Headers#rawGet`          | `Option[String]`    | First entry with that name    |
+| `Headers#rawGetLast`      | `Option[String]`    | Last entry with that name     |
+| `Headers#rawGetAll`       | `Chunk[String]`     | Every entry, in header order  |
+
+All three validate the name before scanning and are case-insensitive:
+
+```scala mdoc:silent:reset
+import zio.http.Headers
+
+val headers = Headers("x-trace" -> "a", "x-trace" -> "b")
+```
+
+Raw reads never fail on content, only on a structurally invalid name:
+
+```scala mdoc
+headers.rawGet("X-Trace")
+headers.rawGetLast("x-trace")
+headers.rawGetAll("x-trace")
+```
+
+`Headers#has` and its alias `Headers#contains` test for presence without reading a value:
+
+```scala mdoc
+headers.has("x-trace")
+headers.contains("x-missing")
+```
+
+## The Parse Cache
+
+`Headers` stores three parallel arrays: lowercased names, raw values, and a lazily-filled slot for the parsed value of each entry. A typed read fills that slot; a second read of the same header reuses it.
+
+The cache is keyed by *codec identity*, compared by reference. Two codecs sharing a wire name therefore never read each other's cached values, which is what keeps a custom `Header.Codec[MyType]` named `content-length` from colliding with `Header.ContentLength`.
+
+Three consequences are worth knowing:
+
+- **The cache is dropped by `Headers#add`.** Appending builds fresh arrays and does not carry parsed values across, so a read-then-add-then-read sequence parses twice. Read after you finish assembling, not between additions.
+- **Duplicate parses are possible under concurrency.** Filling a slot is not synchronized, so two threads reading the same header on the same instance may both parse it. Both produce equal values, so the race is benign — but it is a race, and a codec with side effects would run twice.
+- **Failures are not cached.** An entry that fails to parse leaves its slot empty, so every read retries the failing parse.
+
+## Writing Headers
+
+Writes come in typed and raw forms, and the distinction that matters is append versus replace.
+
+### Appending and Replacing
+
+`Headers#add` appends, keeping any existing header of the same name. `Headers#set` replaces every entry with that name:
+
+```scala
+final class Headers {
+  def add(header: Header): Headers
+  def add(name: String, value: String): Headers
+  def set(header: Header): Headers
+  def set(name: String, value: String): Headers
+  def remove(name: String): Headers
+}
+```
+
+Starting from a collection that already has a value, the two diverge:
+
+```scala mdoc:silent:reset
+import zio.http.{Header, Headers}
+
+val base = Headers.empty.add(Header.ContentLength(100))
+```
+
+`Headers#add` produces two entries, while `Headers#set` produces one:
+
+```scala mdoc
+base.add(Header.ContentLength(200)).toList
+base.set(Header.ContentLength(200)).toList
+```
+
+`Headers#remove` drops every entry with the given name, and `Headers#++` concatenates without deduplicating — the result can hold duplicates from both sides:
+
+```scala mdoc
+base.remove("content-length").toList
+(base ++ Headers("content-length" -> "300")).toList
+```
+
+Every method returns a new `Headers`; the class is immutable and the arrays are never mutated in place.
+
+### `Headers.apply` and `Headers.empty`
+
+The companion builds a collection from name-value pairs, and `Headers.empty` is the identity for `Headers#++`:
+
+```scala
+object Headers {
+  def apply(pairs: (String, String)*): Headers
+  val empty: Headers
+}
+```
+
+Pairs are validated and lowercased as they are added:
+
+```scala mdoc:silent:reset
+import zio.http.Headers
+```
+
+Both entry points produce the same shape, so a builder chain can start from either:
+
+```scala mdoc
+Headers("Content-Type" -> "application/json").toList
+Headers.empty.size
+```
+
+### `HeadersBuilder` — batch construction
+
+Building with `Headers#add` allocates fresh arrays per call, which is wasteful when adding many headers at once. `HeadersBuilder` accumulates into a growable buffer and copies once:
+
+```scala
+final class HeadersBuilder {
+  def add(name: String, value: String): Unit
+  def reset(): Unit
+  def build(): Headers
+}
+
+object HeadersBuilder {
+  def make(initialCapacity: Int = 8): HeadersBuilder
+}
+```
+
+The builder is mutable and single-threaded by design, and `HeadersBuilder#build` snapshots it:
+
+```scala mdoc:silent:reset
+import zio.http.{Header, HeadersBuilder}
+
+val builder = HeadersBuilder.make(4)
+builder.add("content-type", "application/json")
+builder.add(Header.ContentLength(64).headerName, Header.ContentLength(64).renderedValue)
+```
+
+The built collection is an ordinary immutable `Headers`:
+
+```scala mdoc
+builder.build().toList
+```
+
+`HeadersBuilder#reset` clears the buffer for reuse without reallocating, which is why the capacity argument exists. The requested capacity is raised to a minimum of four, and the buffer doubles when it fills.
+
+## Validation and Injection Safety
+
+Header names and values are validated on every write, and the value rule exists for a security reason rather than a formatting one.
+
+A name must be a non-empty HTTP token: ASCII letters, digits, or one of `!#$%&'*+-.^_`|~`. A value may contain anything **except** carriage return or line feed. Rejecting CR and LF is what prevents response splitting and header injection — a value carrying `\r\n` would otherwise terminate the header and let an attacker append headers or a body of their own choosing.
+
+Two public methods expose the checks as values, for validating input before you try to use it:
+
+```scala
+object Headers {
+  def validateName(name: String): Either[String, Unit]
+  def validateValue(value: String): Either[String, Unit]
+}
+```
+
+Both report a message rather than throwing:
+
+```scala mdoc:silent:reset
+import zio.http.Headers
+```
+
+A structurally invalid name and a CR/LF-bearing value are each rejected with a reason:
+
+```scala mdoc
+Headers.validateName("x-trace")
+Headers.validateName("x trace")
+Headers.validateValue("ok")
+Headers.validateValue("evil\r\nSet-Cookie: admin=true")
+```
+
+:::danger[The mutating methods throw]
+`Headers#add`, `Headers#set`, `Headers#remove`, `Headers#has`, the `rawGet*` family, and `HeadersBuilder#add` all enforce the same invariants by throwing `IllegalArgumentException`. When a name or value comes from outside your program — a proxied request, a user-supplied field — check it with `Headers.validateName` or `Headers.validateValue` first, or the throw becomes your error handling.
+:::
+
+Note that the raw *read* methods validate their name argument too, so `headers.rawGet(userSuppliedName)` can throw even though it only reads.
+
+## Equality and Rendering
+
+`Headers#equals` compares `Headers#toList`, so equality is order-sensitive and name-case-insensitive — names were lowercased on the way in, but two collections holding the same headers in a different order are not equal. `Headers#hashCode` is derived from the same list, so it agrees.
+
+`Headers#toString` renders every name and raw value:
+
+```scala mdoc:silent:reset
+import zio.http.Headers
+
+val withAuth = Headers("authorization" -> "Bearer sk-live-1234567890")
+```
+
+The value appears in full, which matters wherever a `Headers` reaches a log:
+
+```scala mdoc
+withAuth.toString
+```
+
+:::warning[`toString` prints credentials]
+There is no redaction. `authorization`, `cookie`, and `set-cookie` values are rendered verbatim, and anything that logs a `Request` or `Response` logs its headers. Strip or replace sensitive entries with `Headers#remove` or `Headers#set` before logging.
+:::
+
+`Headers#toList` and `Headers#toChunk` expose the same pairs for iteration, differing only in collection type.
+
+## The Header Catalog
+
+All 75 built-in headers, grouped the way the module's own test suites group them. Every entry's companion object is its `Header.Typed` codec, and the wire name column is exactly what `Codec#name` returns.
+
+### Authentication
+
+| Type                               | Wire name              | Shape                                          |
+| ---------------------------------- | ---------------------- | ---------------------------------------------- |
+| `Header.Authorization`             | `authorization`        | ADT: `Basic`, `Bearer`, `Digest`, `Unparsed`    |
+| `Header.ProxyAuthorization`        | `proxy-authorization`  | ADT: `Basic`, `Bearer`, `Digest`, `Unparsed`    |
+| `Header.WWWAuthenticate`           | `www-authenticate`     | `scheme: String`, `params: Map[String, String]` |
+| `Header.ProxyAuthenticate`         | `proxy-authenticate`   | `scheme: String`, `params: Map[String, String]` |
+
+`Unparsed` is the escape hatch: a scheme the ADT does not model is preserved rather than rejected, so an unknown authentication scheme survives a parse-render round trip.
+
+### Content
+
+| Type                               | Wire name                   | Shape                                                      |
+| ---------------------------------- | --------------------------- | ---------------------------------------------------------- |
+| `Header.ContentType`               | `content-type`              | `value: ContentType`                                        |
+| `Header.ContentLength`             | `content-length`            | `length: Long`                                              |
+| `Header.ContentEncoding`           | `content-encoding`          | ADT: `GZip`, `Deflate`, `Br`, `Compress`, `Identity`, `Multiple` |
+| `Header.ContentDisposition`        | `content-disposition`       | ADT: `Attachment`, `Inline`, `FormData`                       |
+| `Header.ContentLanguage`           | `content-language`          | `language: String`                                           |
+| `Header.ContentLocation`           | `content-location`          | `location: String`                                           |
+| `Header.ContentRange`              | `content-range`             | `unit: String`, `range: Option[(Long, Long)]`, `size: Option[Long]` |
+| `Header.ContentSecurityPolicy`     | `content-security-policy`   | `directives: String`                                         |
+| `Header.ContentTransferEncoding`   | `content-transfer-encoding` | ADT: `SevenBit`, `EightBit`, `Binary`, `QuotedPrintable`, `Base64` |
+| `Header.ContentMd5`                | `content-md5`               | `value: String`                                              |
+| `Header.ContentBase`               | `content-base`              | `uri: String`                                                |
+
+`Multiple` on `ContentEncoding` carries a `Chunk` of the others, which is how a comma-separated list becomes one value rather than several entries.
+
+### Caching
+
+| Type                        | Wire name             | Shape                                    |
+| --------------------------- | --------------------- | ---------------------------------------- |
+| `Header.CacheControl`       | `cache-control`       | ADT, 17 variants — see below              |
+| `Header.ETag`               | `etag`                | `tag: String`, `weak: Boolean`            |
+| `Header.IfMatch`            | `if-match`            | ADT: `Any`, `ETags`                       |
+| `Header.IfNoneMatch`        | `if-none-match`       | ADT: `Any`, `ETags`                       |
+| `Header.IfModifiedSince`    | `if-modified-since`   | `date: String`                            |
+| `Header.IfUnmodifiedSince`  | `if-unmodified-since` | `date: String`                            |
+| `Header.IfRange`            | `if-range`            | `value: String`                           |
+| `Header.Expires`            | `expires`             | `date: String`                            |
+| `Header.Age`                | `age`                 | `seconds: Long`                           |
+| `Header.LastModified`       | `last-modified`       | `date: String`                            |
+| `Header.Pragma`             | `pragma`              | `directives: String`                      |
+| `Header.Vary`               | `vary`                | ADT: `Any`, `Headers`                     |
+
+`CacheControl` is the largest ADT in the module. Ten variants are flag directives with no argument — `NoCache`, `NoStore`, `NoTransform`, `Public`, `Private`, `MustRevalidate`, `ProxyRevalidate`, `Immutable`, `OnlyIfCached`, `MustUnderstand` — and six take a duration: `MaxAge`, `SMaxAge`, `MinFresh`, `StaleWhileRevalidate`, and `StaleIfError` each hold a `Long`, while `MaxStale` holds an `Option[Long]` because `max-stale` is valid with or without a value. `Multiple` wraps a `Chunk[CacheControl]` for comma-separated directive lists.
+
+Parsing splits on `=` to decide between the two families, so an unknown directive name and a non-numeric duration produce different messages:
+
+```scala mdoc:silent:reset
+import zio.http.Header
+```
+
+Both failures name what went wrong, which is what makes them useful in a 400 response:
+
+```scala mdoc
+Header.CacheControl.parse("max-age=600")
+Header.CacheControl.parse("max-stale")
+Header.CacheControl.parse("nonsense")
+Header.CacheControl.parse("max-age=soon")
+```
+
+### Content Negotiation
+
+| Type                      | Wire name          | Shape                                                            |
+| ------------------------- | ------------------ | ---------------------------------------------------------------- |
+| `Header.Accept`           | `accept`           | `mediaRanges: Chunk[Accept.MediaRange]`                           |
+| `Header.AcceptEncoding`   | `accept-encoding`  | ADT: `GZip`, `Deflate`, `Br`, `Compress`, `Identity`, `Any`, `Multiple` |
+| `Header.AcceptLanguage`   | `accept-language`  | `languages: Chunk[AcceptLanguage.LanguageRange]`                  |
+| `Header.AcceptRanges`     | `accept-ranges`    | ADT: `Bytes`, `None_`                                             |
+| `Header.AcceptPatch`      | `accept-patch`     | `mediaTypes: Chunk[MediaType]`                                    |
+
+`Accept.MediaRange` and `AcceptLanguage.LanguageRange` are the per-entry types that carry a quality weight, which is what makes these headers a `Chunk` rather than a single value. `None_` on `AcceptRanges` is spelled with a trailing underscore because `None` is taken.
+
+### CORS
+
+| Type                                     | Wire name                          | Shape                             |
+| ---------------------------------------- | ---------------------------------- | --------------------------------- |
+| `Header.AccessControlAllowOrigin`        | `access-control-allow-origin`       | ADT: `All`, `Specific`             |
+| `Header.AccessControlAllowMethods`       | `access-control-allow-methods`      | `methods: Chunk[Method]`           |
+| `Header.AccessControlAllowHeaders`       | `access-control-allow-headers`      | `headers: Chunk[String]`           |
+| `Header.AccessControlAllowCredentials`   | `access-control-allow-credentials`  | `allow: Boolean`                   |
+| `Header.AccessControlExposeHeaders`      | `access-control-expose-headers`     | `headers: Chunk[String]`           |
+| `Header.AccessControlMaxAge`             | `access-control-max-age`            | `seconds: Long`                    |
+| `Header.AccessControlRequestHeaders`     | `access-control-request-headers`    | `headers: Chunk[String]`           |
+| `Header.AccessControlRequestMethod`      | `access-control-request-method`     | `method: Method`                   |
+| `Header.Origin`                          | `origin`                           | ADT: `Null_`, `Value`              |
+
+`AccessControlAllowMethods` and `AccessControlRequestMethod` hold `Method` values rather than strings, so an unrecognized verb fails at parse time instead of reaching your CORS logic.
+
+### Routing and Identity
+
+| Type                    | Wire name       | Shape                                |
+| ----------------------- | --------------- | ------------------------------------ |
+| `Header.Host`           | `host`          | `host: String`, `port: Option[Int]`   |
+| `Header.Location`       | `location`      | `uri: String`                         |
+| `Header.Referer`        | `referer`       | `uri: String`                         |
+| `Header.Via`            | `via`           | `entries: Chunk[String]`              |
+| `Header.Forwarded`      | `forwarded`     | `params: String`                      |
+| `Header.MaxForwards`    | `max-forwards`  | `count: Int`                          |
+| `Header.From`           | `from`          | `email: String`                       |
+| `Header.UserAgent`      | `user-agent`    | `product: String`                     |
+| `Header.Server`         | `server`        | `product: String`                     |
+| `Header.Date`           | `date`          | `value: String`                       |
+| `Header.Link`           | `link`          | `value: String`                       |
+| `Header.RetryAfter`     | `retry-after`   | `value: String`                       |
+| `Header.Allow`          | `allow`         | `methods: Chunk[Method]`              |
+| `Header.Expect`         | `expect`        | `value: String`                       |
+| `Header.Range`          | `range`         | `unit: String`, `ranges: String`      |
+
+`Host` splits the port out as an `Option[Int]`, so `example.com` and `example.com:8080` both parse and render back to their original form.
+
+### Cookies
+
+| Type                       | Wire name    | Shape           |
+| -------------------------- | ------------ | --------------- |
+| `Header.CookieHeader`      | `cookie`     | `value: String`  |
+| `Header.SetCookieHeader`   | `set-cookie` | `value: String`  |
+
+Both model the header as an unparsed string; structured cookie handling lives in the separate `Cookie` type documented in [the HTTP model](./model.md). Two aliases exist on the companion for readability at call sites — `Header.Cookie` is `Header.CookieHeader` and `Header.SetCookie` is `Header.SetCookieHeader`, both typed as the codec rather than the case class.
+
+### Connection Management
+
+| Type                       | Wire name            | Shape                                                                  |
+| -------------------------- | -------------------- | ---------------------------------------------------------------------- |
+| `Header.Connection`        | `connection`         | ADT: `Close`, `KeepAlive`, `Other`                                       |
+| `Header.Upgrade`           | `upgrade`            | `protocol: String`                                                      |
+| `Header.Te`                | `te`                 | `value: String`                                                         |
+| `Header.Trailer`           | `trailer`            | `value: String`                                                         |
+| `Header.TransferEncoding`  | `transfer-encoding`  | ADT: `Chunked`, `Compress`, `Deflate`, `GZip`, `Identity`, `Multiple`    |
+
+### Security
+
+| Type                               | Wire name                    | Shape                                              |
+| ---------------------------------- | ---------------------------- | -------------------------------------------------- |
+| `Header.XFrameOptions`             | `x-frame-options`            | ADT: `Deny`, `SameOrigin`                           |
+| `Header.XRequestedWith`            | `x-requested-with`           | `value: String`                                     |
+| `Header.DNT`                       | `dnt`                        | ADT: `TrackingAllowed`, `TrackingNotAllowed`, `Unset` |
+| `Header.UpgradeInsecureRequests`   | `upgrade-insecure-requests`  | `upgrade: Boolean`                                  |
+| `Header.ClearSiteData`             | `clear-site-data`            | `directives: Chunk[String]`                         |
+
+### WebSocket
+
+| Type                              | Wire name                  | Shape                       |
+| --------------------------------- | -------------------------- | --------------------------- |
+| `Header.SecWebSocketAccept`       | `sec-websocket-accept`      | `value: String`              |
+| `Header.SecWebSocketExtensions`   | `sec-websocket-extensions`  | `value: String`              |
+| `Header.SecWebSocketKey`          | `sec-websocket-key`         | `value: String`              |
+| `Header.SecWebSocketLocation`     | `sec-websocket-location`    | `value: String`              |
+| `Header.SecWebSocketOrigin`       | `sec-websocket-origin`      | `value: String`              |
+| `Header.SecWebSocketProtocol`     | `sec-websocket-protocol`    | `protocols: Chunk[String]`   |
+| `Header.SecWebSocketVersion`      | `sec-websocket-version`     | `version: String`            |
+
+## Headers Without a Typed Model
+
+Two mechanisms cover headers the catalog does not include, and the choice between them is whether you want a value or a type.
+
+### `Header.Custom` — a name and a string
+
+`Header.Custom` is a `Header` whose name and value you supply directly. Use it to write an arbitrary header through the same API as a built-in:
+
+```scala mdoc:silent:reset
+import zio.http.{Header, Headers}
+
+val custom = Header.Custom("x-tenant-id", "acme-42")
+```
+
+It renders exactly what it holds, with no parsing on either side:
+
+```scala mdoc
+Headers.empty.add(custom).toList
+```
+
+`Header.Custom` has no codec, so it cannot be passed to `Headers#get`. Reading it back means `Headers#rawGet`.
+
+### A Custom `Header.Codec`
+
+Implementing `Header.Codec[A]` gives a header both a domain type and typed reads. Nothing requires `A` to extend `Header` unless you also want `Headers#getLast`:
+
+```scala mdoc:silent:reset
+import zio.http.{Header, Headers}
+
+final case class TenantId(value: String)
+
+val tenantIdCodec: Header.Codec[TenantId] = new Header.Codec[TenantId] {
+  def name: String = "x-tenant-id"
+
+  def parse(value: String): Either[String, TenantId] =
+    if (value.isEmpty) Left("x-tenant-id must not be empty")
+    else Right(TenantId(value))
+
+  def render(value: TenantId): String = value.value
+}
+```
+
+The custom codec now works with the typed read path, cache included:
+
+```scala mdoc
+val headers = Headers("x-tenant-id" -> "acme-42")
+headers.get(tenantIdCodec)
+```
+
+A rejected value is skipped like any other parse failure, so the collection read is `None` rather than the error message:
+
+```scala mdoc
+Headers("x-tenant-id" -> "").get(tenantIdCodec)
+tenantIdCodec.parse("")
+```
+
+Return a message describing what was expected. Parse errors reach users through whatever 400 response your handler builds, and the codec's message is the only description available.
+
+:::tip[Hold the codec as a `val`]
+The parse cache compares codec identity by reference. A codec constructed inline on every request is a different instance each time, so its cached values are never reused. Define it once as a `val` or an `object`.
+:::
+
+## Integration Points
+
+`Header` and `Headers` are used by `Request` and `Response`, which each hold a `Headers` alongside their status or method, URL, and body — see [the HTTP model](./model.md). `Header.ContentType` wraps the `ContentType` type that `Body` also carries, and the media-type values inside it come from `zio-blocks-mediatype`.
+
+Several headers hold values from elsewhere in the module rather than strings: `Allow`, `AccessControlAllowMethods`, and `AccessControlRequestMethod` hold `Method`, and `Chunk` is the sequence type throughout.
+
+For deriving header codecs from a `Schema[A]` instead of writing them by hand, see [HTTP model schema](./schema.md), which builds `HeaderCodec` and `QueryCodec` instances from schemas. `ServerSentEvent` uses `Headers` indirectly through `Response`, and is documented in [Server-Sent Events](./server-sent-event.md).

--- a/docs/reference/http-model/index.md
+++ b/docs/reference/http-model/index.md
@@ -38,10 +38,12 @@ This separation keeps your domain logic portable and testable while maintaining 
 
 ## Getting Started
 
-Start with the [HTTP Model](./model.md) to understand the core data types and how they compose. Then explore [Schema-Based Typed Access](./schema.md) to learn how to safely extract and validate HTTP parameters and headers.
+Start with the [HTTP Model](./model.md) to understand the core data types and how they compose. [Header](./headers.md) covers the typed header model — the 75 built-in headers, the codec type class behind them, and the parse cache — and [ServerSentEvent](./server-sent-event.md) covers the SSE envelope and its wire format. Then explore [Schema-Based Typed Access](./schema.md) to learn how to safely extract and validate HTTP parameters and headers.
 
 ---
 
 **Modules:**
 - [`zio-http-model`](./model.md) — Core immutable data types for HTTP
+- [`zio-http-model`](./headers.md) — Typed header model and the `Header.Codec` type class
+- [`zio-http-model`](./server-sent-event.md) — Server-Sent Event envelope and payload encoders
 - [`zio-http-model-schema`](./schema.md) — Schema-based typed extraction for query parameters and headers

--- a/docs/reference/http-model/model.md
+++ b/docs/reference/http-model/model.md
@@ -635,36 +635,70 @@ val allIds = params.get("id")         // Some(Chunk("1", "2", "3"))
 
 ## Headers
 
-`Headers` is an immutable, case-insensitive collection of HTTP headers with lazy parsing for typed header access:
+`Headers` is an immutable, case-insensitive collection of HTTP header fields. It stores names pre-lowercased and raw values as strings, allows several entries with the same name, and parses a value into a typed `Header` only when a typed read asks for it:
 
 ```scala
-final class Headers private[http] (...)
+final class Headers private[http] (...) {
+  def size: Int
+  def get[A](headerCodec: Header.Codec[A]): Option[A]
+  def rawGet(name: String): Option[String]
+  def add(header: Header): Headers
+  def set(header: Header): Headers
+  def remove(name: String): Headers
+}
 ```
+
+This section covers the collection itself. The 75 built-in typed headers, the codec type class behind them, the parse cache, and the validation rules all live on the [Header](./headers.md) page.
 
 ### Creating Headers
 
-Create header collections:
+`Headers.apply` takes name-value pairs, and `Headers.empty` is the starting point for a builder chain:
 
-```scala mdoc:compile-only
-import zio.http.Headers
-
-val headers1 = Headers("content-type" -> "application/json", "authorization" -> "Bearer token123")
-val headers2 = Headers.empty
-```
-
-### Headers Operations
-
-Access and modify headers:
-
-```scala mdoc:compile-only
+```scala mdoc:silent
 import zio.http.Headers
 
 val headers = Headers("content-type" -> "application/json", "cache-control" -> "no-cache")
-
-// Headers can be queried and modified using methods
-val withAuth = headers.add("authorization", "Bearer token") // Add header
-val asList = headers.toList                                 // All headers as List
 ```
+
+Names are lowercased as they are stored, so the collection reports them in canonical form regardless of how they were written:
+
+```scala mdoc
+Headers("Content-Type" -> "application/json").toList
+```
+
+### Reading Raw Values
+
+Three methods read the stored string without parsing, differing in which entry they pick when a name repeats:
+
+```scala mdoc
+headers.rawGet("Content-Type")
+headers.rawGetAll("cache-control")
+headers.has("content-type")
+```
+
+Lookups are case-insensitive, and `Headers#contains` is an alias for `Headers#has`. For typed reads — `Headers#get`, `Headers#getAll`, and `Headers#getLast`, which decode into a `Header` — see [Header](./headers.md).
+
+### Modifying Headers
+
+`Headers#add` appends and `Headers#set` replaces every entry with the same name, which is the distinction that matters for multi-value headers:
+
+```scala mdoc:silent
+val twice   = headers.add("set-cookie", "a=1").add("set-cookie", "b=2")
+val replaced = twice.set("set-cookie", "c=3")
+```
+
+Appending keeps both cookies while setting collapses them to one:
+
+```scala mdoc
+twice.rawGetAll("set-cookie")
+replaced.rawGetAll("set-cookie")
+```
+
+`Headers#remove` drops every entry with a name, `Headers#++` concatenates two collections without deduplicating, and `Headers#toList` and `Headers#toChunk` expose the pairs for iteration. Every operation returns a new `Headers`.
+
+:::warning[Names and values are validated by throwing]
+A header name must be an HTTP token and a value must not contain CR or LF — the latter is what prevents response splitting. The mutating methods enforce both with `IllegalArgumentException`, so check untrusted input with `Headers.validateName` or `Headers.validateValue` first. See [Header](./headers.md) for the rules and the safe pre-checks.
+:::
 
 ---
 

--- a/docs/reference/http-model/server-sent-event.md
+++ b/docs/reference/http-model/server-sent-event.md
@@ -1,0 +1,296 @@
+---
+id: server-sent-event
+title: "ServerSentEvent"
+sidebar_label: "ServerSentEvent"
+---
+
+`ServerSentEvent[A]` is an immutable envelope for one Server-Sent Event: a payload of type `A` plus the three optional SSE metadata fields. `SseDataEncoder[A]` turns the payload into the `data:` lines of the wire format. The type is covariant in `A`, and the metadata fields are `Maybe` rather than `Option` to stay allocation-free when absent:
+
+```scala
+final class ServerSentEvent[+A] private (
+  val data: A,
+  val eventType: Maybe[String],
+  val eventId: Maybe[String],
+  val retryMillis: Maybe[Long]
+)
+
+trait SseDataEncoder[-A] {
+  def lines(value: A): Chunk[String]
+}
+```
+
+## Motivation
+
+The SSE wire format is small enough to hand-write and fiddly enough to get wrong. Fields are `name: value` lines, the event ends with a blank line, and a multi-line payload has to become several `data:` lines rather than one line containing newlines. Emit a payload with an embedded `\n` as a single `data:` line and the stream desynchronizes — the client reads the remainder as a new field, or as the end of the event.
+
+`ServerSentEvent` owns that formatting. The envelope holds the metadata, an `SseDataEncoder` decides how the payload becomes lines, and `ServerSentEvent#render` assembles them in the order the specification requires. Splitting a multi-line string is the encoder's job, so a payload containing newlines is correct by construction rather than by remembering.
+
+Separating the encoder from the envelope is what lets the payload be typed. `ServerSentEvent[String]` and `ServerSentEvent[Chunk[String]]` work out of the box, and any other type works as soon as it has an encoder — the envelope never needs to change.
+
+## Quick Showcase
+
+An event is a payload plus optional metadata, and rendering produces the wire format:
+
+```scala mdoc:silent
+import zio.http.ServerSentEvent
+
+val event = ServerSentEvent("hello", "greeting").id("42").retry(3000)
+```
+
+Rendering emits the metadata fields, then the data lines, then the blank line that terminates the event:
+
+```scala mdoc
+print(event.render)
+```
+
+## Construction
+
+Three entry points cover the cases: payload only, payload with an event name, and payload with any combination of metadata.
+
+### `ServerSentEvent.apply` — payload, optionally named
+
+The one-argument form creates an event with no metadata at all, and the two-argument form sets the `event:` field:
+
+```scala
+object ServerSentEvent {
+  def apply[A](data: A): ServerSentEvent[A]
+  def apply[A](data: A, event: String): ServerSentEvent[A]
+}
+```
+
+A bare event renders as a single `data:` line followed by the blank line:
+
+```scala mdoc:silent:reset
+import zio.http.ServerSentEvent
+
+val bare  = ServerSentEvent("tick")
+val named = ServerSentEvent("tick", "heartbeat")
+```
+
+Naming the event adds one line above the data:
+
+```scala mdoc
+print(bare.render)
+print(named.render)
+```
+
+### `ServerSentEvent.fromOptions` — all metadata at once
+
+`ServerSentEvent.fromOptions` takes the three metadata fields as `Option`, each defaulting to `None`, which suits code that already has them in optional form:
+
+```scala
+object ServerSentEvent {
+  def fromOptions[A](
+    data: A,
+    event: Option[String] = None,
+    id: Option[String] = None,
+    retry: Option[Long] = None
+  ): ServerSentEvent[A]
+}
+```
+
+Supplying a subset by name leaves the rest absent:
+
+```scala mdoc:silent:reset
+import zio.http.ServerSentEvent
+
+val event = ServerSentEvent.fromOptions("payload", id = Some("7"), retry = Some(1000))
+```
+
+Only the fields you set appear on the wire:
+
+```scala mdoc
+print(event.render)
+```
+
+This is the only constructor that takes `Option`. The accessors return `Maybe`, so a round trip through `ServerSentEvent.fromOptions` converts between the two.
+
+## Setting Metadata
+
+Four methods produce a modified copy. Each returns a new envelope; nothing mutates.
+
+| Method                        | Effect                                    |
+| ----------------------------- | ----------------------------------------- |
+| `ServerSentEvent#event`       | Sets the `event:` field.                   |
+| `ServerSentEvent#clearEvent`  | Removes the `event:` field.                |
+| `ServerSentEvent#id`          | Sets the `id:` field.                      |
+| `ServerSentEvent#retry`       | Sets the `retry:` field, in milliseconds.  |
+| `ServerSentEvent#clearRetry`  | Removes the `retry:` field.                |
+
+They chain, since each returns a `ServerSentEvent[A]`:
+
+```scala mdoc:silent:reset
+import zio.http.ServerSentEvent
+
+val event = ServerSentEvent("payload").event("update").id("100").retry(5000)
+```
+
+Clearing a field drops its line without disturbing the others:
+
+```scala mdoc
+print(event.clearRetry.render)
+print(event.clearEvent.clearRetry.render)
+```
+
+:::note[There is no `clearId`]
+`ServerSentEvent#clearEvent` and `ServerSentEvent#clearRetry` exist, but the `id:` field has no clearing method. To produce an event without an id, build a fresh envelope or use `ServerSentEvent.fromOptions` with `id = None`.
+:::
+
+The accessors expose what is set, as `Maybe`:
+
+```scala mdoc
+event.data
+event.eventType
+event.eventId
+event.retryMillis
+```
+
+## Validation
+
+Two invariants are enforced at construction, and both throw rather than returning an error, because an invalid event cannot be rendered safely.
+
+The `event:` and `id:` fields must not contain a carriage return or line feed. The reason is the same as for header values: a newline inside a field would terminate that field early and let the remainder be read as a new field or a new event, desynchronizing the stream.
+
+The `retry:` value must be non-negative, since it is a reconnection delay in milliseconds.
+
+Both checks are visible from a bare import:
+
+```scala mdoc:silent:reset
+import zio.http.ServerSentEvent
+```
+
+Both rejections are `IllegalArgumentException` with a message naming the field:
+
+```scala mdoc
+scala.util.Try(ServerSentEvent("data", "bad\nevent")).failed.map(_.getMessage)
+scala.util.Try(ServerSentEvent("data").retry(-1)).failed.map(_.getMessage)
+```
+
+Validation applies to the metadata only. The **payload** is never validated, because embedded newlines in the payload are legitimate — the encoder splits them into separate `data:` lines.
+
+## Rendering
+
+`ServerSentEvent#render` needs an `SseDataEncoder` for the payload type and produces the complete wire representation, terminating blank line included:
+
+```scala
+final class ServerSentEvent[+A] {
+  def render(implicit encoder: SseDataEncoder[A]): String
+}
+```
+
+Fields are emitted in a fixed order — `event:`, then `id:`, then `retry:`, then the `data:` lines — with absent fields omitted entirely. A payload that produces no lines still emits one empty `data:` line, so an event is never rendered without a data field:
+
+```scala mdoc:silent:reset
+import zio.http.ServerSentEvent
+import zio.blocks.chunk.Chunk
+
+val empty = ServerSentEvent(Chunk.empty[String])
+```
+
+The result is a single valueless data line and the terminator:
+
+```scala mdoc
+empty.render
+```
+
+## SseDataEncoder
+
+`SseDataEncoder[A]` maps a payload to its `data:` lines. It is contravariant in `A`, so an encoder for a supertype serves every subtype:
+
+```scala
+trait SseDataEncoder[-A] {
+  def lines(value: A): Chunk[String]
+}
+
+object SseDataEncoder {
+  def apply[A](implicit encoder: SseDataEncoder[A]): SseDataEncoder[A]
+  implicit val string: SseDataEncoder[String]
+  implicit val stringChunk: SseDataEncoder[Chunk[String]]
+}
+```
+
+### Built-in Instances
+
+`SseDataEncoder.string` splits a `String` on line breaks, so a multi-line payload becomes one `data:` line per line. `\n`, `\r`, and `\r\n` all count as a single break:
+
+```scala mdoc:silent:reset
+import zio.http.ServerSentEvent
+
+val multiline = ServerSentEvent("first line\nsecond line\nthird line")
+```
+
+Three lines in the payload become three `data:` lines, which is what the SSE specification requires:
+
+```scala mdoc
+print(multiline.render)
+```
+
+`SseDataEncoder.stringChunk` treats each element as a line and splits each element as well, so a chunk whose elements themselves contain newlines still flattens correctly:
+
+```scala mdoc:silent:reset
+import zio.http.ServerSentEvent
+import zio.blocks.chunk.Chunk
+
+val chunked = ServerSentEvent(Chunk("alpha", "beta\ngamma"))
+```
+
+The two elements yield three lines:
+
+```scala mdoc
+print(chunked.render)
+```
+
+An empty `Chunk` renders as one empty `data:` line rather than none, matching the single-`String` behaviour for an empty payload.
+
+### Custom Instances
+
+An encoder for your own type is one method. Returning several lines is how a structured payload spans multiple `data:` fields:
+
+```scala mdoc:silent:reset
+import zio.http.{ServerSentEvent, SseDataEncoder}
+import zio.blocks.chunk.Chunk
+
+final case class Progress(step: Int, total: Int, note: String)
+
+implicit val progressEncoder: SseDataEncoder[Progress] =
+  new SseDataEncoder[Progress] {
+    def lines(value: Progress): Chunk[String] =
+      Chunk(s"step=${value.step}/${value.total}", s"note=${value.note}")
+  }
+```
+
+With the instance in implicit scope, the payload type flows through the envelope unchanged:
+
+```scala mdoc
+print(ServerSentEvent(Progress(3, 10, "compiling"), "progress").render)
+```
+
+:::warning[Split lines yourself, or don't produce them]
+`ServerSentEvent#render` prefixes each line the encoder returns with `data: ` and does not inspect it. An encoder that returns a string containing `\n` therefore emits a malformed event. Either split within `SseDataEncoder#lines`, or delegate to `SseDataEncoder.string` for the parts that might contain breaks.
+:::
+
+For a JSON payload, encode to a `String` with the JSON codec and reuse `SseDataEncoder.string`, which handles any newlines the rendered document contains.
+
+## Equality and Rendering as Text
+
+`ServerSentEvent#equals` compares the payload and all three metadata fields, so two envelopes are equal when they would render identically. `ServerSentEvent#hashCode` agrees with it.
+
+`ServerSentEvent#toString` is a diagnostic rendering, not the wire format — absent fields appear as `null` and no `data:` prefixes are added:
+
+```scala mdoc:silent:reset
+import zio.http.ServerSentEvent
+
+val event = ServerSentEvent("payload").id("9")
+```
+
+Use `ServerSentEvent#render` for anything that goes over the wire and `ServerSentEvent#toString` only for logs:
+
+```scala mdoc
+event.toString
+```
+
+## Integration Points
+
+An SSE response is an ordinary `Response` whose body streams rendered events with a `text/event-stream` content type, so `ServerSentEvent` composes with the rest of [the HTTP model](./model.md) rather than replacing any of it. Setting that content type is a `Header.ContentType` — see [Header](./headers.md).
+
+The type depends on `Chunk` for the line sequence and on `Maybe` for its optional fields, both from the core blocks: see [Chunk](../chunk.md) and [Maybe](../maybe.md).

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -164,6 +164,8 @@ const sidebars = {
             link: { type: "doc", id: "reference/http-model/index" },
             items: [
               "reference/http-model/model",
+              "reference/http-model/headers",
+              "reference/http-model/server-sent-event",
               "reference/http-model/schema",
             ]
           },

--- a/docs/undocumented-report.md
+++ b/docs/undocumented-report.md
@@ -7,7 +7,9 @@ title: "Documentation Coverage Report"
 
 Full re-scan of documentation coverage across every library module aggregated by the `root` project. Replaces the 2026-02-13 report, which predated most of the current `docs/reference` tree and covered only 12 modules.
 
-**Progress since this report was generated:** the `config` family has been documented — `docs/reference/config.md` was replaced by a seven-page `docs/reference/config/` directory (2,212 lines, all code blocks mdoc-verified), taking the family from 31% to 72% explained coverage and from 43 absent types to 3. Tier 1 item 2 is complete; the numbers in this report have been updated to match.
+**Progress since this report was generated:** the `http-model` typed header surface has been documented — `docs/reference/http-model/headers.md` (660 lines) and `server-sent-event.md` (296 lines) are new, and `model.md`'s `## Headers` section was rewritten, taking the module from 31% to 55% explained coverage and from 101 absent types to 6. Tier 1 items 1 and 7 are complete.
+
+Earlier: the `config` family has been documented — `docs/reference/config.md` was replaced by a seven-page `docs/reference/config/` directory (2,212 lines, all code blocks mdoc-verified), taking the family from 31% to 72% explained coverage and from 43 absent types to 3. Tier 1 item 2 is complete; the numbers in this report have been updated to match.
 
 **What changed since the previous (2026-02-13) report:** every published module now has a reference page, and every page is linked from `docs/sidebars.js`. There are no longer any modules with zero documentation, and four of the six "critical missing pages" from the old report now exist (`media-type.md`, `schema/schema-expr.md`, `schema/schema-error.md`, `built-in-codecs/json/json-patch.md`). The remaining gaps are (a) whole subsystems inside otherwise-documented modules, (b) pages far too short for the surface they cover, and (c) an almost complete absence of task-oriented guides.
 
@@ -20,17 +22,17 @@ Full re-scan of documentation coverage across every library module aggregated by
 | Reference pages | 164 |
 | Guides | 9 |
 | Public types found (`class` / `trait` / `object` / `enum`, non-`private`) | 1,828 |
-| Types never named anywhere in `docs/` | **568** |
-| Types with no prose or heading reference | **847** |
-| Name-mention coverage | **68%** |
-| Explained-type coverage | **53%** |
+| Types never named anywhere in `docs/` | **471** |
+| Types with no prose or heading reference | **796** |
+| Name-mention coverage | **74%** |
+| Explained-type coverage | **56%** |
 
 Two coverage numbers are reported because they answer different questions.
 
-- **Name-mention coverage** counts a type as covered if its name appears anywhere in `docs/`, including inside an example code block. Its complement — 568 types — is the set that is entirely absent from the documentation.
-- **Explained-type coverage** is stricter: it requires the name in prose (inline code) or in a heading. Its complement — 847 types — additionally captures the 279 types that appear only as tokens inside examples and are never explained.
+- **Name-mention coverage** counts a type as covered if its name appears anywhere in `docs/`, including inside an example code block. Its complement — 471 types — is the set that is entirely absent from the documentation.
+- **Explained-type coverage** is stricter: it requires the name in prose (inline code) or in a heading. Its complement — 796 types — additionally captures the 325 types that appear only as tokens inside examples and are never explained.
 
-This report file is excluded from the scan, so listing a type here does not make it count as documented. Counts are per module, so a name defined in two modules is counted twice; the distinct-name totals are 1,632 types and 564 absent. Both figures are name-based lower bounds; see *Methodology*.
+This report file is excluded from the scan, so listing a type here does not make it count as documented. Counts are per module, so a name defined in two modules is counted twice; the distinct-name totals are 1,632 types and 467 absent. Both figures are name-based lower bounds; see *Methodology*.
 
 ---
 
@@ -40,7 +42,6 @@ This report file is excluded from the scan, so listing a type here does not make
 
 | Module | types | absent | unexplained | explained cov | src LOC | doc LOC | ratio | Primary page |
 |---|---:|---:|---:|---:|---:|---:|---:|---|
-| **http-model** | 191 | 101 | 132 | **31%** | 4,712 | 1,528 | 0.32 | `reference/http-model/model.md` |
 | **http-model-schema** | 18 | 14 | 14 | **22%** | 1,249 | 607 | 0.49 | `reference/http-model/schema.md` |
 | **smithy** | 42 | 16 | 32 | 24% | 2,585 | 533 | 0.21 | `reference/smithy.md` |
 | **async** | 24 | 17 | 18 | 25% | 6,540 | 1,291 | 0.20 | `reference/async.md` |
@@ -51,6 +52,7 @@ This report file is excluded from the scan, so listing a type here does not make
 | **typeid** | 91 | 26 | 44 | 52% | 6,493 | 2,124 | 0.33 | `reference/typeid.md` |
 | **htmx** | 82 | 26 | 38 | 54% | 1,548 | 2,521 | 1.63 | `reference/htmx/` |
 | **telemetry** | 134 | 25 | 58 | 57% | 7,509 | 2,856 | 0.38 | `reference/telemetry/` |
+| http-model | 191 | 6 | 85 | 55% | 4,712 | 3,127 | 0.66 | `reference/http-model/` |
 | **otel** | 12 | 2 | 3 | 75% | 1,325 | 162 | **0.12** | `reference/telemetry/otel/` |
 | schema-xml | 35 | 6 | 15 | 57% | 3,334 | 1,034 | 0.31 | `built-in-codecs/xml.md` |
 | schema-bson | 18 | 1 | 7 | 61% | 1,790 | 472 | 0.26 | `built-in-codecs/bson.md` |
@@ -117,31 +119,33 @@ What remains, all minor:
 - [ ] `ConfigError.DuplicateKey` and `ConfigError.Unauthorized` are documented as unused by the module; decide whether they should exist at all
 - [ ] `ConfigValidationError` is sealed with zero implementations, so matching on it can never match; either give it a constructor or remove it
 
-### 2. `http-model` — typed headers entirely undocumented
+### 2. `http-model` — RESOLVED
 
-`Header.scala` is 1,861 lines defining ~100 typed header case classes. The `## Headers` section of `model.md` is 33 lines and shows only the untyped `String` API (`Headers("content-type" -> "...")`, `.add`, `.toList`). Not one typed header is explained, and lazy typed parsing — the reason `Headers` exists — gets a single sentence. 131 of 191 public types are unexplained, 101 absent.
+`Header.scala` is 1,861 lines defining 76 header types, of which 75 are typed built-ins. The `## Headers` section of `model.md` was 36 lines showing only the untyped `String` API; 101 of the module's 191 public types were absent.
 
-- **Content**: `ContentLength` ✗, `ContentEncoding` ✗, `ContentLanguage` ✗, `ContentLocation` ✗, `ContentRange` ✗, `ContentBase` ✗, `ContentMd5` ✗, `ContentDisposition` ✗, `ContentSecurityPolicy` ✗, `ContentTransferEncoding` ✗, `Attachment` ✗
-- **Caching**: `CacheControl` ✗, `MaxAge` ✗, `SMaxAge` ✗, `MaxStale` ✗, `MinFresh` ✗, `NoCache` ✗, `NoStore` ✗, `NoTransform` ✗, `MustRevalidate` ✗, `MustUnderstand` ✗, `ProxyRevalidate` ✗, `OnlyIfCached` ✗, `StaleIfError` ✗, `StaleWhileRevalidate` ✗, `Expires` ✗, `Pragma` ✗, `Private` ✗, `Immutable`, `Public`
-- **Conditional**: `ETag` ✗, `ETags` ✗, `IfMatch` ✗, `IfNoneMatch` ✗, `IfModifiedSince` ✗, `IfUnmodifiedSince` ✗, `IfRange` ✗, `LastModified` ✗
-- **Negotiation**: `AcceptEncoding` ✗, `AcceptLanguage` ✗, `AcceptPatch` ✗, `AcceptRanges` ✗, `MediaRange` ✗, `LanguageRange` ✗, `Vary` ✗, `Accept`
-- **CORS**: `AccessControlAllowOrigin` ✗, `AccessControlAllowCredentials` ✗, `AccessControlAllowHeaders` ✗, `AccessControlAllowMethods` ✗, `AccessControlExposeHeaders` ✗, `AccessControlMaxAge` ✗, `AccessControlRequestHeaders` ✗, `AccessControlRequestMethod` ✗, `Origin`
-- **WebSocket**: `SecWebSocketKey` ✗, `SecWebSocketAccept` ✗, `SecWebSocketProtocol` ✗, `SecWebSocketVersion` ✗, `SecWebSocketExtensions` ✗, `SecWebSocketOrigin` ✗, `SecWebSocketLocation` ✗, `UpgradeInsecureRequests` ✗, `Upgrade`, `WS`, `WSS`
-- **Transfer**: `TransferEncoding` ✗, `Chunked` ✗, `GZip` ✗, `Deflate` ✗, `Compress` ✗, `Br` ✗, `Te` ✗, `Trailer` ✗, `KeepAlive` ✗, `Expect` ✗
-- **Auth / proxy**: `WWWAuthenticate` ✗, `ProxyAuthenticate` ✗, `UserInfo` ✗, `ProxyAuthorization`
-- **Cookies**: `CookieHeader` ✗, `SetCookieHeader` ✗, `CookiePriority`, `Lax`, `SameOrigin` ✗
-- **Other**: `Forwarded` ✗, `Referer` ✗, `RetryAfter` ✗, `MaxForwards` ✗, `UserAgent` ✗, `XFrameOptions` ✗, `XRequestedWith` ✗, `Deny` ✗, `DNT` ✗, `TrackingAllowed` ✗, `TrackingNotAllowed` ✗, `ClearSiteData` ✗, `Unparsed` ✗, `Allow`, `Date`, `Host`
-- **Supporting**: `HeadersBuilder` ✗, `QueryParamsBuilder` ✗, `QueryKey` ✗, `QueryValue` ✗, `PercentEncoder` ✗ (143 lines), `FormData` ✗, `ComponentType` ✗, `SevenBit` ✗, `EightBit` ✗, `QuotedPrintable` ✗, `PathSegment`, `Boundary`, and the charset constants `UTF8`, `UTF16`, `UTF16BE`, `UTF16LE`, `ISO_8859_1`, `ASCII`
-- **SSE**: `ServerSentEvent` ✗ (206 lines), `SseDataEncoder`
+Two new pages, 956 lines together, with every code block mdoc-verified:
 
-Actions:
+| Page                   | Covers                                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------------------ |
+| `headers.md`           | `Header`, `Header.Codec`, `Header.Typed`, `Header.Custom`, all 75 built-ins catalogued in ten groups with wire names and ADT variants, the six read methods, the parse cache, write operations, `HeadersBuilder`, validation and injection safety, writing a custom codec |
+| `server-sent-event.md` | `ServerSentEvent`, its constructors and metadata builders, validation, render order, `SseDataEncoder` and its instances, custom encoders |
 
-- [ ] Write `reference/http-model/headers.md` — a typed-header catalog grouped as above, with the parse/render round trip and what happens on malformed input
-- [ ] Document lazy typed access on `Headers`: when parsing happens, what it costs, and how failures surface
-- [ ] Write `reference/http-model/server-sent-event.md` — `ServerSentEvent` and `SseDataEncoder`
-- [ ] Document `PercentEncoder` and the `QueryKey` / `QueryValue` / `PathSegment` encoding rules in the URL section of `model.md`
-- [ ] Document the charset constants and the multipart types (`Boundary`, `FormData`, `ComponentType`, transfer-encoding variants)
-- [ ] Document `HeadersBuilder` / `QueryParamsBuilder`
+The `## Headers` section of `model.md` was rewritten to cover the collection itself — creation, raw reads, append versus replace — and now links out for the typed model rather than omitting it. The module is at 55% explained coverage with 6 absent types.
+
+Three behaviours the source made non-obvious, now stated with worked output:
+
+- **`Headers#get` discards parse errors.** A malformed header is indistinguishable from an absent one, and a malformed entry followed by a well-formed one silently yields the latter. No collection read surfaces the error.
+- **The parse cache is keyed by codec identity, compared by reference.** A codec constructed inline per request never reuses its cached values, and `Headers#add` drops the cache entirely.
+- **`Headers#toString` prints credentials verbatim.** There is no redaction, so anything logging a `Request` logs its `authorization` and `cookie` values.
+
+Writing the catalog also surfaced a genuine defect, documented in a warning admonition and worth fixing in the source:
+
+- [ ] `Header.AcceptEncoding.parseSingle` ends with `case _ => GZip(weight)` (`Header.scala:1252`), so any unrecognized encoding name silently parses as `GZip` — `accept-encoding: bogus` reads as a gzip request. Its `parse` fails only on an empty value. The sibling ADTs handle the same situation correctly: `Authorization` has an `Unparsed` case and `Connection` has `Other`. `AcceptEncoding` should either gain an equivalent case or return `Left`.
+
+What remains is the report's own items 4 and 5 rather than anything new:
+
+- [ ] Document `PercentEncoder`, `QueryKey`, `QueryValue`, and `QueryParamsBuilder` in the URL and query sections of `model.md`
+- [ ] Document `ComponentType` and `UserInfo`
 
 ### 3. `http-model-schema` — the codec layer is invisible
 
@@ -354,13 +358,13 @@ Ordered by user impact per unit of writing effort.
 
 **Tier 1 — new pages for missing subsystems**
 
-1. - [ ] `reference/http-model/headers.md` — typed header catalog (~100 types, 1,861 source lines undocumented)
+1. - [x] `reference/http-model/headers.md` — **done**: 660 lines cataloguing all 75 built-ins, mdoc-verified
 2. - [x] Split `reference/config.md` into `reference/config/` — **done**: seven pages, 2,212 lines, mdoc-verified; family went from 31% to 72% explained coverage
 3. - [ ] Split `reference/telemetry/otel/` into four pages
 4. - [ ] `reference/htmx/response-headers.md`
 5. - [ ] `reference/schema/schema-search.md` (`SchemaSearch`, `SchemaMatch`, `TypeSearch`, `SearchTraversal`, `Updater`)
 6. - [ ] `reference/telemetry/common/any-value.md`
-7. - [ ] `reference/http-model/server-sent-event.md`
+7. - [x] `reference/http-model/server-sent-event.md` — **done**: 296 lines
 8. - [ ] `reference/schema/reflect-transformer.md`
 9. - [ ] `reference/telemetry/logging/log-emitter.md`
 


### PR DESCRIPTION
## What

Documents the typed header model in `http-model`, which the coverage report flagged as the largest remaining gap after the config split in #1610.

`Header.scala` is 1,861 lines defining 75 typed headers. The `## Headers` section of `model.md` was 36 lines showing only the untyped `String` API, so not one typed header was explained, and lazy typed parsing — the reason `Headers` exists at all — got a single sentence. 101 of the module's 191 public types were absent from the documentation.

Unlike the config gap, this was one hole in an otherwise solid page: `Method`, `Status`, `Version`, `Scheme`, `URL`, `Path`, `QueryParams`, `Body`, and `Cookie` are all documented properly in `model.md`. Headers were the exception.

## Changes

### `docs/reference/http-model/headers.md` (new, 660 lines)

The `Header` trait, the `Header.Codec` type class and its `Typed` refinement, and `Header.Custom`. All 75 built-ins are catalogued in ten groups — authentication, content, caching, negotiation, CORS, routing and identity, cookies, connection management, security, WebSocket — each with its wire name and its shape, including ADT variants. `CacheControl` alone has 17.

Also covers the six read methods and how they differ, the parse cache, append versus replace on writes, `HeadersBuilder`, the validation rules, and how to write a custom `Header.Codec`.

### `docs/reference/http-model/server-sent-event.md` (new, 296 lines)

`ServerSentEvent`, its three constructors and four metadata builders, the two validated invariants, the fixed field order in `render`, and `SseDataEncoder` with its built-in and custom instances.

### `docs/reference/http-model/model.md`

The `## Headers` section is rewritten (36 → 69 lines) to cover the collection itself — creation, raw reads, append versus replace — and to link out for the typed model rather than omitting it. Its code blocks now evaluate rather than being `compile-only`, so the append-versus-replace distinction is shown rather than asserted.

Coverage for the module goes from **31% to 55%** explained type coverage, and from **101 absent types to 6**.

## Three behaviours the docs now state that the source did not

Each is shown with real mdoc output rather than described:

- **`Headers#get` discards parse errors.** It treats a parse failure exactly like a name mismatch and keeps scanning, so a malformed header is indistinguishable from an absent one — and a malformed entry followed by a well-formed one silently yields the latter. No collection read surfaces the error; recovering it means `rawGet` plus an explicit `parse`.
- **The parse cache is keyed by codec identity, compared by reference.** A codec constructed inline on each request is a different instance every time and never reuses its cached values. `Headers#add` also drops the cache, since it builds fresh arrays without carrying parsed values across.
- **`Headers#toString` prints credentials verbatim.** There is no redaction, so anything that logs a `Request` or `Response` logs its `authorization` and `cookie` values in full.

## A defect found while writing the catalog

`Header.scala:1252` — `AcceptEncoding.parseSingle` ends with:

```scala
case _ => GZip(weight)
```

Any unrecognized encoding name parses as `GZip`. `accept-encoding: bogus` reads as a gzip request, and so does a typo like `identityy`. `AcceptEncoding.parse` therefore fails only on an empty value:

```scala
Header.AcceptEncoding.parse("!!!")
// res24: Either[String, AcceptEncoding] = Right(GZip(None))
```

A server selecting a response encoding from this header will gzip a response for a client that never asked for it.

This looks like an oversight rather than a design choice, because the sibling ADTs handle the same situation properly: `Authorization` and `ProxyAuthorization` have an `Unparsed` case, and `Connection` has `Other`. `AcceptEncoding` has neither, so it picks a real encoding instead of admitting it does not know. `ContentDisposition`'s `case _` fallbacks are sound by comparison — they fire only after a prefix has already been confirmed, and genuinely unknown values return `Left`.

This PR only documents the behaviour, in a warning admonition. Fixing it changes parse results and belongs in its own change with a test, so it is left as a checklist item in the report.

## Verification

- `sbt "docs/mdoc --in docs/reference/http-model"` — **0 errors**. Run twice: the first run is what exposed the `AcceptEncoding` behaviour, because a `getAll` example asserted that one of three entries would be dropped and the rendered output showed all three surviving.
- `sbt "++2.13; check"` — **success**.
- Style and mdoc-convention checkers clean on both new pages. The hits remaining in `model.md` are all pre-existing and outside the rewritten section; they are left alone to keep the diff readable.
- All relative links resolve, and sidebar entries match the files on disk.

Two mdoc warnings for `../chunk.md` and `../maybe.md` appear only because `--in` was scoped to the subdirectory, so mdoc cannot see files above it. `schema.md:747` already carries the identical pre-existing warning for `../combinators.md`, and both link targets exist.

## Report update

`docs/undocumented-report.md` is re-scanned: section 2 now records what shipped, the three behaviours above, the `AcceptEncoding` defect, and the two remaining items — which are the report's own items 4 and 5 (`PercentEncoder`, `QueryKey`, `QueryValue`, `QueryParamsBuilder`, `ComponentType`, `UserInfo`) rather than anything new. Repository totals move from 568 to 471 absent types and 847 to 796 unexplained.
