### PR TITLE
docs(htmx): reference documentation for request/response headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ website/.docusaurus
 *.class
 *.tasty
 .flowrite/
+.docs-audit-state.json

--- a/docs/reference/htmx/index.md
+++ b/docs/reference/htmx/index.md
@@ -228,7 +228,7 @@ The `Js` type is intentionally raw—do not build it from unsanitized user input
 
 **With JavaScript:** Attributes that accept raw JavaScript expressions (`hxOn:*`, `hxTrigger.filter()`) accept the `Js` type, making it explicit that you're writing unescaped JavaScript code. This prevents accidental XSS while allowing intentional dynamic behavior.
 
-**With headers:** The `zio.http.htmx.headers` submodule provides typed HTMX request/response headers (HX-Request, HX-Trigger, HX-Redirect, etc.), letting you inspect and build headers with the same type safety as attributes.
+**With headers:** The [`zio.http.htmx.headers`](./response-headers.md) submodule provides typed HTMX request/response headers (HX-Request, HX-Trigger, HX-Redirect, etc.), letting you inspect and build headers with the same type safety as attributes.
 
 **Extending with custom types:** Implement `ToHtmxValue[MyType]` to let your domain types render themselves in the DSL. For example, a custom `enum Status { Active, Inactive }` defines `implicit val statusToHtmx: ToHtmxValue[Status] = ...` and renders directly in HTMX attributes.
 

--- a/docs/reference/htmx/response-headers.md
+++ b/docs/reference/htmx/response-headers.md
@@ -1,0 +1,229 @@
+---
+id: response-headers
+title: Request and Response Headers
+---
+
+`zio.http.htmx.headers` provides typed HTTP headers for the request/response side of an HTMX exchange: the headers HTMX sends with every request, and the headers a handler sets to steer the client afterward. Each header follows the same `Header` / `Header.Typed` pattern that `zio.http` applies everywhere else, so reading one from a `Request` or `Response` returns a parsed domain value instead of a raw string, and several response headers reuse the same `HxSwap`, `HxTarget`, and `HxUrlUpdate` types that back the attribute DSL, keeping the two sides of an interaction consistent.
+
+Here are the core patterns for reading and writing HTMX headers:
+
+```scala mdoc:compile-only
+import zio.http.{Header, Headers, Request, Response, URL}
+import zio.http.htmx.headers._
+
+// Reading a request header HTMX sent
+def handle(request: Request): Boolean =
+  request.header(HxRequest).exists(_.enabled)
+
+// Setting response headers that steer the client afterward
+val response = Response.ok.addHeaders(
+  Headers(HxRefresh.name -> "true", HxTriggerHeader.name -> "orderPlaced")
+)
+```
+
+## Overview
+
+The module splits into two directions and reuses supporting types from the attribute DSL for structured values:
+
+| Direction | Type                     | Wire name                   | Shape                                             |
+| --------- | ------------------------ | ---------------------------- | -------------------------------------------------- |
+| Request   | `HxRequest`               | `hx-request`                 | `Boolean`, always `true` on an HTMX request         |
+| Request   | `HxBoosted`                | `hx-boosted`                 | `Boolean`, set when the request came from `hxBoost` |
+| Request   | `HxHistoryRestoreRequest`  | `hx-history-restore-request` | `Boolean`                                           |
+| Request   | `HxCurrentUrl`             | `hx-current-url`             | non-empty `String` or `URL`                         |
+| Request   | `HxTargetId`               | `hx-target`                  | non-empty `String` (target element id)              |
+| Request   | `HxTriggerId`              | `hx-trigger`                 | non-empty `String` (triggering element id)          |
+| Request   | `HxTriggerName`            | `hx-trigger-name`            | non-empty `String`                                  |
+| Request   | `HxPrompt`                 | `hx-prompt`                  | `String`, trimmed                                   |
+| Response  | `HxRedirect`               | `hx-redirect`                | non-empty `String` or `URL`                         |
+| Response  | `HxRefresh`                | `hx-refresh`                 | `Boolean`                                           |
+| Response  | `HxPushUrl`                | `hx-push-url`                | `HxUrlUpdate`                                       |
+| Response  | `HxReplaceUrl`             | `hx-replace-url`             | `HxUrlUpdate`                                       |
+| Response  | `HxReswap`                 | `hx-reswap`                  | `HxSwap`                                            |
+| Response  | `HxRetarget`               | `hx-retarget`                | `CssSelector`                                       |
+| Response  | `HxReselect`               | `hx-reselect`                | `CssSelector`                                       |
+| Response  | `HxTriggerHeader`          | `hx-trigger`                 | `HxEventPayload`                                    |
+| Response  | `HxTriggerAfterSettle`     | `hx-trigger-after-settle`    | `HxEventPayload`                                    |
+| Response  | `HxTriggerAfterSwap`       | `hx-trigger-after-swap`      | `HxEventPayload`                                    |
+| Response  | `HxLocation`               | `hx-location`                | `Json.Object`, built from path/target/swap          |
+
+`HxTriggerId` (request) and `HxTriggerHeader` (response) share the wire name `hx-trigger` but read in opposite directions—one reports which element fired the request, the other tells the client which events to dispatch after the response arrives.
+
+## Reading Request Headers
+
+These headers describe the HTMX request itself: whether it came from HTMX at all, which element and value triggered it, and what the browser's current URL was. All of them parse from plain strings with no structured payload.
+
+### Presence Flags
+
+`HxRequest`, `HxBoosted`, and `HxHistoryRestoreRequest` are boolean headers—present with value `"true"` or `"false"`, parsed case-insensitively. Checking whether a request came from HTMX at all is the most common read:
+
+```scala mdoc:silent
+import zio.http.{Headers, Request, URL}
+import zio.http.htmx.headers._
+
+val boosted = Request.get(URL.root).addHeaders(Headers(HxRequest.name -> "true", HxBoosted.name -> "true"))
+```
+
+Reading each flag back through `Request#header` parses the stored string into the typed value:
+
+```scala mdoc
+boosted.header(HxRequest)
+boosted.header(HxBoosted)
+```
+
+### Identifiers and Text Values
+
+`HxTargetId`, `HxTriggerId`, and `HxTriggerName` carry the id or name of the element involved in the request; `HxCurrentUrl` carries the browser's current URL. All four trim their value and reject blank input except `HxPrompt`, which passes through any trimmed string including an empty one:
+
+```scala mdoc:silent
+import zio.http.{Headers, Request, URL}
+import zio.http.htmx.headers._
+
+val request = Request
+  .get(URL.root)
+  .addHeaders(Headers(HxTriggerName.name -> "search", HxCurrentUrl.name -> "https://zio.dev/blocks"))
+```
+
+Reading them back gives the trimmed values as typed headers:
+
+```scala mdoc
+request.header(HxTriggerName)
+request.header(HxCurrentUrl)
+```
+
+`HxCurrentUrl` also accepts a `zio.http.URL` directly at construction time, encoding it to a string: `HxCurrentUrl(URL.parse("https://zio.dev/htmx").toOption.get)`.
+
+## Setting Response Headers
+
+Response headers tell HTMX what to do once the response body has been swapped in—redirect, refresh, change what gets swapped or where, fire client-side events, or update the URL bar. Several reuse types already documented for the attribute DSL, so the same modifiers and constructors apply on both sides of the exchange.
+
+### Redirecting and Refreshing
+
+`HxRedirect` sends the browser to a new URL with a full page load, and `HxRefresh` forces a full page reload of the current URL:
+
+```scala mdoc:silent:reset
+import zio.http.{Headers, Response, URL}
+import zio.http.htmx.headers._
+
+val redirect = Response.ok.addHeaders(Headers(HxRedirect.name -> "/login", HxRefresh.name -> "true"))
+```
+
+Reading them back through `Response#header` gives the parsed values:
+
+```scala mdoc
+redirect.header(HxRedirect)
+redirect.header(HxRefresh)
+```
+
+`HxRedirect` also has a `URL` constructor—`HxRedirect(URL.parse("https://zio.dev/login").toOption.get)`—that encodes the URL before storing it.
+
+### Controlling the URL Bar
+
+`HxPushUrl` and `HxReplaceUrl` decide whether the browser's URL bar updates after a swap, using the same `HxUrlUpdate` type as the `hx-push-url` attribute: `HxUrlUpdate.Enabled` or `HxUrlUpdate.Disabled` for a plain boolean, or a `String`/`Path`/`URL` to push a specific address:
+
+```scala mdoc:compile-only
+import zio.http.Path
+import zio.http.htmx.HxUrlUpdate
+import zio.http.htmx.headers.HxPushUrl
+
+HxPushUrl(HxUrlUpdate.Enabled)
+HxPushUrl(HxUrlUpdate(Path("/orders/42")))
+```
+
+### Overriding the Swap Strategy
+
+`HxReswap` lets a response override the `hx-swap` strategy the requesting element declared, using the identical `HxSwap` DSL—including its timing and animation modifiers—documented in [HxSwap](./hx-swap.md):
+
+```scala mdoc:silent:reset
+import scala.concurrent.duration._
+import zio.http.htmx.HxSwap
+import zio.http.htmx.headers.HxReswap
+
+val header = HxReswap(HxSwap.InnerHTML.swap(1.second).settle(250.millis))
+```
+
+Rendering reproduces the raw `hx-swap` syntax, and parsing that string round-trips it back to the same header:
+
+```scala mdoc
+HxReswap.render(header)
+HxReswap.parse(HxReswap.render(header)) == Right(header)
+```
+
+### Retargeting and Reselecting
+
+`HxRetarget` overrides where the response swaps in, and `HxReselect` overrides which part of the response fragment the client applies—both take a `CssSelector` from `zio.blocks.html`, the same type `hxTarget` and `hxSelect` accept:
+
+```scala mdoc:compile-only
+import zio.blocks.html.CssSelector
+import zio.http.htmx.headers.{HxReselect, HxRetarget}
+
+HxRetarget(CssSelector.id("result"))
+HxReselect(CssSelector.raw(".items > li"))
+```
+
+### Triggering Client-Side Events
+
+`HxTriggerHeader`, `HxTriggerAfterSettle`, and `HxTriggerAfterSwap` fire HTMX events on the client—before, after settle, and after swap respectively. Each carries an `HxEventPayload`: either a plain event name or a JSON value forwarded to listeners as `event.detail`:
+
+```scala mdoc:silent:reset
+import zio.blocks.schema.json.Json
+import zio.http.htmx.headers.{HxEventPayload, HxTriggerAfterSwap}
+
+val plain = HxTriggerAfterSwap(HxEventPayload.Event("orderPlaced"))
+val withDetail = HxTriggerAfterSwap(HxEventPayload.JsonValue(Json.Object("orderId" -> Json.Number(42))))
+```
+
+Rendering shows the two payload shapes side by side—a bare event name and a JSON object:
+
+```scala mdoc
+HxTriggerAfterSwap.render(plain)
+HxTriggerAfterSwap.render(withDetail)
+```
+
+`HxEventPayload.parse` decides which shape it saw by inspecting the value: a leading `{` or `[` parses as JSON, anything else is treated as a plain event name, and a blank value is rejected.
+
+:::note[Why `HxTriggerHeader`, not `HxTrigger`]
+The response header is named `HxTriggerHeader` rather than `HxTrigger` to avoid colliding with the attribute-DSL type documented in [HxTrigger](./hx-trigger.md)—`zio.http.htmx.HxTrigger` declares which client event fires a request, while `zio.http.htmx.headers.HxTriggerHeader` tells the client which events to dispatch after a response. Both share the wire name `hx-trigger` but never appear in the same import.
+:::
+
+### Redirecting Without a Full Navigation
+
+`HxLocation` triggers a client-side navigation to a new path without a full page load, optionally specifying where to swap the result and how—reusing `HxTarget` and `HxSwap` from the attribute DSL:
+
+```scala mdoc:silent:reset
+import zio.http.htmx.{HxSwap, HxTarget}
+import zio.http.htmx.headers.HxLocation
+
+val location = HxLocation("/next", target = Some(HxTarget.closest("section")), swap = Some(HxSwap.AfterEnd))
+```
+
+Rendering it produces the JSON object HTMX expects on the wire:
+
+```scala mdoc
+HxLocation.render(location)
+```
+
+`HxLocation` also has overloads accepting a `zio.http.Path` or `zio.http.URL` for the first argument, encoding it the same way before building the JSON object. Parsing rejects anything that isn't a JSON object, since the wire format is always `{"path": ..., "target": ..., "swap": ...}` with `target` and `swap` omitted when absent.
+
+## Reading and Writing Through Request and Response
+
+Every header in this module is a `Header.Typed[H]`, so it works with the same `Request#header` / `Response#header` / `addHeader` / `addHeaders` methods `zio.http` provides everywhere else—there is no HTMX-specific accessor. Combining several response headers in one call is the common case, for example after processing a form submission:
+
+```scala mdoc:compile-only
+import zio.http.{Response, URL}
+import zio.http.htmx.headers.{HxRedirect, HxRefresh, HxTriggerAfterSettle, HxEventPayload}
+
+val afterSubmit = Response.ok
+  .addHeader(HxRedirect(URL.parse("/orders").toOption.get))
+  .addHeader(HxTriggerAfterSettle(HxEventPayload.Event("orderPlaced")))
+```
+
+Because parsing failures return `Left` rather than throwing, `Request#header`/`Response#header` return `None` for a header that is present but malformed, exactly as they do for any other typed header in `zio.http`—see [Header](../http-model/headers.md) for the full read/write surface these types plug into.
+
+## Integration Points
+
+**With the attribute DSL:** `HxReswap`, `HxLocation`, `HxRetarget`, and `HxReselect` accept the exact same `HxSwap`, `HxTarget`, and `CssSelector` values that `hxSwap`, `hxTarget`, and `hxSelect` attributes accept, so a value built for one side works unchanged on the other.
+
+**With `zio.blocks.schema.json`:** `HxEventPayload.JsonValue` wraps a `zio.blocks.schema.json.Json` value, letting event payloads carry structured data without a separate serialization step.
+
+**With `zio.http`:** every type here is a `Header`/`Header.Typed[H]`, the same type class the built-in HTTP headers use, so `Headers`, `Request`, and `Response` treat HTMX headers no differently than `Content-Length` or `Cache-Control`.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -216,6 +216,7 @@ const sidebars = {
               "reference/htmx/hx-encoding",
               "reference/htmx/hx-sync",
               "reference/htmx/attribute-values",
+              "reference/htmx/response-headers",
             ]
           },
           {

--- a/docs/undocumented-report.md
+++ b/docs/undocumented-report.md
@@ -9,6 +9,8 @@ Full re-scan of documentation coverage across every library module aggregated by
 
 **Progress since this report was generated:** the `http-model` typed header surface has been documented — `docs/reference/http-model/headers.md` (660 lines) and `server-sent-event.md` (296 lines) are new, and `model.md`'s `## Headers` section was rewritten, taking the module from 31% to 55% explained coverage and from 101 absent types to 6. `otel` is complete at 100%, though that item as originally written was mis-scoped — most of the module is `private[otel]`; see section 4 for what was actually missing and the lesson for other low-ratio rows. Tier 1 items 1, 3, and 7 are complete, and the totals below account for both.
 
+Earlier: the `htmx` header side has been documented — `docs/reference/htmx/response-headers.md` (229 lines, mdoc-verified) covers the 22 request/response header types in `HtmxHeaders.scala` that the attribute-DSL pages never mentioned, taking the module from 54% to 85% explained coverage and from 26 absent types to 0. Tier 1 item 4 is complete; the coverage table has been updated to match.
+
 Earlier: the `config` family has been documented — `docs/reference/config.md` was replaced by a seven-page `docs/reference/config/` directory (2,212 lines, all code blocks mdoc-verified), taking the family from 31% to 72% explained coverage and from 43 absent types to 3. Tier 1 item 2 is complete; the numbers in this report have been updated to match.
 
 **What changed since the previous (2026-02-13) report:** every published module now has a reference page, and every page is linked from `docs/sidebars.js`. There are no longer any modules with zero documentation, and four of the six "critical missing pages" from the old report now exist (`media-type.md`, `schema/schema-expr.md`, `schema/schema-error.md`, `built-in-codecs/json/json-patch.md`). The remaining gaps are (a) whole subsystems inside otherwise-documented modules, (b) pages far too short for the surface they cover, and (c) an almost complete absence of task-oriented guides.
@@ -50,7 +52,6 @@ This report file is excluded from the scan, so listing a type here does not make
 | **schema** | 516 | 210 | 268 | 48% | 84,969 | 23,842 | 0.28 | `reference/schema/` |
 | **scope** | 24 | 8 | 12 | 50% | 7,085 | 3,577 | 0.50 | `reference/resource-management/` |
 | **typeid** | 91 | 26 | 44 | 52% | 6,493 | 2,124 | 0.33 | `reference/typeid.md` |
-| **htmx** | 82 | 26 | 38 | 54% | 1,548 | 2,521 | 1.63 | `reference/htmx/` |
 | **telemetry** | 134 | 25 | 58 | 57% | 7,509 | 2,856 | 0.38 | `reference/telemetry/` |
 | http-model | 191 | 6 | 85 | 55% | 4,712 | 3,127 | 0.66 | `reference/http-model/` |
 | otel | 12 | 0 | 0 | **100%** | 1,325 | 421 | 0.32 | `reference/telemetry/otel/` |
@@ -65,6 +66,7 @@ This report file is excluded from the scan, so listing a type here does not make
 | chunk | 20 | 2 | 5 | 75% | 5,069 | 3,140 | 0.62 | `reference/chunk.md` |
 | markdown | 46 | 3 | 10 | 78% | 2,596 | 1,539 | 0.59 | `reference/docs.md` |
 | schema-toon | 28 | 2 | 5 | 82% | 4,690 | 1,050 | 0.22 | `built-in-codecs/toon.md` |
+| **htmx** | 82 | 0 | 12 | 85% | 1,548 | 2,750 | 1.78 | `reference/htmx/` |
 | mux | 13 | 2 | 2 | 85% | 1,222 | 823 | 0.67 | `reference/mux.mdx` |
 | openapi | 45 | 1 | 6 | 87% | 2,431 | 1,301 | 0.54 | `reference/openapi.md` |
 | schema-csv | 9 | 0 | 1 | 89% | 1,247 | 564 | 0.45 | `built-in-codecs/csv.md` |
@@ -250,11 +252,11 @@ Actions:
 
 ### 8. `htmx` — response headers
 
-The attribute DSL is well covered (2,521 doc lines, ratio 1.63), but the header side is undocumented. `HtmxHeaders` ✗ (334 lines) and `HtmxSupport` ✗ never appear, and 26 header types are absent: `HxLocation` ✗, `HxPushUrl` ✗, `HxRedirect` ✗, `HxRefresh` ✗, `HxReplaceUrl` ✗, `HxReswap` ✗, `HxRetarget` ✗, `HxReselect` ✗, `HxTriggerHeader` ✗, `HxTriggerAfterSwap` ✗, `HxTriggerAfterSettle` ✗, `HxRequest` ✗, `HxBoosted` ✗, `HxCurrentUrl` ✗, `HxPrompt` ✗, `HxHistoryRestoreRequest` ✗, `HxTargetId` ✗, `HxTriggerId` ✗, `HxTriggerName` ✗, `HxTriggerValue` ✗, `HxEventPayload` ✗, `HxOnKey` ✗, `PartialHxOn` ✗, `JsonValue` ✗, `Changed` ✗, `Threshold` ✗.
+**Done.** The attribute DSL was well covered (2,521 doc lines, ratio 1.63), but the header side — `HtmxHeaders` (334 lines) and its 22 request/response header types — was absent. `reference/htmx/response-headers.md` (229 lines, mdoc-verified) now covers both directions: the request headers HTMX sends (`HxRequest`, `HxBoosted`, `HxCurrentUrl`, `HxTargetId`, `HxTriggerId`, `HxTriggerName`, `HxHistoryRestoreRequest`, `HxPrompt`), the response headers a handler sets (`HxLocation`, `HxPushUrl`, `HxReplaceUrl`, `HxRedirect`, `HxRefresh`, `HxReswap`, `HxRetarget`, `HxReselect`, `HxTriggerHeader`, `HxTriggerAfterSettle`, `HxTriggerAfterSwap`, `HxEventPayload`), and how each reuses `HxSwap`/`HxTarget`/`HxUrlUpdate`/`CssSelector` from the attribute DSL. `HxTriggerValue`, `HxOnKey`, `PartialHxOn`, `Changed`, and `Threshold` from the original absent-types list are attribute-DSL types (not headers) and remain covered by `hx-trigger.md`/`attribute-values.md`. The internal `HtmxHeaderSupport` parsing helper is `private[headers]` and intentionally left undocumented as an implementation detail, not a public integration point.
 
 Actions:
 
-- [ ] Write `reference/htmx/response-headers.md` — request headers htmx sends, response headers you set, and the `HtmxSupport` integration point
+- [x] Write `reference/htmx/response-headers.md` — **done**: 229 lines, mdoc-verified, wired into `sidebars.js` and cross-linked from `reference/htmx/index.md`
 
 ### 9. `smithy` — 32 unexplained types, mostly the shape catalog
 
@@ -372,7 +374,7 @@ Ordered by user impact per unit of writing effort.
 1. - [x] `reference/http-model/headers.md` — **done**: 660 lines cataloguing all 75 built-ins, mdoc-verified
 2. - [x] Split `reference/config.md` into `reference/config/` — **done**: seven pages, 2,212 lines, mdoc-verified; family went from 31% to 72% explained coverage
 3. - [x] ~~Split `reference/telemetry/otel/` into four pages~~ — **done differently**: the four-page split was mis-scoped (the exporters are `private[otel]`); resolved with one new page plus index additions, module now at 100%
-4. - [ ] `reference/htmx/response-headers.md`
+4. - [x] `reference/htmx/response-headers.md` — **done**: 229 lines, mdoc-verified
 5. - [ ] `reference/schema/schema-search.md` (`SchemaSearch`, `SchemaMatch`, `TypeSearch`, `SearchTraversal`, `Updater`)
 6. - [ ] `reference/telemetry/common/any-value.md`
 7. - [x] `reference/http-model/server-sent-event.md` — **done**: 296 lines


### PR DESCRIPTION
## Summary
- Adds `reference/htmx/response-headers.md` covering all 22 typed HTMX request/response header types in `zio.http.htmx.headers` (`HxRequest`, `HxBoosted`, `HxRedirect`, `HxRefresh`, `HxReswap`, `HxTriggerHeader`, `HxLocation`, etc.), including how several reuse `HxSwap`/`HxTarget`/`HxUrlUpdate`/`CssSelector` from the attribute DSL.
- Wires the page into `docs/sidebars.js` and cross-links it from `reference/htmx/index.md`.
- Marks the corresponding item done in `docs/undocumented-report.md` (`htmx` module: 54% -> 85% explained coverage, 26 -> 0 absent types).

## Test plan
- [x] `sbt "docs/mdoc --in docs/reference/htmx/response-headers.md"` — 0 errors
- [x] `sbt scalafmtAll`
- [x] `sbt "++2.13; check"` — passes