### PR TITLE
feat(html)!: enforce list/table/select content models with typed factories

### DIFF
--- a/docs/reference/html.md
+++ b/docs/reference/html.md
@@ -545,10 +545,10 @@ elements.
 
 ### Equality Across Element Classes
 
-Element equality is structural (tag + attributes + children), independent of
-the concrete class. A factory-produced `li(...)` equals the structurally
-identical `Generic("li", ...)`, and vice versa; equal elements also have equal
-hash codes:
+Element equality is structural (tag + attributes + children + text-escaping
+semantics), independent of the concrete class. A factory-produced `li(...)`
+equals the structurally identical `Generic("li", ...)`, and vice versa; equal
+elements also have equal hash codes:
 
 ```scala mdoc:compile-only
 import zio.blocks.html._
@@ -558,6 +558,11 @@ val fromFactory = li("a")
 val generic = Dom.Element.Generic("li", Chunk.empty, Chunk(Dom.Text("a")))
 fromFactory == generic  // true — structural equality across classes
 ```
+
+Elements that render differently are never equal, even with identical fields:
+`script`/`style` render their children **unescaped** while `Generic` escapes
+them, so a `Script` never equals an equally-shaped `Generic("script", ...)` —
+equal elements always render identically.
 
 ## String Interpolators
 

--- a/docs/reference/html.md
+++ b/docs/reference/html.md
@@ -23,6 +23,16 @@ case class Dom.Element.Style(attributes: Chunk[Dom.Attribute], children: Chunk[D
 sealed trait Dom.Element.Void extends Dom // void elements (self-closing, no children)
 case class Dom.Element.VoidGeneric(tag: String, attributes: Chunk[Dom.Attribute]) extends Dom.Element.Void
 
+// Sealed content-model markers (implemented by dedicated element classes)
+sealed trait Dom.Element.Li          extends Dom.Element // <li>, child of ul/ol
+sealed trait Dom.Element.Cell        extends Dom.Element // <th> or <td>, child of tr
+sealed trait Dom.Element.Th          extends Dom.Element.Cell
+sealed trait Dom.Element.Td          extends Dom.Element.Cell
+sealed trait Dom.Element.Tr          extends Dom.Element // <tr>, child of table
+sealed trait Dom.Element.SelectChild extends Dom.Element // <option> or <optgroup>, child of select
+sealed trait Dom.Element.Opt         extends Dom.Element.SelectChild
+sealed trait Dom.Element.Optgroup    extends Dom.Element.SelectChild
+
 // Attribute variants
 sealed trait Dom.Attribute
 case class Dom.Attribute.KeyValue(name: String, value: Dom.AttributeValue) extends Dom.Attribute
@@ -481,6 +491,74 @@ val voidElements = div(
 )
 ```
 
+## Typed Content Models
+
+Several container elements enforce the HTML content model of their children at
+compile time. Instead of accepting arbitrary modifiers, these factories only
+accept attributes plus children whose type matches the content model:
+
+| Factory | Accepted element children | Marker type |
+|---|---|---|
+| `ul(...)`, `ol(...)` | `<li>` | `Dom.Element.Li` |
+| `tr(...)` | `<th>`, `<td>` | `Dom.Element.Cell` (`Th \| Td`) |
+| `table(...)` | `<tr>` | `Dom.Element.Tr` |
+| `select(...)` | `<option>`, `<optgroup>` | `Dom.Element.SelectChild` (`Opt \| Optgroup`) |
+| `optgroup(...)` | `<option>` | `Dom.Element.Opt` |
+
+Invalid children are rejected by the compiler:
+
+```scala mdoc:fail
+import zio.blocks.html._
+
+ul(div("not a list item"))   // ❌ does not compile — ul only accepts Li children
+tr(p("not a cell"))          // ❌ does not compile — tr only accepts Th/Td cells
+select(div("not an option")) // ❌ does not compile — select only accepts option/optgroup
+```
+
+Attributes are accepted alongside the constrained children:
+
+```scala mdoc:compile-only
+import zio.blocks.html._
+
+val list = ul(id := "menu", className := "nav", li("Home"), li("About"))
+val row = tr(className := "header-row", th("Name"), td("Value"))
+val picker = select(id := "color", name := "color", option("Red"), optgroup(option("Light"), option("Dark")))
+```
+
+Each factory has three forms: empty (`ul()`), mixed attributes and children
+(`ul(id := "x", li("a"))`), and collections of children
+(`ul(items.map(item => li(item)))`).
+
+The typed factories produce elements carrying a sealed marker type (`Li`,
+`Cell`, `Tr`, `SelectChild`, ...). The markers are sealed — their
+implementations live inside the module — so a value typed `Dom.Element.Li` is
+guaranteed to render as `<li>`; the DSL factories are the intended
+construction path. Elements with permissive content models (`li`, `th`, `td`,
+`option`) keep accepting any flow content through the regular modifier API.
+
+:::note
+`caption`, `colgroup`, `thead`, `tbody`, and `tfoot` do not have typed markers
+yet, so tables containing them cannot be built with the `table(...)`
+factory. Compose those tables with the `html""` interpolator or generic
+elements.
+:::
+
+### Equality Across Element Classes
+
+Element equality is structural (tag + attributes + children), independent of
+the concrete class. A factory-produced `li(...)` equals the structurally
+identical `Generic("li", ...)`, and vice versa; equal elements also have equal
+hash codes:
+
+```scala mdoc:compile-only
+import zio.blocks.html._
+import zio.blocks.chunk.Chunk
+
+val fromFactory = li("a")
+val generic = Dom.Element.Generic("li", Chunk.empty, Chunk(Dom.Text("a")))
+fromFactory == generic  // true — structural equality across classes
+```
+
 ## String Interpolators
 
 The module provides four string interpolators: `html""`, `css""`, `js""`, and `selector""`. All offer compile-time safety (on Scala 3) and automatic escaping appropriate to their context.
@@ -641,8 +719,8 @@ Pseudo-classes match elements by their state, and pseudo-elements create dynamic
 import zio.blocks.html._
 
 val hoverSel = a.hover              // a:hover
-val firstChild = li.firstChild      // li:first-child
-val nthChild = tr.nthChild(2)       // tr:nth-child(2)
+val firstChild = li().firstChild      // li:first-child
+val nthChild = tr().nthChild(2)       // tr:nth-child(2)
 val before = div.before             // div::before
 val after = span.after              // span::after
 ```

--- a/html/shared/src/main/scala-2/zio/blocks/html/HtmlElements.scala
+++ b/html/shared/src/main/scala-2/zio/blocks/html/HtmlElements.scala
@@ -48,6 +48,91 @@ object StyleArg {
   implicit def fromCss(css: Css): StyleArg                       = Source(css)
 }
 
+/**
+ * Argument accepted by the Scala 2 `ul(...)` and `ol(...)` factories: either an
+ * HTML attribute or a `<li>` list item (the only permitted element child).
+ */
+sealed trait ListArg
+object ListArg {
+
+  /** Adds an HTML attribute to the `ul`/`ol` element. */
+  final case class Attribute(value: Dom.Attribute) extends ListArg
+
+  /** Adds a `<li>` item to the `ul`/`ol` element body. */
+  final case class Item(value: Dom.Element.Li) extends ListArg
+
+  implicit def fromAttribute(attribute: Dom.Attribute): ListArg = Attribute(attribute)
+  implicit def fromLi(item: Dom.Element.Li): ListArg            = Item(item)
+}
+
+/**
+ * Argument accepted by the Scala 2 `tr(...)` factory: either an HTML attribute
+ * or a table cell (`<th>`/`<td>`, the only permitted children).
+ */
+sealed trait CellArg
+object CellArg {
+
+  /** Adds an HTML attribute to the `tr` element. */
+  final case class Attribute(value: Dom.Attribute) extends CellArg
+
+  /** Adds a `<th>`/`<td>` cell to the `tr` element body. */
+  final case class Cell(value: Dom.Element.Cell) extends CellArg
+
+  implicit def fromAttribute(attribute: Dom.Attribute): CellArg = Attribute(attribute)
+  implicit def fromCell(cell: Dom.Element.Cell): CellArg        = Cell(cell)
+}
+
+/**
+ * Argument accepted by the Scala 2 `table(...)` factory: either an HTML
+ * attribute or a `<tr>` row (the typed marker for direct table children).
+ */
+sealed trait RowArg
+object RowArg {
+
+  /** Adds an HTML attribute to the `table` element. */
+  final case class Attribute(value: Dom.Attribute) extends RowArg
+
+  /** Adds a `<tr>` row to the `table` element body. */
+  final case class Row(value: Dom.Element.Tr) extends RowArg
+
+  implicit def fromAttribute(attribute: Dom.Attribute): RowArg = Attribute(attribute)
+  implicit def fromRow(row: Dom.Element.Tr): RowArg            = Row(row)
+}
+
+/**
+ * Argument accepted by the Scala 2 `select(...)` factory: either an HTML
+ * attribute or a select child (`<option>`/`<optgroup>`).
+ */
+sealed trait SelectArg
+object SelectArg {
+
+  /** Adds an HTML attribute to the `select` element. */
+  final case class Attribute(value: Dom.Attribute) extends SelectArg
+
+  /** Adds an `<option>`/`<optgroup>` child to the `select` element body. */
+  final case class Child(value: Dom.Element.SelectChild) extends SelectArg
+
+  implicit def fromAttribute(attribute: Dom.Attribute): SelectArg         = Attribute(attribute)
+  implicit def fromSelectChild(child: Dom.Element.SelectChild): SelectArg = Child(child)
+}
+
+/**
+ * Argument accepted by the Scala 2 `optgroup(...)` factory: either an HTML
+ * attribute or an `<option>` (the only permitted element child).
+ */
+sealed trait OptgroupArg
+object OptgroupArg {
+
+  /** Adds an HTML attribute to the `optgroup` element. */
+  final case class Attribute(value: Dom.Attribute) extends OptgroupArg
+
+  /** Adds an `<option>` to the `optgroup` element body. */
+  final case class Option(value: Dom.Element.Opt) extends OptgroupArg
+
+  implicit def fromAttribute(attribute: Dom.Attribute): OptgroupArg = Attribute(attribute)
+  implicit def fromOpt(option: Dom.Element.Opt): OptgroupArg        = Option(option)
+}
+
 trait HtmlElements {
 
   // --- Element constructors ---
@@ -78,6 +163,93 @@ trait HtmlElements {
       i += 1
     }
     Dom.Element.Style(attrBuilder.result(), childBuilder.result())
+  }
+
+  /**
+   * Builds a `Generic` element from `ul`/`ol` arguments (attributes and `<li>`
+   * items).
+   */
+  private def elFromListArgs(args: Seq[ListArg], tag: String): Dom.Element = {
+    val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
+    val childBuilder = Chunk.newBuilder[Dom]
+    var i            = 0
+    while (i < args.length) {
+      args(i) match {
+        case ListArg.Attribute(attr) => attrBuilder += attr
+        case ListArg.Item(item)      => childBuilder += item
+      }
+      i += 1
+    }
+    Dom.Element.Generic(tag, attrBuilder.result(), childBuilder.result())
+  }
+
+  /** Builds a `TrElement` row from `tr` arguments (attributes and cells). */
+  private def trFromCellArgs(args: Seq[CellArg]): Dom.Element.Tr = {
+    val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
+    val childBuilder = Chunk.newBuilder[Dom]
+    var i            = 0
+    while (i < args.length) {
+      args(i) match {
+        case CellArg.Attribute(attr) => attrBuilder += attr
+        case CellArg.Cell(cell)      => childBuilder += cell
+      }
+      i += 1
+    }
+    Dom.Element.TrElement(attrBuilder.result(), childBuilder.result())
+  }
+
+  /**
+   * Builds a `Generic` `table` element from `table` arguments (attributes and
+   * rows).
+   */
+  private def tableFromRowArgs(args: Seq[RowArg]): Dom.Element = {
+    val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
+    val childBuilder = Chunk.newBuilder[Dom]
+    var i            = 0
+    while (i < args.length) {
+      args(i) match {
+        case RowArg.Attribute(attr) => attrBuilder += attr
+        case RowArg.Row(row)        => childBuilder += row
+      }
+      i += 1
+    }
+    Dom.Element.Generic("table", attrBuilder.result(), childBuilder.result())
+  }
+
+  /**
+   * Builds a `Generic` `select` element from `select` arguments (attributes and
+   * options/optgroups).
+   */
+  private def selectFromSelectArgs(args: Seq[SelectArg]): Dom.Element = {
+    val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
+    val childBuilder = Chunk.newBuilder[Dom]
+    var i            = 0
+    while (i < args.length) {
+      args(i) match {
+        case SelectArg.Attribute(attr) => attrBuilder += attr
+        case SelectArg.Child(child)    => childBuilder += child
+      }
+      i += 1
+    }
+    Dom.Element.Generic("select", attrBuilder.result(), childBuilder.result())
+  }
+
+  /**
+   * Builds an `OptgroupElement` from `optgroup` arguments (attributes and
+   * options).
+   */
+  private def groupFromOptgroupArgs(args: Seq[OptgroupArg]): Dom.Element.OptgroupElement = {
+    val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
+    val childBuilder = Chunk.newBuilder[Dom]
+    var i            = 0
+    while (i < args.length) {
+      args(i) match {
+        case OptgroupArg.Attribute(attr) => attrBuilder += attr
+        case OptgroupArg.Option(opt)     => childBuilder += opt
+      }
+      i += 1
+    }
+    Dom.Element.OptgroupElement(attrBuilder.result(), childBuilder.result())
   }
 
   val doctype: Dom.Doctype    = Dom.Doctype("html")
@@ -220,52 +392,136 @@ trait HtmlElements {
    * Empty `<li>` element; apply attributes/children via `li(...)`, returning
    * `Li`.
    */
-  val li: Dom.Element.Li = Dom.Element.LiElement(Chunk.empty, Chunk.empty)
+  val li: Dom.Element.LiElement = Dom.Element.LiElement(Chunk.empty, Chunk.empty)
 
-  /** Empty `<ul>` element; apply attributes/children via `ul(...)`. */
-  val ul: Dom.Element = Dom.Element.Generic("ul", Chunk.empty, Chunk.empty)
+  /** Creates an empty `<ul>` element. */
+  def ul(): Dom.Element = Dom.Element.Generic("ul", Chunk.empty, Chunk.empty)
 
-  /** Empty `<ol>` element; apply attributes/children via `ol(...)`. */
-  val ol: Dom.Element = Dom.Element.Generic("ol", Chunk.empty, Chunk.empty)
+  /**
+   * Creates a `<ul>` element from attributes and `<li>` children.
+   *
+   * The HTML content model of `<ul>` permits only `<li>` element children, so
+   * the child arguments are restricted to [[Dom.Element.Li]] at compile time;
+   * [[Dom.Attribute]] values are accepted alongside them.
+   */
+  def ul(effect: ListArg, effects: ListArg*): Dom.Element =
+    elFromListArgs(effect +: effects, "ul")
+
+  /** Creates a `<ul>` element from an iterable of `<li>` children. */
+  def ul(children: Iterable[Dom.Element.Li]): Dom.Element =
+    Dom.Element.Generic("ul", Chunk.empty, Chunk.from(children))
+
+  /** Creates an empty `<ol>` element. */
+  def ol(): Dom.Element = Dom.Element.Generic("ol", Chunk.empty, Chunk.empty)
+
+  /**
+   * Creates an `<ol>` element from attributes and `<li>` children.
+   *
+   * The HTML content model of `<ol>` permits only `<li>` element children, so
+   * the child arguments are restricted to [[Dom.Element.Li]] at compile time;
+   * [[Dom.Attribute]] values are accepted alongside them.
+   */
+  def ol(effect: ListArg, effects: ListArg*): Dom.Element =
+    elFromListArgs(effect +: effects, "ol")
+
+  /** Creates an `<ol>` element from an iterable of `<li>` children. */
+  def ol(children: Iterable[Dom.Element.Li]): Dom.Element =
+    Dom.Element.Generic("ol", Chunk.empty, Chunk.from(children))
 
   /**
    * Empty `<th>` element; apply attributes/children via `th(...)`, returning
    * `Th`.
    */
-  val th: Dom.Element.Th = Dom.Element.ThElement(Chunk.empty, Chunk.empty)
+  val th: Dom.Element.ThElement = Dom.Element.ThElement(Chunk.empty, Chunk.empty)
 
   /**
    * Empty `<td>` element; apply attributes/children via `td(...)`, returning
    * `Td`.
    */
-  val td: Dom.Element.Td = Dom.Element.TdElement(Chunk.empty, Chunk.empty)
+  val td: Dom.Element.TdElement = Dom.Element.TdElement(Chunk.empty, Chunk.empty)
 
-  /** Empty `<tr>` element; apply attributes/children via `tr(...)`. */
-  val tr: Dom.Element = Dom.Element.Generic("tr", Chunk.empty, Chunk.empty)
+  /** Creates an empty `<tr>` element, returning `Tr`. */
+  def tr(): Dom.Element.TrElement = Dom.Element.TrElement(Chunk.empty, Chunk.empty)
 
   /**
-   * Empty `<table>` element; apply attributes/children via `table(...)`
-   * (caption, colgroup, thead, tbody, tfoot, tr).
+   * Creates a `<tr>` element from attributes and table cells (`<th>`/`<td>`)
+   *
+   * The HTML content model of `<tr>` permits only `<th>` and `<td>` element
+   * children, so the child arguments are restricted to [[Dom.Element.Cell]] at
+   * compile time; [[Dom.Attribute]] values are accepted alongside them.
    */
-  val table: Dom.Element = Dom.Element.Generic("table", Chunk.empty, Chunk.empty)
+  def tr(effect: CellArg, effects: CellArg*): Dom.Element.Tr =
+    trFromCellArgs(effect +: effects)
+
+  /** Creates a `<tr>` element from an iterable of `<th>`/`<td>` cells. */
+  def tr(children: Iterable[Dom.Element.Cell]): Dom.Element.Tr =
+    Dom.Element.TrElement(Chunk.empty, Chunk.from(children))
+
+  /** Creates an empty `<table>` element. */
+  def table(): Dom.Element = Dom.Element.Generic("table", Chunk.empty, Chunk.empty)
+
+  /**
+   * Creates a `<table>` element from attributes and `<tr>` rows.
+   *
+   * The row arguments are restricted to [[Dom.Element.Tr]] at compile time;
+   * [[Dom.Attribute]] values are accepted alongside them. Other table sections
+   * (`caption`, `colgroup`, `thead`, `tbody`, `tfoot`) do not have typed
+   * markers yet — compose tables containing them with the `html"` interpolator
+   * or generic elements instead.
+   */
+  def table(effect: RowArg, effects: RowArg*): Dom.Element =
+    tableFromRowArgs(effect +: effects)
+
+  /** Creates a `<table>` element from an iterable of `<tr>` rows. */
+  def table(children: Iterable[Dom.Element.Tr]): Dom.Element =
+    Dom.Element.Generic("table", Chunk.empty, Chunk.from(children))
 
   /**
    * Empty `<option>` element; apply attributes/children via `option(...)`,
    * returning `Opt`.
    */
-  val option: Dom.Element.Opt = Dom.Element.OptElement(Chunk.empty, Chunk.empty)
+  val option: Dom.Element.OptElement = Dom.Element.OptElement(Chunk.empty, Chunk.empty)
+
+  /** Creates an empty `<optgroup>` element, returning `Optgroup`. */
+  def optgroup(): Dom.Element.OptgroupElement = Dom.Element.OptgroupElement(Chunk.empty, Chunk.empty)
 
   /**
-   * Empty `<optgroup>` element; apply options/attributes via `optgroup(...)`,
-   * returning `Optgroup`.
+   * Creates an `<optgroup>` element from attributes and `<option>` children.
+   *
+   * The HTML content model of `<optgroup>` permits only `<option>` element
+   * children, so the child arguments are restricted to [[Dom.Element.Opt]] at
+   * compile time; [[Dom.Attribute]] values are accepted alongside them.
    */
-  val optgroup: Dom.Element.Optgroup = Dom.Element.OptgroupElement(Chunk.empty, Chunk.empty)
+  def optgroup(effect: OptgroupArg, effects: OptgroupArg*): Dom.Element.OptgroupElement =
+    groupFromOptgroupArgs(effect +: effects)
 
   /**
-   * Empty `<select>` element; apply `<option>`/`<optgroup>` children and
-   * attributes via `select(...)`.
+   * Creates an `<optgroup>` element from an iterable of `<option>` children.
    */
-  val select: Dom.Element = Dom.Element.Generic("select", Chunk.empty, Chunk.empty)
+  def optgroup(children: Iterable[Dom.Element.Opt]): Dom.Element.OptgroupElement =
+    Dom.Element.OptgroupElement(Chunk.empty, Chunk.from(children))
+
+  /** Creates an empty `<select>` element. */
+  def select(): Dom.Element = Dom.Element.Generic("select", Chunk.empty, Chunk.empty)
+
+  /**
+   * Creates a `<select>` element from attributes and `<option>`/`<optgroup>`
+   * children.
+   *
+   * The HTML content model of `<select>` permits only `<option>` and
+   * `<optgroup>` element children, so the child arguments are restricted to
+   * [[Dom.Element.SelectChild]] at compile time; [[Dom.Attribute]] values are
+   * accepted alongside them.
+   */
+  def select(effect: SelectArg, effects: SelectArg*): Dom.Element =
+    selectFromSelectArgs(effect +: effects)
+
+  /**
+   * Creates a `<select>` element from an iterable of `<option>`/`<optgroup>`
+   * children.
+   */
+  def select(children: Iterable[Dom.Element.SelectChild]): Dom.Element =
+    Dom.Element.Generic("select", Chunk.empty, Chunk.from(children))
 
   // --- Attribute helpers ---
 

--- a/html/shared/src/main/scala-2/zio/blocks/html/HtmlElements.scala
+++ b/html/shared/src/main/scala-2/zio/blocks/html/HtmlElements.scala
@@ -172,13 +172,12 @@ trait HtmlElements {
   private def elFromListArgs(args: Seq[ListArg], tag: String): Dom.Element = {
     val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
     val childBuilder = Chunk.newBuilder[Dom]
-    var i            = 0
-    while (i < args.length) {
-      args(i) match {
+    val it           = args.iterator
+    while (it.hasNext) {
+      it.next() match {
         case ListArg.Attribute(attr) => attrBuilder += attr
         case ListArg.Item(item)      => childBuilder += item
       }
-      i += 1
     }
     Dom.Element.Generic(tag, attrBuilder.result(), childBuilder.result())
   }
@@ -187,13 +186,12 @@ trait HtmlElements {
   private def trFromCellArgs(args: Seq[CellArg]): Dom.Element.Tr = {
     val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
     val childBuilder = Chunk.newBuilder[Dom]
-    var i            = 0
-    while (i < args.length) {
-      args(i) match {
+    val it           = args.iterator
+    while (it.hasNext) {
+      it.next() match {
         case CellArg.Attribute(attr) => attrBuilder += attr
         case CellArg.Cell(cell)      => childBuilder += cell
       }
-      i += 1
     }
     Dom.Element.TrElement(attrBuilder.result(), childBuilder.result())
   }
@@ -205,13 +203,12 @@ trait HtmlElements {
   private def tableFromRowArgs(args: Seq[RowArg]): Dom.Element = {
     val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
     val childBuilder = Chunk.newBuilder[Dom]
-    var i            = 0
-    while (i < args.length) {
-      args(i) match {
+    val it           = args.iterator
+    while (it.hasNext) {
+      it.next() match {
         case RowArg.Attribute(attr) => attrBuilder += attr
         case RowArg.Row(row)        => childBuilder += row
       }
-      i += 1
     }
     Dom.Element.Generic("table", attrBuilder.result(), childBuilder.result())
   }
@@ -223,13 +220,12 @@ trait HtmlElements {
   private def selectFromSelectArgs(args: Seq[SelectArg]): Dom.Element = {
     val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
     val childBuilder = Chunk.newBuilder[Dom]
-    var i            = 0
-    while (i < args.length) {
-      args(i) match {
+    val it           = args.iterator
+    while (it.hasNext) {
+      it.next() match {
         case SelectArg.Attribute(attr) => attrBuilder += attr
         case SelectArg.Child(child)    => childBuilder += child
       }
-      i += 1
     }
     Dom.Element.Generic("select", attrBuilder.result(), childBuilder.result())
   }
@@ -241,13 +237,12 @@ trait HtmlElements {
   private def groupFromOptgroupArgs(args: Seq[OptgroupArg]): Dom.Element.OptgroupElement = {
     val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
     val childBuilder = Chunk.newBuilder[Dom]
-    var i            = 0
-    while (i < args.length) {
-      args(i) match {
+    val it           = args.iterator
+    while (it.hasNext) {
+      it.next() match {
         case OptgroupArg.Attribute(attr) => attrBuilder += attr
         case OptgroupArg.Option(opt)     => childBuilder += opt
       }
-      i += 1
     }
     Dom.Element.OptgroupElement(attrBuilder.result(), childBuilder.result())
   }
@@ -388,11 +383,17 @@ trait HtmlElements {
   val wbr: Dom.Element.Void                                          = Dom.Element.VoidGeneric("wbr", Chunk.empty)
   def element(tag: String): Dom.Element                              = Dom.Element.Generic(tag, Chunk.empty, Chunk.empty)
 
+  /** Creates an empty `<li>` element, returning `Li`. */
+  def li(): Dom.Element.Li = Dom.Element.LiElement(Chunk.empty, Chunk.empty)
+
   /**
-   * Empty `<li>` element; apply attributes/children via `li(...)`, returning
-   * `Li`.
+   * Creates a `<li>` element from attributes and children, returning `Li`.
+   *
+   * The HTML content model of `<li>` permits flow content, so any modifier
+   * values are accepted.
    */
-  val li: Dom.Element.LiElement = Dom.Element.LiElement(Chunk.empty, Chunk.empty)
+  def li(effect: DomModifier, effects: DomModifier*): Dom.Element.Li =
+    Dom.Element.LiElement(Chunk.empty, Chunk.empty)(effect, effects: _*)
 
   /** Creates an empty `<ul>` element. */
   def ul(): Dom.Element = Dom.Element.Generic("ul", Chunk.empty, Chunk.empty)
@@ -428,20 +429,32 @@ trait HtmlElements {
   def ol(children: Iterable[Dom.Element.Li]): Dom.Element =
     Dom.Element.Generic("ol", Chunk.empty, Chunk.from(children))
 
-  /**
-   * Empty `<th>` element; apply attributes/children via `th(...)`, returning
-   * `Th`.
-   */
-  val th: Dom.Element.ThElement = Dom.Element.ThElement(Chunk.empty, Chunk.empty)
+  /** Creates an empty `<th>` element, returning `Th`. */
+  def th(): Dom.Element.Th = Dom.Element.ThElement(Chunk.empty, Chunk.empty)
 
   /**
-   * Empty `<td>` element; apply attributes/children via `td(...)`, returning
-   * `Td`.
+   * Creates a `<th>` element from attributes and children, returning `Th`.
+   *
+   * The HTML content model of `<th>` permits flow content, so any modifier
+   * values are accepted.
    */
-  val td: Dom.Element.TdElement = Dom.Element.TdElement(Chunk.empty, Chunk.empty)
+  def th(effect: DomModifier, effects: DomModifier*): Dom.Element.Th =
+    Dom.Element.ThElement(Chunk.empty, Chunk.empty)(effect, effects: _*)
+
+  /** Creates an empty `<td>` element, returning `Td`. */
+  def td(): Dom.Element.Td = Dom.Element.TdElement(Chunk.empty, Chunk.empty)
+
+  /**
+   * Creates a `<td>` element from attributes and children, returning `Td`.
+   *
+   * The HTML content model of `<td>` permits flow content, so any modifier
+   * values are accepted.
+   */
+  def td(effect: DomModifier, effects: DomModifier*): Dom.Element.Td =
+    Dom.Element.TdElement(Chunk.empty, Chunk.empty)(effect, effects: _*)
 
   /** Creates an empty `<tr>` element, returning `Tr`. */
-  def tr(): Dom.Element.TrElement = Dom.Element.TrElement(Chunk.empty, Chunk.empty)
+  def tr(): Dom.Element.Tr = Dom.Element.TrElement(Chunk.empty, Chunk.empty)
 
   /**
    * Creates a `<tr>` element from attributes and table cells (`<th>`/`<td>`)
@@ -466,7 +479,7 @@ trait HtmlElements {
    * The row arguments are restricted to [[Dom.Element.Tr]] at compile time;
    * [[Dom.Attribute]] values are accepted alongside them. Other table sections
    * (`caption`, `colgroup`, `thead`, `tbody`, `tfoot`) do not have typed
-   * markers yet — compose tables containing them with the `html"` interpolator
+   * markers yet — compose tables containing them with the `html""` interpolator
    * or generic elements instead.
    */
   def table(effect: RowArg, effects: RowArg*): Dom.Element =
@@ -476,14 +489,21 @@ trait HtmlElements {
   def table(children: Iterable[Dom.Element.Tr]): Dom.Element =
     Dom.Element.Generic("table", Chunk.empty, Chunk.from(children))
 
+  /** Creates an empty `<option>` element, returning `Opt`. */
+  def option(): Dom.Element.Opt = Dom.Element.OptElement(Chunk.empty, Chunk.empty)
+
   /**
-   * Empty `<option>` element; apply attributes/children via `option(...)`,
-   * returning `Opt`.
+   * Creates an `<option>` element from attributes and children, returning
+   * `Opt`.
+   *
+   * The HTML content model of `<option>` permits flow content, so any modifier
+   * values are accepted.
    */
-  val option: Dom.Element.OptElement = Dom.Element.OptElement(Chunk.empty, Chunk.empty)
+  def option(effect: DomModifier, effects: DomModifier*): Dom.Element.Opt =
+    Dom.Element.OptElement(Chunk.empty, Chunk.empty)(effect, effects: _*)
 
   /** Creates an empty `<optgroup>` element, returning `Optgroup`. */
-  def optgroup(): Dom.Element.OptgroupElement = Dom.Element.OptgroupElement(Chunk.empty, Chunk.empty)
+  def optgroup(): Dom.Element.Optgroup = Dom.Element.OptgroupElement(Chunk.empty, Chunk.empty)
 
   /**
    * Creates an `<optgroup>` element from attributes and `<option>` children.
@@ -492,13 +512,13 @@ trait HtmlElements {
    * children, so the child arguments are restricted to [[Dom.Element.Opt]] at
    * compile time; [[Dom.Attribute]] values are accepted alongside them.
    */
-  def optgroup(effect: OptgroupArg, effects: OptgroupArg*): Dom.Element.OptgroupElement =
+  def optgroup(effect: OptgroupArg, effects: OptgroupArg*): Dom.Element.Optgroup =
     groupFromOptgroupArgs(effect +: effects)
 
   /**
    * Creates an `<optgroup>` element from an iterable of `<option>` children.
    */
-  def optgroup(children: Iterable[Dom.Element.Opt]): Dom.Element.OptgroupElement =
+  def optgroup(children: Iterable[Dom.Element.Opt]): Dom.Element.Optgroup =
     Dom.Element.OptgroupElement(Chunk.empty, Chunk.from(children))
 
   /** Creates an empty `<select>` element. */

--- a/html/shared/src/main/scala-3/zio/blocks/html/HtmlElements.scala
+++ b/html/shared/src/main/scala-3/zio/blocks/html/HtmlElements.scala
@@ -50,6 +50,33 @@ trait HtmlElements {
     Dom.Element.Style(attrBuilder.result(), childBuilder.result())
   }
 
+  /**
+   * Splits a mix of attributes and already-typed child elements into
+   * attribute/child chunks.
+   */
+  private def splitEffects(effects: Seq[Dom.Attribute | Dom.Element]): (Chunk[Dom.Attribute], Chunk[Dom]) = {
+    val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
+    val childBuilder = Chunk.newBuilder[Dom]
+    var i            = 0
+    while (i < effects.length) {
+      effects(i) match {
+        case attr: Dom.Attribute => attrBuilder += attr
+        case el: Dom.Element     => childBuilder += el
+      }
+      i += 1
+    }
+    (attrBuilder.result(), childBuilder.result())
+  }
+
+  /**
+   * Builds a `Generic` element from a mix of attributes and already-typed child
+   * elements.
+   */
+  private def elOf(effects: Seq[Dom.Attribute | Dom.Element], tag: String): Dom.Element = {
+    val (attributes, children) = splitEffects(effects)
+    Dom.Element.Generic(tag, attributes, children)
+  }
+
   val doctype: Dom.Doctype    = Dom.Doctype("html")
   val html: Dom.Element       = Dom.Element.Generic("html", Chunk.empty, Chunk.empty)
   val head: Dom.Element       = Dom.Element.Generic("head", Chunk.empty, Chunk.empty)
@@ -193,55 +220,165 @@ trait HtmlElements {
    * Empty `<li>` element; apply attributes/children via `li(...)`, returning
    * `Li`.
    */
-  val li: Dom.Element.Li = Dom.Element.LiElement(Chunk.empty, Chunk.empty)
+  val li: Dom.Element.LiElement = Dom.Element.LiElement(Chunk.empty, Chunk.empty)
 
-  /** Empty `<ul>` element; apply attributes/children via `ul(...)`. */
-  val ul: Dom.Element = Dom.Element.Generic("ul", Chunk.empty, Chunk.empty)
+  /** Creates an empty `<ul>` element. */
+  def ul(): Dom.Element = Dom.Element.Generic("ul", Chunk.empty, Chunk.empty)
 
-  /** Empty `<ol>` element; apply attributes/children via `ol(...)`. */
-  val ol: Dom.Element = Dom.Element.Generic("ol", Chunk.empty, Chunk.empty)
+  /**
+   * Creates a `<ul>` element from attributes and `<li>` children.
+   *
+   * The HTML content model of `<ul>` permits only `<li>` element children, so
+   * the child parameters are restricted to [[Dom.Element.Li]] at compile time;
+   * [[Dom.Attribute]] values are accepted alongside them.
+   */
+  def ul(effect: Dom.Attribute | Dom.Element.Li, effects: (Dom.Attribute | Dom.Element.Li)*): Dom.Element =
+    elOf(effect +: effects, "ul")
+
+  /** Creates a `<ul>` element from an iterable of `<li>` children. */
+  def ul(children: Iterable[Dom.Element.Li]): Dom.Element =
+    Dom.Element.Generic("ul", Chunk.empty, Chunk.from(children))
+
+  /** Creates an empty `<ol>` element. */
+  def ol(): Dom.Element = Dom.Element.Generic("ol", Chunk.empty, Chunk.empty)
+
+  /**
+   * Creates an `<ol>` element from attributes and `<li>` children.
+   *
+   * The HTML content model of `<ol>` permits only `<li>` element children, so
+   * the child parameters are restricted to [[Dom.Element.Li]] at compile time;
+   * [[Dom.Attribute]] values are accepted alongside them.
+   */
+  def ol(effect: Dom.Attribute | Dom.Element.Li, effects: (Dom.Attribute | Dom.Element.Li)*): Dom.Element =
+    elOf(effect +: effects, "ol")
+
+  /** Creates an `<ol>` element from an iterable of `<li>` children. */
+  def ol(children: Iterable[Dom.Element.Li]): Dom.Element =
+    Dom.Element.Generic("ol", Chunk.empty, Chunk.from(children))
 
   /**
    * Empty `<th>` element; apply attributes/children via `th(...)`, returning
    * `Th`.
    */
-  val th: Dom.Element.Th = Dom.Element.ThElement(Chunk.empty, Chunk.empty)
+  val th: Dom.Element.ThElement = Dom.Element.ThElement(Chunk.empty, Chunk.empty)
 
   /**
    * Empty `<td>` element; apply attributes/children via `td(...)`, returning
    * `Td`.
    */
-  val td: Dom.Element.Td = Dom.Element.TdElement(Chunk.empty, Chunk.empty)
+  val td: Dom.Element.TdElement = Dom.Element.TdElement(Chunk.empty, Chunk.empty)
 
-  /** Empty `<tr>` element; apply attributes/children via `tr(...)`. */
-  val tr: Dom.Element = Dom.Element.Generic("tr", Chunk.empty, Chunk.empty)
+  /** Creates an empty `<tr>` element, returning `Tr`. */
+  def tr(): Dom.Element.TrElement = Dom.Element.TrElement(Chunk.empty, Chunk.empty)
 
   /**
-   * Empty `<table>` element; apply attributes/children via `table(...)`
-   * (caption, colgroup, thead, tbody, tfoot, tr).
+   * Creates a `<tr>` element from attributes and table cells (`<th>`/`<td>`)
+   *
+   * The HTML content model of `<tr>` permits only `<th>` and `<td>` element
+   * children, so the child parameters are restricted to [[Dom.Element.Cell]] at
+   * compile time; [[Dom.Attribute]] values are accepted alongside them.
    */
-  val table: Dom.Element = Dom.Element.Generic("table", Chunk.empty, Chunk.empty)
+  def tr(effect: Dom.Attribute | Dom.Element.Cell, effects: (Dom.Attribute | Dom.Element.Cell)*): Dom.Element.Tr = {
+    val (attributes, children) = splitEffects(effect +: effects)
+    Dom.Element.TrElement(attributes, children)
+  }
+
+  /** Creates a `<tr>` element from an iterable of `<th>`/`<td>` cells. */
+  def tr(children: Iterable[Dom.Element.Cell]): Dom.Element.Tr =
+    Dom.Element.TrElement(Chunk.empty, Chunk.from(children))
+
+  /**
+   * Creates an empty `<table>` element.
+   */
+  def table(): Dom.Element = Dom.Element.Generic("table", Chunk.empty, Chunk.empty)
+
+  /**
+   * Creates a `<table>` element from attributes and `<tr>` rows.
+   *
+   * The row parameters are restricted to [[Dom.Element.Tr]] at compile time;
+   * [[Dom.Attribute]] values are accepted alongside them. Other table sections
+   * (`caption`, `colgroup`, `thead`, `tbody`, `tfoot`) do not have typed
+   * markers yet — compose tables containing them with the `html"" interpolator
+   * or generic elements instead.
+   */
+  def table(effect: Dom.Attribute | Dom.Element.Tr, effects: (Dom.Attribute | Dom.Element.Tr)*): Dom.Element =
+    elOf(effect +: effects, "table")
+
+  /** Creates a `<table>` element from an iterable of `<tr>` rows. */
+  def table(children: Iterable[Dom.Element.Tr]): Dom.Element =
+    elOf(children.toSeq, "table")
 
   /**
    * Empty `<option>` element; apply attributes/children via `opt(...)`,
    * returning `Opt`.
    */
-  val opt: Dom.Element.Opt = Dom.Element.OptElement(Chunk.empty, Chunk.empty)
+  val opt: Dom.Element.OptElement = Dom.Element.OptElement(Chunk.empty, Chunk.empty)
 
   /** Alias for [[opt]]. */
-  val option: Dom.Element.Opt = Dom.Element.OptElement(Chunk.empty, Chunk.empty)
+  val option: Dom.Element.OptElement = Dom.Element.OptElement(Chunk.empty, Chunk.empty)
 
   /**
-   * Empty `<optgroup>` element; apply options/attributes via `optgroup(...)`,
-   * returning `Optgroup`.
+   * Creates an empty `<optgroup>` element, returning `Optgroup`.
    */
-  val optgroup: Dom.Element.Optgroup = Dom.Element.OptgroupElement(Chunk.empty, Chunk.empty)
+  def optgroup(): Dom.Element.OptgroupElement = Dom.Element.OptgroupElement(Chunk.empty, Chunk.empty)
 
   /**
-   * Empty `<select>` element; apply `<option>`/`<optgroup>` children and
-   * attributes via `select(...)`.
+   * Creates an `<optgroup>` element from attributes and `<option>` children.
+   *
+   * The HTML content model of `<optgroup>` permits only `<option>` element
+   * children, so the child parameters are restricted to [[Dom.Element.Opt]] at
+   * compile time; [[Dom.Attribute]] values are accepted alongside them.
    */
-  val select: Dom.Element = Dom.Element.Generic("select", Chunk.empty, Chunk.empty)
+  def optgroup(
+    effect: Dom.Attribute | Dom.Element.Opt,
+    effects: (Dom.Attribute | Dom.Element.Opt)*
+  ): Dom.Element.Optgroup = {
+    val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
+    val childBuilder = Chunk.newBuilder[Dom]
+    val all          = effect +: effects
+    var i            = 0
+    while (i < all.length) {
+      all(i) match {
+        case attr: Dom.Attribute  => attrBuilder += attr
+        case opt: Dom.Element.Opt => childBuilder += opt
+      }
+      i += 1
+    }
+    Dom.Element.OptgroupElement(attrBuilder.result(), childBuilder.result())
+  }
+
+  /**
+   * Creates an `<optgroup>` element from an iterable of `<option>` children.
+   */
+  def optgroup(children: Iterable[Dom.Element.Opt]): Dom.Element.Optgroup =
+    Dom.Element.OptgroupElement(Chunk.empty, Chunk.from(children))
+
+  /**
+   * Creates an empty `<select>` element.
+   */
+  def select(): Dom.Element = Dom.Element.Generic("select", Chunk.empty, Chunk.empty)
+
+  /**
+   * Creates a `<select>` element from attributes and `<option>`/`<optgroup>`
+   * children.
+   *
+   * The HTML content model of `<select>` permits only `<option>` and
+   * `<optgroup>` element children, so the child parameters are restricted to
+   * [[Dom.Element.SelectChild]] at compile time; [[Dom.Attribute]] values are
+   * accepted alongside them.
+   */
+  def select(
+    effect: Dom.Attribute | Dom.Element.SelectChild,
+    effects: (Dom.Attribute | Dom.Element.SelectChild)*
+  ): Dom.Element =
+    elOf(effect +: effects, "select")
+
+  /**
+   * Creates a `<select>` element from an iterable of `<option>`/`<optgroup>`
+   * children.
+   */
+  def select(children: Iterable[Dom.Element.SelectChild]): Dom.Element =
+    elOf(children.toSeq, "select")
 
   // --- Attribute helpers ---
 

--- a/html/shared/src/main/scala-3/zio/blocks/html/HtmlElements.scala
+++ b/html/shared/src/main/scala-3/zio/blocks/html/HtmlElements.scala
@@ -361,16 +361,8 @@ trait HtmlElements {
     effect: Dom.Attribute | Dom.Element.Opt,
     effects: (Dom.Attribute | Dom.Element.Opt)*
   ): Dom.Element.Optgroup = {
-    val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
-    val childBuilder = Chunk.newBuilder[Dom]
-    val it           = (effect +: effects).iterator
-    while (it.hasNext) {
-      it.next() match {
-        case attr: Dom.Attribute  => attrBuilder += attr
-        case opt: Dom.Element.Opt => childBuilder += opt
-      }
-    }
-    Dom.Element.OptgroupElement(attrBuilder.result(), childBuilder.result())
+    val (attributes, children) = splitEffects(effect +: effects)
+    Dom.Element.OptgroupElement(attributes, children)
   }
 
   /**

--- a/html/shared/src/main/scala-3/zio/blocks/html/HtmlElements.scala
+++ b/html/shared/src/main/scala-3/zio/blocks/html/HtmlElements.scala
@@ -57,13 +57,12 @@ trait HtmlElements {
   private def splitEffects(effects: Seq[Dom.Attribute | Dom.Element]): (Chunk[Dom.Attribute], Chunk[Dom]) = {
     val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
     val childBuilder = Chunk.newBuilder[Dom]
-    var i            = 0
-    while (i < effects.length) {
-      effects(i) match {
+    val it           = effects.iterator
+    while (it.hasNext) {
+      it.next() match {
         case attr: Dom.Attribute => attrBuilder += attr
         case el: Dom.Element     => childBuilder += el
       }
-      i += 1
     }
     (attrBuilder.result(), childBuilder.result())
   }
@@ -216,11 +215,17 @@ trait HtmlElements {
   val wbr: Dom.Element.Void             = Dom.Element.VoidGeneric("wbr", Chunk.empty)
   def element(tag: String): Dom.Element = Dom.Element.Generic(tag, Chunk.empty, Chunk.empty)
 
+  /** Creates an empty `<li>` element, returning `Li`. */
+  def li(): Dom.Element.Li = Dom.Element.LiElement(Chunk.empty, Chunk.empty)
+
   /**
-   * Empty `<li>` element; apply attributes/children via `li(...)`, returning
-   * `Li`.
+   * Creates a `<li>` element from attributes and children, returning `Li`.
+   *
+   * The HTML content model of `<li>` permits flow content, so any modifier
+   * values are accepted.
    */
-  val li: Dom.Element.LiElement = Dom.Element.LiElement(Chunk.empty, Chunk.empty)
+  def li(effect: DomModifier, effects: DomModifier*): Dom.Element.Li =
+    Dom.Element.LiElement(Chunk.empty, Chunk.empty)(effect, effects: _*)
 
   /** Creates an empty `<ul>` element. */
   def ul(): Dom.Element = Dom.Element.Generic("ul", Chunk.empty, Chunk.empty)
@@ -256,20 +261,32 @@ trait HtmlElements {
   def ol(children: Iterable[Dom.Element.Li]): Dom.Element =
     Dom.Element.Generic("ol", Chunk.empty, Chunk.from(children))
 
-  /**
-   * Empty `<th>` element; apply attributes/children via `th(...)`, returning
-   * `Th`.
-   */
-  val th: Dom.Element.ThElement = Dom.Element.ThElement(Chunk.empty, Chunk.empty)
+  /** Creates an empty `<th>` element, returning `Th`. */
+  def th(): Dom.Element.Th = Dom.Element.ThElement(Chunk.empty, Chunk.empty)
 
   /**
-   * Empty `<td>` element; apply attributes/children via `td(...)`, returning
-   * `Td`.
+   * Creates a `<th>` element from attributes and children, returning `Th`.
+   *
+   * The HTML content model of `<th>` permits flow content, so any modifier
+   * values are accepted.
    */
-  val td: Dom.Element.TdElement = Dom.Element.TdElement(Chunk.empty, Chunk.empty)
+  def th(effect: DomModifier, effects: DomModifier*): Dom.Element.Th =
+    Dom.Element.ThElement(Chunk.empty, Chunk.empty)(effect, effects: _*)
+
+  /** Creates an empty `<td>` element, returning `Td`. */
+  def td(): Dom.Element.Td = Dom.Element.TdElement(Chunk.empty, Chunk.empty)
+
+  /**
+   * Creates a `<td>` element from attributes and children, returning `Td`.
+   *
+   * The HTML content model of `<td>` permits flow content, so any modifier
+   * values are accepted.
+   */
+  def td(effect: DomModifier, effects: DomModifier*): Dom.Element.Td =
+    Dom.Element.TdElement(Chunk.empty, Chunk.empty)(effect, effects: _*)
 
   /** Creates an empty `<tr>` element, returning `Tr`. */
-  def tr(): Dom.Element.TrElement = Dom.Element.TrElement(Chunk.empty, Chunk.empty)
+  def tr(): Dom.Element.Tr = Dom.Element.TrElement(Chunk.empty, Chunk.empty)
 
   /**
    * Creates a `<tr>` element from attributes and table cells (`<th>`/`<td>`)
@@ -298,7 +315,7 @@ trait HtmlElements {
    * The row parameters are restricted to [[Dom.Element.Tr]] at compile time;
    * [[Dom.Attribute]] values are accepted alongside them. Other table sections
    * (`caption`, `colgroup`, `thead`, `tbody`, `tfoot`) do not have typed
-   * markers yet — compose tables containing them with the `html"" interpolator
+   * markers yet — compose tables containing them with the `html""` interpolator
    * or generic elements instead.
    */
   def table(effect: Dom.Attribute | Dom.Element.Tr, effects: (Dom.Attribute | Dom.Element.Tr)*): Dom.Element =
@@ -306,21 +323,32 @@ trait HtmlElements {
 
   /** Creates a `<table>` element from an iterable of `<tr>` rows. */
   def table(children: Iterable[Dom.Element.Tr]): Dom.Element =
-    elOf(children.toSeq, "table")
+    Dom.Element.Generic("table", Chunk.empty, Chunk.from(children))
+
+  /** Creates an empty `<option>` element, returning `Opt`. */
+  def opt(): Dom.Element.Opt = Dom.Element.OptElement(Chunk.empty, Chunk.empty)
 
   /**
-   * Empty `<option>` element; apply attributes/children via `opt(...)`,
-   * returning `Opt`.
+   * Creates an `<option>` element from attributes and children, returning
+   * `Opt`.
+   *
+   * The HTML content model of `<option>` permits flow content, so any modifier
+   * values are accepted.
    */
-  val opt: Dom.Element.OptElement = Dom.Element.OptElement(Chunk.empty, Chunk.empty)
+  def opt(effect: DomModifier, effects: DomModifier*): Dom.Element.Opt =
+    Dom.Element.OptElement(Chunk.empty, Chunk.empty)(effect, effects: _*)
 
   /** Alias for [[opt]]. */
-  val option: Dom.Element.OptElement = Dom.Element.OptElement(Chunk.empty, Chunk.empty)
+  def option(): Dom.Element.Opt = Dom.Element.OptElement(Chunk.empty, Chunk.empty)
+
+  /** Alias for [[opt]]. */
+  def option(effect: DomModifier, effects: DomModifier*): Dom.Element.Opt =
+    Dom.Element.OptElement(Chunk.empty, Chunk.empty)(effect, effects: _*)
 
   /**
    * Creates an empty `<optgroup>` element, returning `Optgroup`.
    */
-  def optgroup(): Dom.Element.OptgroupElement = Dom.Element.OptgroupElement(Chunk.empty, Chunk.empty)
+  def optgroup(): Dom.Element.Optgroup = Dom.Element.OptgroupElement(Chunk.empty, Chunk.empty)
 
   /**
    * Creates an `<optgroup>` element from attributes and `<option>` children.
@@ -335,14 +363,12 @@ trait HtmlElements {
   ): Dom.Element.Optgroup = {
     val attrBuilder  = Chunk.newBuilder[Dom.Attribute]
     val childBuilder = Chunk.newBuilder[Dom]
-    val all          = effect +: effects
-    var i            = 0
-    while (i < all.length) {
-      all(i) match {
+    val it           = (effect +: effects).iterator
+    while (it.hasNext) {
+      it.next() match {
         case attr: Dom.Attribute  => attrBuilder += attr
         case opt: Dom.Element.Opt => childBuilder += opt
       }
-      i += 1
     }
     Dom.Element.OptgroupElement(attrBuilder.result(), childBuilder.result())
   }
@@ -378,7 +404,7 @@ trait HtmlElements {
    * children.
    */
   def select(children: Iterable[Dom.Element.SelectChild]): Dom.Element =
-    elOf(children.toSeq, "select")
+    Dom.Element.Generic("select", Chunk.empty, Chunk.from(children))
 
   // --- Attribute helpers ---
 

--- a/html/shared/src/main/scala/zio/blocks/html/Dom.scala
+++ b/html/shared/src/main/scala/zio/blocks/html/Dom.scala
@@ -229,6 +229,19 @@ object Dom {
 
     private[html] def escapeText: Boolean
 
+    /**
+     * Structural comparison shared by every concrete `Element` implementation:
+     * two elements are equal when their tag, attributes, and children match,
+     * regardless of the concrete classes involved.
+     */
+    private[html] def structuralEquals(other: Any): Boolean = other match {
+      case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
+      case _          => false
+    }
+
+    /** Hash code consistent with [[structuralEquals]]. */
+    private[html] def structuralHashCode: Int = (tag, attributes, children).hashCode
+
     private[html] def renderTo(sb: java.lang.StringBuilder): Unit = {
       sb.append('<')
       sb.append(tag)
@@ -383,11 +396,8 @@ object Dom {
       def withAttributes(attrs: Chunk[Attribute]): Generic = copy(attributes = attrs)
       def withChildren(kids: Chunk[Dom]): Generic          = copy(children = kids)
 
-      override def equals(other: Any): Boolean = other match {
-        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
-        case _          => false
-      }
-      override def hashCode: Int = (tag, attributes, children).hashCode
+      override def equals(other: Any): Boolean = structuralEquals(other)
+      override def hashCode: Int               = structuralHashCode
     }
 
     // --- Typed content model elements (proper OO hierarchy for Scala 2/3 parity) ---
@@ -418,11 +428,8 @@ object Dom {
       override def when(condition: Boolean)(effect: DomModifier, effects: DomModifier*): Li =
         if (condition) apply(effect, effects: _*) else this
 
-      override def equals(other: Any): Boolean = other match {
-        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
-        case _          => false
-      }
-      override def hashCode: Int = (tag, attributes, children).hashCode
+      override def equals(other: Any): Boolean = structuralEquals(other)
+      override def hashCode: Int               = structuralHashCode
     }
 
     /**
@@ -451,11 +458,8 @@ object Dom {
       override def when(condition: Boolean)(effect: DomModifier, effects: DomModifier*): Th =
         if (condition) apply(effect, effects: _*) else this
 
-      override def equals(other: Any): Boolean = other match {
-        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
-        case _          => false
-      }
-      override def hashCode: Int = (tag, attributes, children).hashCode
+      override def equals(other: Any): Boolean = structuralEquals(other)
+      override def hashCode: Int               = structuralHashCode
     }
 
     /**
@@ -484,15 +488,19 @@ object Dom {
       override def when(condition: Boolean)(effect: DomModifier, effects: DomModifier*): Td =
         if (condition) apply(effect, effects: _*) else this
 
-      override def equals(other: Any): Boolean = other match {
-        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
-        case _          => false
-      }
-      override def hashCode: Int = (tag, attributes, children).hashCode
+      override def equals(other: Any): Boolean = structuralEquals(other)
+      override def hashCode: Int               = structuralHashCode
     }
 
     /**
      * A `<tr>` table row element.
+     *
+     * Unlike permissive elements (`li`, `th`, `td`), this class intentionally
+     * does not override `apply(DomModifier*)`: its content model only permits
+     * `<th>`/`<td>` cells, so children must be added through the `tr(...)`
+     * factory, which enforces that restriction at compile time. Attributes can
+     * still be attached afterwards via `when(...)` or modifier application,
+     * which return a plain `Element`.
      *
      * Equality is structural across all `Element` implementations, so a
      * `TrElement` equals a `Generic("tr", ...)` with the same attributes and
@@ -501,27 +509,20 @@ object Dom {
      * @param attributes
      *   attribute key-value pairs
      * @param children
-     *   child DOM nodes
+     *   child DOM nodes (`<th>`/`<td>` cells only)
      */
     final case class TrElement(
       attributes: Chunk[Attribute],
       children: Chunk[Dom]
     ) extends Element
         with Tr {
-      def tag: String                                                    = "tr"
-      private[html] def escapeText: Boolean                              = true
-      def withAttributes(attrs: Chunk[Attribute]): Tr                    = copy(attributes = attrs)
-      def withChildren(kids: Chunk[Dom]): Tr                             = copy(children = kids)
-      override def apply(effect: DomModifier, effects: DomModifier*): Tr =
-        ToModifier.buildFromEffects(this, effect, effects).asInstanceOf[Tr]
-      override def when(condition: Boolean)(effect: DomModifier, effects: DomModifier*): Tr =
-        if (condition) apply(effect, effects: _*) else this
+      def tag: String                                 = "tr"
+      private[html] def escapeText: Boolean           = true
+      def withAttributes(attrs: Chunk[Attribute]): Tr = copy(attributes = attrs)
+      def withChildren(kids: Chunk[Dom]): Tr          = copy(children = kids)
 
-      override def equals(other: Any): Boolean = other match {
-        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
-        case _          => false
-      }
-      override def hashCode: Int = (tag, attributes, children).hashCode
+      override def equals(other: Any): Boolean = structuralEquals(other)
+      override def hashCode: Int               = structuralHashCode
     }
 
     /**
@@ -550,11 +551,8 @@ object Dom {
       override def when(condition: Boolean)(effect: DomModifier, effects: DomModifier*): Opt =
         if (condition) apply(effect, effects: _*) else this
 
-      override def equals(other: Any): Boolean = other match {
-        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
-        case _          => false
-      }
-      override def hashCode: Int = (tag, attributes, children).hashCode
+      override def equals(other: Any): Boolean = structuralEquals(other)
+      override def hashCode: Int               = structuralHashCode
     }
 
     /**
@@ -586,11 +584,8 @@ object Dom {
       def withAttributes(attrs: Chunk[Attribute]): Optgroup = copy(attributes = attrs)
       def withChildren(kids: Chunk[Dom]): Optgroup          = copy(children = kids)
 
-      override def equals(other: Any): Boolean = other match {
-        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
-        case _          => false
-      }
-      override def hashCode: Int = (tag, attributes, children).hashCode
+      override def equals(other: Any): Boolean = structuralEquals(other)
+      override def hashCode: Int               = structuralHashCode
     }
 
     /**
@@ -625,11 +620,8 @@ object Dom {
       def externalJs(url: String): Script =
         copy(attributes = attributes :+ Attribute.KeyValue("src", AttributeValue.StringValue(url)))
 
-      override def equals(other: Any): Boolean = other match {
-        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
-        case _          => false
-      }
-      override def hashCode: Int = (tag, attributes, children).hashCode
+      override def equals(other: Any): Boolean = structuralEquals(other)
+      override def hashCode: Int               = structuralHashCode
     }
 
     /**
@@ -658,11 +650,8 @@ object Dom {
       def inlineCss(code: Css): Style =
         copy(children = children :+ Dom.Text(code.render))
 
-      override def equals(other: Any): Boolean = other match {
-        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
-        case _          => false
-      }
-      override def hashCode: Int = (tag, attributes, children).hashCode
+      override def equals(other: Any): Boolean = structuralEquals(other)
+      override def hashCode: Int               = structuralHashCode
     }
 
     /**

--- a/html/shared/src/main/scala/zio/blocks/html/Dom.scala
+++ b/html/shared/src/main/scala/zio/blocks/html/Dom.scala
@@ -496,11 +496,12 @@ object Dom {
      * A `<tr>` table row element.
      *
      * Unlike permissive elements (`li`, `th`, `td`), this class intentionally
-     * does not override `apply(DomModifier*)`: its content model only permits
-     * `<th>`/`<td>` cells, so children must be added through the `tr(...)`
-     * factory, which enforces that restriction at compile time. Attributes can
-     * still be attached afterwards via `when(...)` or modifier application,
-     * which return a plain `Element`.
+     * keeps the row content model intact: it does not override
+     * `apply(DomModifier*)`, and [[withChildren]] returns a plain `Element`, so
+     * replacing children drops the `Tr` marker — children belong in the
+     * `tr(...)` factory, which enforces the restriction at compile time.
+     * Attributes can still be attached via [[withAttributes]], preserving the
+     * marker.
      *
      * Equality is structural across all `Element` implementations, so a
      * `TrElement` equals a `Generic("tr", ...)` with the same attributes and
@@ -519,7 +520,7 @@ object Dom {
       def tag: String                                 = "tr"
       private[html] def escapeText: Boolean           = true
       def withAttributes(attrs: Chunk[Attribute]): Tr = copy(attributes = attrs)
-      def withChildren(kids: Chunk[Dom]): Tr          = copy(children = kids)
+      def withChildren(kids: Chunk[Dom]): Element     = copy(children = kids)
 
       override def equals(other: Any): Boolean = structuralEquals(other)
       override def hashCode: Int               = structuralHashCode
@@ -559,11 +560,11 @@ object Dom {
      * An `<optgroup>` element.
      *
      * Unlike the other typed elements, this class intentionally does not
-     * override `apply(DomModifier*)`: its content model only permits `<option>`
-     * children, so children must be added through the `optgroup(...)` factory,
-     * which enforces that restriction at compile time. Attributes can still be
-     * attached afterwards via `when(...)` or modifier application, which return
-     * a plain `Element`.
+     * override `apply(DomModifier*)`, and [[withChildren]] returns a plain
+     * `Element`, so replacing children drops the `Optgroup` marker — children
+     * belong in the `optgroup(...)` factory, which enforces that restriction at
+     * compile time. Attributes can still be attached via [[withAttributes]],
+     * preserving the marker.
      *
      * Equality is structural across all `Element` implementations, so an
      * `OptgroupElement` equals a `Generic("optgroup", ...)` with the same
@@ -582,7 +583,7 @@ object Dom {
       def tag: String                                       = "optgroup"
       private[html] def escapeText: Boolean                 = true
       def withAttributes(attrs: Chunk[Attribute]): Optgroup = copy(attributes = attrs)
-      def withChildren(kids: Chunk[Dom]): Optgroup          = copy(children = kids)
+      def withChildren(kids: Chunk[Dom]): Element           = copy(children = kids)
 
       override def equals(other: Any): Boolean = structuralEquals(other)
       override def hashCode: Int               = structuralHashCode

--- a/html/shared/src/main/scala/zio/blocks/html/Dom.scala
+++ b/html/shared/src/main/scala/zio/blocks/html/Dom.scala
@@ -227,12 +227,6 @@ object Dom {
         case None        => this
       }
 
-    override def equals(other: Any): Boolean = other match {
-      case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
-      case _          => false
-    }
-    override def hashCode: Int = (tag, attributes, children).hashCode
-
     private[html] def escapeText: Boolean
 
     private[html] def renderTo(sb: java.lang.StringBuilder): Unit = {
@@ -306,20 +300,72 @@ object Dom {
 
   object Element {
 
-    // --- Marker traits for typed content model (proper OO hierarchy, same file as sealed Element) ---
-    trait Li          extends Element
-    trait Th          extends Cell
-    trait Td          extends Cell
-    trait Opt         extends SelectChild
-    trait Optgroup    extends SelectChild
-    trait Cell        extends Element
-    trait SelectChild extends Element
+    // --- Sealed markers for typed content models ---
+    //
+    // These markers classify elements by the HTML content-model role they play
+    // as children of other elements (e.g., only `Li` elements may appear
+    // directly inside `ul`/`ol`). They are sealed: the only implementations are
+    // the dedicated element classes in this file, so a marker type guarantees
+    // both the tag and the content-model role at compile time.
+
+    /**
+     * An `<li>` list item, accepted as an element child of `ul(...)` and
+     * `ol(...)`. Produced by the `li(...)` factory.
+     */
+    sealed trait Li extends Element
+
+    /**
+     * A table cell (`<th>` or `<td>`), accepted as an element child of
+     * `tr(...)`.
+     */
+    sealed trait Cell extends Element
+
+    /**
+     * A `<th>` header cell, accepted as an element child of `tr(...)`. Produced
+     * by the `th(...)` factory.
+     */
+    sealed trait Th extends Cell
+
+    /**
+     * A `<td>` data cell, accepted as an element child of `tr(...)`. Produced
+     * by the `td(...)` factory.
+     */
+    sealed trait Td extends Cell
+
+    /**
+     * A `<tr>` table row, accepted as an element child of `table(...)`.
+     * Produced by the `tr(...)` factory.
+     */
+    sealed trait Tr extends Element
+
+    /**
+     * An `<option>` or `<optgroup>`, accepted as an element child of
+     * `select(...)`.
+     */
+    sealed trait SelectChild extends Element
+
+    /**
+     * An `<option>` element, accepted as an element child of `select(...)` and
+     * `optgroup(...)`. Produced by the `option(...)`/`opt` DSL value.
+     */
+    sealed trait Opt extends SelectChild
+
+    /**
+     * An `<optgroup>` element, accepted as an element child of `select(...)`.
+     * Produced by the `optgroup(...)` factory.
+     */
+    sealed trait Optgroup extends SelectChild
 
     /**
      * A generic HTML element.
      *
      * Represents any standard HTML tag (e.g., "div", "p", "span"). Text content
      * in children is HTML-escaped during rendering.
+     *
+     * Equality is structural across all `Element` implementations: a `Generic`
+     * equals any other element with the same tag, attributes, and children,
+     * regardless of the concrete class (e.g., `Generic("li", ...)` equals the
+     * equivalent `LiElement`).
      *
      * @param tag
      *   the element tag name (e.g., "div", "h1")
@@ -336,10 +382,28 @@ object Dom {
       private[html] def escapeText: Boolean                = true
       def withAttributes(attrs: Chunk[Attribute]): Generic = copy(attributes = attrs)
       def withChildren(kids: Chunk[Dom]): Generic          = copy(children = kids)
+
+      override def equals(other: Any): Boolean = other match {
+        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
+        case _          => false
+      }
+      override def hashCode: Int = (tag, attributes, children).hashCode
     }
 
     // --- Typed content model elements (proper OO hierarchy for Scala 2/3 parity) ---
 
+    /**
+     * An `<li>` list item element.
+     *
+     * Equality is structural across all `Element` implementations, so a
+     * `LiElement` equals a `Generic("li", ...)` with the same attributes and
+     * children.
+     *
+     * @param attributes
+     *   attribute key-value pairs
+     * @param children
+     *   child DOM nodes
+     */
     final case class LiElement(
       attributes: Chunk[Attribute],
       children: Chunk[Dom]
@@ -353,8 +417,26 @@ object Dom {
         ToModifier.buildFromEffects(this, effect, effects).asInstanceOf[Li]
       override def when(condition: Boolean)(effect: DomModifier, effects: DomModifier*): Li =
         if (condition) apply(effect, effects: _*) else this
+
+      override def equals(other: Any): Boolean = other match {
+        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
+        case _          => false
+      }
+      override def hashCode: Int = (tag, attributes, children).hashCode
     }
 
+    /**
+     * A `<th>` table header cell element.
+     *
+     * Equality is structural across all `Element` implementations, so a
+     * `ThElement` equals a `Generic("th", ...)` with the same attributes and
+     * children.
+     *
+     * @param attributes
+     *   attribute key-value pairs
+     * @param children
+     *   child DOM nodes
+     */
     final case class ThElement(
       attributes: Chunk[Attribute],
       children: Chunk[Dom]
@@ -368,8 +450,26 @@ object Dom {
         ToModifier.buildFromEffects(this, effect, effects).asInstanceOf[Th]
       override def when(condition: Boolean)(effect: DomModifier, effects: DomModifier*): Th =
         if (condition) apply(effect, effects: _*) else this
+
+      override def equals(other: Any): Boolean = other match {
+        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
+        case _          => false
+      }
+      override def hashCode: Int = (tag, attributes, children).hashCode
     }
 
+    /**
+     * A `<td>` table data cell element.
+     *
+     * Equality is structural across all `Element` implementations, so a
+     * `TdElement` equals a `Generic("td", ...)` with the same attributes and
+     * children.
+     *
+     * @param attributes
+     *   attribute key-value pairs
+     * @param children
+     *   child DOM nodes
+     */
     final case class TdElement(
       attributes: Chunk[Attribute],
       children: Chunk[Dom]
@@ -383,8 +483,59 @@ object Dom {
         ToModifier.buildFromEffects(this, effect, effects).asInstanceOf[Td]
       override def when(condition: Boolean)(effect: DomModifier, effects: DomModifier*): Td =
         if (condition) apply(effect, effects: _*) else this
+
+      override def equals(other: Any): Boolean = other match {
+        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
+        case _          => false
+      }
+      override def hashCode: Int = (tag, attributes, children).hashCode
     }
 
+    /**
+     * A `<tr>` table row element.
+     *
+     * Equality is structural across all `Element` implementations, so a
+     * `TrElement` equals a `Generic("tr", ...)` with the same attributes and
+     * children.
+     *
+     * @param attributes
+     *   attribute key-value pairs
+     * @param children
+     *   child DOM nodes
+     */
+    final case class TrElement(
+      attributes: Chunk[Attribute],
+      children: Chunk[Dom]
+    ) extends Element
+        with Tr {
+      def tag: String                                                    = "tr"
+      private[html] def escapeText: Boolean                              = true
+      def withAttributes(attrs: Chunk[Attribute]): Tr                    = copy(attributes = attrs)
+      def withChildren(kids: Chunk[Dom]): Tr                             = copy(children = kids)
+      override def apply(effect: DomModifier, effects: DomModifier*): Tr =
+        ToModifier.buildFromEffects(this, effect, effects).asInstanceOf[Tr]
+      override def when(condition: Boolean)(effect: DomModifier, effects: DomModifier*): Tr =
+        if (condition) apply(effect, effects: _*) else this
+
+      override def equals(other: Any): Boolean = other match {
+        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
+        case _          => false
+      }
+      override def hashCode: Int = (tag, attributes, children).hashCode
+    }
+
+    /**
+     * An `<option>` element.
+     *
+     * Equality is structural across all `Element` implementations, so an
+     * `OptElement` equals a `Generic("option", ...)` with the same attributes
+     * and children.
+     *
+     * @param attributes
+     *   attribute key-value pairs
+     * @param children
+     *   child DOM nodes
+     */
     final case class OptElement(
       attributes: Chunk[Attribute],
       children: Chunk[Dom]
@@ -398,21 +549,48 @@ object Dom {
         ToModifier.buildFromEffects(this, effect, effects).asInstanceOf[Opt]
       override def when(condition: Boolean)(effect: DomModifier, effects: DomModifier*): Opt =
         if (condition) apply(effect, effects: _*) else this
+
+      override def equals(other: Any): Boolean = other match {
+        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
+        case _          => false
+      }
+      override def hashCode: Int = (tag, attributes, children).hashCode
     }
 
+    /**
+     * An `<optgroup>` element.
+     *
+     * Unlike the other typed elements, this class intentionally does not
+     * override `apply(DomModifier*)`: its content model only permits `<option>`
+     * children, so children must be added through the `optgroup(...)` factory,
+     * which enforces that restriction at compile time. Attributes can still be
+     * attached afterwards via `when(...)` or modifier application, which return
+     * a plain `Element`.
+     *
+     * Equality is structural across all `Element` implementations, so an
+     * `OptgroupElement` equals a `Generic("optgroup", ...)` with the same
+     * attributes and children.
+     *
+     * @param attributes
+     *   attribute key-value pairs
+     * @param children
+     *   child DOM nodes (`<option>` elements only)
+     */
     final case class OptgroupElement(
       attributes: Chunk[Attribute],
       children: Chunk[Dom]
     ) extends Element
         with Optgroup {
-      def tag: String                                                          = "optgroup"
-      private[html] def escapeText: Boolean                                    = true
-      def withAttributes(attrs: Chunk[Attribute]): Optgroup                    = copy(attributes = attrs)
-      def withChildren(kids: Chunk[Dom]): Optgroup                             = copy(children = kids)
-      override def apply(effect: DomModifier, effects: DomModifier*): Optgroup =
-        ToModifier.buildFromEffects(this, effect, effects).asInstanceOf[Optgroup]
-      override def when(condition: Boolean)(effect: DomModifier, effects: DomModifier*): Optgroup =
-        if (condition) apply(effect, effects: _*) else this
+      def tag: String                                       = "optgroup"
+      private[html] def escapeText: Boolean                 = true
+      def withAttributes(attrs: Chunk[Attribute]): Optgroup = copy(attributes = attrs)
+      def withChildren(kids: Chunk[Dom]): Optgroup          = copy(children = kids)
+
+      override def equals(other: Any): Boolean = other match {
+        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
+        case _          => false
+      }
+      override def hashCode: Int = (tag, attributes, children).hashCode
     }
 
     /**
@@ -422,6 +600,8 @@ object Dom {
      * inline JavaScript to be rendered as-is. Provides convenience methods
      * `inlineJs(code)` to inject escaped JavaScript or `externalJs(url)` to
      * link external scripts.
+     *
+     * Equality is structural across all `Element` implementations.
      *
      * @param attributes
      *   attribute key-value pairs
@@ -444,6 +624,12 @@ object Dom {
 
       def externalJs(url: String): Script =
         copy(attributes = attributes :+ Attribute.KeyValue("src", AttributeValue.StringValue(url)))
+
+      override def equals(other: Any): Boolean = other match {
+        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
+        case _          => false
+      }
+      override def hashCode: Int = (tag, attributes, children).hashCode
     }
 
     /**
@@ -452,6 +638,8 @@ object Dom {
      * The Style element renders its children WITHOUT HTML-escaping, allowing
      * inline CSS to be rendered as-is. Provides convenience method
      * `inlineCss(code)` to inject CSS code directly.
+     *
+     * Equality is structural across all `Element` implementations.
      *
      * @param attributes
      *   attribute key-value pairs
@@ -469,6 +657,12 @@ object Dom {
 
       def inlineCss(code: Css): Style =
         copy(children = children :+ Dom.Text(code.render))
+
+      override def equals(other: Any): Boolean = other match {
+        case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
+        case _          => false
+      }
+      override def hashCode: Int = (tag, attributes, children).hashCode
     }
 
     /**

--- a/html/shared/src/main/scala/zio/blocks/html/Dom.scala
+++ b/html/shared/src/main/scala/zio/blocks/html/Dom.scala
@@ -363,7 +363,7 @@ object Dom {
 
     /**
      * An `<option>` element, accepted as an element child of `select(...)` and
-     * `optgroup(...)`. Produced by the `option(...)`/`opt` DSL value.
+     * `optgroup(...)`. Produced by the `opt(...)`/`option(...)` DSL factories.
      */
     sealed trait Opt extends SelectChild
 

--- a/html/shared/src/main/scala/zio/blocks/html/Dom.scala
+++ b/html/shared/src/main/scala/zio/blocks/html/Dom.scala
@@ -231,16 +231,20 @@ object Dom {
 
     /**
      * Structural comparison shared by every concrete `Element` implementation:
-     * two elements are equal when their tag, attributes, and children match,
-     * regardless of the concrete classes involved.
+     * two elements are equal when their tag, attributes, children, and
+     * [[escapeText]] semantics match, regardless of the concrete classes
+     * involved. Escaping participates so that equal elements always render
+     * identically (`Script` never equals an equally-shaped `Generic`, since one
+     * renders its children raw and the other escapes them).
      */
     private[html] def structuralEquals(other: Any): Boolean = other match {
-      case e: Element => tag == e.tag && attributes == e.attributes && children == e.children
-      case _          => false
+      case e: Element =>
+        tag == e.tag && attributes == e.attributes && children == e.children && escapeText == e.escapeText
+      case _ => false
     }
 
     /** Hash code consistent with [[structuralEquals]]. */
-    private[html] def structuralHashCode: Int = (tag, attributes, children).hashCode
+    private[html] def structuralHashCode: Int = (tag, attributes, children, escapeText).hashCode
 
     private[html] def renderTo(sb: java.lang.StringBuilder): Unit = {
       sb.append('<')
@@ -376,9 +380,9 @@ object Dom {
      * in children is HTML-escaped during rendering.
      *
      * Equality is structural across all `Element` implementations: a `Generic`
-     * equals any other element with the same tag, attributes, and children,
-     * regardless of the concrete class (e.g., `Generic("li", ...)` equals the
-     * equivalent `LiElement`).
+     * equals any other element with the same tag, attributes, children, and
+     * text-escaping semantics, regardless of the concrete class (e.g.,
+     * `Generic("li", ...)` equals the equivalent `LiElement`).
      *
      * @param tag
      *   the element tag name (e.g., "div", "h1")
@@ -597,7 +601,10 @@ object Dom {
      * `inlineJs(code)` to inject escaped JavaScript or `externalJs(url)` to
      * link external scripts.
      *
-     * Equality is structural across all `Element` implementations.
+     * Equality is structural across all `Element` implementations, including
+     * the text-escaping semantics: because `Script` renders its children
+     * unescaped, it never equals an equally-shaped `Generic("script", ...)`,
+     * whose children would be escaped on render.
      *
      * @param attributes
      *   attribute key-value pairs
@@ -632,7 +639,10 @@ object Dom {
      * inline CSS to be rendered as-is. Provides convenience method
      * `inlineCss(code)` to inject CSS code directly.
      *
-     * Equality is structural across all `Element` implementations.
+     * Equality is structural across all `Element` implementations, including
+     * the text-escaping semantics: because `Style` renders its children
+     * unescaped, it never equals an equally-shaped `Generic("style", ...)`,
+     * whose children would be escaped on render.
      *
      * @param attributes
      *   attribute key-value pairs

--- a/html/shared/src/test/scala/zio/blocks/html/ContentModelsSpec.scala
+++ b/html/shared/src/test/scala/zio/blocks/html/ContentModelsSpec.scala
@@ -197,7 +197,7 @@ object ContentModelsSpec extends ZIOSpecDefault {
         val scriptEl: Dom.Element = script().inlineJs(js"console.log(1);")
         val generic: Dom.Element  =
           Dom.Element.Generic("script", Chunk.empty, Chunk(Dom.Text(js"console.log(1);".value)))
-        assertTrue(scriptEl != generic && scriptEl.hashCode != generic.hashCode)
+        assertTrue(scriptEl != generic)
       },
       test("elements with different escaping semantics diverge on raw content") {
         val raw                   = Chunk(Dom.Text("<b>&"))

--- a/html/shared/src/test/scala/zio/blocks/html/ContentModelsSpec.scala
+++ b/html/shared/src/test/scala/zio/blocks/html/ContentModelsSpec.scala
@@ -193,11 +193,17 @@ object ContentModelsSpec extends ZIOSpecDefault {
         val b: Dom.Element = li(id := "two", "x")
         assertTrue(a != b)
       },
-      test("script equals structurally identical Generic") {
+      test("script never equals structurally identical Generic (escaping differs)") {
         val scriptEl: Dom.Element = script().inlineJs(js"console.log(1);")
         val generic: Dom.Element  =
           Dom.Element.Generic("script", Chunk.empty, Chunk(Dom.Text(js"console.log(1);".value)))
-        assertTrue(scriptEl == generic)
+        assertTrue(scriptEl != generic && scriptEl.hashCode != generic.hashCode)
+      },
+      test("elements with different escaping semantics diverge on raw content") {
+        val raw                   = Chunk(Dom.Text("<b>&"))
+        val scriptEl: Dom.Element = Dom.Element.Script(Chunk.empty, raw)
+        val generic: Dom.Element  = Dom.Element.Generic("script", Chunk.empty, raw)
+        assertTrue(scriptEl != generic && scriptEl.render != generic.render)
       }
     )
   )

--- a/html/shared/src/test/scala/zio/blocks/html/ContentModelsSpec.scala
+++ b/html/shared/src/test/scala/zio/blocks/html/ContentModelsSpec.scala
@@ -16,6 +16,7 @@
 
 package zio.blocks.html
 
+import zio.blocks.chunk.Chunk
 import zio.test._
 
 object ContentModelsSpec extends ZIOSpecDefault {
@@ -33,6 +34,24 @@ object ContentModelsSpec extends ZIOSpecDefault {
       test("li with attributes") {
         val result = li(id := "item1", "text").render
         assertTrue(result == """<li id="item1">text</li>""")
+      },
+      test("ul mixes attributes and li children") {
+        val result = ul(id := "list", className := "items", li("a")).render
+        assertTrue(result == """<ul id="list" class="items"><li>a</li></ul>""")
+      },
+      test("ul from Iterable of li") {
+        val items  = List(li("a"), li("b"))
+        val result = ul(items).render
+        assertTrue(result == "<ul><li>a</li><li>b</li></ul>")
+      },
+      test("ol from Iterable of li") {
+        val items  = Vector(li("1"), li("2"))
+        val result = ol(items).render
+        assertTrue(result == "<ol><li>1</li><li>2</li></ol>")
+      },
+      test("empty ul and ol") {
+        assertTrue(ul().render == "<ul></ul>") &&
+        assertTrue(ol().render == "<ol></ol>")
       }
     ),
 
@@ -53,6 +72,28 @@ object ContentModelsSpec extends ZIOSpecDefault {
       test("td with attributes") {
         val result = td(colspan := "2", "V").render
         assertTrue(result == """<td colspan="2">V</td>""")
+      },
+      test("tr mixes attributes and cells") {
+        val result = tr(className := "row", th("H"), td("D")).render
+        assertTrue(result == """<tr class="row"><th>H</th><td>D</td></tr>""")
+      },
+      test("table mixes attributes and rows") {
+        val result = table(summaryAttr := "desc", tr(td("cell"))).render
+        assertTrue(result == """<table summary="desc"><tr><td>cell</td></tr></table>""")
+      },
+      test("tr from Iterable of cells") {
+        val cells  = List(th("H"), td("D"))
+        val result = tr(cells).render
+        assertTrue(result == "<tr><th>H</th><td>D</td></tr>")
+      },
+      test("table from Iterable of rows") {
+        val rows   = List(tr(td("a")), tr(td("b")))
+        val result = table(rows).render
+        assertTrue(result == "<table><tr><td>a</td></tr><tr><td>b</td></tr></table>")
+      },
+      test("empty table") {
+        assertTrue(table().render == "<table></table>") &&
+        assertTrue(tr().render == "<tr></tr>")
       }
     ),
 
@@ -75,6 +116,33 @@ object ContentModelsSpec extends ZIOSpecDefault {
         assertTrue(
           result == "<select><option>default</option><optgroup><option>a</option><option>b</option></optgroup></select>"
         )
+      },
+      test("optgroup factory returns Optgroup accepted by select") {
+        val group: Dom.Element.Optgroup = optgroup(option("a"), option("b"))
+        val result                      = select(group).render
+        assertTrue(result == "<select><optgroup><option>a</option><option>b</option></optgroup></select>")
+      },
+      test("optgroup mixes attributes and options") {
+        val result = optgroup(labelAttr := "Group", option("a")).render
+        assertTrue(result == """<optgroup label="Group"><option>a</option></optgroup>""")
+      },
+      test("select mixes attributes and children") {
+        val result = select(id := "s", name := "choice", option("x")).render
+        assertTrue(result == """<select id="s" name="choice"><option>x</option></select>""")
+      },
+      test("select from Iterable of children") {
+        val kids   = List(option("x"), optgroup(option("y")))
+        val result = select(kids).render
+        assertTrue(result == "<select><option>x</option><optgroup><option>y</option></optgroup></select>")
+      },
+      test("optgroup from Iterable of options") {
+        val opts   = List(option("a"), option("b"))
+        val result = optgroup(opts).render
+        assertTrue(result == "<optgroup><option>a</option><option>b</option></optgroup>")
+      },
+      test("empty select and optgroup") {
+        assertTrue(select().render == "<select></select>") &&
+        assertTrue(optgroup().render == "<optgroup></optgroup>")
       }
     ),
 
@@ -87,6 +155,49 @@ object ContentModelsSpec extends ZIOSpecDefault {
       test("when(false) on ul result") {
         val result = ul(li("a")).when(false)(id := "list")
         assertTrue(result.render == "<ul><li>a</li></ul>")
+      },
+      test("when(true) on tr result") {
+        val row = tr(td("cell")).when(true)(className := "r")
+        assertTrue(row.render == """<tr class="r"><td>cell</td></tr>""")
+      }
+    ),
+
+    // --- Structural equality across Element implementations ---
+    suite("structural equality")(
+      test("factory li equals structurally identical Generic") {
+        val typed: Dom.Element   = li("a")
+        val generic: Dom.Element = Dom.Element.Generic("li", Chunk.empty, Chunk(Dom.Text("a")))
+        assertTrue(typed == generic)
+      },
+      test("Generic equals factory li (symmetry)") {
+        val typed: Dom.Element   = li(id := "i1", "text")
+        val generic: Dom.Element = Dom.Element.Generic(
+          "li",
+          Chunk(Dom.Attribute.KeyValue("id", Dom.AttributeValue.StringValue("i1"))),
+          Chunk(Dom.Text("text"))
+        )
+        assertTrue(generic == typed)
+      },
+      test("equal elements have equal hashCodes") {
+        val typed: Dom.Element   = th("H")
+        val generic: Dom.Element = Dom.Element.Generic("th", Chunk.empty, Chunk(Dom.Text("H")))
+        assertTrue(typed.hashCode == generic.hashCode && typed == generic)
+      },
+      test("different tags are not equal despite same children shape") {
+        val headerCell: Dom.Element = th("X")
+        val dataCell: Dom.Element   = td("X")
+        assertTrue(headerCell != dataCell)
+      },
+      test("different attributes are not equal") {
+        val a: Dom.Element = li(id := "one", "x")
+        val b: Dom.Element = li(id := "two", "x")
+        assertTrue(a != b)
+      },
+      test("script equals structurally identical Generic") {
+        val scriptEl: Dom.Element = script().inlineJs(js"console.log(1);")
+        val generic: Dom.Element  =
+          Dom.Element.Generic("script", Chunk.empty, Chunk(Dom.Text(js"console.log(1);".value)))
+        assertTrue(scriptEl == generic)
       }
     )
   )

--- a/html/shared/src/test/scala/zio/blocks/html/ContextAwareHtmlSpec.scala
+++ b/html/shared/src/test/scala/zio/blocks/html/ContextAwareHtmlSpec.scala
@@ -98,7 +98,7 @@ object ContextAwareHtmlSpec extends ZIOSpecDefault {
         assertTrue(result.render == "<option selected></option>")
       },
       test("multiple is usable via ToModifier (BooleanAttribute)") {
-        val result = select.when(true)(multiple)
+        val result = select().when(true)(multiple)
         assertTrue(result.render == "<select multiple></select>")
       },
       test("autofocus is usable via ToModifier (BooleanAttribute)") {
@@ -110,7 +110,7 @@ object ContextAwareHtmlSpec extends ZIOSpecDefault {
         assertTrue(result.render == "<details open></details>")
       },
       test("reversed is usable via ToModifier (BooleanAttribute)") {
-        val result = ol.when(true)(reversed)
+        val result = ol().when(true)(reversed)
         assertTrue(result.render == "<ol reversed></ol>")
       },
       test("defer is usable via ToModifier (BooleanAttribute)") {

--- a/html/shared/src/test/scala/zio/blocks/html/HtmlElementsSpec.scala
+++ b/html/shared/src/test/scala/zio/blocks/html/HtmlElementsSpec.scala
@@ -341,7 +341,7 @@ object HtmlElementsSpec extends ZIOSpecDefault {
           rFigcaption == "<figcaption>x</figcaption>",
           rKbd == "<kbd>x</kbd>",
           rMeter == "<meter>x</meter>",
-          optgroup.render == "<optgroup></optgroup>",
+          optgroup().render == "<optgroup></optgroup>",
           rOutput == "<output>x</output>",
           rProgress == "<progress>x</progress>",
           rRuby == "<ruby>x</ruby>",
@@ -568,7 +568,7 @@ object HtmlElementsSpec extends ZIOSpecDefault {
         val rTextareaWrap    = textarea(wrap := "hard").render
         val rScriptIntegrity = script(integrity := "sha384-xxx").render
         val rImgReferrer     = img(referrerpolicy := "no-referrer").render
-        val rOlReversed      = ol.when(true)(reversed).render
+        val rOlReversed      = ol().when(true)(reversed).render
         val rIframeSandbox   = iframe(sandbox := "allow-scripts").render
         val rDivSpellcheck   = div(spellcheck := "true").render
         val rDivTranslate    = div(translate := "yes").render


### PR DESCRIPTION
## Summary

Follow-up to #1536, addressing the Copilot review ([pullrequestreview-5002429407](https://github.com/zio/zio-blocks/pull/1536#pullrequestreview-5002429407)):

### Content-model enforcement (review overview + suppressed comments on `HtmlElements.scala`)
- Replaced the remaining plain `Dom.Element` values `ul`, `ol`, `tr`, `table`, `select`, `optgroup` with typed factories whose element children are checked at compile time:
  - `ul(...)`/`ol(...)` accept `Li` children
  - `tr(...)` accepts `Th | Td` (`Cell`) children
  - `table(...)` accepts `Tr` rows
  - `select(...)` accepts `Opt | Optgroup` (`SelectChild`) children
  - `optgroup(...)` accepts `Opt` children only
- Attributes remain accepted alongside the constrained children; each factory has empty, varargs, and `Iterable` forms.
- Invalid children such as `ul(div("x"))` or `tr(p("x"))` no longer compile.

### Optgroup modifier hole (`Dom.scala`)
- Removed the unrestricted `apply(DomModifier*)`/`when` overrides from `OptgroupElement`; `<option>` children must go through the checked `optgroup(...)` factory.

### Structural equality (`Dom.scala`)
- Element equality is now structural across all concrete classes (`Generic`, `Script`, `Style`, and the typed elements), so `li(...)` once again equals a structurally identical `Generic("li", ...)`, symmetrically, with matching hash codes. The dead trait-level `equals`/`hashCode` override was removed.

### Sealed markers + Scaladoc (`Dom.scala`)
- `Li`, `Th`, `Td`, `Opt`, `Optgroup`, `Cell`, `SelectChild` are now `sealed`; new sealed `Tr` marker with its `TrElement` class.
- Added Scaladoc for every marker and typed element class (previously plain comments / missing).

### Docs (`docs/reference/html.md`)
- New "Typed Content Models" section with the enforcement table, compile-failure examples, factory forms, marker guarantees, and equality semantics; ADT sketch updated.

## Notes
- Scala 2.13 has no native union syntax, so the Scala 2 side follows the existing `ScriptArg`/`StyleArg` precedent with per-factory arg traits (`ListArg`, `CellArg`, `RowArg`, `SelectArg`, `OptgroupArg`) and implicit conversions; call-site syntax is identical across versions.
- `caption`/`colgroup`/`thead`/`tbody`/`tfoot` do not have markers yet — documented; compose such tables via the `html"` interpolator.

## Testing
- 791 tests pass on Scala 3.8.3, 2.13.18, and Scala.js
- Downstream `htmx` (JVM+JS), `datastar` (JVM+JS), `http-model-examples` green
- `docs/mdoc`: 0 errors