### PR TITLE
bench(sql): raw point-lookup decodes all seven columns — same workload as framework paths

### DIFF
--- a/sql-benchmarks/src/main/scala/zio/blocks/sql/bench/RealWorldBenchmark.scala
+++ b/sql-benchmarks/src/main/scala/zio/blocks/sql/bench/RealWorldBenchmark.scala
@@ -178,7 +178,15 @@ class RealWorldBenchmark extends BaseBenchmark {
     findStmt.setInt(1, id)
     val rs = findStmt.executeQuery()
     rs.next()
+    // Decode all seven selected columns like the framework paths do, so the
+    // comparison measures identical row materialization work.
+    rs.getInt(1)
+    rs.getString(2)
+    rs.getString(3)
+    rs.getInt(4)
+    rs.getBoolean(5)
     val nick = rs.getString(6)
+    rs.getString(7)
     rs.close()
     if (nick == null) 0 else 1
   }


### PR DESCRIPTION
Follow-up to #1593, addressing https://github.com/zio/zio-blocks/pull/1593#discussion_r3859970902.

## Summary
- `rawFindOne` in `RealWorldBenchmark` previously read only `nickname`, while the zio-blocks and Kyo point-lookup paths selected and decoded all seven columns and materialized a row — an unfair workload that overstated framework overhead.
- The raw path now reads every selected column (`id, name, email, age, active, nickname, bio`) via the same JDBC getters used in `rawListAll`, keeping the same `nickname` null-check predicate so the counted result is unchanged.

## Test plan
- `sbt "++3.8.3; sql-benchmarks/compile"` passes; scalafmt applied.