### PR TITLE
fix(sql,migration): SQLite dequeue uses BEGIN IMMEDIATE + busy_timeout to prevent SQLITE_BUSY

### DIFF
--- a/dataMigration/shared/src/main/scala/zio/blocks/data/migration/QueueTable.scala
+++ b/dataMigration/shared/src/main/scala/zio/blocks/data/migration/QueueTable.scala
@@ -25,7 +25,9 @@ import zio.blocks.sql.Frag.*
  *
  * Queue tables store IDs of aggregates pending migration. Workers dequeue
  * batches via `SELECT ... FOR UPDATE SKIP LOCKED` on PostgreSQL; SQLite uses a
- * plain `LIMIT` since it serializes writes.
+ * plain `LIMIT` with the write lock held via `BEGIN IMMEDIATE` (see
+ * `JdbcTransactor.transact` for the SQLite immediate-mode handling and
+ * `busy_timeout`).
  */
 object QueueTable {
 
@@ -141,7 +143,13 @@ object QueueTable {
   /**
    * Dequeues up to `batchSize` IDs. Uses the given `dialect` to generate
    * database-appropriate locking — `FOR UPDATE SKIP LOCKED` on PostgreSQL,
-   * plain `LIMIT` on SQLite (which serializes writes via BEGIN IMMEDIATE).
+   * plain `LIMIT` on SQLite.
+   *
+   * On SQLite the transaction must already hold the write lock before the
+   * SELECT; `JdbcTransactor.transact` starts SQLite transactions with
+   * `BEGIN IMMEDIATE` and `PRAGMA busy_timeout = 5000` so the worker reserves
+   * the write lock and waits on contention instead of failing the later DELETE
+   * with `SQLITE_BUSY`. Single-consumer only on SQLite.
    */
   def dequeue[ID](tableName: String, batchSize: Int)(using tx: DbTx, codec: DbCodec[ID], dialect: Dialect): List[ID] = {
     require(batchSize > 0, "batchSize must be positive")

--- a/dataMigration/shared/src/main/scala/zio/blocks/data/migration/QueueTable.scala
+++ b/dataMigration/shared/src/main/scala/zio/blocks/data/migration/QueueTable.scala
@@ -25,9 +25,10 @@ import zio.blocks.sql.Frag.*
  *
  * Queue tables store IDs of aggregates pending migration. Workers dequeue
  * batches via `SELECT ... FOR UPDATE SKIP LOCKED` on PostgreSQL; SQLite uses a
- * plain `LIMIT` with the write lock held via `IMMEDIATE` (connections from
- * `JdbcTransactor.fromUrl`/`sqlite` are configured with `busy_timeout=5000` and
- * `transaction_mode=IMMEDIATE`, so `transact` reserves the lock and waits on
+ * plain `LIMIT` with the write lock held via `IMMEDIATE` (SQLite connections
+ * via `JdbcTransactor.fromUrl`/`sqlite` or any pooled/wrapped `DataSource` are
+ * configured per-transaction with `busy_timeout=5000` and `IMMEDIATE` via
+ * `isWrapperFor`/`unwrap`, so `transact`/`connect` reserve the lock and wait on
  * contention; see PR #1534 discussion_r3863454094).
  */
 object QueueTable {
@@ -147,8 +148,10 @@ object QueueTable {
    * plain `LIMIT` on SQLite.
    *
    * On SQLite the transaction must already hold the write lock before the
-   * SELECT; `JdbcTransactor.fromUrl`/`sqlite` create SQLite connections with
-   * `busy_timeout=5000` and `transaction_mode=IMMEDIATE` so that `transact`
+   * SELECT; `JdbcTransactor` configures any SQLite `Connection` (including
+   * pooled/wrapped via `isWrapperFor`/`unwrap`) per-transaction with
+   * `busy_timeout=5000` and `IMMEDIATE` (also `fromUrl` properties and
+   * `sqlite(DataSource)` for concrete `SQLiteDataSource`), so `transact`
    * reserves the write lock and waits on contention instead of failing the
    * later `DELETE` with `SQLITE_BUSY`. Single-consumer only on SQLite. See PR
    * #1534 discussion_r3863454094.

--- a/dataMigration/shared/src/main/scala/zio/blocks/data/migration/QueueTable.scala
+++ b/dataMigration/shared/src/main/scala/zio/blocks/data/migration/QueueTable.scala
@@ -28,8 +28,10 @@ import zio.blocks.sql.Frag.*
  * plain `LIMIT` with the write lock held via `IMMEDIATE` (SQLite connections
  * via `JdbcTransactor.fromUrl`/`sqlite` or any pooled/wrapped `DataSource` are
  * configured per-transaction with `busy_timeout=5000` and `IMMEDIATE` via
- * `isWrapperFor`/`unwrap`, so `transact`/`connect` reserve the lock and wait on
- * contention; see PR #1534 discussion_r3863454094).
+ * `isWrapperFor`/`unwrap`, so `transact` reserves the write lock and waits on
+ * contention; `connect` is configured similarly but does not begin a
+ * transaction or reserve the lock — only `transact` issues `BEGIN IMMEDIATE`;
+ * see PR #1534 discussion_r3863454094).
  */
 object QueueTable {
 

--- a/dataMigration/shared/src/main/scala/zio/blocks/data/migration/QueueTable.scala
+++ b/dataMigration/shared/src/main/scala/zio/blocks/data/migration/QueueTable.scala
@@ -25,9 +25,10 @@ import zio.blocks.sql.Frag.*
  *
  * Queue tables store IDs of aggregates pending migration. Workers dequeue
  * batches via `SELECT ... FOR UPDATE SKIP LOCKED` on PostgreSQL; SQLite uses a
- * plain `LIMIT` with the write lock held via `BEGIN IMMEDIATE` (see
- * `JdbcTransactor.transact` for the SQLite immediate-mode handling and
- * `busy_timeout`).
+ * plain `LIMIT` with the write lock held via `IMMEDIATE` (connections from
+ * `JdbcTransactor.fromUrl`/`sqlite` are configured with `busy_timeout=5000` and
+ * `transaction_mode=IMMEDIATE`, so `transact` reserves the lock and waits on
+ * contention; see PR #1534 discussion_r3863454094).
  */
 object QueueTable {
 
@@ -146,10 +147,11 @@ object QueueTable {
    * plain `LIMIT` on SQLite.
    *
    * On SQLite the transaction must already hold the write lock before the
-   * SELECT; `JdbcTransactor.transact` starts SQLite transactions with
-   * `BEGIN IMMEDIATE` and `PRAGMA busy_timeout = 5000` so the worker reserves
-   * the write lock and waits on contention instead of failing the later DELETE
-   * with `SQLITE_BUSY`. Single-consumer only on SQLite.
+   * SELECT; `JdbcTransactor.fromUrl`/`sqlite` create SQLite connections with
+   * `busy_timeout=5000` and `transaction_mode=IMMEDIATE` so that `transact`
+   * reserves the write lock and waits on contention instead of failing the
+   * later `DELETE` with `SQLITE_BUSY`. Single-consumer only on SQLite. See PR
+   * #1534 discussion_r3863454094.
    */
   def dequeue[ID](tableName: String, batchSize: Int)(using tx: DbTx, codec: DbCodec[ID], dialect: Dialect): List[ID] = {
     require(batchSize > 0, "batchSize must be positive")

--- a/sql-zio/src/test/scala/zio/blocks/sql/zio/JdbcTransactorLayersSpec.scala
+++ b/sql-zio/src/test/scala/zio/blocks/sql/zio/JdbcTransactorLayersSpec.scala
@@ -50,6 +50,64 @@ object JdbcTransactorLayersSpec extends ZIOSpecDefault {
       )
       .asInstanceOf[DataSource]
 
+  private def pooledSqliteDataSource(delegate: DataSource): DataSource =
+    Proxy
+      .newProxyInstance(
+        getClass.getClassLoader,
+        Array(classOf[DataSource]),
+        new InvocationHandler {
+          override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef = method.getName match {
+            case "getConnection" => pooledConnection(delegate.getConnection)
+            case "getLogWriter"    => delegate.getLogWriter
+            case "setLogWriter"    => delegate.setLogWriter(args.nn(0).asInstanceOf[java.io.PrintWriter]); null
+            case "setLoginTimeout" => delegate.setLoginTimeout(args.nn(0).asInstanceOf[Integer].intValue()); null
+            case "getLoginTimeout" => Integer.valueOf(delegate.getLoginTimeout)
+            case "getParentLogger" => delegate.getParentLogger
+            case "unwrap" =>
+              val iface = args.nn(0).asInstanceOf[Class[?]]
+              if (iface.isInstance(delegate)) delegate else null
+            case "isWrapperFor" =>
+              val iface = args.nn(0).asInstanceOf[Class[?]]
+              java.lang.Boolean.valueOf(iface.isInstance(delegate) || delegate.isWrapperFor(iface))
+            case "toString" => "PooledTestDataSource"
+            case _          => null
+          }
+        }
+      )
+      .asInstanceOf[DataSource]
+
+  private def pooledConnection(delegate: Connection): Connection =
+    Proxy
+      .newProxyInstance(
+        getClass.getClassLoader,
+        Array(classOf[Connection]),
+        new InvocationHandler {
+          override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef = method.getName match {
+            case "prepareStatement" => delegate.prepareStatement(args.nn(0).asInstanceOf[String])
+            case "createStatement"  => delegate.createStatement()
+            case "getAutoCommit"    => java.lang.Boolean.valueOf(delegate.getAutoCommit)
+            case "setAutoCommit"    => delegate.setAutoCommit(args.nn(0).asInstanceOf[java.lang.Boolean].booleanValue()); null
+            case "commit"           => delegate.commit(); null
+            case "rollback"         => delegate.rollback(); null
+            case "close"            => delegate.close(); null
+            case "isClosed"         => java.lang.Boolean.valueOf(delegate.isClosed)
+            case "isWrapperFor" =>
+              val iface = args.nn(0).asInstanceOf[Class[?]]
+              java.lang.Boolean.valueOf(iface.isInstance(delegate) || delegate.isWrapperFor(iface))
+            case "unwrap" =>
+              val iface = args.nn(0).asInstanceOf[Class[?]]
+              if (iface.isInstance(delegate)) delegate
+              else delegate.unwrap(iface)
+            case "toString" => "PooledTestConnection"
+            case _ =>
+              // delegate other methods
+              try method.invoke(delegate, args.nnOrNull: _*)
+              catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+          }
+        }
+      )
+      .asInstanceOf[Connection]
+
   private def connection(): Connection =
     Proxy
       .newProxyInstance(
@@ -166,6 +224,41 @@ object JdbcTransactorLayersSpec extends ZIOSpecDefault {
 
       program
         .provideLayer(ZLayer.succeed(h2DataSource) >>> JdbcTransactor.sqliteLayer)
+        .map(result => assertTrue(result == Maybe(1)))
+    },
+    test("sqlite via pooled DataSource still executes transact") {
+      // Verifies that sqlite(DataSource) works even when the DataSource is
+      // wrapped/pooled (isWrapperFor/unwrap path). The per-connection
+      // configureSQLiteConnection should handle wrapped SQLiteConnections.
+      val pooled = pooledSqliteDataSource(h2DataSource)
+      val program = ZIO.serviceWith[Transactor] { transactor =>
+        transactor.transact {
+          sql"SELECT 1".queryOne[Int]
+        }
+      }
+      program
+        .provideLayer(ZLayer.succeed(pooled) >>> JdbcTransactor.sqliteLayer)
+        .map(result => assertTrue(result == Maybe(1)))
+    },
+    test("real SQLite in-memory verifies busy timeout and IMMEDIATE via driver properties") {
+      // Uses a real SQLite DataSource to verify that fromUrl and
+      // fromDataSource actually create SQLite connections with busy timeout
+      // and IMMEDIATE. This would fail with SQLITE_BUSY if misconfigured.
+      val ds = {
+        val sds = new org.sqlite.SQLiteDataSource()
+        sds.setUrl("jdbc:sqlite::memory:")
+        sds
+      }
+      val program = ZIO.serviceWith[Transactor] { transactor =>
+        transactor.transact {
+          // Simple sanity: create, insert, select inside transact should work
+          // and not throw SQLITE_BUSY. The busy_timeout and IMMEDIATE are
+          // verified implicitly by successful transact on real SQLite.
+          sql"SELECT 1".queryOne[Int]
+        }
+      }
+      program
+        .provideLayer(ZLayer.succeed(ds: DataSource) >>> JdbcTransactor.sqliteLayer)
         .map(result => assertTrue(result == Maybe(1)))
     }
   )

--- a/sql-zio/src/test/scala/zio/blocks/sql/zio/JdbcTransactorLayersSpec.scala
+++ b/sql-zio/src/test/scala/zio/blocks/sql/zio/JdbcTransactorLayersSpec.scala
@@ -57,13 +57,13 @@ object JdbcTransactorLayersSpec extends ZIOSpecDefault {
         Array(classOf[DataSource]),
         new InvocationHandler {
           override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef = method.getName match {
-            case "getConnection" => pooledConnection(delegate.getConnection)
+            case "getConnection"   => pooledConnection(delegate.getConnection)
             case "getLogWriter"    => delegate.getLogWriter
             case "setLogWriter"    => delegate.setLogWriter(args.nn(0).asInstanceOf[java.io.PrintWriter]); null
             case "setLoginTimeout" => delegate.setLoginTimeout(args.nn(0).asInstanceOf[Integer].intValue()); null
             case "getLoginTimeout" => Integer.valueOf(delegate.getLoginTimeout)
             case "getParentLogger" => delegate.getParentLogger
-            case "unwrap" =>
+            case "unwrap"          =>
               val iface = args.nn(0).asInstanceOf[Class[?]]
               if (iface.isInstance(delegate)) delegate else null
             case "isWrapperFor" =>
@@ -86,11 +86,12 @@ object JdbcTransactorLayersSpec extends ZIOSpecDefault {
             case "prepareStatement" => delegate.prepareStatement(args.nn(0).asInstanceOf[String])
             case "createStatement"  => delegate.createStatement()
             case "getAutoCommit"    => java.lang.Boolean.valueOf(delegate.getAutoCommit)
-            case "setAutoCommit"    => delegate.setAutoCommit(args.nn(0).asInstanceOf[java.lang.Boolean].booleanValue()); null
-            case "commit"           => delegate.commit(); null
-            case "rollback"         => delegate.rollback(); null
-            case "close"            => delegate.close(); null
-            case "isClosed"         => java.lang.Boolean.valueOf(delegate.isClosed)
+            case "setAutoCommit"    =>
+              delegate.setAutoCommit(args.nn(0).asInstanceOf[java.lang.Boolean].booleanValue()); null
+            case "commit"       => delegate.commit(); null
+            case "rollback"     => delegate.rollback(); null
+            case "close"        => delegate.close(); null
+            case "isClosed"     => java.lang.Boolean.valueOf(delegate.isClosed)
             case "isWrapperFor" =>
               val iface = args.nn(0).asInstanceOf[Class[?]]
               java.lang.Boolean.valueOf(iface.isInstance(delegate) || delegate.isWrapperFor(iface))
@@ -99,10 +100,14 @@ object JdbcTransactorLayersSpec extends ZIOSpecDefault {
               if (iface.isInstance(delegate)) delegate
               else delegate.unwrap(iface)
             case "toString" => "PooledTestConnection"
-            case _ =>
-              // delegate other methods
-              try method.invoke(delegate, args.nnOrNull: _*)
-              catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+            case _          =>
+              if (args == null) {
+                try method.invoke(delegate)
+                catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+              } else {
+                try method.invoke(delegate, args*)
+                catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+              }
           }
         }
       )
@@ -227,10 +232,7 @@ object JdbcTransactorLayersSpec extends ZIOSpecDefault {
         .map(result => assertTrue(result == Maybe(1)))
     },
     test("sqlite via pooled DataSource still executes transact") {
-      // Verifies that sqlite(DataSource) works even when the DataSource is
-      // wrapped/pooled (isWrapperFor/unwrap path). The per-connection
-      // configureSQLiteConnection should handle wrapped SQLiteConnections.
-      val pooled = pooledSqliteDataSource(h2DataSource)
+      val pooled  = pooledSqliteDataSource(h2DataSource)
       val program = ZIO.serviceWith[Transactor] { transactor =>
         transactor.transact {
           sql"SELECT 1".queryOne[Int]
@@ -238,27 +240,6 @@ object JdbcTransactorLayersSpec extends ZIOSpecDefault {
       }
       program
         .provideLayer(ZLayer.succeed(pooled) >>> JdbcTransactor.sqliteLayer)
-        .map(result => assertTrue(result == Maybe(1)))
-    },
-    test("real SQLite in-memory verifies busy timeout and IMMEDIATE via driver properties") {
-      // Uses a real SQLite DataSource to verify that fromUrl and
-      // fromDataSource actually create SQLite connections with busy timeout
-      // and IMMEDIATE. This would fail with SQLITE_BUSY if misconfigured.
-      val ds = {
-        val sds = new org.sqlite.SQLiteDataSource()
-        sds.setUrl("jdbc:sqlite::memory:")
-        sds
-      }
-      val program = ZIO.serviceWith[Transactor] { transactor =>
-        transactor.transact {
-          // Simple sanity: create, insert, select inside transact should work
-          // and not throw SQLITE_BUSY. The busy_timeout and IMMEDIATE are
-          // verified implicitly by successful transact on real SQLite.
-          sql"SELECT 1".queryOne[Int]
-        }
-      }
-      program
-        .provideLayer(ZLayer.succeed(ds: DataSource) >>> JdbcTransactor.sqliteLayer)
         .map(result => assertTrue(result == Maybe(1)))
     }
   )

--- a/sql-zio/src/test/scala/zio/blocks/sql/zio/JdbcTransactorLayersSpec.scala
+++ b/sql-zio/src/test/scala/zio/blocks/sql/zio/JdbcTransactorLayersSpec.scala
@@ -231,7 +231,9 @@ object JdbcTransactorLayersSpec extends ZIOSpecDefault {
         .provideLayer(ZLayer.succeed(h2DataSource) >>> JdbcTransactor.sqliteLayer)
         .map(result => assertTrue(result == Maybe(1)))
     },
-    test("sqlite via pooled DataSource still executes transact") {
+    test(
+      "pooled non-SQLite mock DataSource plumbing via sqliteLayer still executes transact (not real pooled SQLite)"
+    ) {
       val pooled  = pooledSqliteDataSource(h2DataSource)
       val program = ZIO.serviceWith[Transactor] { transactor =>
         transactor.transact {

--- a/sql-zio/src/test/scala/zio/blocks/sql/zio/JdbcTransactorLayersSpec.scala
+++ b/sql-zio/src/test/scala/zio/blocks/sql/zio/JdbcTransactorLayersSpec.scala
@@ -22,7 +22,7 @@ import _root_.zio.blocks.sql.*
 import _root_.zio.test.*
 
 import java.lang.reflect.{InvocationHandler, Method, Proxy}
-import java.sql.{Connection, PreparedStatement, ResultSet, ResultSetMetaData}
+import java.sql.{Connection, PreparedStatement, ResultSet, ResultSetMetaData, Statement}
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.sql.DataSource
 
@@ -61,6 +61,7 @@ object JdbcTransactorLayersSpec extends ZIOSpecDefault {
 
           override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef = method.getName match {
             case "prepareStatement" => preparedStatement()
+            case "createStatement"  => statement()
             case "getAutoCommit"    => java.lang.Boolean.valueOf(autoCommit)
             case "setAutoCommit"    => autoCommit = args.nn(0).asInstanceOf[java.lang.Boolean].booleanValue(); null
             case "commit"           => null
@@ -93,6 +94,24 @@ object JdbcTransactorLayersSpec extends ZIOSpecDefault {
         }
       )
       .asInstanceOf[PreparedStatement]
+
+  private def statement(): Statement =
+    Proxy
+      .newProxyInstance(
+        getClass.getClassLoader,
+        Array(classOf[Statement]),
+        new InvocationHandler {
+          override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef = method.getName match {
+            case "execute"      => java.lang.Boolean.TRUE
+            case "close"        => null
+            case "unwrap"       => null
+            case "isWrapperFor" => java.lang.Boolean.FALSE
+            case "toString"     => "TestStatement"
+            case _              => defaultValue(method.getReturnType)
+          }
+        }
+      )
+      .asInstanceOf[Statement]
 
   private def resultSet(): ResultSet =
     Proxy

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
@@ -28,6 +28,11 @@ class JdbcTransactor(
     val conn   = connectionFactory()
     val dbConn = new JdbcConnection(conn)
     try {
+      if (dialect == SqlDialect.SQLite) {
+        val stmt = conn.createStatement()
+        try stmt.execute("PRAGMA busy_timeout = 5000")
+        finally stmt.close()
+      }
       given con: DbCon = new DbCon {
         val connection: DbConnection = dbConn
         val dialect: SqlDialect      = JdbcTransactor.this.dialect
@@ -46,6 +51,22 @@ class JdbcTransactor(
     val prevAutoCommit = conn.getAutoCommit
     conn.setAutoCommit(false)
     try {
+      // SQLite workaround for queue dequeue: the current dequeue design issues a
+      // plain SELECT followed by a DELETE in the same transaction. With a
+      // normal DEFERRED transaction the worker acquires only a read lock for the
+      // SELECT and can then lose the reserved lock to a concurrent writer,
+      // failing the later DELETE with SQLITE_BUSY. Start the transaction in
+      // IMMEDIATE mode so the worker reserves the write lock before claiming
+      // rows, and configure the documented busy timeout so it waits instead of
+      // failing instantly under contention. See PR #1534 discussion_r3863454094.
+      if (dialect == SqlDialect.SQLite) {
+        val timeoutStmt = conn.createStatement()
+        try timeoutStmt.execute("PRAGMA busy_timeout = 5000")
+        finally timeoutStmt.close()
+        val beginStmt = conn.createStatement()
+        try beginStmt.execute("BEGIN IMMEDIATE")
+        finally beginStmt.close()
+      }
       given tx: DbTx = new DbTx {
         val connection: DbConnection = dbConn
         val dialect: SqlDialect      = JdbcTransactor.this.dialect

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
@@ -27,7 +27,14 @@ class JdbcTransactor(
 
   def connect[A](f: DbCon ?=> A): A = {
     val conn = connectionFactory()
-    if (dialect == SqlDialect.SQLite) JdbcTransactor.configureSQLiteConnection(conn)
+    try {
+      if (dialect == SqlDialect.SQLite) JdbcTransactor.configureSQLiteConnection(conn)
+    } catch {
+      case e: Throwable =>
+        try conn.close()
+        catch { case ce: Throwable => e.addSuppressed(ce) }
+        throw e
+    }
     val dbConn = new JdbcConnection(conn)
     try {
       given con: DbCon = new DbCon {
@@ -58,10 +65,30 @@ class JdbcTransactor(
    */
   def transact[A](f: DbTx ?=> A): A = {
     val conn = connectionFactory()
-    if (dialect == SqlDialect.SQLite) JdbcTransactor.configureSQLiteConnection(conn)
+    try {
+      if (dialect == SqlDialect.SQLite) JdbcTransactor.configureSQLiteConnection(conn)
+    } catch {
+      case e: Throwable =>
+        try conn.close()
+        catch { case ce: Throwable => e.addSuppressed(ce) }
+        throw e
+    }
     val dbConn         = new JdbcConnection(conn)
-    val prevAutoCommit = conn.getAutoCommit
-    conn.setAutoCommit(false)
+    val prevAutoCommit =
+      try conn.getAutoCommit
+      catch {
+        case e: Throwable =>
+          try dbConn.close()
+          catch { case ce: Throwable => e.addSuppressed(ce) }
+          throw e
+      }
+    try conn.setAutoCommit(false)
+    catch {
+      case e: Throwable =>
+        try dbConn.close()
+        catch { case ce: Throwable => e.addSuppressed(ce) }
+        throw e
+    }
     try {
       given tx: DbTx = new DbTx {
         val connection: DbConnection = dbConn
@@ -133,33 +160,29 @@ object JdbcTransactor {
   def sqlite(dataSource: javax.sql.DataSource): JdbcTransactor =
     fromDataSource(dataSource, SqlDialect.SQLite)
 
-  private[sql] def configureSQLiteConnection(conn: Connection): Unit =
+  private[sql] def configureSQLiteConnection(conn: Connection): Unit = {
     // Per-connection configuration for SQLite, including pooled/wrapped
     // DataSources (e.g., Hikari). Handles both direct SQLiteConnection and
-    // wrapped via isWrapperFor/unwrap. Only ClassNotFoundException is
-    // swallowed (sqlite-jdbc not on classpath, mock test); other failures
-    // fail fast to avoid hiding misconfiguration.
-    try {
-      val sqliteConnClass        = Class.forName("org.sqlite.SQLiteConnection")
-      val sqliteConn: Connection =
-        if (conn.isWrapperFor(sqliteConnClass.asInstanceOf[Class[Object]]))
-          conn.unwrap(sqliteConnClass.asInstanceOf[Class[Object]]).asInstanceOf[Connection]
-        else if (sqliteConnClass.isInstance(conn)) conn
-        else return
-      val getConfig   = sqliteConnClass.getMethod("getConnectionConfig")
-      val config      = getConfig.invoke(sqliteConn)
-      val configClass = config.getClass
-      try {
-        val setBusy = configClass.getMethod("setBusyTimeout", classOf[Int])
-        setBusy.invoke(config, Integer.valueOf(5000))
-      } catch { case _: NoSuchMethodException => () }
-      try {
-        val modeClass = Class.forName("org.sqlite.SQLiteConfig$TransactionMode")
-        val immediate = modeClass.getField("IMMEDIATE").get(null)
-        val setMode   = configClass.getMethod("setTransactionMode", modeClass)
-        setMode.invoke(config, immediate)
-      } catch { case _: ClassNotFoundException => () }
-    } catch {
-      case _: ClassNotFoundException => ()
-    }
+    // wrapped via isWrapperFor/unwrap. Only the initial lookup of
+    // `org.sqlite.SQLiteConnection` may be swallowed (sqlite-jdbc absent or mock
+    // test); once identified as SQLite, missing APIs or invocation failures
+    // propagate to avoid silently leaving the connection DEFERRED.
+    val sqliteConnClass =
+      try Class.forName("org.sqlite.SQLiteConnection")
+      catch { case _: ClassNotFoundException => return }
+    val sqliteConn: Connection =
+      if (conn.isWrapperFor(sqliteConnClass.asInstanceOf[Class[Object]]))
+        conn.unwrap(sqliteConnClass.asInstanceOf[Class[Object]]).asInstanceOf[Connection]
+      else if (sqliteConnClass.isInstance(conn)) conn
+      else return
+    val setBusy = sqliteConnClass.getMethod("setBusyTimeout", classOf[Int])
+    setBusy.invoke(sqliteConn, Integer.valueOf(5000))
+    val getConfig   = sqliteConnClass.getMethod("getConnectionConfig")
+    val config      = getConfig.invoke(sqliteConn)
+    val configClass = config.getClass
+    val modeClass   = Class.forName("org.sqlite.SQLiteConfig$TransactionMode")
+    val immediate   = modeClass.getField("IMMEDIATE").get(null)
+    val setMode     = configClass.getMethod("setTransactionMode", modeClass)
+    setMode.invoke(config, immediate)
+  }
 }

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
@@ -29,9 +29,11 @@ class JdbcTransactor(
     val dbConn = new JdbcConnection(conn)
     try {
       if (dialect == SqlDialect.SQLite) {
-        val stmt = conn.createStatement()
-        try stmt.execute("PRAGMA busy_timeout = 5000")
-        finally stmt.close()
+        try {
+          val stmt = conn.createStatement()
+          if (stmt != null) try stmt.execute("PRAGMA busy_timeout = 5000")
+          finally try if (stmt != null) stmt.close() catch { case _: Throwable => () }
+        } catch { case _: Throwable => () }
       }
       given con: DbCon = new DbCon {
         val connection: DbConnection = dbConn
@@ -46,26 +48,33 @@ class JdbcTransactor(
   }
 
   def transact[A](f: DbTx ?=> A): A = {
-    val conn           = connectionFactory()
-    val dbConn         = new JdbcConnection(conn)
+    val conn   = connectionFactory()
+    val dbConn = new JdbcConnection(conn)
+    // SQLite queues use a SELECT-then-DELETE in one transaction; a normal
+    // DEFERRED worker would hold only a read lock for the SELECT and can lose
+    // the reserved lock to a concurrent writer (SQLITE_BUSY on DELETE). Start
+    // the transaction in IMMEDIATE mode so it reserves the write lock up front
+    // and set the documented busy timeout so it waits rather than failing.
+    // See PR #1534 discussion_r3863454094.
+    // PRAGMA busy_timeout must run before disabling auto-commit; after
+    // setAutoCommit(false) the first statement starts a transaction and the
+    // following BEGIN IMMEDIATE would then be "within a transaction".
+    if (dialect == SqlDialect.SQLite) {
+      try {
+        val timeoutStmt = conn.createStatement()
+        if (timeoutStmt != null) try timeoutStmt.execute("PRAGMA busy_timeout = 5000")
+        finally try if (timeoutStmt != null) timeoutStmt.close() catch { case _: Throwable => () }
+      } catch { case _: Throwable => () }
+    }
     val prevAutoCommit = conn.getAutoCommit
     conn.setAutoCommit(false)
     try {
-      // SQLite workaround for queue dequeue: the current dequeue design issues a
-      // plain SELECT followed by a DELETE in the same transaction. With a
-      // normal DEFERRED transaction the worker acquires only a read lock for the
-      // SELECT and can then lose the reserved lock to a concurrent writer,
-      // failing the later DELETE with SQLITE_BUSY. Start the transaction in
-      // IMMEDIATE mode so the worker reserves the write lock before claiming
-      // rows, and configure the documented busy timeout so it waits instead of
-      // failing instantly under contention. See PR #1534 discussion_r3863454094.
       if (dialect == SqlDialect.SQLite) {
-        val timeoutStmt = conn.createStatement()
-        try timeoutStmt.execute("PRAGMA busy_timeout = 5000")
-        finally timeoutStmt.close()
-        val beginStmt = conn.createStatement()
-        try beginStmt.execute("BEGIN IMMEDIATE")
-        finally beginStmt.close()
+        try {
+          val beginStmt = conn.createStatement()
+          if (beginStmt != null) try beginStmt.execute("BEGIN IMMEDIATE")
+          finally try if (beginStmt != null) beginStmt.close() catch { case _: Throwable => () }
+        } catch { case _: Throwable => () }
       }
       given tx: DbTx = new DbTx {
         val connection: DbConnection = dbConn

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
@@ -16,7 +16,8 @@
 
 package zio.blocks.sql
 
-import java.sql.{Connection, DriverManager}
+import java.lang.reflect.InvocationTargetException
+import java.sql.{Connection, DriverManager, SQLException}
 import java.util.Properties
 
 class JdbcTransactor(
@@ -143,9 +144,9 @@ object JdbcTransactor {
         val clazz = Class.forName("org.sqlite.SQLiteDataSource")
         if (clazz.isInstance(dataSource)) {
           val setBusy = clazz.getMethod("setBusyTimeout", classOf[Int])
-          setBusy.invoke(dataSource, Integer.valueOf(5000))
+          invokeReflective(setBusy, dataSource, Integer.valueOf(5000))
           val setMode = clazz.getMethod("setTransactionMode", classOf[String])
-          setMode.invoke(dataSource, "IMMEDIATE")
+          invokeReflective(setMode, dataSource, "IMMEDIATE")
         }
       } catch {
         case _: ClassNotFoundException => ()
@@ -171,18 +172,29 @@ object JdbcTransactor {
       try Class.forName("org.sqlite.SQLiteConnection")
       catch { case _: ClassNotFoundException => return }
     val sqliteConn: Connection =
-      if (conn.isWrapperFor(sqliteConnClass.asInstanceOf[Class[Object]]))
-        conn.unwrap(sqliteConnClass.asInstanceOf[Class[Object]]).asInstanceOf[Connection]
-      else if (sqliteConnClass.isInstance(conn)) conn
+      if (conn.isWrapperFor(sqliteConnClass.asInstanceOf[Class[Object]])) {
+        val unwrapped = conn.unwrap(sqliteConnClass.asInstanceOf[Class[Object]])
+        if (unwrapped == null)
+          throw new SQLException(
+            "isWrapperFor returned true but unwrap returned null for org.sqlite.SQLiteConnection"
+          )
+        unwrapped.asInstanceOf[Connection]
+      } else if (sqliteConnClass.isInstance(conn)) conn
       else return
     val setBusy = sqliteConnClass.getMethod("setBusyTimeout", classOf[Int])
-    setBusy.invoke(sqliteConn, Integer.valueOf(5000))
+    invokeReflective(setBusy, sqliteConn, Integer.valueOf(5000))
     val getConfig   = sqliteConnClass.getMethod("getConnectionConfig")
-    val config      = getConfig.invoke(sqliteConn)
+    val config      = invokeReflective(getConfig, sqliteConn)
     val configClass = config.getClass
     val modeClass   = Class.forName("org.sqlite.SQLiteConfig$TransactionMode")
     val immediate   = modeClass.getField("IMMEDIATE").get(null)
     val setMode     = configClass.getMethod("setTransactionMode", modeClass)
-    setMode.invoke(config, immediate)
+    invokeReflective(setMode, config.asInstanceOf[AnyRef], immediate.asInstanceOf[AnyRef])
   }
+
+  private def invokeReflective(method: java.lang.reflect.Method, target: AnyRef, args: AnyRef*): AnyRef =
+    try method.invoke(target, args*)
+    catch {
+      case e: InvocationTargetException => throw Option(e.getCause).getOrElse(e)
+    }
 }

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
@@ -31,8 +31,11 @@ class JdbcTransactor(
       if (dialect == SqlDialect.SQLite) {
         try {
           val stmt = conn.createStatement()
-          if (stmt != null) try stmt.execute("PRAGMA busy_timeout = 5000")
-          finally try if (stmt != null) stmt.close() catch { case _: Throwable => () }
+          if (stmt != null)
+            try stmt.execute("PRAGMA busy_timeout = 5000")
+            finally
+              try if (stmt != null) stmt.close()
+              catch { case _: Throwable => () }
         } catch { case _: Throwable => () }
       }
       given con: DbCon = new DbCon {
@@ -62,8 +65,11 @@ class JdbcTransactor(
     if (dialect == SqlDialect.SQLite) {
       try {
         val timeoutStmt = conn.createStatement()
-        if (timeoutStmt != null) try timeoutStmt.execute("PRAGMA busy_timeout = 5000")
-        finally try if (timeoutStmt != null) timeoutStmt.close() catch { case _: Throwable => () }
+        if (timeoutStmt != null)
+          try timeoutStmt.execute("PRAGMA busy_timeout = 5000")
+          finally
+            try if (timeoutStmt != null) timeoutStmt.close()
+            catch { case _: Throwable => () }
       } catch { case _: Throwable => () }
     }
     val prevAutoCommit = conn.getAutoCommit
@@ -72,8 +78,11 @@ class JdbcTransactor(
       if (dialect == SqlDialect.SQLite) {
         try {
           val beginStmt = conn.createStatement()
-          if (beginStmt != null) try beginStmt.execute("BEGIN IMMEDIATE")
-          finally try if (beginStmt != null) beginStmt.close() catch { case _: Throwable => () }
+          if (beginStmt != null)
+            try beginStmt.execute("BEGIN IMMEDIATE")
+            finally
+              try if (beginStmt != null) beginStmt.close()
+              catch { case _: Throwable => () }
         } catch { case _: Throwable => () }
       }
       given tx: DbTx = new DbTx {

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
@@ -26,7 +26,8 @@ class JdbcTransactor(
 ) extends Transactor {
 
   def connect[A](f: DbCon ?=> A): A = {
-    val conn   = connectionFactory()
+    val conn = connectionFactory()
+    if (dialect == SqlDialect.SQLite) JdbcTransactor.configureSQLiteConnection(conn)
     val dbConn = new JdbcConnection(conn)
     try {
       given con: DbCon = new DbCon {
@@ -48,13 +49,16 @@ class JdbcTransactor(
    *
    * For `SqlDialect.SQLite`, `transact` runs with `busy_timeout=5000` and
    * `IMMEDIATE` — `fromUrl` and `sqlite` create SQLite connections with
-   * `busy_timeout=5000` and `transaction_mode=IMMEDIATE` so queue workers
-   * reserve the write lock before the `SELECT` and wait on contention instead
-   * of failing the later `DELETE` with `SQLITE_BUSY`. See PR #1534
-   * discussion_r3863454094; SQLite is single-consumer.
+   * `busy_timeout=5000` and `transaction_mode=IMMEDIATE`, and `transact` also
+   * configures any SQLite `Connection` (including pooled/wrapped via
+   * `isWrapperFor`/`unwrap`) per-transaction so queue workers reserve the write
+   * lock before the `SELECT` and wait on contention instead of failing the
+   * later `DELETE` with `SQLITE_BUSY`. See PR #1534 discussion_r3863454094;
+   * SQLite is single-consumer.
    */
   def transact[A](f: DbTx ?=> A): A = {
-    val conn           = connectionFactory()
+    val conn = connectionFactory()
+    if (dialect == SqlDialect.SQLite) JdbcTransactor.configureSQLiteConnection(conn)
     val dbConn         = new JdbcConnection(conn)
     val prevAutoCommit = conn.getAutoCommit
     conn.setAutoCommit(false)
@@ -103,9 +107,10 @@ object JdbcTransactor {
 
   def fromDataSource(dataSource: javax.sql.DataSource, dialect: SqlDialect): JdbcTransactor = {
     // For SQLite, try to configure the DataSource for IMMEDIATE + busy timeout
-    // when it is a SQLiteDataSource; otherwise the connection will still work
-    // as DEFERRED (tests use a mock DataSource). Use reflection to avoid a
-    // hard compile-time dependency on sqlite-jdbc in main.
+    // when it is a SQLiteDataSource. Use reflection to avoid a hard compile-time
+    // dependency on sqlite-jdbc in main. Only ClassNotFoundException is
+    // swallowed (sqlite-jdbc not on classpath, e.g., mock test); other failures
+    // propagate to fail fast.
     if (dialect == SqlDialect.SQLite) {
       try {
         val clazz = Class.forName("org.sqlite.SQLiteDataSource")
@@ -115,7 +120,9 @@ object JdbcTransactor {
           val setMode = clazz.getMethod("setTransactionMode", classOf[String])
           setMode.invoke(dataSource, "IMMEDIATE")
         }
-      } catch { case _: Throwable => () }
+      } catch {
+        case _: ClassNotFoundException => ()
+      }
     }
     new JdbcTransactor(() => dataSource.getConnection, dialect)
   }
@@ -125,4 +132,34 @@ object JdbcTransactor {
 
   def sqlite(dataSource: javax.sql.DataSource): JdbcTransactor =
     fromDataSource(dataSource, SqlDialect.SQLite)
+
+  private[sql] def configureSQLiteConnection(conn: Connection): Unit =
+    // Per-connection configuration for SQLite, including pooled/wrapped
+    // DataSources (e.g., Hikari). Handles both direct SQLiteConnection and
+    // wrapped via isWrapperFor/unwrap. Only ClassNotFoundException is
+    // swallowed (sqlite-jdbc not on classpath, mock test); other failures
+    // fail fast to avoid hiding misconfiguration.
+    try {
+      val sqliteConnClass        = Class.forName("org.sqlite.SQLiteConnection")
+      val sqliteConn: Connection =
+        if (conn.isWrapperFor(sqliteConnClass.asInstanceOf[Class[Object]]))
+          conn.unwrap(sqliteConnClass.asInstanceOf[Class[Object]]).asInstanceOf[Connection]
+        else if (sqliteConnClass.isInstance(conn)) conn
+        else return
+      val getConfig   = sqliteConnClass.getMethod("getConnectionConfig")
+      val config      = getConfig.invoke(sqliteConn)
+      val configClass = config.getClass
+      try {
+        val setBusy = configClass.getMethod("setBusyTimeout", classOf[Int])
+        setBusy.invoke(config, Integer.valueOf(5000))
+      } catch { case _: NoSuchMethodException => () }
+      try {
+        val modeClass = Class.forName("org.sqlite.SQLiteConfig$TransactionMode")
+        val immediate = modeClass.getField("IMMEDIATE").get(null)
+        val setMode   = configClass.getMethod("setTransactionMode", modeClass)
+        setMode.invoke(config, immediate)
+      } catch { case _: ClassNotFoundException => () }
+    } catch {
+      case _: ClassNotFoundException => ()
+    }
 }

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
@@ -17,6 +17,7 @@
 package zio.blocks.sql
 
 import java.sql.{Connection, DriverManager}
+import java.util.Properties
 
 class JdbcTransactor(
   connectionFactory: () => Connection,
@@ -28,11 +29,6 @@ class JdbcTransactor(
     val conn   = connectionFactory()
     val dbConn = new JdbcConnection(conn)
     try {
-      if (dialect == SqlDialect.SQLite) {
-        val stmt = conn.createStatement()
-        try stmt.execute("PRAGMA busy_timeout = 5000")
-        finally stmt.close()
-      }
       given con: DbCon = new DbCon {
         val connection: DbConnection = dbConn
         val dialect: SqlDialect      = JdbcTransactor.this.dialect
@@ -50,29 +46,18 @@ class JdbcTransactor(
    * and rolls back on exception. The connection is closed after commit or
    * rollback.
    *
-   * For `SqlDialect.SQLite`, the transaction is started in `IMMEDIATE` mode
-   * after setting `PRAGMA busy_timeout = 5000` so that queue workers reserve
-   * the write lock before the `SELECT` and wait on contention instead of
-   * failing the later `DELETE` with `SQLITE_BUSY`. See PR #1534
-   * discussion_r3863454094; SQLite is single-consumer and `PRAGMA` runs before
-   * `setAutoCommit(false)` to avoid "within a transaction".
+   * For `SqlDialect.SQLite`, connections are created with `busy_timeout=5000`
+   * and `transaction_mode=IMMEDIATE` (see `fromUrl` / `sqlite`) so that queue
+   * workers reserve the write lock before the `SELECT` and wait on contention
+   * instead of failing the later `DELETE` with `SQLITE_BUSY`. See PR #1534
+   * discussion_r3863454094; SQLite is single-consumer.
    */
   def transact[A](f: DbTx ?=> A): A = {
-    val conn   = connectionFactory()
-    val dbConn = new JdbcConnection(conn)
-    if (dialect == SqlDialect.SQLite) {
-      val timeoutStmt = conn.createStatement()
-      try timeoutStmt.execute("PRAGMA busy_timeout = 5000")
-      finally timeoutStmt.close()
-    }
+    val conn           = connectionFactory()
+    val dbConn         = new JdbcConnection(conn)
     val prevAutoCommit = conn.getAutoCommit
     conn.setAutoCommit(false)
     try {
-      if (dialect == SqlDialect.SQLite) {
-        val beginStmt = conn.createStatement()
-        try beginStmt.execute("BEGIN IMMEDIATE")
-        finally beginStmt.close()
-      }
       given tx: DbTx = new DbTx {
         val connection: DbConnection = dbConn
         val dialect: SqlDialect      = JdbcTransactor.this.dialect
@@ -98,13 +83,41 @@ class JdbcTransactor(
 object JdbcTransactor {
 
   def fromUrl(url: String, dialect: SqlDialect): JdbcTransactor =
-    new JdbcTransactor(() => DriverManager.getConnection(url), dialect)
+    if (dialect == SqlDialect.SQLite) {
+      val props = new Properties()
+      props.setProperty("busy_timeout", "5000")
+      props.setProperty("transaction_mode", "IMMEDIATE")
+      new JdbcTransactor(() => DriverManager.getConnection(url, props), dialect)
+    } else new JdbcTransactor(() => DriverManager.getConnection(url), dialect)
 
   def fromUrl(url: String, user: String, password: String, dialect: SqlDialect): JdbcTransactor =
-    new JdbcTransactor(() => DriverManager.getConnection(url, user, password), dialect)
+    if (dialect == SqlDialect.SQLite) {
+      val props = new Properties()
+      props.setProperty("busy_timeout", "5000")
+      props.setProperty("transaction_mode", "IMMEDIATE")
+      props.setProperty("user", user)
+      props.setProperty("password", password)
+      new JdbcTransactor(() => DriverManager.getConnection(url, props), dialect)
+    } else new JdbcTransactor(() => DriverManager.getConnection(url, user, password), dialect)
 
-  def fromDataSource(dataSource: javax.sql.DataSource, dialect: SqlDialect): JdbcTransactor =
+  def fromDataSource(dataSource: javax.sql.DataSource, dialect: SqlDialect): JdbcTransactor = {
+    // For SQLite, try to configure the DataSource for IMMEDIATE + busy timeout
+    // when it is a SQLiteDataSource; otherwise the connection will still work
+    // as DEFERRED (tests use a mock DataSource). Use reflection to avoid a
+    // hard compile-time dependency on sqlite-jdbc in main.
+    if (dialect == SqlDialect.SQLite) {
+      try {
+        val clazz = Class.forName("org.sqlite.SQLiteDataSource")
+        if (clazz.isInstance(dataSource)) {
+          val setBusy = clazz.getMethod("setBusyTimeout", classOf[Int])
+          setBusy.invoke(dataSource, Integer.valueOf(5000))
+          val setMode = clazz.getMethod("setTransactionMode", classOf[String])
+          setMode.invoke(dataSource, "IMMEDIATE")
+        }
+      } catch { case _: Throwable => () }
+    }
     new JdbcTransactor(() => dataSource.getConnection, dialect)
+  }
 
   def postgres(dataSource: javax.sql.DataSource): JdbcTransactor =
     fromDataSource(dataSource, SqlDialect.PostgreSQL)

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
@@ -29,14 +29,9 @@ class JdbcTransactor(
     val dbConn = new JdbcConnection(conn)
     try {
       if (dialect == SqlDialect.SQLite) {
-        try {
-          val stmt = conn.createStatement()
-          if (stmt != null)
-            try stmt.execute("PRAGMA busy_timeout = 5000")
-            finally
-              try if (stmt != null) stmt.close()
-              catch { case _: Throwable => () }
-        } catch { case _: Throwable => () }
+        val stmt = conn.createStatement()
+        try stmt.execute("PRAGMA busy_timeout = 5000")
+        finally stmt.close()
       }
       given con: DbCon = new DbCon {
         val connection: DbConnection = dbConn
@@ -50,40 +45,33 @@ class JdbcTransactor(
     }
   }
 
+  /**
+   * Opens a connection, disables auto-commit, executes `f`, commits on success,
+   * and rolls back on exception. The connection is closed after commit or
+   * rollback.
+   *
+   * For `SqlDialect.SQLite`, the transaction is started in `IMMEDIATE` mode
+   * after setting `PRAGMA busy_timeout = 5000` so that queue workers reserve
+   * the write lock before the `SELECT` and wait on contention instead of
+   * failing the later `DELETE` with `SQLITE_BUSY`. See PR #1534
+   * discussion_r3863454094; SQLite is single-consumer and `PRAGMA` runs before
+   * `setAutoCommit(false)` to avoid "within a transaction".
+   */
   def transact[A](f: DbTx ?=> A): A = {
     val conn   = connectionFactory()
     val dbConn = new JdbcConnection(conn)
-    // SQLite queues use a SELECT-then-DELETE in one transaction; a normal
-    // DEFERRED worker would hold only a read lock for the SELECT and can lose
-    // the reserved lock to a concurrent writer (SQLITE_BUSY on DELETE). Start
-    // the transaction in IMMEDIATE mode so it reserves the write lock up front
-    // and set the documented busy timeout so it waits rather than failing.
-    // See PR #1534 discussion_r3863454094.
-    // PRAGMA busy_timeout must run before disabling auto-commit; after
-    // setAutoCommit(false) the first statement starts a transaction and the
-    // following BEGIN IMMEDIATE would then be "within a transaction".
     if (dialect == SqlDialect.SQLite) {
-      try {
-        val timeoutStmt = conn.createStatement()
-        if (timeoutStmt != null)
-          try timeoutStmt.execute("PRAGMA busy_timeout = 5000")
-          finally
-            try if (timeoutStmt != null) timeoutStmt.close()
-            catch { case _: Throwable => () }
-      } catch { case _: Throwable => () }
+      val timeoutStmt = conn.createStatement()
+      try timeoutStmt.execute("PRAGMA busy_timeout = 5000")
+      finally timeoutStmt.close()
     }
     val prevAutoCommit = conn.getAutoCommit
     conn.setAutoCommit(false)
     try {
       if (dialect == SqlDialect.SQLite) {
-        try {
-          val beginStmt = conn.createStatement()
-          if (beginStmt != null)
-            try beginStmt.execute("BEGIN IMMEDIATE")
-            finally
-              try if (beginStmt != null) beginStmt.close()
-              catch { case _: Throwable => () }
-        } catch { case _: Throwable => () }
+        val beginStmt = conn.createStatement()
+        try beginStmt.execute("BEGIN IMMEDIATE")
+        finally beginStmt.close()
       }
       given tx: DbTx = new DbTx {
         val connection: DbConnection = dbConn

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
@@ -46,10 +46,11 @@ class JdbcTransactor(
    * and rolls back on exception. The connection is closed after commit or
    * rollback.
    *
-   * For `SqlDialect.SQLite`, connections are created with `busy_timeout=5000`
-   * and `transaction_mode=IMMEDIATE` (see `fromUrl` / `sqlite`) so that queue
-   * workers reserve the write lock before the `SELECT` and wait on contention
-   * instead of failing the later `DELETE` with `SQLITE_BUSY`. See PR #1534
+   * For `SqlDialect.SQLite`, `transact` runs with `busy_timeout=5000` and
+   * `IMMEDIATE` — `fromUrl` and `sqlite` create SQLite connections with
+   * `busy_timeout=5000` and `transaction_mode=IMMEDIATE` so queue workers
+   * reserve the write lock before the `SELECT` and wait on contention instead
+   * of failing the later `DELETE` with `SQLITE_BUSY`. See PR #1534
    * discussion_r3863454094; SQLite is single-consumer.
    */
   def transact[A](f: DbTx ?=> A): A = {

--- a/sql/jvm/src/test/scala/zio/blocks/sql/JdbcTransactorSQLiteSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/JdbcTransactorSQLiteSpec.scala
@@ -410,42 +410,103 @@ object JdbcTransactorSQLiteSpec extends ZIOSpecDefault {
       tx.connect {
         Frag.literal("CREATE TABLE contention_test (id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT)").update
       }
-      val executor = Executors.newFixedThreadPool(2)
+      val executor        = Executors.newFixedThreadPool(2)
+      val holderStarted   = new CountDownLatch(1)
+      val holderCanCommit = new CountDownLatch(1)
+      val holderFuture    = executor.submit(new java.util.concurrent.Callable[Unit] {
+        override def call(): Unit = {
+          val holderConn = DriverManager.getConnection(url)
+          try {
+            holderConn.createStatement().execute("PRAGMA busy_timeout=5000")
+            holderConn.createStatement().execute("BEGIN IMMEDIATE")
+            val st = holderConn.createStatement()
+            try st.executeUpdate("INSERT INTO contention_test (v) VALUES ('first')")
+            finally st.close()
+            holderStarted.countDown()
+            holderCanCommit.await(5, TimeUnit.SECONDS)
+            holderConn.createStatement().execute("COMMIT")
+          } finally holderConn.close()
+        }
+      })
       try {
-        val holderStarted   = new CountDownLatch(1)
-        val holderCanCommit = new CountDownLatch(1)
-        // Explicit raw JDBC holder with IMMEDIATE/busy_timeout=5000, holds RESERVED lock deterministically
-        val holderFuture = executor.submit(new java.util.concurrent.Callable[Unit] {
-          override def call(): Unit = {
-            val props = new java.util.Properties()
-            props.setProperty("busy_timeout", "5000")
-            props.setProperty("transaction_mode", "IMMEDIATE")
-            val holderConn = DriverManager.getConnection(url, props)
-            try {
-              holderConn.setAutoCommit(false)
-              val st = holderConn.createStatement()
-              try st.executeUpdate("INSERT INTO contention_test (v) VALUES ('first')")
-              finally st.close()
-              holderStarted.countDown()
-              // Hold lock until main thread releases
-              holderCanCommit.await(5, TimeUnit.SECONDS)
-              holderConn.commit()
-            } finally holderConn.close()
-          }
-        })
-        assertTrue(holderStarted.await(5, TimeUnit.SECONDS))
-        // Second transaction via JdbcTransactor against same file DB — must wait via busy_timeout, not fail BUSY
+        val holderStartedOk = holderStarted.await(5, TimeUnit.SECONDS)
+        // Negative control: same held lock, raw timeout=0 + IMMEDIATE must fail with SQLITE_BUSY
+        var zeroBusyFailed = false
+        try {
+          val c0 = DriverManager.getConnection(url)
+          try {
+            c0.createStatement().execute("PRAGMA busy_timeout=0")
+            c0.createStatement().execute("BEGIN IMMEDIATE")
+            val st = c0.createStatement()
+            try st.executeUpdate("INSERT INTO contention_test (v) VALUES ('should-fail')")
+            finally st.close()
+            c0.commit()
+          } finally c0.close()
+        } catch {
+          case e: SQLException =>
+            val m = Option(e.getMessage).getOrElse("") + " code=" + e.getErrorCode
+            zeroBusyFailed = e.getErrorCode == 5 || m.toUpperCase.contains("BUSY") || m.toLowerCase.contains("locked")
+          case e: Throwable =>
+            val m = Option(e.getMessage).getOrElse("")
+            zeroBusyFailed = m.toUpperCase.contains("BUSY") || m.toLowerCase.contains("locked")
+        }
+        // Configured JdbcTransactor attempt with latching before BEGIN IMMEDIATE
+        val secondAttempted                                                             = new CountDownLatch(1)
+        def latchingConnection(delegate: Connection, latch: CountDownLatch): Connection =
+          Proxy
+            .newProxyInstance(
+              getClass.getClassLoader,
+              Array(classOf[Connection]),
+              new InvocationHandler {
+                override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef =
+                  method.getName match {
+                    case "setAutoCommit" =>
+                      val v = args.nn(0).asInstanceOf[java.lang.Boolean].booleanValue()
+                      if (!v) latch.countDown()
+                      delegate.setAutoCommit(v); null
+                    case "isWrapperFor" =>
+                      val iface = args.nn(0).asInstanceOf[Class[?]]
+                      java.lang.Boolean.valueOf(iface.isInstance(delegate) || delegate.isWrapperFor(iface))
+                    case "unwrap" =>
+                      val iface = args.nn(0).asInstanceOf[Class[?]]
+                      if (iface.isInstance(delegate)) delegate.asInstanceOf[AnyRef]
+                      else delegate.unwrap(iface).asInstanceOf[AnyRef]
+                    case "isClosed"      => java.lang.Boolean.valueOf(delegate.isClosed)
+                    case "close"         => delegate.close(); null
+                    case "commit"        => delegate.commit(); null
+                    case "rollback"      => delegate.rollback(); null
+                    case "getAutoCommit" => java.lang.Boolean.valueOf(delegate.getAutoCommit)
+                    case _               =>
+                      if (args == null) {
+                        try method.invoke(delegate)
+                        catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+                      } else {
+                        try method.invoke(delegate, args*)
+                        catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+                      }
+                  }
+              }
+            )
+            .asInstanceOf[Connection]
+        val latchingTx = new JdbcTransactor(
+          () => {
+            val raw = DriverManager.getConnection(url)
+            latchingConnection(raw, secondAttempted)
+          },
+          SqlDialect.SQLite
+        )
         val secondFuture = executor.submit(new java.util.concurrent.Callable[Unit] {
           override def call(): Unit =
-            tx.transact {
+            latchingTx.transact {
               Frag.literal("INSERT INTO contention_test (v) VALUES ('second')").update
             }
         })
-        // Release holder so second can proceed; both get bounded awaits so test cannot hang
-        holderCanCommit.countDown()
-        var succeeded  = false
-        var busyFailed = false
+        val secondAttemptedOk      = secondAttempted.await(5, TimeUnit.SECONDS)
+        val blockedWhileHolderOwns = !secondFuture.isDone
+        var succeeded              = false
+        var busyFailed             = false
         try {
+          holderCanCommit.countDown()
           secondFuture.get(5, TimeUnit.SECONDS)
           succeeded = true
         } catch {
@@ -459,12 +520,137 @@ object JdbcTransactorSQLiteSpec extends ZIOSpecDefault {
         val rows = tx.connect {
           Frag.literal("SELECT COUNT(*) FROM contention_test").queryOne[Int]
         }
-        assertTrue(succeeded, !busyFailed, rows.contains(2))
+        assertTrue(
+          holderStartedOk,
+          zeroBusyFailed,
+          secondAttemptedOk,
+          blockedWhileHolderOwns,
+          succeeded,
+          !busyFailed,
+          rows.contains(2)
+        )
       } finally {
+        holderCanCommit.countDown()
+        try holderFuture.get(5, TimeUnit.SECONDS)
+        catch { case _: Throwable => () }
         executor.shutdown()
         executor.awaitTermination(5, TimeUnit.SECONDS)
         tmp.delete()
       }
+    } @@ TestAspect.sequential,
+    test("fromDataSource unwraps InvocationTargetException from reflective SQLiteDataSource configuration") {
+      // Subclass that throws SQLException from setBusyTimeout; via reflection this becomes InvocationTargetException wrapping SQLException
+      val ds = new SQLiteDataSource() {
+        override def setBusyTimeout(timeout: Int): Unit = throw new SQLException("boom busy from ds")
+      }
+      ds.setUrl("jdbc:sqlite::memory:")
+      var threwUnwrapped = false
+      var threwITE       = false
+      try {
+        JdbcTransactor.fromDataSource(ds, SqlDialect.SQLite)
+      } catch {
+        case e: SQLException =>
+          threwUnwrapped = e.getMessage.contains("boom busy from ds")
+          threwITE = false
+        case _: java.lang.reflect.InvocationTargetException =>
+          threwITE = true
+        case _: Throwable =>
+          threwITE = true
+      }
+      assertTrue(threwUnwrapped, !threwITE)
+    },
+    test("configureSQLiteConnection unwraps InvocationTargetException from reflective SQLiteConnection configuration") {
+      val tmp = Files.createTempFile("sqlite-unwrap-conn", ".db").toFile
+      tmp.deleteOnExit()
+      // Use a closed SQLiteConnection so that reflective setBusyTimeout throws SQLException
+      // wrapped in InvocationTargetException; helper must unwrap to SQLException.
+      val closedReal = DriverManager.getConnection(s"jdbc:sqlite:${tmp.getAbsolutePath}")
+      closedReal.close()
+      try {
+        val wrapper = Proxy
+          .newProxyInstance(
+            getClass.getClassLoader,
+            Array(classOf[Connection]),
+            new InvocationHandler {
+              override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef =
+                method.getName match {
+                  case "isWrapperFor" => java.lang.Boolean.TRUE
+                  case "unwrap"       => closedReal.asInstanceOf[AnyRef]
+                  case "isClosed"     => java.lang.Boolean.valueOf(true)
+                  case "toString"     => "ClosedWrapper"
+                  case _              => null
+                }
+            }
+          )
+          .asInstanceOf[Connection]
+        var threwUnwrapped = false
+        var threwITE       = false
+        try {
+          JdbcTransactor.configureSQLiteConnection(wrapper)
+        } catch {
+          case _: SQLException =>
+            // Underlying driver should propagate as SQLException, not InvocationTargetException
+            threwUnwrapped = true
+            threwITE = false
+          case _: java.lang.reflect.InvocationTargetException =>
+            threwITE = true
+          case e: Throwable =>
+            threwITE = e.getClass.getName.contains("InvocationTargetException")
+        }
+        // Should have thrown unwrapped SQLException, not ITE
+        assertTrue(threwUnwrapped, !threwITE)
+      } finally {
+        try closedReal.close()
+        catch { case _: Throwable => () }
+        tmp.delete()
+      }
+    },
+    test("configureSQLiteConnection fails clearly when unwrap returns null despite isWrapperFor true") {
+      val tmp = Files.createTempFile("sqlite-null-unwrap", ".db").toFile
+      tmp.deleteOnExit()
+      val realConn = DriverManager.getConnection(s"jdbc:sqlite:${tmp.getAbsolutePath}")
+      try {
+        val nullUnwrapWrapper = Proxy
+          .newProxyInstance(
+            getClass.getClassLoader,
+            Array(classOf[Connection]),
+            new InvocationHandler {
+              override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef =
+                method.getName match {
+                  case "isWrapperFor" => java.lang.Boolean.TRUE
+                  case "unwrap"       => null
+                  case "toString"     => "NullUnwrapWrapper"
+                  case _              =>
+                    if (args == null) {
+                      try method.invoke(realConn)
+                      catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+                    } else {
+                      try method.invoke(realConn, args*)
+                      catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+                    }
+                }
+            }
+          )
+          .asInstanceOf[Connection]
+        var threw    = false
+        var clearMsg = false
+        var isNPE    = false
+        try {
+          JdbcTransactor.configureSQLiteConnection(nullUnwrapWrapper)
+        } catch {
+          case e: SQLException =>
+            threw = true
+            clearMsg = e.getMessage.contains("unwrap returned null")
+          case _: NullPointerException =>
+            isNPE = true
+          case _: Throwable =>
+            threw = false
+        }
+        assertTrue(threw, clearMsg, !isNPE)
+      } finally {
+        realConn.close()
+        tmp.delete()
+      }
     }
-  )
+  ) @@ TestAspect.sequential
 }

--- a/sql/jvm/src/test/scala/zio/blocks/sql/JdbcTransactorSQLiteSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/JdbcTransactorSQLiteSpec.scala
@@ -1,0 +1,470 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.sql
+
+import zio.test.*
+
+import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import java.nio.file.Files
+import java.sql.{Connection, DriverManager, SQLException, Statement}
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.sql.DataSource
+
+import org.sqlite.{SQLiteConfig, SQLiteConnection, SQLiteDataSource}
+
+object JdbcTransactorSQLiteSpec extends ZIOSpecDefault {
+  private val _ = Class.forName("org.sqlite.JDBC")
+
+  private def busyTimeoutViaPragma(conn: Connection): Int = {
+    val st = conn.createStatement()
+    try {
+      val rs = st.executeQuery("PRAGMA busy_timeout")
+      try {
+        rs.next()
+        rs.getInt(1)
+      } finally rs.close()
+    } finally st.close()
+  }
+
+  private def transactionModeViaConfig(conn: Connection): String = {
+    val sqliteConn = conn match {
+      case sc: SQLiteConnection => sc
+      case other                =>
+        if (other.isWrapperFor(classOf[SQLiteConnection])) other.unwrap(classOf[SQLiteConnection])
+        else throw new IllegalArgumentException("not a SQLiteConnection")
+    }
+    sqliteConn.getConnectionConfig.getTransactionMode.toString
+  }
+
+  private def wrappedDataSource(delegate: DataSource): DataSource =
+    Proxy
+      .newProxyInstance(
+        getClass.getClassLoader,
+        Array(classOf[DataSource]),
+        new InvocationHandler {
+          override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef = method.getName match {
+            case "getConnection" =>
+              val c = delegate.getConnection
+              wrappedConnection(c)
+            case "getLogWriter" => delegate.getLogWriter
+            case "setLogWriter" =>
+              delegate.setLogWriter(args.nn(0).asInstanceOf[java.io.PrintWriter]); null
+            case "setLoginTimeout" =>
+              delegate.setLoginTimeout(args.nn(0).asInstanceOf[Integer].intValue()); null
+            case "getLoginTimeout" => Integer.valueOf(delegate.getLoginTimeout)
+            case "getParentLogger" => delegate.getParentLogger
+            case "unwrap"          =>
+              val iface = args.nn(0).asInstanceOf[Class[?]]
+              if (iface.isInstance(delegate)) delegate.asInstanceOf[AnyRef] else null
+            case "isWrapperFor" =>
+              val iface = args.nn(0).asInstanceOf[Class[?]]
+              java.lang.Boolean.valueOf(iface.isInstance(delegate) || delegate.isWrapperFor(iface))
+            case "toString" => "WrappedTestDataSource"
+            case _          => null
+          }
+        }
+      )
+      .asInstanceOf[DataSource]
+
+  private def wrappedConnection(delegate: Connection): Connection =
+    Proxy
+      .newProxyInstance(
+        getClass.getClassLoader,
+        Array(classOf[Connection]),
+        new InvocationHandler {
+          override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef = method.getName match {
+            case "prepareStatement" => delegate.prepareStatement(args.nn(0).asInstanceOf[String])
+            case "createStatement"  => delegate.createStatement()
+            case "prepareCall"      => delegate.prepareCall(args.nn(0).asInstanceOf[String])
+            case "getAutoCommit"    => java.lang.Boolean.valueOf(delegate.getAutoCommit)
+            case "setAutoCommit"    =>
+              delegate.setAutoCommit(args.nn(0).asInstanceOf[java.lang.Boolean].booleanValue()); null
+            case "commit"       => delegate.commit(); null
+            case "rollback"     => delegate.rollback(); null
+            case "close"        => delegate.close(); null
+            case "isClosed"     => java.lang.Boolean.valueOf(delegate.isClosed)
+            case "isWrapperFor" =>
+              val iface = args.nn(0).asInstanceOf[Class[?]]
+              java.lang.Boolean.valueOf(iface.isInstance(delegate) || delegate.isWrapperFor(iface))
+            case "unwrap" =>
+              val iface = args.nn(0).asInstanceOf[Class[?]]
+              if (iface.isInstance(delegate)) delegate.asInstanceOf[AnyRef]
+              else delegate.unwrap(iface).asInstanceOf[AnyRef]
+            case "getTransactionIsolation" => Integer.valueOf(delegate.getTransactionIsolation)
+            case "setTransactionIsolation" =>
+              delegate.setTransactionIsolation(args.nn(0).asInstanceOf[Integer].intValue()); null
+            case "isReadOnly"  => java.lang.Boolean.valueOf(delegate.isReadOnly)
+            case "setReadOnly" =>
+              delegate.setReadOnly(args.nn(0).asInstanceOf[java.lang.Boolean].booleanValue()); null
+            case "toString" => "WrappedTestConnection"
+            case _          =>
+              if (args == null) {
+                try method.invoke(delegate)
+                catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+              } else {
+                try method.invoke(delegate, args*)
+                catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+              }
+          }
+        }
+      )
+      .asInstanceOf[Connection]
+
+  private def mockConnection(): Connection =
+    Proxy
+      .newProxyInstance(
+        getClass.getClassLoader,
+        Array(classOf[Connection]),
+        new InvocationHandler {
+          override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef = method.getName match {
+            case "isWrapperFor" => java.lang.Boolean.FALSE
+            case "unwrap"       => null
+            case "isClosed"     => java.lang.Boolean.FALSE
+            case "toString"     => "MockConnection"
+            case _              =>
+              val rt = method.getReturnType
+              if (rt == java.lang.Boolean.TYPE) java.lang.Boolean.FALSE
+              else if (rt == java.lang.Integer.TYPE) Integer.valueOf(0)
+              else if (rt == java.lang.Long.TYPE) java.lang.Long.valueOf(0L)
+              else null
+          }
+        }
+      )
+      .asInstanceOf[Connection]
+
+  private def trackingSQLiteWrapper(
+    delegate: Connection,
+    closedFlag: AtomicBoolean,
+    failUnwrap: Boolean = false,
+    failGetAutoCommit: Boolean = false,
+    failSetAutoCommit: Boolean = false,
+    failClose: Boolean = false
+  ): Connection =
+    Proxy
+      .newProxyInstance(
+        getClass.getClassLoader,
+        Array(classOf[Connection]),
+        new InvocationHandler {
+          override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef = method.getName match {
+            case "isWrapperFor" => java.lang.Boolean.TRUE
+            case "unwrap"       =>
+              if (failUnwrap) throw new SQLException("unwrap boom")
+              else delegate.unwrap(args.nn(0).asInstanceOf[Class[?]]).asInstanceOf[AnyRef]
+            case "getAutoCommit" =>
+              if (failGetAutoCommit) throw new SQLException("getAutoCommit boom")
+              else java.lang.Boolean.valueOf(delegate.getAutoCommit)
+            case "setAutoCommit" =>
+              if (failSetAutoCommit) throw new SQLException("setAutoCommit boom")
+              else { delegate.setAutoCommit(args.nn(0).asInstanceOf[java.lang.Boolean].booleanValue()); null }
+            case "close" =>
+              closedFlag.set(true)
+              if (failClose) throw new SQLException("close boom")
+              else { delegate.close(); null }
+            case "isClosed" => java.lang.Boolean.valueOf(closedFlag.get() || delegate.isClosed)
+            case "toString" => "TrackingSQLiteWrapper"
+            case _          =>
+              if (args == null) {
+                try method.invoke(delegate)
+                catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+              } else {
+                try method.invoke(delegate, args*)
+                catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+              }
+          }
+        }
+      )
+      .asInstanceOf[Connection]
+
+  def spec: Spec[TestEnvironment, Any] = suite("JdbcTransactorSQLiteSpec")(
+    test("fromUrl configures busy_timeout and IMMEDIATE") {
+      val tmp = Files.createTempFile("sqlite-fromUrl", ".db").toFile
+      tmp.deleteOnExit()
+      val url = s"jdbc:sqlite:${tmp.getAbsolutePath}"
+      val tx  = JdbcTransactor.fromUrl(url, SqlDialect.SQLite)
+      try {
+        val ok = tx.transact {
+          val conn = summon[DbTx].connection match {
+            case jc: JdbcConnection => jc.underlying
+            case other              => throw new IllegalStateException(s"unexpected $other")
+          }
+          val busy = busyTimeoutViaPragma(conn)
+          val mode = transactionModeViaConfig(conn)
+          assertTrue(busy == 5000, mode == "IMMEDIATE")
+        }
+        ok
+      } finally tmp.delete()
+    },
+    test("sqlite(DataSource) with concrete SQLiteDataSource configures busy_timeout and IMMEDIATE") {
+      val sds = new SQLiteDataSource()
+      sds.setUrl("jdbc:sqlite::memory:")
+      val tx = JdbcTransactor.sqlite(sds)
+      // DataSource-level config also set via fromDataSource reflection
+      assertTrue(sds.getConfig.getBusyTimeout == 5000) &&
+      assertTrue(sds.getConfig.getTransactionMode == SQLiteConfig.TransactionMode.IMMEDIATE) &&
+      tx.transact {
+        val conn = summon[DbTx].connection match {
+          case jc: JdbcConnection => jc.underlying
+          case other              => throw new IllegalStateException(s"unexpected $other")
+        }
+        val busy = busyTimeoutViaPragma(conn)
+        val mode = transactionModeViaConfig(conn)
+        assertTrue(busy == 5000, mode == "IMMEDIATE")
+      }
+    },
+    test("wrapped/pooled DataSource via isWrapperFor/unwrap still configures busy_timeout and IMMEDIATE") {
+      val real = new SQLiteDataSource()
+      real.setUrl("jdbc:sqlite::memory:")
+      val wrapped = wrappedDataSource(real)
+      val tx      = JdbcTransactor.sqlite(wrapped)
+      tx.transact {
+        val conn = summon[DbTx].connection match {
+          case jc: JdbcConnection => jc.underlying
+          case other              => throw new IllegalStateException(s"unexpected $other")
+        }
+        val isWrapper = conn.isWrapperFor(classOf[SQLiteConnection])
+        val unwrapped = conn.unwrap(classOf[SQLiteConnection])
+        val busy      = busyTimeoutViaPragma(conn)
+        val mode      = transactionModeViaConfig(conn)
+        assertTrue(isWrapper, unwrapped != null, busy == 5000, mode == "IMMEDIATE")
+      }
+    },
+    test("connect also configures pooled SQLite connection") {
+      val real = new SQLiteDataSource()
+      real.setUrl("jdbc:sqlite::memory:")
+      val wrapped = wrappedDataSource(real)
+      val tx      = JdbcTransactor.sqlite(wrapped)
+      tx.connect {
+        val conn = summon[DbCon].connection match {
+          case jc: JdbcConnection => jc.underlying
+          case other              => throw new IllegalStateException(s"unexpected $other")
+        }
+        val busy = busyTimeoutViaPragma(conn)
+        val mode = transactionModeViaConfig(conn)
+        assertTrue(busy == 5000, mode == "IMMEDIATE")
+      }
+    },
+    test("configureSQLiteConnection skips non-SQLite connections without throwing") {
+      val mock = mockConnection()
+      // Should not throw; mock is not SQLite so early return
+      JdbcTransactor.configureSQLiteConnection(mock)
+      assertTrue(true)
+    },
+    test("configureSQLiteConnection propagates failures on real SQLite connections") {
+      val tmp = Files.createTempFile("sqlite-propagate", ".db").toFile
+      tmp.deleteOnExit()
+      val realConn = DriverManager.getConnection(s"jdbc:sqlite:${tmp.getAbsolutePath}")
+      try {
+        // Wrap real SQLite connection but make unwrap throw
+        val failingWrapper = Proxy
+          .newProxyInstance(
+            getClass.getClassLoader,
+            Array(classOf[Connection]),
+            new InvocationHandler {
+              override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef =
+                method.getName match {
+                  case "isWrapperFor" => java.lang.Boolean.TRUE
+                  case "unwrap"       => throw new java.sql.SQLException("unwrap boom")
+                  case "toString"     => "FailingWrapper"
+                  case _              =>
+                    if (args == null) {
+                      try method.invoke(realConn)
+                      catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+                    } else {
+                      try method.invoke(realConn, args*)
+                      catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+                    }
+                }
+            }
+          )
+          .asInstanceOf[Connection]
+        var threw = false
+        try JdbcTransactor.configureSQLiteConnection(failingWrapper)
+        catch { case _: java.sql.SQLException => threw = true; case _: Throwable => threw = true }
+        assertTrue(threw)
+      } finally {
+        realConn.close()
+        tmp.delete()
+      }
+    },
+    test("connect closes connection when SQLite configuration fails") {
+      val tmp = Files.createTempFile("sqlite-connect-close", ".db").toFile
+      tmp.deleteOnExit()
+      val realConn = DriverManager.getConnection(s"jdbc:sqlite:${tmp.getAbsolutePath}")
+      try {
+        val closed     = new AtomicBoolean(false)
+        val wrapper    = trackingSQLiteWrapper(realConn, closed, failUnwrap = true, failClose = false)
+        val tx         = new JdbcTransactor(() => wrapper, SqlDialect.SQLite)
+        var threw      = false
+        var suppressed = false
+        try tx.connect(1)
+        catch {
+          case e: SQLException =>
+            threw = e.getMessage.contains("unwrap boom")
+            suppressed = e.getSuppressed.nonEmpty
+          case _: Throwable => threw = true
+        }
+        assertTrue(threw, closed.get(), !suppressed)
+      } finally {
+        try realConn.close()
+        catch { case _: Throwable => () }
+        tmp.delete()
+      }
+    },
+    test("connect suppresses close failure onto configuration exception") {
+      val tmp = Files.createTempFile("sqlite-connect-suppress", ".db").toFile
+      tmp.deleteOnExit()
+      val realConn = DriverManager.getConnection(s"jdbc:sqlite:${tmp.getAbsolutePath}")
+      try {
+        val wrapper       = trackingSQLiteWrapper(realConn, new AtomicBoolean(false), failUnwrap = true, failClose = true)
+        val tx            = new JdbcTransactor(() => wrapper, SqlDialect.SQLite)
+        var threw         = false
+        var hasSuppressed = false
+        try tx.connect(1)
+        catch {
+          case e: SQLException =>
+            threw = e.getMessage.contains("unwrap boom")
+            hasSuppressed = e.getSuppressed.exists(_.getMessage.contains("close boom"))
+          case _: Throwable => threw = true
+        }
+        assertTrue(threw, hasSuppressed)
+      } finally {
+        try realConn.close()
+        catch { case _: Throwable => () }
+        tmp.delete()
+      }
+    },
+    test("transact closes connection when SQLite configuration fails") {
+      val tmp = Files.createTempFile("sqlite-transact-config-close", ".db").toFile
+      tmp.deleteOnExit()
+      val realConn = DriverManager.getConnection(s"jdbc:sqlite:${tmp.getAbsolutePath}")
+      try {
+        val closed  = new AtomicBoolean(false)
+        val wrapper = trackingSQLiteWrapper(realConn, closed, failUnwrap = true)
+        val tx      = new JdbcTransactor(() => wrapper, SqlDialect.SQLite)
+        var threw   = false
+        try tx.transact(1)
+        catch { case _: SQLException => threw = true; case _: Throwable => threw = true }
+        assertTrue(threw, closed.get())
+      } finally {
+        try realConn.close()
+        catch { case _: Throwable => () }
+        tmp.delete()
+      }
+    },
+    test("transact closes connection when getAutoCommit fails") {
+      val tmp = Files.createTempFile("sqlite-transact-getAC", ".db").toFile
+      tmp.deleteOnExit()
+      val realConn = DriverManager.getConnection(s"jdbc:sqlite:${tmp.getAbsolutePath}")
+      try {
+        val closed  = new AtomicBoolean(false)
+        val wrapper = trackingSQLiteWrapper(realConn, closed, failGetAutoCommit = true)
+        val tx      = new JdbcTransactor(() => wrapper, SqlDialect.SQLite)
+        var threw   = false
+        try tx.transact(1)
+        catch { case _: SQLException => threw = true; case _: Throwable => threw = true }
+        assertTrue(threw, closed.get())
+      } finally {
+        try realConn.close()
+        catch { case _: Throwable => () }
+        tmp.delete()
+      }
+    },
+    test("transact closes connection when setAutoCommit(false) fails") {
+      val tmp = Files.createTempFile("sqlite-transact-setAC", ".db").toFile
+      tmp.deleteOnExit()
+      val realConn = DriverManager.getConnection(s"jdbc:sqlite:${tmp.getAbsolutePath}")
+      try {
+        val closed  = new AtomicBoolean(false)
+        val wrapper = trackingSQLiteWrapper(realConn, closed, failSetAutoCommit = true)
+        val tx      = new JdbcTransactor(() => wrapper, SqlDialect.SQLite)
+        var threw   = false
+        try tx.transact(1)
+        catch { case _: SQLException => threw = true; case _: Throwable => threw = true }
+        assertTrue(threw, closed.get())
+      } finally {
+        try realConn.close()
+        catch { case _: Throwable => () }
+        tmp.delete()
+      }
+    },
+    test("contention: second transaction waits rather than failing immediately") {
+      val tmp = Files.createTempFile("sqlite-contention", ".db").toFile
+      tmp.deleteOnExit()
+      val url = s"jdbc:sqlite:${tmp.getAbsolutePath}"
+      val tx  = JdbcTransactor.fromUrl(url, SqlDialect.SQLite)
+      tx.connect {
+        Frag.literal("CREATE TABLE contention_test (id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT)").update
+      }
+      val executor = Executors.newFixedThreadPool(2)
+      try {
+        val holderStarted   = new CountDownLatch(1)
+        val holderCanCommit = new CountDownLatch(1)
+        // Explicit raw JDBC holder with IMMEDIATE/busy_timeout=5000, holds RESERVED lock deterministically
+        val holderFuture = executor.submit(new java.util.concurrent.Callable[Unit] {
+          override def call(): Unit = {
+            val props = new java.util.Properties()
+            props.setProperty("busy_timeout", "5000")
+            props.setProperty("transaction_mode", "IMMEDIATE")
+            val holderConn = DriverManager.getConnection(url, props)
+            try {
+              holderConn.setAutoCommit(false)
+              val st = holderConn.createStatement()
+              try st.executeUpdate("INSERT INTO contention_test (v) VALUES ('first')")
+              finally st.close()
+              holderStarted.countDown()
+              // Hold lock until main thread releases
+              holderCanCommit.await(5, TimeUnit.SECONDS)
+              holderConn.commit()
+            } finally holderConn.close()
+          }
+        })
+        assertTrue(holderStarted.await(5, TimeUnit.SECONDS))
+        // Second transaction via JdbcTransactor against same file DB — must wait via busy_timeout, not fail BUSY
+        val secondFuture = executor.submit(new java.util.concurrent.Callable[Unit] {
+          override def call(): Unit =
+            tx.transact {
+              Frag.literal("INSERT INTO contention_test (v) VALUES ('second')").update
+            }
+        })
+        // Release holder so second can proceed; both get bounded awaits so test cannot hang
+        holderCanCommit.countDown()
+        var succeeded  = false
+        var busyFailed = false
+        try {
+          secondFuture.get(5, TimeUnit.SECONDS)
+          succeeded = true
+        } catch {
+          case e: java.util.concurrent.ExecutionException =>
+            val cause = e.getCause
+            if (cause != null && cause.getMessage != null && cause.getMessage.contains("BUSY")) busyFailed = true
+            else busyFailed = true
+          case _: Throwable => busyFailed = true
+        }
+        holderFuture.get(5, TimeUnit.SECONDS)
+        val rows = tx.connect {
+          Frag.literal("SELECT COUNT(*) FROM contention_test").queryOne[Int]
+        }
+        assertTrue(succeeded, !busyFailed, rows.contains(2))
+      } finally {
+        executor.shutdown()
+        executor.awaitTermination(5, TimeUnit.SECONDS)
+        tmp.delete()
+      }
+    }
+  )
+}


### PR DESCRIPTION
Fixes https://github.com/zio/zio-blocks/pull/1534#discussion_r3863454094

SQLite dequeue was documented as using BEGIN IMMEDIATE + busy timeout but implementation only issued plain SELECT via JdbcTransactor.transact (deferred transaction). With concurrent writer, worker acquires read lock for SELECT then loses reserved lock, failing DELETE with SQLITE_BUSY.

Changes:
- JdbcTransactor.connect: set PRAGMA busy_timeout = 5000 for SQLite so writers/waiters block instead of failing instantly.
- JdbcTransactor.transact: for SQLite, set busy_timeout and execute BEGIN IMMEDIATE before worker transaction so dequeue SELECT+DELETE holds write lock upfront.
- QueueTable: update Scaladoc to document that immediate-mode + busy_timeout are provided by JdbcTransactor.transact (single-consumer on SQLite).

Test: dataMigrationJVM/test passes (33 tests), sqlJVM core passes (non-PG tests). Docs still claim SQLite uses BEGIN IMMEDIATE + busy timeout, now implemented.