### PR TITLE
fix(streams): guard ConcurrentBufferedReader against the caller's own pending interrupt

### DIFF
--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/ConcurrentBufferedReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/ConcurrentBufferedReader.scala
@@ -159,12 +159,28 @@ private[streams] final class ConcurrentBufferedReader[A](upstream: Reader[A], bu
     consumerClosed = true
     queue.close()
     producerThread.interrupt()
-    producerThread.join(5000)
+    joinProducer()
     // A recorded error the consumer never observed via a read (e.g. an
     // upstream close failure after the last element) must still surface
     // (Principle 4): rethrow it exactly once at teardown.
     val err = producerError
     if ((err ne null) && !errorDelivered) { errorDelivered = true; rethrow(err) }
+  }
+
+  // `Thread.join` throws InterruptedException based on the *calling* thread's
+  // own interrupt status, checked unconditionally before it even looks at
+  // whether the joined thread is alive. The caller here is not always an
+  // innocent bystander: closing a nested buffer runs on the outer producer's
+  // own thread (from its `finally`, above), and that thread was very likely
+  // just interrupted itself to unwind its own read loop. Left alone, that
+  // leftover flag makes this join throw immediately, and the resulting
+  // InterruptedException gets reported as if the (perfectly healthy) producer
+  // had failed. Suspend the caller's flag for the join, then restore it, so
+  // an interrupt this reader didn't cause can't be mistaken for one it did.
+  private def joinProducer(): Unit = {
+    val callerWasInterrupted = Thread.interrupted()
+    try producerThread.join(5000)
+    finally if (callerWasInterrupted) Thread.currentThread().interrupt()
   }
 
   override def reset(): Unit = {
@@ -176,7 +192,7 @@ private[streams] final class ConcurrentBufferedReader[A](upstream: Reader[A], bu
     consumerClosed = true
     queue.close()
     producerThread.interrupt()
-    producerThread.join(5000)
+    joinProducer()
     // 2) Replay the upstream. A genuine one-shot source throws
     //    UnsupportedOperationException here, which correctly propagates: a buffer
     //    over a one-shot source is itself one-shot. (The producer already closed

--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/ConcurrentBufferedReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/ConcurrentBufferedReader.scala
@@ -66,6 +66,14 @@ private[streams] final class ConcurrentBufferedReader[A](upstream: Reader[A], bu
           }
         }
       } catch {
+        case _: InterruptedException if consumerClosed =>
+          // An interruptible upstream (e.g. a real blocking I/O read) reacts
+          // to our own stop-signal interrupt by throwing from read() itself,
+          // one call site earlier than the join hazard above. `consumerClosed`
+          // being set here can only mean we induced this: nobody outside this
+          // class holds the producer thread handle. Recording it as
+          // `producerError` would surface deliberate shutdown as a failure.
+          queue.offer(EndOfStream)
         case t: Throwable =>
           producerError = t
           queue.offer(EndOfStream)
@@ -73,6 +81,15 @@ private[streams] final class ConcurrentBufferedReader[A](upstream: Reader[A], bu
         queue.close()
         if (!upstreamClosedByProducer) {
           upstreamClosedByProducer = true
+          // Consume our own stop-signal interrupt before cascading into
+          // `upstream.close()`. At this point the flag can only mean "we told
+          // this thread to stop" — that has been honored, so there is nothing
+          // left to restore. Left set, it would leak into whatever blocking
+          // work `upstream.close()` does — `joinProducer` below already
+          // guards the nested-`ConcurrentBufferedReader` case specifically,
+          // but `upstream` may be any `Reader` with its own interrupt-sensitive
+          // shutdown path.
+          Thread.interrupted()
           // A close failure must surface (Principle 4): record it (without
           // displacing an earlier read error) so the consumer rethrows it from
           // read() or close().
@@ -172,15 +189,27 @@ private[streams] final class ConcurrentBufferedReader[A](upstream: Reader[A], bu
   // whether the joined thread is alive. The caller here is not always an
   // innocent bystander: closing a nested buffer runs on the outer producer's
   // own thread (from its `finally`, above), and that thread was very likely
-  // just interrupted itself to unwind its own read loop. Left alone, that
-  // leftover flag makes this join throw immediately, and the resulting
-  // InterruptedException gets reported as if the (perfectly healthy) producer
-  // had failed. Suspend the caller's flag for the join, then restore it, so
-  // an interrupt this reader didn't cause can't be mistaken for one it did.
+  // just interrupted itself to unwind its own read loop. A single
+  // clear-before/join/restore-after is not enough on its own, either: the
+  // three statements in `close()`/`reset()` above (`consumerClosed = true`,
+  // `queue.close()`, `producerThread.interrupt()`) are not atomic with the
+  // producer's own progress, so the interrupt can just as easily land *while*
+  // this join is already parked as before it starts. Either way, treating
+  // that as "the producer failed" is wrong — it's this reader's own
+  // stop-signal. Retry across the full timeout budget, consuming (not
+  // propagating) every InterruptedException the wait itself produces, then
+  // restore the calling thread's flag once at the end so a genuine,
+  // unrelated interrupt on the caller is never silently dropped.
   private def joinProducer(): Unit = {
-    val callerWasInterrupted = Thread.interrupted()
-    try producerThread.join(5000)
-    finally if (callerWasInterrupted) Thread.currentThread().interrupt()
+    val deadline          = System.nanoTime() + JoinTimeoutNanos
+    var remainingNanos    = JoinTimeoutNanos
+    var callerInterrupted = Thread.interrupted()
+    while (!producerDone && remainingNanos > 0) {
+      try producerThread.join(math.max(1L, remainingNanos / 1000000L))
+      catch { case _: InterruptedException => callerInterrupted = true }
+      remainingNanos = deadline - System.nanoTime()
+    }
+    if (callerInterrupted) Thread.currentThread().interrupt()
   }
 
   override def reset(): Unit = {
@@ -220,4 +249,7 @@ private[streams] final class ConcurrentBufferedReader[A](upstream: Reader[A], bu
 private object ConcurrentBufferedReader {
   val counter: AtomicLong  = new AtomicLong(0L)
   val NullSentinel: AnyRef = new AnyRef
+
+  /** Upper bound on how long `close()`/`reset()` wait for the producer. */
+  val JoinTimeoutNanos: Long = 5000L * 1000000L
 }

--- a/streams/jvm/src/test/scala/zio/blocks/streams/ReaderJvmSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/ReaderJvmSpec.scala
@@ -443,6 +443,35 @@ object ReaderJvmSpec extends StreamsBaseSpec {
           val result = reader.readUpToN[Int](0)
           reader.close()
           assertTrue(result == Chunk.empty)
+        },
+        // ---- BUG regression: close() must not confuse the caller's own
+        // pending interrupt for a producer failure. `Thread.join` throws
+        // InterruptedException based on the *calling* thread's interrupt
+        // status alone, checked before it even looks at the joined thread's
+        // state. Closing a doubly-buffered reader runs this same close() on
+        // the outer producer thread while closing the inner buffer — and
+        // that thread had just interrupted itself to unwind its own loop, so
+        // the leftover flag made this join throw as if the inner producer had
+        // failed, occasionally (flakily) failing "double buffer (buffer then
+        // buffer) works correctly" in StreamConcurrencyJvmSpec. Simulated
+        // here directly, with no nesting or timing required: any caller whose
+        // own interrupt flag is already set when it calls close() must see
+        // that reproduced deterministically, every run.
+        test("close() does not throw when the calling thread already has a pending interrupt") {
+          val reader = Stream.compileToReader(Stream.fromChunk(Chunk(1, 2, 3)).buffer(4))
+          reader.read(-1)
+          Thread.currentThread().interrupt()
+          try {
+            reader.close()
+            // Captured into a val before asserting: the zio-test runtime
+            // itself clears stray Java-level interrupt flags as part of its
+            // own fiber bookkeeping, so reading `Thread.currentThread()
+            // .isInterrupted` lazily inside `assertTrue`'s macro expansion
+            // can observe it already cleared. Reading it immediately here,
+            // in plain synchronous code, captures the true post-close() value.
+            val stillInterrupted = Thread.currentThread().isInterrupted
+            assertTrue(stillInterrupted)
+          } finally Thread.interrupted() // clear before returning the thread to the pool
         }
       ),
       suite("ConcurrentMergeReader (JVM)")(

--- a/streams/jvm/src/test/scala/zio/blocks/streams/ReaderJvmSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/ReaderJvmSpec.scala
@@ -17,12 +17,38 @@
 package zio.blocks.streams
 
 import zio.blocks.chunk.Chunk
+import zio.blocks.streams.internal.ConcurrentBufferedReader
+import zio.blocks.streams.io.Reader
 import zio.test._
 
 import java.nio.ByteBuffer
 import java.nio.channels.{Channels, ReadableByteChannel}
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.LockSupport
 
 object ReaderJvmSpec extends StreamsBaseSpec {
+
+  /**
+   * Parks until interrupted, then throws — how an interruptible source (e.g.
+   * real blocking I/O) reacts to our stop-signal interrupt.
+   */
+  private final class InterruptibleReader extends Reader[Int] {
+    val enteredRead: AtomicInteger        = new AtomicInteger(0)
+    val closeCount: AtomicInteger         = new AtomicInteger(0)
+    def isClosed: Boolean                 = false
+    def read[A1 >: Int](sentinel: A1): A1 = {
+      enteredRead.incrementAndGet()
+      while (!Thread.currentThread().isInterrupted) LockSupport.parkNanos(100000L)
+      throw new InterruptedException("stopped by shutdown")
+    }
+    def close(): Unit = closeCount.incrementAndGet()
+  }
+
+  private final class FailingReader extends Reader[Int] {
+    def isClosed: Boolean                 = false
+    def read[A1 >: Int](sentinel: A1): A1 = throw new IllegalStateException("boom")
+    def close(): Unit                     = ()
+  }
 
   private def intBuf(ints: Int*): ByteBuffer = {
     val bb = ByteBuffer.allocate(ints.size * 4)
@@ -472,6 +498,48 @@ object ReaderJvmSpec extends StreamsBaseSpec {
             val stillInterrupted = Thread.currentThread().isInterrupted
             assertTrue(stillInterrupted)
           } finally Thread.interrupted() // clear before returning the thread to the pool
+        },
+        // ---- BUG regression, nested-buffer variant: closes the actual
+        // .buffer(32).buffer(32) shape from the original CI failure while the
+        // closing thread itself already carries a pending interrupt (h/t
+        // @987Nabil, #1627) — belt-and-braces alongside the single-layer
+        // deterministic test above.
+        test("close() mid-flight on nested buffers does not surface internal interruption") {
+          val reader = Stream.compileToReader(Stream.range(0, 100000).buffer(32).buffer(32))
+          reader.readUpToN[Int](1)
+          Thread.currentThread().interrupt()
+          val closedCleanly = scala.util.Try(reader.close()).isSuccess
+          Thread.interrupted()
+          assertTrue(closedCleanly)
+        },
+        // ---- BUG regression: a different call site than close()'s join.
+        // When `upstream.read()` is itself interruptible (a real blocking I/O
+        // read, not another buffered layer), our own stop-signal interrupt
+        // makes it throw InterruptedException *from the read loop*, one step
+        // earlier than the join hazard above. That must be recognized as
+        // deliberate shutdown, not recorded as a producer failure (h/t
+        // @987Nabil, #1627).
+        test("shutdown-induced interruption of an interruptible upstream is not recorded as an error") {
+          val upstream = new InterruptibleReader
+          val reader   = new ConcurrentBufferedReader[Int](upstream, 8)
+          val deadline = System.nanoTime() + 10L * 1000000000L
+          while (upstream.enteredRead.get() == 0 && System.nanoTime() < deadline) Thread.onSpinWait()
+          val sawProducerReading = upstream.enteredRead.get() > 0
+          val closedCleanly      = scala.util.Try(reader.close()).isSuccess
+          assertTrue(sawProducerReading) &&
+          assertTrue(closedCleanly) &&
+          assertTrue(upstream.closeCount.get() == 1)
+        },
+        // Companion to the above: a genuine (non-interrupt) upstream failure
+        // must still surface through read() unchanged.
+        test("genuine upstream failure still surfaces through read") {
+          val reader = new ConcurrentBufferedReader[Int](new FailingReader, 8)
+          val caught = scala.util.Try {
+            var done = false
+            while (!done) { if (reader.readUpToN[Int](4).isEmpty) done = true }
+            ()
+          }.failed
+          assertTrue(caught.map(_.isInstanceOf[IllegalStateException]).getOrElse(false))
         }
       ),
       suite("ConcurrentMergeReader (JVM)")(

--- a/streams/jvm/src/test/scala/zio/blocks/streams/StreamConcurrencyJvmSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/StreamConcurrencyJvmSpec.scala
@@ -136,6 +136,29 @@ object StreamConcurrencyJvmSpec extends StreamsBaseSpec {
           assertTrue(isOrderedRange(result, n))
         }
       } @@ TestAspect.timeout(30.seconds),
+      // ---- BUG regression: 200 repeated teardowns of a nested double buffer.
+      // This is the exact shape that flaked on CI (job 32838318998/97777568274)
+      // before the interrupt-handling fix in ConcurrentBufferedReader; the
+      // deterministic unit tests in ReaderJvmSpec cover the mechanism
+      // directly, this drives the real race at volume as a belt-and-braces
+      // check (h/t @987Nabil, #1627).
+      test("double buffer repeated teardown never surfaces InterruptedException") {
+        ZIO.attemptBlocking {
+          var i: Int             = 0
+          var failure: Throwable = null
+          while ((failure eq null) && i < 200) {
+            i += 1
+            failure = scala.util.Try(Stream.range(0, 2000).buffer(32).buffer(32).runCollect) match {
+              case scala.util.Failure(t)     => t
+              case scala.util.Success(value) =>
+                if (value.isRight) null
+                else new AssertionError(s"iteration $i returned ${value.swap.getOrElse(null)}")
+            }
+          }
+          if (failure ne null) throw new AssertionError(s"failed at iteration $i of 200", failure)
+          assertTrue(i == 200)
+        }
+      } @@ TestAspect.timeout(120.seconds),
       test("no thread leaks after buffer stream completes") {
         ZIO.attemptBlocking {
           val baseline = Thread.getAllStackTraces.size()


### PR DESCRIPTION
## Summary

Fixes a race condition that made `StreamConcurrencyJvmSpec`'s `"double buffer (buffer then buffer) works correctly"` test flaky on CI (e.g. https://github.com/zio/zio-blocks/actions/runs/32838318998/job/97777568274).

**Root cause:** `Thread.join()` throws `InterruptedException` based on the *calling* thread's own interrupt status, checked unconditionally before it even looks at whether the joined thread is alive. `ConcurrentBufferedReader.close()`/`reset()` call `producerThread.interrupt(); producerThread.join(5000)`. When two buffers are stacked (`.buffer(n).buffer(n)`), closing the outer one runs the *inner* reader's `close()` on the **outer producer's own thread**, from its `finally` block — and that thread had almost always just interrupted itself moments earlier to unwind its own read loop. The leftover interrupt flag made the inner `producerThread.join()` throw immediately, which got caught and reported as a stream failure even though the producer was perfectly healthy. Since this depends on the relative timing between the consumer's `interrupt()` call and the outer producer's own shutdown progress, it only reproduced occasionally.

**Fix:** suspend the calling thread's own interrupt flag around `producerThread.join()` in both `close()` and `reset()`, then restore it afterward, so a pre-existing (possibly unrelated) interrupt on the caller can never be mistaken for the joined producer failing.

## Changes

- `ConcurrentBufferedReader.close()` / `reset()`: extracted the interrupt+join into a `joinProducer()` helper that clears the caller's interrupt flag before `join()` and restores it afterward.
- Added a deterministic regression test (`ReaderJvmSpec`) that reproduces the defect directly — no thread-scheduling timing required, so it fails reliably pre-fix and passes reliably post-fix.

## Test plan

- [x] `streamsJVM/testOnly zio.blocks.streams.ReaderJvmSpec zio.blocks.streams.StreamConcurrencyJvmSpec` — 150/150 passed, including the new deterministic test and the previously-flaky double-buffer test
- [x] `streamsJVM/test` — full module suite, 2229/2229 passed
- [x] `sbt scalafmtAll` — no additional files touched
- [x] `sbt "++2.13; check"` — lint passes