### PR TITLE
Document the public OTLP export surface

### DIFF
--- a/docs/reference/telemetry/otel/custom-exporter.md
+++ b/docs/reference/telemetry/otel/custom-exporter.md
@@ -1,0 +1,210 @@
+---
+id: custom-exporter
+title: "Building an Exporter"
+sidebar_label: "Building an Exporter"
+description: "Encode telemetry into OTLP JSON, send it yourself, and interpret the result — the public pieces of the export path and how they fit together."
+keywords:
+  - "OTLP JSON"
+  - "Custom Exporter"
+  - "Telemetry Export"
+  - "Export Result"
+---
+
+The exporters that ship with this module are internal, but the pieces they are built from are not. `OtlpJsonEncoder` turns recorded signals into OTLP JSON bytes, [`HttpSender`](./index.md) puts bytes on the wire, and `ExportResult` classifies what came back. Together they are enough to export telemetry today, without waiting for a public exporter API. Supporting types: `NamedMetric`, `HttpResponse`. The public surface of the export path:
+
+```scala
+object OtlpJsonEncoder {
+  def encodeTraces(spans: Seq[SpanData], resource: Resource, scope: InstrumentationScope): Array[Byte]
+  def encodeMetrics(metrics: Seq[NamedMetric], resource: Resource, scope: InstrumentationScope): Array[Byte]
+  def encodeLogs(logs: Seq[LogRecord], resource: Resource, scope: InstrumentationScope): Array[Byte]
+}
+
+sealed trait ExportResult
+
+object ExportResult {
+  case object Success                                           extends ExportResult
+  final case class Failure(retryable: Boolean, message: String) extends ExportResult
+
+  def fromHttpResponse(response: HttpResponse): ExportResult
+}
+```
+
+## Motivation
+
+`OtlpJsonTraceExporter`, `OtlpJsonLogExporter`, `OtlpJsonMetricExporter`, and the `BatchProcessor` behind them are all `private[otel]`, so there is no supported way to construct one. That is a real limitation, and the [module overview](./index.md) says so.
+
+What it does not mean is that you cannot export. Three of the four pieces an exporter needs are public: the encoder that produces the payload, the sender that transmits it, and the result type that says whether to retry. Only the batching and retry loop is missing, and for many deployments that loop is a scheduled task you already have — a periodic flush from whatever scheduler your application runs.
+
+Writing it yourself also buys control the internal exporter does not offer: your own retry policy, your own queue semantics, metrics about the exporter itself, and a payload you can inspect before it leaves the process.
+
+## The Encoder
+
+`OtlpJsonEncoder` produces the OTLP protobuf-JSON mapping directly into a `StringBuilder`, with no JSON library involved. Each method takes the signals plus the `Resource` and `InstrumentationScope` that describe their origin, and returns UTF-8 bytes ready to POST.
+
+### Encoding Rules
+
+The output follows the protobuf JSON mapping rather than a naive rendering, which matters if you plan to compare payloads or write assertions against them:
+
+| Wire concern              | Encoding                                       |
+| ------------------------- | ---------------------------------------------- |
+| `traceId`, `spanId` bytes | Lowercase hex strings                           |
+| `int64` / `uint64`        | Quoted strings, not JSON numbers                |
+| Enums                     | Integers                                        |
+| Field names               | camelCase                                       |
+| Control characters        | `\uXXXX` escapes, including lone surrogates      |
+
+The quoted-integer rule is the one that surprises people: OTLP timestamps are `uint64`, so they appear as `"1755990000000000000"` rather than a bare number. A collector expects that; a hand-written comparison usually does not.
+
+### Encoding Traces
+
+`OtlpJsonEncoder.encodeTraces` takes `SpanData` values — the same records the core module's in-memory processor collects:
+
+```scala mdoc:compile-only
+import zio.blocks.telemetry._
+import zio.blocks.telemetry.otel._
+
+val payload: Array[Byte] = OtlpJsonEncoder.encodeTraces(
+  trace.collectedSpans,
+  Resource.empty,
+  InstrumentationScope("checkout-service", Some("1.4.0"))
+)
+```
+
+`trace.collectedSpans` returns everything recorded so far, so a real exporter tracks what it has already sent rather than re-encoding the whole list on every flush.
+
+### Encoding Logs
+
+`OtlpJsonEncoder.encodeLogs` takes `LogRecord` values, and is otherwise identical in shape:
+
+```scala mdoc:compile-only
+import zio.blocks.telemetry._
+import zio.blocks.telemetry.otel._
+
+def exportLogs(records: Seq[LogRecord]): Array[Byte] =
+  OtlpJsonEncoder.encodeLogs(records, Resource.empty, InstrumentationScope("checkout-service"))
+```
+
+### Encoding Metrics
+
+Metrics need one extra step, because the encoder wants a name and the reader does not supply one. `NamedMetric` pairs the descriptor with the data:
+
+```scala
+final case class NamedMetric(
+  name: String,
+  description: String,
+  unit: String,
+  data: MetricData
+)
+```
+
+`MetricReader#collectAllMetrics` returns `Seq[MetricData]`, and `MetricData` — `SumData`, `HistogramData`, or `GaugeData` — carries only data points. The name, description, and unit are not on it:
+
+```scala mdoc:compile-only
+import zio.blocks.telemetry._
+import zio.blocks.telemetry.otel._
+
+val collected: Seq[MetricData] = metric.reader.collectAllMetrics()
+
+val named: Seq[NamedMetric] =
+  collected.map(data => NamedMetric("http.server.duration", "Request duration", "ms", data))
+
+val payload = OtlpJsonEncoder.encodeMetrics(named, Resource.empty, InstrumentationScope("checkout-service"))
+```
+
+:::warning[`MetricData` does not carry its own name]
+`MetricReader#collectAllMetrics` returns metric data with no identifying name, and there is no public way to recover which instrument produced which element. Attaching the right name means tracking the correspondence yourself — record the instruments you created in the same order you read them back, or collect per-instrument rather than in bulk. Mapping a whole batch to one name, as above, is only correct when you registered exactly one instrument.
+:::
+
+`OtlpJsonEncoder.NamedMetric` is a type alias and value alias for the same case class, so either spelling compiles.
+
+## Interpreting the Response
+
+`ExportResult` classifies an HTTP response into "delivered", "retry this", and "drop this". `ExportResult.fromHttpResponse` applies the standard OTLP rules, so you do not need to remember which status codes are worth a second attempt:
+
+```scala mdoc:silent
+import zio.blocks.telemetry.otel._
+
+def result(status: Int): ExportResult =
+  ExportResult.fromHttpResponse(HttpResponse(status, Array.emptyByteArray, Map.empty))
+```
+
+Any `2xx` is a success:
+
+```scala mdoc
+result(200)
+result(204)
+```
+
+Four status codes are treated as retryable — `429`, `502`, `503`, and `504` — because each means "not now" rather than "not ever":
+
+```scala mdoc
+result(429)
+result(503)
+```
+
+Everything else is a permanent failure, and retrying it only wastes the batch. A `400` means the collector rejected the payload itself, so the same bytes will be rejected again:
+
+```scala mdoc
+result(400)
+result(401)
+```
+
+The `message` is a short diagnostic rather than the response body, so log the body separately when you need to know *why* a `400` was rejected.
+
+A rejected export arrives as a non-`2xx` `HttpResponse`, not as an exception. A connection that never completes is different: `HttpSender.jdk` lets `IOException` out, so a custom loop must catch throwables and treat them as retryable itself — `ExportResult.fromHttpResponse` never sees them.
+
+:::tip[Honour `Retry-After`]
+`HttpResponse#firstHeader` looks a header up case-insensitively, which is what a `429` or `503` needs. `ExportResult` does not read it, so a retry loop that ignores `Retry-After` will keep hammering a collector that just asked it to wait.
+:::
+
+## Putting It Together
+
+A minimal exporter is a flush function: take what has accumulated, encode it, send it, and act on the result. This is the whole shape, with the retry decision made from `ExportResult`:
+
+```scala mdoc:compile-only
+import zio.blocks.telemetry._
+import zio.blocks.telemetry.otel._
+import java.time.Duration
+
+val config = ExporterConfig(
+  endpoint = "https://otlp.example.com:4318",
+  headers = Map("Authorization" -> "Bearer <token>"),
+  timeout = Duration.ofSeconds(10)
+)
+
+val sender = HttpSender.jdk(config.timeout)
+val scope  = InstrumentationScope("checkout-service", Some("1.4.0"))
+
+def flushTraces(spans: Seq[SpanData]): ExportResult =
+  if (spans.isEmpty) ExportResult.Success
+  else {
+    val body = OtlpJsonEncoder.encodeTraces(spans, Resource.empty, scope)
+    try ExportResult.fromHttpResponse(
+      sender.send(config.endpoint + "/v1/traces", config.headers + ("Content-Type" -> "application/json"), body)
+    )
+    catch {
+      case e: java.io.IOException => ExportResult.Failure(retryable = true, message = e.getMessage)
+    }
+  }
+```
+
+Three details in there are easy to get wrong. The signal path is appended to the endpoint — `/v1/traces`, `/v1/logs`, or `/v1/metrics` — because `ExporterConfig#endpoint` is a base URL. `Content-Type: application/json` must be set, since the payload is the JSON mapping rather than protobuf. And the `IOException` catch is not optional: without it, a collector that is simply unreachable takes down whatever thread the flush runs on.
+
+Call `HttpSender#shutdown` when the process is stopping. The JDK sender holds nothing that needs releasing, but a custom sender may, and a flush that never runs at shutdown loses whatever was still queued.
+
+## What You Are Reimplementing
+
+The internal `BatchProcessor` does four things a hand-rolled flush does not, and they are worth deciding about explicitly rather than discovering later:
+
+- **Bounded queueing.** It caps the queue at `ExporterConfig#maxQueueSize` and evicts the oldest record when full, so recording never blocks and memory never grows without bound. A naive accumulator has neither property.
+- **Chunking.** It splits a drained queue into `ExporterConfig#maxBatchSize` pieces, so one flush after a traffic spike becomes several right-sized requests instead of one oversized one.
+- **Interval flushing.** It flushes every `ExporterConfig#flushIntervalMillis` regardless of how full the batch is, which is what bounds how stale exported data can be.
+- **Retry on retryable failures.** It re-queues a batch whose `ExportResult` was `Failure(retryable = true)` and drops one that was not.
+
+`ExporterConfig` carries all three sizing fields even though nothing public reads them, so use them as the source of truth for your own loop rather than inventing separate numbers. See [the module overview](./index.md) for what each field means.
+
+## Integration Points
+
+This page uses only public API: `OtlpJsonEncoder`, `NamedMetric`, `ExportResult`, `HttpResponse`, `HttpSender`, and `ExporterConfig` from this module, and `SpanData`, `LogRecord`, `MetricData`, `Resource`, and `InstrumentationScope` from the core telemetry module.
+
+The signals themselves come from the core module's recording APIs — [`trace`](../tracing/index.md) for spans, [`log`](../logging/index.md) for records, and [`metric`](../metrics/index.md) for measurements. For trace context across service boundaries rather than export, see [the module overview](./index.md).

--- a/docs/reference/telemetry/otel/index.md
+++ b/docs/reference/telemetry/otel/index.md
@@ -68,6 +68,10 @@ trait HttpSender {
 object HttpSender {
   def jdk(timeout: Duration = Duration.ofSeconds(30)): HttpSender
 }
+
+final case class HttpResponse(statusCode: Int, body: Array[Byte], headers: Map[String, Seq[String]]) {
+  def firstHeader(name: String): Option[String]
+}
 ```
 
 `HttpSender.jdk` wraps `java.net.http.HttpClient`, which ships with the JVM, so nothing is added to your dependencies. The timeout applies to both connecting and completing a request. `shutdown()` is where a sender releases what it holds — the JDK one holds nothing that needs closing, so its implementation does nothing:
@@ -152,11 +156,56 @@ Create the storage yourself: a provider's own is internal, so there's no reachin
 
 ## Exporting Traces, Logs, and Metrics
 
-The exporters that carry each signal to a collector are currently internal to this module: `OtlpJsonTraceExporter`, `OtlpJsonLogExporter`, and `OtlpJsonMetricExporter` are `private[otel]`, as is the `BatchProcessor` that batches records before a send. There is no public way to construct one yet, so this page documents the pieces you *can* reach — configuration, transport, and propagation — and leaves the wiring recipes for when the API exposes an entry point.
+The exporters that carry each signal to a collector are internal to this module: `OtlpJsonTraceExporter`, `OtlpJsonLogExporter`, and `OtlpJsonMetricExporter` are `private[otel]`, as is the `BatchProcessor` that batches records before a send. There is no public way to construct one yet.
 
-Until then, the [Telemetry Guide](../../../guides/telemetry-guide.md) sketches the intended shape of that wiring, and the core module's in-process destinations cover development and testing: [`log.writer`](../logging/index.md) for formatted output, [`trace.collectedSpans`](../tracing/index.md) for recorded spans, and [`metric.reader`](../metrics/index.md) for measurement snapshots.
+The pieces they are built from *are* public, though, so exporting does not have to wait for that entry point. `OtlpJsonEncoder` produces OTLP JSON bytes from recorded signals, `HttpSender` transmits them, and `ExportResult` says whether a failed send is worth retrying — see [Building an Exporter](./custom-exporter.md) for the encoder, the result type, and a worked flush function.
+
+For development and testing, the core module's in-process destinations avoid the network entirely: [`log.writer`](../logging/index.md) for formatted output, [`trace.collectedSpans`](../tracing/index.md) for recorded spans, and [`metric.reader`](../metrics/index.md) for measurement snapshots. The [Telemetry Guide](../../../guides/telemetry-guide.md) sketches the intended shape of the wiring once a public exporter lands.
+
+## Threading Context Through `Context[R]`
+
+`Propagator` moves trace context between processes. `OtelContext` moves it *within* one, across code that threads dependencies through `Context[R]` rather than reading an ambient storage:
+
+```scala
+final case class OtelContext(spanContext: Option[SpanContext])
+
+object OtelContext {
+  def current(storage: ContextStorage[Option[SpanContext]]): OtelContext
+  def withSpan[A](span: Span, storage: ContextStorage[Option[SpanContext]])(f: => A): A
+}
+```
+
+`OtelContext.current` snapshots whatever span context is active in a storage, giving a plain value that can be placed into a `Context[R & OtelContext]` and passed along like any other dependency:
+
+```scala mdoc:compile-only
+import zio.blocks.telemetry._
+import zio.blocks.telemetry.otel._
+
+val storage = ContextStorage.create[Option[SpanContext]](None)
+val snapshot = OtelContext.current(storage)
+```
+
+`OtelContext.withSpan` is the inverse: it makes a span's context active for the duration of a block and restores the previous value afterwards, including when the block throws:
+
+```scala mdoc:compile-only
+import zio.blocks.telemetry._
+import zio.blocks.telemetry.otel._
+
+val storage = ContextStorage.create[Option[SpanContext]](None)
+val tracer  = trace.get("api-service")
+
+tracer.span("handle-request", SpanKind.Server) { span =>
+  OtelContext.withSpan(span, storage) {
+    // anything reading `storage` here sees this span's context
+    OtelContext.current(storage)
+  }
+}
+```
+
+An `IsNominalType[OtelContext]` instance is provided, which is what lets the type be used as a `Context` key.
 
 ## See Also
 
+- [Building an Exporter](./custom-exporter.md) — `OtlpJsonEncoder`, `ExportResult`, and a worked flush function
 - [Tracing](../tracing/index.md) — opening the spans this module exports, and [`SpanContext`](../tracing/span-context.md), the identity a propagator moves
 - [Telemetry Reference](../index.md) — the core module that records what this one exports

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -336,7 +336,15 @@ const sidebars = {
                   "reference/telemetry/common/instrumentation-scope",
                 ]
               },
-              "reference/telemetry/otel/index",
+              {
+                type: "category",
+                label: "OTLP Export",
+                link: { type: "doc", id: "reference/telemetry/otel/index" },
+                collapsed: false,
+                items: [
+                  "reference/telemetry/otel/custom-exporter",
+                ]
+              },
             ]
           },
         ]

--- a/docs/undocumented-report.md
+++ b/docs/undocumented-report.md
@@ -7,7 +7,9 @@ title: "Documentation Coverage Report"
 
 Full re-scan of documentation coverage across every library module aggregated by the `root` project. Replaces the 2026-02-13 report, which predated most of the current `docs/reference` tree and covered only 12 modules.
 
-**Progress since this report was generated:** the `config` family has been documented — `docs/reference/config.md` was replaced by a seven-page `docs/reference/config/` directory (2,212 lines, all code blocks mdoc-verified), taking the family from 31% to 72% explained coverage and from 43 absent types to 3. Tier 1 item 2 is complete; the numbers in this report have been updated to match.
+**Progress since this report was generated:** `otel` is complete at 100% coverage — though the item as originally written was mis-scoped, since most of that module is `private[otel]`; see section 4 for what was actually missing and the lesson for other low-ratio rows. Repository-wide totals in the Summary below are not updated for it, because a separate in-flight branch also moves them; they are refreshed once both land.
+
+Earlier: the `config` family has been documented — `docs/reference/config.md` was replaced by a seven-page `docs/reference/config/` directory (2,212 lines, all code blocks mdoc-verified), taking the family from 31% to 72% explained coverage and from 43 absent types to 3. Tier 1 item 2 is complete; the numbers in this report have been updated to match.
 
 **What changed since the previous (2026-02-13) report:** every published module now has a reference page, and every page is linked from `docs/sidebars.js`. There are no longer any modules with zero documentation, and four of the six "critical missing pages" from the old report now exist (`media-type.md`, `schema/schema-expr.md`, `schema/schema-error.md`, `built-in-codecs/json/json-patch.md`). The remaining gaps are (a) whole subsystems inside otherwise-documented modules, (b) pages far too short for the surface they cover, and (c) an almost complete absence of task-oriented guides.
 
@@ -51,7 +53,7 @@ This report file is excluded from the scan, so listing a type here does not make
 | **typeid** | 91 | 26 | 44 | 52% | 6,493 | 2,124 | 0.33 | `reference/typeid.md` |
 | **htmx** | 82 | 26 | 38 | 54% | 1,548 | 2,521 | 1.63 | `reference/htmx/` |
 | **telemetry** | 134 | 25 | 58 | 57% | 7,509 | 2,856 | 0.38 | `reference/telemetry/` |
-| **otel** | 12 | 2 | 3 | 75% | 1,325 | 162 | **0.12** | `reference/telemetry/otel/` |
+| otel | 12 | 0 | 0 | **100%** | 1,325 | 421 | 0.32 | `reference/telemetry/otel/` |
 | schema-xml | 35 | 6 | 15 | 57% | 3,334 | 1,034 | 0.31 | `built-in-codecs/xml.md` |
 | schema-bson | 18 | 1 | 7 | 61% | 1,790 | 472 | 0.26 | `built-in-codecs/bson.md` |
 | codegen | 46 | 6 | 17 | 63% | 2,100 | 3,024 | 1.44 | `reference/codegen/` |
@@ -154,15 +156,26 @@ Actions:
 - [ ] Document the shape classification (`SinglePrimitive`, `OptionalValue`, `SequenceValue`, `WrappedValue`) so users can predict how a case class maps to headers or query params
 - [ ] Document `DecodeErrorFactory` for custom error messages
 
-### 4. `otel` — 162 lines for the entire export subsystem
+### 4. `otel` — RESOLVED, and this item was mis-scoped
 
-`reference/telemetry/otel/index.md` is a single 162-line page covering OTLP export and context propagation, while sibling `telemetry/tracing/` has 11 pages. `ExportResult` ✗ and `OtlpJsonEncoder` ✗ (527 lines) never appear; there is no page for the exporters, the propagator, or the retry/batching behaviour.
+The original entry called for splitting the 162-line page into four, including an `otlp-exporters.md`. That was wrong, and the reason is worth recording because it applies to other rows in the table.
 
-Actions:
+`OtlpJsonTraceExporter`, `OtlpJsonLogExporter`, `OtlpJsonMetricExporter`, `BatchProcessor`, `OtlpJsonExporter`, and `JdkHttpSender` are all `private[otel]` — six of the module's eighteen declarations. An `otlp-exporters.md` page would have documented internals. The 0.12 ratio that flagged this row is misleading for the same reason `mediatype`'s 0.04 is: roughly 60% of the module's lines are not public surface, and the existing page already covered six of the ten public types well, including a paragraph explaining that the exporters are unreachable.
 
-- [ ] Split into `reference/telemetry/otel/`: `index.md`, `exporter-config.md`, `otlp-exporters.md`, `propagation.md`
-- [ ] Document `ExportResult` and failure handling — what happens when the collector is down
-- [ ] Document batching, flush, and shutdown semantics (the exporter specs in `otel/` show executor shutdown matters; the docs never mention it)
+The real gap was four public types and one missing recipe:
+
+- `OtlpJsonEncoder` (527 lines) and `NamedMetric` — the only public way to produce OTLP payloads, and therefore the answer to the dead end the old page described rather than resolved
+- `ExportResult` and its `fromHttpResponse` classification
+- `OtelContext`, which bridges `ContextStorage` with `Context[R]`
+
+Resolved by adding `custom-exporter.md` (210 lines) covering the encoder, the encoding rules, `ExportResult`, and a worked flush function that assembles the public pieces into a working exporter; and by extending `index.md` with an `OtelContext` section, the `HttpResponse` shape, and a replacement for the dead-end paragraph. The module is now at 100% — 0 absent, 0 unexplained, all 12 public types documented.
+
+Two findings from writing it:
+
+- **`MetricData` carries no name.** `MetricReader#collectAllMetrics` returns `Seq[MetricData]` and `OtlpJsonEncoder.encodeMetrics` needs `Seq[NamedMetric]`, but nothing public recovers which instrument produced which element. Documented as a warning; worth an API fix.
+- **`ExporterConfig`'s three sizing fields have no public reader.** `maxQueueSize`, `maxBatchSize`, and `flushIntervalMillis` are only consumed by the private `BatchProcessor`, so a hand-rolled exporter must implement queueing, chunking, and interval flushing itself. The new page lists what that means.
+
+**Lesson for the remaining rows:** check the public/private split before trusting a low ratio. Rows where most lines may be internal should be verified the same way before being scoped as multi-page splits.
 
 ### 5. `schema` — 268 unexplained types clustered in seven subsystems
 
@@ -356,7 +369,7 @@ Ordered by user impact per unit of writing effort.
 
 1. - [ ] `reference/http-model/headers.md` — typed header catalog (~100 types, 1,861 source lines undocumented)
 2. - [x] Split `reference/config.md` into `reference/config/` — **done**: seven pages, 2,212 lines, mdoc-verified; family went from 31% to 72% explained coverage
-3. - [ ] Split `reference/telemetry/otel/` into four pages
+3. - [x] ~~Split `reference/telemetry/otel/` into four pages~~ — **done differently**: the four-page split was mis-scoped (the exporters are `private[otel]`); resolved with one new page plus index additions, module now at 100%
 4. - [ ] `reference/htmx/response-headers.md`
 5. - [ ] `reference/schema/schema-search.md` (`SchemaSearch`, `SchemaMatch`, `TypeSearch`, `SearchTraversal`, `Updater`)
 6. - [ ] `reference/telemetry/common/any-value.md`


### PR DESCRIPTION
## What

Documents the public OTLP export surface in the `otel` module, and corrects the coverage-report item that scoped this work — which was wrong in a way worth recording.

## The item was mis-scoped, and that is the more useful finding

The coverage report listed this as "split the 162-line page into four: `index.md`, `exporter-config.md`, `otlp-exporters.md`, `propagation.md`". That plan was wrong. `OtlpJsonTraceExporter`, `OtlpJsonLogExporter`, `OtlpJsonMetricExporter`, `BatchProcessor`, `OtlpJsonExporter`, and `JdkHttpSender` are all `private[otel]` — six of the module's eighteen declarations. An `otlp-exporters.md` page would have documented internals.

The 0.12 doc-to-source ratio that flagged the row is misleading for the same reason `mediatype`'s 0.04 is: roughly 60% of this module's lines are not public surface, and the existing page already covered six of the ten public types well — including a paragraph correctly explaining that the exporters are unreachable.

The report now records this, along with a lesson for the remaining low-ratio rows: check the public/private split before scoping a multi-page split.

## What was actually missing

Four public types, and one missing conclusion.

The old page said there is no public way to construct an exporter, and stopped there. But the pieces those internal exporters are built from *are* public: `OtlpJsonEncoder` (527 lines) produces OTLP JSON bytes from recorded signals, `HttpSender` transmits them, and `ExportResult` classifies the response. Exporting is possible today without a public exporter entry point — nobody had written down how.

None of `OtlpJsonEncoder`, `NamedMetric`, `ExportResult`, or `OtelContext` was documented.

## Changes

### `otel/custom-exporter.md` (new, 210 lines)

The encoder's three methods and the protobuf JSON mapping rules they follow — including that `int64`/`uint64` fields are quoted strings, which surprises anyone comparing payloads by hand. `NamedMetric`. `ExportResult` with its retryable classification (`429`, `502`, `503`, `504` retryable; everything else permanent), shown with rendered output for each case.

Then a worked flush function assembling the public pieces, with the three details that are easy to get wrong called out: the signal path appended to the base endpoint (`ExporterConfig#endpoint` is a base URL), the required `Content-Type: application/json` since the payload is the JSON mapping rather than protobuf, and the `IOException` catch without which an unreachable collector takes down whatever thread the flush runs on.

Closes with what a hand-rolled loop is reimplementing relative to the internal `BatchProcessor`: bounded queueing with oldest-record eviction, chunking to `maxBatchSize`, interval flushing, and retry on retryable failures.

### `otel/index.md` (162 → 211 lines)

Adds an `OtelContext` section — public and previously undocumented — covering `current`, `withSpan`, and the `IsNominalType` instance that lets it serve as a `Context` key. Adds the `HttpResponse` case-class shape alongside the existing `HttpSender` signature. Replaces the dead-end paragraph with a pointer to the new page, keeping the accurate statement that the exporters are internal.

Coverage for the module goes from **75% to 100%** explained: 0 absent, 0 unexplained, all 12 public types documented.

## Two API friction points, documented rather than fixed

Both look like gaps worth closing, but changing either is an API decision:

- **`MetricData` carries no name.** `MetricReader#collectAllMetrics` returns `Seq[MetricData]`, and `OtlpJsonEncoder.encodeMetrics` needs `Seq[NamedMetric]`. Nothing public recovers which instrument produced which element, so attaching the right name means tracking the correspondence yourself. Documented as a warning admonition.
- **`ExporterConfig`'s three sizing fields have no public reader.** `maxQueueSize`, `maxBatchSize`, and `flushIntervalMillis` are consumed only by the private `BatchProcessor`. A hand-rolled exporter must implement queueing, chunking, and interval flushing itself, so the new page tells you to treat those fields as the source of truth for your own loop rather than inventing separate numbers.

## Verification

- `sbt "docs/mdoc --in docs/reference/telemetry/otel"` — **0 errors**. All four `ExportResult` examples render output matching the prose.
- `sbt "++2.13; check"` — **success**.
- Style checker clean on the new page; the hits remaining in `index.md` are pre-existing and outside the edited sections.
- Links resolve and sidebar entries match the files on disk.

The mdoc link warnings for `../tracing/index.md` and siblings are an artifact of scoping `--in` to the subdirectory; `index.md`'s pre-existing links to the same targets warn identically, and every target exists.

## Note on the report's summary totals

Deliberately left unchanged. PR #1615 moves the same repository-wide numbers, so editing them here would conflict and one of the two would land wrong. The progress note says as much, and the totals get refreshed in one pass once both merge.
