### PR TITLE
fix(streams): make buffer teardown interrupt-safe across nested close cascades

### DIFF
--- a/streams/jvm/src/main/scala/zio/blocks/streams/internal/ConcurrentBufferedReader.scala
+++ b/streams/jvm/src/main/scala/zio/blocks/streams/internal/ConcurrentBufferedReader.scala
@@ -67,12 +67,27 @@ private[streams] final class ConcurrentBufferedReader[A](upstream: Reader[A], bu
         }
       } catch {
         case t: Throwable =>
-          producerError = t
+          // An InterruptedException we induced ourselves (by interrupting this
+          // producer from `close()`/`reset()`) is an internal shutdown
+          // artifact, not an upstream failure: recording it would surface a
+          // spurious error to the consumer at teardown. Genuine failures
+          // outside a stop request keep the previous behavior unchanged.
+          if (!(t.isInstanceOf[InterruptedException] && consumerClosed)) {
+            producerError = t
+          }
           queue.offer(EndOfStream)
       } finally {
         queue.close()
         if (!upstreamClosedByProducer) {
           upstreamClosedByProducer = true
+          // Consume the stop-signal interrupt before cascading teardown. At
+          // this point the flag can only mean "we told you to stop" (nobody
+          // outside this class holds the producer thread handle), and that
+          // signal has been honored. Forwarding it into another reader's
+          // close() — whose join() is interrupt-sensitive, e.g. nested
+          // buffers — would abort that teardown with a spurious
+          // InterruptedException.
+          Thread.interrupted()
           // A close failure must surface (Principle 4): record it (without
           // displacing an earlier read error) so the consumer rethrows it from
           // read() or close().
@@ -159,7 +174,7 @@ private[streams] final class ConcurrentBufferedReader[A](upstream: Reader[A], bu
     consumerClosed = true
     queue.close()
     producerThread.interrupt()
-    producerThread.join(5000)
+    awaitProducerTermination()
     // A recorded error the consumer never observed via a read (e.g. an
     // upstream close failure after the last element) must still surface
     // (Principle 4): rethrow it exactly once at teardown.
@@ -170,13 +185,13 @@ private[streams] final class ConcurrentBufferedReader[A](upstream: Reader[A], bu
   override def reset(): Unit = {
     // `buffer` is a pure decoupling transform: it must not weaken replayability.
     // 1) Fully terminate the current producer so no thread touches `upstream` or
-    //    the fields below. `Thread.join` establishes happens-before with the
-    //    producer's termination, making the subsequent single-threaded mutation
+    //    the fields below. Awaiting the producer establishes happens-before with
+    //    its termination, making the subsequent single-threaded mutation
     //    (including the non-volatile `upstreamClosedByProducer`) safe.
     consumerClosed = true
     queue.close()
     producerThread.interrupt()
-    producerThread.join(5000)
+    awaitProducerTermination()
     // 2) Replay the upstream. A genuine one-shot source throws
     //    UnsupportedOperationException here, which correctly propagates: a buffer
     //    over a one-shot source is itself one-shot. (The producer already closed
@@ -192,6 +207,24 @@ private[streams] final class ConcurrentBufferedReader[A](upstream: Reader[A], bu
     producerThread = spawnProducer()
   }
 
+  /**
+   * Waits up to [[JoinTimeoutNanos]] for the producer to terminate, ignoring
+   * interruption of the calling thread. Teardown legitimately runs on threads
+   * that carry an interrupt status (nested buffers cascade close() across
+   * producer threads, and effect runtimes may interrupt a blocked closer),
+   * while `Thread.join` aborts immediately in that case — leaving the producer
+   * unjoined and teardown half-done. Any interrupt observed here is consumed.
+   */
+  private def awaitProducerTermination(): Unit = {
+    val deadline  = System.nanoTime() + JoinTimeoutNanos
+    var remaining = JoinTimeoutNanos
+    while (!producerDone && remaining > 0) {
+      try producerThread.join(math.max(1L, remaining / 1000000L))
+      catch { case _: InterruptedException => () }
+      remaining = deadline - System.nanoTime()
+    }
+  }
+
   private def rethrow(t: Throwable): Nothing = {
     errorDelivered = true
     t match {
@@ -204,4 +237,7 @@ private[streams] final class ConcurrentBufferedReader[A](upstream: Reader[A], bu
 private object ConcurrentBufferedReader {
   val counter: AtomicLong  = new AtomicLong(0L)
   val NullSentinel: AnyRef = new AnyRef
+
+  /** Upper bound on how long `close()`/`reset()` wait for the producer. */
+  val JoinTimeoutNanos: Long = 5000L * 1000000L
 }

--- a/streams/jvm/src/test/scala/zio/blocks/streams/ReaderJvmSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/ReaderJvmSpec.scala
@@ -17,12 +17,38 @@
 package zio.blocks.streams
 
 import zio.blocks.chunk.Chunk
+import zio.blocks.streams.internal.ConcurrentBufferedReader
+import zio.blocks.streams.io.Reader
 import zio.test._
 
 import java.nio.ByteBuffer
 import java.nio.channels.{Channels, ReadableByteChannel}
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.LockSupport
 
 object ReaderJvmSpec extends StreamsBaseSpec {
+
+  /**
+   * Parks until interrupted, then throws — how an interruptible source reacts
+   * to our stop-signal.
+   */
+  private final class InterruptibleReader extends Reader[Int] {
+    val enteredRead                       = new AtomicInteger(0)
+    val closeCount                        = new AtomicInteger(0)
+    def isClosed: Boolean                 = false
+    def read[A1 >: Int](sentinel: A1): A1 = {
+      enteredRead.incrementAndGet()
+      while (!Thread.currentThread().isInterrupted()) LockSupport.parkNanos(100000L)
+      throw new InterruptedException("stopped by shutdown")
+    }
+    def close(): Unit = closeCount.incrementAndGet()
+  }
+
+  private final class FailingReader extends Reader[Int] {
+    def isClosed: Boolean                 = false
+    def read[A1 >: Int](sentinel: A1): A1 = throw new IllegalStateException("boom")
+    def close(): Unit                     = ()
+  }
 
   private def intBuf(ints: Int*): ByteBuffer = {
     val bb = ByteBuffer.allocate(ints.size * 4)
@@ -443,6 +469,40 @@ object ReaderJvmSpec extends StreamsBaseSpec {
           val result = reader.readUpToN[Int](0)
           reader.close()
           assertTrue(result == Chunk.empty)
+        },
+        test("close() mid-flight on nested buffers does not surface internal interruption") {
+          // Regression: closing while both producers are still draining forces
+          // the stop-interrupt cascade across nested teardown — the outer
+          // producer runs the inner close() while carrying its own stop-signal
+          // interrupt, and the inner join() used to abort with a spurious
+          // InterruptedException that surfaced from close(). The preset flag on
+          // the closing thread additionally pins the caller-side contract.
+          val reader = Stream.compileToReader(Stream.range(0, 100000).buffer(32).buffer(32))
+          reader.readUpToN[Int](1)
+          Thread.currentThread().interrupt()
+          val closedCleanly = scala.util.Try(reader.close()).isSuccess
+          Thread.interrupted()
+          assertTrue(closedCleanly)
+        },
+        test("shutdown-induced interruption of an interruptible upstream is not recorded as an error") {
+          val upstream = new InterruptibleReader
+          val reader   = new ConcurrentBufferedReader[Int](upstream, 8)
+          val deadline = System.nanoTime() + 10L * 1000000000L
+          while (upstream.enteredRead.get() == 0 && System.nanoTime() < deadline) Thread.onSpinWait()
+          val sawProducerReading = upstream.enteredRead.get() > 0
+          val closedCleanly      = scala.util.Try(reader.close()).isSuccess
+          assertTrue(sawProducerReading) &&
+          assertTrue(closedCleanly) &&
+          assertTrue(upstream.closeCount.get() == 1)
+        },
+        test("genuine upstream failure still surfaces through read") {
+          val reader = new ConcurrentBufferedReader[Int](new FailingReader, 8)
+          val caught = scala.util.Try {
+            var done = false
+            while (!done) { if (reader.readUpToN[Int](4).isEmpty) done = true }
+            ()
+          }.failed
+          assertTrue(caught.map(_.isInstanceOf[IllegalStateException]).getOrElse(false))
         }
       ),
       suite("ConcurrentMergeReader (JVM)")(

--- a/streams/jvm/src/test/scala/zio/blocks/streams/StreamConcurrencyJvmSpec.scala
+++ b/streams/jvm/src/test/scala/zio/blocks/streams/StreamConcurrencyJvmSpec.scala
@@ -136,6 +136,25 @@ object StreamConcurrencyJvmSpec extends StreamsBaseSpec {
           assertTrue(isOrderedRange(result, n))
         }
       } @@ TestAspect.timeout(30.seconds),
+      test("double buffer repeated teardown never surfaces InterruptedException") {
+        ZIO.attemptBlocking {
+          var i: Int             = 0
+          var failure: Throwable = null
+          while ((failure eq null) && i < 200) {
+            i += 1
+            failure = scala.util.Try(Stream.range(0, 2000).buffer(32).buffer(32).runCollect) match {
+              case scala.util.Failure(t)     => t
+              case scala.util.Success(value) =>
+                if (value.isRight) null
+                else new java.lang.AssertionError(s"iteration $i returned ${value.swap.getOrElse(null)}")
+            }
+          }
+          // Fail with the original exception (and its stack trace), tagged
+          // with the iteration that broke, instead of a bare boolean.
+          if (failure ne null) throw new java.lang.AssertionError(s"failed at iteration $i of 200", failure)
+          assertTrue(i == 200)
+        }
+      } @@ TestAspect.timeout(120.seconds),
       test("no thread leaks after buffer stream completes") {
         ZIO.attemptBlocking {
           val baseline = Thread.getAllStackTraces.size()


### PR DESCRIPTION
## Summary

Fixes a flaky teardown race in `ConcurrentBufferedReader` that broke `main` CI (run 32838318998, `testJVM (25, JVM, 2.13.x)` leg): `StreamConcurrencyJvmSpec` "double buffer (buffer then buffer) works correctly" failed with `java.lang.InterruptedException` born at `ConcurrentBufferedReader.close`'s `producerThread.join`.

### Root cause

With nested buffers, the outer producer runs the inner reader's `close()` from its own finally block. The stop-signal interrupt issued by the outer `close()` could land after the producer left its read loop but before it entered the nested close — leaving its interrupt flag set. Since `Thread.join` aborts immediately when the *calling* thread is interrupted, the inner close threw `InterruptedException`, which was recorded as `producerError` and rethrown to the consumer at teardown.

### Fix — three layers, each closing a distinct door

1. **Producer consumes its own stop-signal** (`Thread.interrupted()` before cascading into `upstream.close()`): nobody outside this class holds the producer thread handle, so at that point the flag can only mean "stop" — which has already been honored. It must not leak into another reader's interrupt-sensitive `join`.
2. **Interrupt-insensitive, deadline-bounded wait**: `close()`/`reset()` use `awaitProducerTermination()` instead of bare `join(5000)`, so teardown also survives external interruption of the *closing* thread (e.g. effect-runtime cancellation mid-teardown). Timeout semantics unchanged.
3. **Honest error taxonomy**: an `InterruptedException` induced by our own shutdown is no longer recorded as `producerError`; genuine failures outside a stop request keep prior behavior (Principle 4 preserved).

Hot read path untouched — only teardown changed; zero cost on element flow, virtual-thread friendly (park/join based).

## Test plan

- New deterministic regressions in `ReaderJvmSpec` (JVM):
  - `close()` mid-flight on nested buffers with a preset caller interrupt flag must return cleanly (fails on old code by construction: the cascade hits `join` on a flagged thread).
  - An interruptible upstream's shutdown-induced `InterruptedException` is not surfaced; genuine upstream failures still propagate through `read`.
- New stress test in `StreamConcurrencyJvmSpec`: 200 rounds of `range(0,2000).buffer(32).buffer(32).runCollect` must never fail.
- `sbt fmt` clean; `streamsJVM/test` green on both legs: Scala 3.8.3 (2232 passed) and Scala 2.13.18 (2224 passed), JDK 25.
- `streams-benchmark/compile` sanity-checked.