### PR TITLE
feat(sql): upsert and keyset pagination

### DIFF
--- a/docs/guides/query-dsl-sql.md
+++ b/docs/guides/query-dsl-sql.md
@@ -726,6 +726,166 @@ println(toSql(Product.price * 0.9))
 // (price * 0.9)
 ```
 
+## Upsert (ON CONFLICT)
+
+Upsert (insert-or-update) combines an `INSERT` with a conflict handler so the
+statement is idempotent. When a row with the conflicting key already exists, the
+database either skips the insert or updates specified columns.
+
+All identifiers (table name, column names, conflict column) are validated through
+`SqlIdentifier.validate` and assignment columns are additionally checked against
+`Table.columns`. Invalid or unknown names throw `IllegalArgumentException` at
+build time, not at execution time.
+
+### Table-aware builders
+
+The high-level `Upsert` builders accept a `Table[A]` and an entity. The table
+provides column names and a codec that extracts `DbValue` parameters.
+
+`Upsert.insertDoNothing` builds `INSERT ... ON CONFLICT ("id") DO NOTHING`:
+
+```scala mdoc:compile-only
+import zio.blocks.sql.*
+import zio.blocks.schema.Schema
+
+case class User(id: Int, name: String, email: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
+
+val table: Table[User] = Table.derived[User]
+val user = User(42, "Alice", "alice@example.com")
+
+// INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO NOTHING
+val frag: Frag = Upsert.insertDoNothing(table, user, conflictColumn = "id")
+```
+
+`Upsert.insertDoUpdate` builds `INSERT ... ON CONFLICT ("id") DO UPDATE SET`
+for **all** non-conflict columns:
+
+```scala mdoc:compile-only
+import zio.blocks.sql.*
+import zio.blocks.schema.Schema
+
+case class User(id: Int, name: String, email: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
+
+val table: Table[User] = Table.derived[User]
+val user = User(42, "Alice", "alice@example.com")
+
+// INSERT INTO user (id, name, email) VALUES (?, ?, ?)
+//   ON CONFLICT ("id") DO UPDATE SET "name" = ?, "email" = ?
+val frag: Frag = Upsert.insertDoUpdate(table, user, conflictColumn = "id")
+```
+
+Pass `updateColumns` to restrict which columns are overwritten on conflict:
+
+```scala mdoc:compile-only
+import zio.blocks.sql.*
+import zio.blocks.schema.Schema
+
+case class User(id: Int, name: String, email: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
+
+val table: Table[User] = Table.derived[User]
+val user = User(42, "Alice", "alice@example.com")
+
+// Only "name" is updated on conflict; "email" keeps its original value
+val frag: Frag = Upsert.insertDoUpdate(table, user, conflictColumn = "id", updateColumns = Seq("name"))
+```
+
+### Low-level builders
+
+When you need full control over column names and values (e.g. computed or
+transformed data), use the low-level `Upsert.doNothing`, `Upsert.doNothingRaw`,
+and `Upsert.doUpdate` builders:
+
+```scala mdoc:compile-only
+import zio.blocks.sql.*
+
+// Low-level DO NOTHING with explicit columns and values
+val frag1: Frag = Upsert.doNothing(
+  tableName   = "users",
+  columns     = IndexedSeq("id", "name", "email"),
+  values      = IndexedSeq(DbValue.DbInt(1), DbValue.DbString("Bob"), DbValue.DbString("bob@example.com")),
+  conflictColumn = "id"
+)
+
+// Comma-joined column string variant
+val frag2: Frag = Upsert.doNothingRaw(
+  tableName   = "users",
+  allColumns  = "id, name, email",
+  values      = IndexedSeq(DbValue.DbInt(1), DbValue.DbString("Bob"), DbValue.DbString("bob@example.com")),
+  conflictColumn = "id"
+)
+
+// Low-level DO UPDATE with explicit assignments
+val frag3: Frag = Upsert.doUpdate(
+  tableName      = "users",
+  columns        = IndexedSeq("id", "name", "email"),
+  values         = IndexedSeq(DbValue.DbInt(1), DbValue.DbString("Bob"), DbValue.DbString("bob@example.com")),
+  conflictColumn = "id",
+  assignments    = IndexedSeq("name" -> DbValue.DbString("Bob"), "email" -> DbValue.DbString("bob@example.com"))
+)
+```
+
+### Suffix builders
+
+To append an `ON CONFLICT` clause to an existing `INSERT` `Frag`, use the suffix
+builders:
+
+```scala mdoc:compile-only
+import zio.blocks.sql.*
+
+val base: Frag = Frag.literal("INSERT INTO users (id, name) VALUES (?, ?)")
+
+// Append DO NOTHING suffix
+val withNothing: Frag = base ++ Upsert.doNothingSuffix(conflictColumn = "id")
+
+// Append DO UPDATE suffix with explicit assignments
+val withUpdate: Frag = base ++ Upsert.doUpdateSuffix(
+  conflictColumn = "id",
+  assignments    = IndexedSeq("name" -> DbValue.DbString("updated"))
+)
+```
+
+### Repository integration
+
+`Repo` provides `insertOrUpdate` and `insertOrUpdateBatch` as convenience
+wrappers that use `Upsert.insertDoUpdate` under the hood. The conflict target is
+the repository's validated ID column, and all non-ID columns are overwritten with
+the entity's values.
+
+```scala mdoc:compile-only
+import zio.blocks.sql.*
+import zio.blocks.schema.Schema
+
+case class User(id: Int, name: String, email: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
+
+given DbCon = ???
+
+val table: Table[User] = Table.derived[User]
+val repo: Repo[User, Int] = ???
+
+val user = User(42, "Alice", "alice@example.com")
+
+// Single upsert
+val affected: Int = repo.insertOrUpdate(user)
+
+// Batch upsert
+val users: List[User] = List(user, User(43, "Bob", "bob@example.com"))
+val totalAffected: Int = repo.insertOrUpdateBatch(users)
+```
+
+These generate SQL like:
+
+```sql
+INSERT INTO user (id, name, email) VALUES (?, ?, ?)
+  ON CONFLICT ("id") DO UPDATE SET "name" = ?, "email" = ?
+```
+
+`insertOrUpdateBatch` uses a JDBC batch for efficiency, mirroring the pattern of
+`insertBatch`. Both return the total affected row count.
+
 ## Keyset Pagination
 
 Keyset (cursor) pagination avoids the cost and drift of `OFFSET` by seeking

--- a/docs/guides/query-dsl-sql.md
+++ b/docs/guides/query-dsl-sql.md
@@ -726,6 +726,65 @@ println(toSql(Product.price * 0.9))
 // (price * 0.9)
 ```
 
+## Keyset Pagination
+
+Keyset (cursor) pagination avoids the cost and drift of `OFFSET` by seeking
+after the last seen key: `WHERE id > ? ORDER BY id ASC LIMIT n`. The row
+identified by the cursor is excluded (`>` not `>=`) so consecutive pages do
+not duplicate the boundary row.
+
+`Repo` exposes this directly for primary-key cursors:
+
+```scala mdoc:compile-only
+import zio.blocks.sql.*
+
+// repo: Repo[User, Int] with idColumn = "id"
+val firstPage: List[User]  = repo.pageAfter(cursorId = 0, limit = 20)
+val nextPage: List[User]   = repo.pageAfter(cursorId = firstPage.last.id, limit = 20)
+// when cursorId == last id, nextPage is empty
+```
+
+It renders as:
+
+```sql
+SELECT id, name, email FROM user WHERE id > ? ORDER BY id ASC LIMIT 20
+```
+
+where `?` is bound via `idCodec.toDbValues(cursorId)`. `limit` must be `> 0`.
+
+For non-ID orderings or ad-hoc queries, `Frag.keysetAfter` builds the
+portable `WHERE col > ? ORDER BY col ASC LIMIT n` fragment without a `Repo`:
+
+```scala mdoc:compile-only
+import zio.blocks.sql.*
+
+case class User(id: Int, name: String, email: String)
+import zio.blocks.schema.Schema
+object User { implicit val schema: Schema[User] = Schema.derived }
+val table: Table[User] = Table.derived[User]
+
+// Table-validated: rejects unknown columns
+val frag: Frag = Frag.keysetAfter(table, orderCol = "id", lastValue = DbValue.DbInt(42), limit = 20)
+// frag.sql(dialect) == " WHERE id > ? ORDER BY id ASC LIMIT 20"
+
+// Without a table: identifier-only validation
+val frag2: Frag = Frag.keysetAfter(orderCol = "created_at", lastValue = DbValue.DbLong(1000L), limit = 10)
+```
+
+- `Frag.keysetAfter(table, orderCol, lastValue, limit)` validates `orderCol`
+  with `SqlIdentifier.validate` and checks membership in `table.columns`;
+  unknown columns throw `IllegalArgumentException`.
+- `Frag.keysetAfter(orderCol, lastValue, limit)` validates the identifier only.
+- `limit` must be `> 0`; single-column cursors only (composite cursors are v2).
+
+Compose with a base `SELECT`:
+
+```scala mdoc:compile-only
+val base     = Frag.literal("SELECT id, name, email FROM user")
+val pageFrag = base ++ Frag.keysetAfter(table, "id", DbValue.DbInt(42), 20)
+val rows: List[User] = pageFrag.query[User] // via given DbCon + DbCodec[User]
+```
+
 ## Going Further
 
 - **[Part 1: Expressions](./query-dsl-reified-optics.md)** -- Building query expressions with reified optics

--- a/docs/guides/query-dsl-sql.md
+++ b/docs/guides/query-dsl-sql.md
@@ -787,6 +787,13 @@ val frag2: Frag = Frag.keysetAfter(orderCol = "created_at", lastValue = DbValue.
 Compose with a base `SELECT`:
 
 ```scala mdoc:compile-only
+import zio.blocks.sql.*
+import zio.blocks.schema.Schema
+
+case class User(id: Int, name: String, email: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
+val table: Table[User] = Table.derived[User]
+
 val base     = Frag.literal("SELECT id, name, email FROM user")
 val pageFrag = base ++ Frag.keysetAfter(table, "id", DbValue.DbInt(42), 20)
 // Rendering the SQL does not require a DbCon:

--- a/docs/guides/query-dsl-sql.md
+++ b/docs/guides/query-dsl-sql.md
@@ -737,8 +737,15 @@ not duplicate the boundary row.
 
 ```scala mdoc:compile-only
 import zio.blocks.sql.*
+import zio.blocks.schema.Schema
 
-// repo: Repo[User, Int] with idColumn = "id"
+case class User(id: Int, name: String, email: String)
+object User { implicit val schema: Schema[User] = Schema.derived }
+
+given DbCon = ???
+
+val repo: Repo[User, Int] = ??? // e.g. Repo(table, "id", idCodec, _.id)
+
 val firstPage: List[User]  = repo.pageAfter(cursorId = 0, limit = 20)
 val nextPage: List[User]   = repo.pageAfter(cursorId = firstPage.last.id, limit = 20)
 // when cursorId == last id, nextPage is empty
@@ -782,7 +789,12 @@ Compose with a base `SELECT`:
 ```scala mdoc:compile-only
 val base     = Frag.literal("SELECT id, name, email FROM user")
 val pageFrag = base ++ Frag.keysetAfter(table, "id", DbValue.DbInt(42), 20)
-val rows: List[User] = pageFrag.query[User] // via given DbCon + DbCodec[User]
+// Rendering the SQL does not require a DbCon:
+val sql: String = pageFrag.sql(SqlDialect.SQLite) // SELECT id, name, email FROM user WHERE id > ? ORDER BY id ASC LIMIT 20
+// Executing needs givens at the call site:
+// given DbCon = ???
+// given DbCodec[User] = table.codec
+// val rows: List[User] = pageFrag.query[User]
 ```
 
 ## Going Further

--- a/sql/jvm/src/test/scala/zio/blocks/sql/RepoKeysetSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/RepoKeysetSpec.scala
@@ -28,27 +28,29 @@ object RepoKeysetSpec extends ZIOSpecDefault {
     implicit val schema: Schema[User] = Schema.derived
   }
 
-  private val userTable = Table.derived[User]
-  private given DbCodec[User] = User.schema.deriving(DbCodecDeriver).derive
-  private given DbCodec[Int] = implicitly[Schema[Int]].deriving(DbCodecDeriver).derive
+  private val userTable              = Table.derived[User]
+  private given DbCodec[User]        = User.schema.deriving(DbCodecDeriver).derive
+  private given DbCodec[Int]         = implicitly[Schema[Int]].deriving(DbCodecDeriver).derive
   private val intCodec: DbCodec[Int] = summon[DbCodec[Int]]
-  private val userRepo = Repo(userTable, "id", intCodec, (_: User).id)
+  private val userRepo               = Repo(userTable, "id", intCodec, (_: User).id)
 
   private def withFreshDb[A](f: JdbcTransactor => A): A = {
     val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
-    val tx = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+    val tx   = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
       override def connect[B](f: DbCon ?=> B): B = {
-        val dbConn = new JdbcConnection(conn)
+        val dbConn       = new JdbcConnection(conn)
         given con: DbCon = new DbCon {
           val connection: DbConnection = dbConn
-          val dialect: SqlDialect = SqlDialect.SQLite
-          val logger: SqlLogger = SqlLogger.noop
+          val dialect: SqlDialect      = SqlDialect.SQLite
+          val logger: SqlLogger        = SqlLogger.noop
         }
         f
       }
     }
     tx.connect {
-      Frag.literal("CREATE TABLE IF NOT EXISTS user (id INTEGER NOT NULL, name TEXT NOT NULL, email TEXT NOT NULL)").update
+      Frag
+        .literal("CREATE TABLE IF NOT EXISTS user (id INTEGER NOT NULL, name TEXT NOT NULL, email TEXT NOT NULL)")
+        .update
     }
     try f(tx)
     finally conn.close()
@@ -61,7 +63,7 @@ object RepoKeysetSpec extends ZIOSpecDefault {
           tx.connect {
             (1 to 5).foreach(i => userRepo.insert(User(i, s"u$i", s"u$i@test.com")))
             val lastId = 5
-            val page = userRepo.pageAfter(lastId, 10)
+            val page   = userRepo.pageAfter(lastId, 10)
             assertTrue(page.isEmpty)
           }
         }
@@ -86,9 +88,9 @@ object RepoKeysetSpec extends ZIOSpecDefault {
         withFreshDb { tx =>
           tx.connect {
             (1 to 100).foreach(i => userRepo.insert(User(i, s"user$i", s"user$i@example.com")))
-            var cursor = 0
-            var seen = List.empty[Int]
-            var pages = 0
+            var cursor   = 0
+            var seen     = List.empty[Int]
+            var pages    = 0
             var continue = true
             while (continue) {
               val page = userRepo.pageAfter(cursor, 7)

--- a/sql/jvm/src/test/scala/zio/blocks/sql/RepoKeysetSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/RepoKeysetSpec.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.sql
+
+import zio.test._
+import zio.blocks.schema._
+import java.sql.DriverManager
+
+object RepoKeysetSpec extends ZIOSpecDefault {
+  private val _ = Class.forName("org.sqlite.JDBC")
+
+  case class User(id: Int, name: String, email: String)
+  object User {
+    implicit val schema: Schema[User] = Schema.derived
+  }
+
+  private val userTable = Table.derived[User]
+  private given DbCodec[User] = User.schema.deriving(DbCodecDeriver).derive
+  private given DbCodec[Int] = implicitly[Schema[Int]].deriving(DbCodecDeriver).derive
+  private val intCodec: DbCodec[Int] = summon[DbCodec[Int]]
+  private val userRepo = Repo(userTable, "id", intCodec, (_: User).id)
+
+  private def withFreshDb[A](f: JdbcTransactor => A): A = {
+    val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
+    val tx = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+      override def connect[B](f: DbCon ?=> B): B = {
+        val dbConn = new JdbcConnection(conn)
+        given con: DbCon = new DbCon {
+          val connection: DbConnection = dbConn
+          val dialect: SqlDialect = SqlDialect.SQLite
+          val logger: SqlLogger = SqlLogger.noop
+        }
+        f
+      }
+    }
+    tx.connect {
+      Frag.literal("CREATE TABLE IF NOT EXISTS user (id INTEGER NOT NULL, name TEXT NOT NULL, email TEXT NOT NULL)").update
+    }
+    try f(tx)
+    finally conn.close()
+  }
+
+  def spec: Spec[TestEnvironment, Any] = suite("RepoKeysetSpec")(
+    suite("Repo.pageAfter")(
+      test("boundary: cursor=last id gives empty page") {
+        withFreshDb { tx =>
+          tx.connect {
+            (1 to 5).foreach(i => userRepo.insert(User(i, s"u$i", s"u$i@test.com")))
+            val lastId = 5
+            val page = userRepo.pageAfter(lastId, 10)
+            assertTrue(page.isEmpty)
+          }
+        }
+      },
+      test("stable cross-page ordering (ORDER BY id ASC, cursor excluded)") {
+        withFreshDb { tx =>
+          tx.connect {
+            // insert out of order to ensure ordering is by SQL, not insertion order
+            Seq(3, 1, 5, 2, 4).foreach(i => userRepo.insert(User(i, s"u$i", s"u$i@test.com")))
+            val p1 = userRepo.pageAfter(0, 2)
+            val p2 = userRepo.pageAfter(p1.last.id, 2)
+            val p3 = userRepo.pageAfter(p2.last.id, 10)
+            assertTrue(
+              p1.map(_.id) == List(1, 2),
+              p2.map(_.id) == List(3, 4),
+              p3.map(_.id) == List(5)
+            )
+          }
+        }
+      },
+      test("walk 100 rows in pages of 7 - each row seen exactly once") {
+        withFreshDb { tx =>
+          tx.connect {
+            (1 to 100).foreach(i => userRepo.insert(User(i, s"user$i", s"user$i@example.com")))
+            var cursor = 0
+            var seen = List.empty[Int]
+            var pages = 0
+            var continue = true
+            while (continue) {
+              val page = userRepo.pageAfter(cursor, 7)
+              if (page.isEmpty) continue = false
+              else {
+                assertTrue(page.map(_.id) == page.map(_.id).sorted)
+                assertTrue(!page.exists(u => seen.contains(u.id)))
+                seen = seen ++ page.map(_.id)
+                cursor = page.last.id
+                pages += 1
+                if (pages > 100) continue = false
+              }
+            }
+            assertTrue(
+              seen.size == 100,
+              seen.sorted == (1 to 100).toList,
+              seen.distinct.size == 100,
+              pages == 15
+            )
+          }
+        }
+      },
+      test("limit validation rejects <=0") {
+        withFreshDb { tx =>
+          tx.connect {
+            userRepo.insert(User(1, "a", "a@test.com"))
+            val r1 = scala.util.Try(userRepo.pageAfter(0, 0))
+            val r2 = scala.util.Try(userRepo.pageAfter(0, -1))
+            assertTrue(
+              r1.isFailure && r1.failed.get.isInstanceOf[IllegalArgumentException],
+              r2.isFailure && r2.failed.get.isInstanceOf[IllegalArgumentException]
+            )
+          }
+        }
+      },
+      test("uses > not >= (cursor row not repeated)") {
+        withFreshDb { tx =>
+          tx.connect {
+            (1 to 3).foreach(i => userRepo.insert(User(i, s"u$i", s"u$i@test.com")))
+            val p1 = userRepo.pageAfter(0, 2)
+            val p2 = userRepo.pageAfter(p1.last.id, 2)
+            assertTrue(
+              p1.map(_.id) == List(1, 2),
+              p2.map(_.id) == List(3),
+              !p2.exists(_.id == p1.last.id)
+            )
+          }
+        }
+      }
+    ),
+    suite("Frag.keysetAfter integration")(
+      test("unknown order column rejected via Frag.keysetAfter with table") {
+        withFreshDb { tx =>
+          tx.connect {
+            val result = scala.util.Try(Frag.keysetAfter(userTable, "bad_col", DbValue.DbInt(1), 10))
+            assertTrue(result.isFailure && result.failed.get.isInstanceOf[IllegalArgumentException])
+          }
+        }
+      },
+      test("Frag.keysetAfter composes into SELECT and paginates") {
+        withFreshDb { tx =>
+          tx.connect {
+            (1 to 10).foreach(i => userRepo.insert(User(i, s"u$i", s"u$i@test.com")))
+            val base = Frag.literal("SELECT id, name, email FROM user")
+            val frag = base ++ Frag.keysetAfter(userTable, "id", DbValue.DbInt(5), 3)
+            val rows = frag.query[User]
+            assertTrue(rows.map(_.id) == List(6, 7, 8))
+          }
+        }
+      }
+    )
+  )
+}

--- a/sql/jvm/src/test/scala/zio/blocks/sql/RepoUpsertSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/RepoUpsertSpec.scala
@@ -164,8 +164,10 @@ object RepoUpsertSpec extends ZIOSpecDefault {
       test("insert new via upsert inserts 1 row") {
         withFreshDb { tx =>
           tx.connect {
-            val c = userRepo.insertOrUpdate(User(1, "Alice", "alice@test.com"))
-            assertTrue(c == 1, userRepo.count == 1L, userRepo.find(1).get.name == "Alice")
+            val c     = userRepo.insertOrUpdate(User(1, "Alice", "alice@test.com"))
+            val cnt   = userRepo.count
+            val found = userRepo.find(1)
+            assertTrue(c == 1, cnt == 1L, found.get.name == "Alice")
           }
         }
       },
@@ -175,12 +177,13 @@ object RepoUpsertSpec extends ZIOSpecDefault {
             userRepo.insert(User(1, "Alice", "alice@test.com"))
             val c     = userRepo.insertOrUpdate(User(1, "Alice Updated", "new@test.com"))
             val found = userRepo.find(1)
+            val cnt   = userRepo.count
             assertTrue(
               c == 1,
               found.isDefined,
               found.get.name == "Alice Updated",
               found.get.email == "new@test.com",
-              userRepo.count == 1L
+              cnt == 1L
             )
           }
         }
@@ -191,9 +194,11 @@ object RepoUpsertSpec extends ZIOSpecDefault {
             userRepo.insertOrUpdate(User(1, "First", "first@test.com"))
             userRepo.insertOrUpdate(User(1, "Second", "second@test.com"))
             val found = userRepo.find(1)
+            val cnt   = userRepo.count
+            val all   = userRepo.all
             assertTrue(
-              userRepo.count == 1L,
-              userRepo.all.size == 1,
+              cnt == 1L,
+              all.size == 1,
               found.isDefined,
               found.get.name == "Second",
               found.get.email == "second@test.com"
@@ -204,10 +209,11 @@ object RepoUpsertSpec extends ZIOSpecDefault {
       test("insertOrUpdate new vs update both return 1") {
         withFreshDb { tx =>
           tx.connect {
-            val c1 = userRepo.insertOrUpdate(User(10, "A", "a@test.com"))
-            val c2 = userRepo.insertOrUpdate(User(10, "B", "b@test.com"))
-            val c3 = userRepo.insertOrUpdate(User(11, "C", "c@test.com"))
-            assertTrue(c1 == 1, c2 == 1, c3 == 1, userRepo.count == 2L)
+            val c1  = userRepo.insertOrUpdate(User(10, "A", "a@test.com"))
+            val c2  = userRepo.insertOrUpdate(User(10, "B", "b@test.com"))
+            val c3  = userRepo.insertOrUpdate(User(11, "C", "c@test.com"))
+            val cnt = userRepo.count
+            assertTrue(c1 == 1, c2 == 1, c3 == 1, cnt == 2L)
           }
         }
       },
@@ -217,8 +223,9 @@ object RepoUpsertSpec extends ZIOSpecDefault {
             userRepo.insert(User(1, "Alice", "a@test.com"))
             userRepo.insert(User(2, "Bob", "b@test.com"))
             userRepo.insertOrUpdate(User(1, "Alice2", "a2@test.com"))
-            val b = userRepo.find(2)
-            assertTrue(b.isDefined, b.get.name == "Bob", b.get.email == "b@test.com", userRepo.count == 2L)
+            val b   = userRepo.find(2)
+            val cnt = userRepo.count
+            assertTrue(b.isDefined, b.get.name == "Bob", b.get.email == "b@test.com", cnt == 2L)
           }
         }
       },
@@ -252,7 +259,9 @@ object RepoUpsertSpec extends ZIOSpecDefault {
                 User(3, "Charlie", "c@test.com")
               )
             )
-            assertTrue(c == 3, userRepo.count == 3L, userRepo.all.size == 3)
+            val cnt = userRepo.count
+            val all = userRepo.all
+            assertTrue(c == 3, cnt == 3L, all.size == 3)
           }
         }
       },
@@ -268,12 +277,13 @@ object RepoUpsertSpec extends ZIOSpecDefault {
                 User(2, "Bob Updated", "b2@test.com")
               )
             )
-            val a1 = userRepo.find(1)
-            val a2 = userRepo.find(2)
-            val a3 = userRepo.find(3)
+            val a1  = userRepo.find(1)
+            val a2  = userRepo.find(2)
+            val a3  = userRepo.find(3)
+            val cnt = userRepo.count
             assertTrue(
               c == 3,
-              userRepo.count == 3L,
+              cnt == 3L,
               a1.get.name == "Alice Updated",
               a1.get.email == "a2@test.com",
               a2.get.name == "Bob Updated",
@@ -285,25 +295,29 @@ object RepoUpsertSpec extends ZIOSpecDefault {
       test("batch counts correct") {
         withFreshDb { tx =>
           tx.connect {
-            val c1 = userRepo.insertOrUpdateBatch(List(User(1, "A", "a@test.com"), User(2, "B", "b@test.com")))
-            val c2 = userRepo.insertOrUpdateBatch(List(User(1, "A2", "a2@test.com"), User(3, "C", "c@test.com")))
-            assertTrue(c1 == 2, c2 == 2, userRepo.count == 3L)
+            val c1  = userRepo.insertOrUpdateBatch(List(User(1, "A", "a@test.com"), User(2, "B", "b@test.com")))
+            val c2  = userRepo.insertOrUpdateBatch(List(User(1, "A2", "a2@test.com"), User(3, "C", "c@test.com")))
+            val cnt = userRepo.count
+            assertTrue(c1 == 2, c2 == 2, cnt == 3L)
           }
         }
       },
       test("empty batch returns 0 without touching db") {
         withFreshDb { tx =>
           tx.connect {
-            val c = userRepo.insertOrUpdateBatch(List.empty[User])
-            assertTrue(c == 0, userRepo.count == 0L)
+            val c   = userRepo.insertOrUpdateBatch(List.empty[User])
+            val cnt = userRepo.count
+            assertTrue(c == 0, cnt == 0L)
           }
         }
       },
       test("single entity batch") {
         withFreshDb { tx =>
           tx.connect {
-            val c = userRepo.insertOrUpdateBatch(List(User(99, "Solo", "solo@test.com")))
-            assertTrue(c == 1, userRepo.count == 1L, userRepo.find(99).isDefined)
+            val c     = userRepo.insertOrUpdateBatch(List(User(99, "Solo", "solo@test.com")))
+            val cnt   = userRepo.count
+            val found = userRepo.find(99)
+            assertTrue(c == 1, cnt == 1L, found.isDefined)
           }
         }
       },
@@ -318,11 +332,14 @@ object RepoUpsertSpec extends ZIOSpecDefault {
                 User(2, "B2", "b2@test.com")
               )
             )
+            val f1  = userRepo.find(1)
+            val f2  = userRepo.find(2)
+            val cnt = userRepo.count
             assertTrue(
               c == 2,
-              userRepo.find(1).get.name == "A2",
-              userRepo.find(2).get.name == "B2",
-              userRepo.count == 2L
+              f1.get.name == "A2",
+              f2.get.name == "B2",
+              cnt == 2L
             )
           }
         }
@@ -332,7 +349,9 @@ object RepoUpsertSpec extends ZIOSpecDefault {
           tx.connect {
             userRepo.insertOrUpdateBatch(List(User(1, "A", "a@test.com")))
             userRepo.insertOrUpdateBatch(List(User(1, "B", "b@test.com")))
-            assertTrue(userRepo.count == 1L, userRepo.find(1).get.name == "B")
+            val cnt   = userRepo.count
+            val found = userRepo.find(1)
+            assertTrue(cnt == 1L, found.get.name == "B")
           }
         }
       }

--- a/sql/jvm/src/test/scala/zio/blocks/sql/RepoUpsertSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/RepoUpsertSpec.scala
@@ -58,96 +58,92 @@ object RepoUpsertSpec extends ZIOSpecDefault {
 
   private def withFreshDb[A](f: JdbcTransactor => A): A = {
     val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
-    try {
-      val tx = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
-        override def connect[B](f: DbCon ?=> B): B = {
-          val dbConn       = new JdbcConnection(conn)
-          given con: DbCon = new DbCon {
-            val connection: DbConnection = dbConn
-            val dialect: SqlDialect      = SqlDialect.SQLite
-            val logger: SqlLogger        = SqlLogger.noop
-          }
-          f
+    val tx   = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+      override def connect[B](f: DbCon ?=> B): B = {
+        val dbConn       = new JdbcConnection(conn)
+        given con: DbCon = new DbCon {
+          val connection: DbConnection = dbConn
+          val dialect: SqlDialect      = SqlDialect.SQLite
+          val logger: SqlLogger        = SqlLogger.noop
         }
+        f
       }
-      tx.connect {
-        Frag
-          .literal("CREATE TABLE IF NOT EXISTS user (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)")
-          .update
-      }
-      f(tx)
-    } finally conn.close()
+    }
+    tx.connect {
+      Frag
+        .literal("CREATE TABLE IF NOT EXISTS user (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)")
+        .update
+    }
+    try f(tx)
+    finally conn.close()
   }
 
   private def withFreshDbAndLogger[A](f: (JdbcTransactor, CapturingLogger) => A): A = {
     val conn       = DriverManager.getConnection("jdbc:sqlite::memory:")
     val testLogger = new CapturingLogger
-    try {
-      val tx = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
-        override def connect[B](f: DbCon ?=> B): B = {
-          val dbConn       = new JdbcConnection(conn)
-          given con: DbCon = new DbCon {
-            val connection: DbConnection = dbConn
-            val dialect: SqlDialect      = SqlDialect.SQLite
-            val logger: SqlLogger        = testLogger
-          }
-          f
+    val tx         = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+      override def connect[B](f: DbCon ?=> B): B = {
+        val dbConn       = new JdbcConnection(conn)
+        given con: DbCon = new DbCon {
+          val connection: DbConnection = dbConn
+          val dialect: SqlDialect      = SqlDialect.SQLite
+          val logger: SqlLogger        = testLogger
         }
+        f
       }
-      tx.connect {
-        Frag
-          .literal("CREATE TABLE IF NOT EXISTS user (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)")
-          .update
-      }
-      testLogger.clear()
-      f(tx, testLogger)
-    } finally conn.close()
+    }
+    tx.connect {
+      Frag
+        .literal("CREATE TABLE IF NOT EXISTS user (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)")
+        .update
+    }
+    testLogger.clear()
+    try f(tx, testLogger)
+    finally conn.close()
   }
 
   private def withUniqueDb[A](f: JdbcTransactor => A): A = {
     val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
-    try {
-      val tx = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
-        override def connect[B](f: DbCon ?=> B): B = {
-          val dbConn       = new JdbcConnection(conn)
-          given con: DbCon = new DbCon {
-            val connection: DbConnection = dbConn
-            val dialect: SqlDialect      = SqlDialect.SQLite
-            val logger: SqlLogger        = SqlLogger.noop
-          }
-          f
+    val tx   = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+      override def connect[B](f: DbCon ?=> B): B = {
+        val dbConn       = new JdbcConnection(conn)
+        given con: DbCon = new DbCon {
+          val connection: DbConnection = dbConn
+          val dialect: SqlDialect      = SqlDialect.SQLite
+          val logger: SqlLogger        = SqlLogger.noop
         }
+        f
       }
-      tx.connect {
-        Frag
-          .literal(
-            "CREATE TABLE IF NOT EXISTS user_unique (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE)"
-          )
-          .update
-      }
-      f(tx)
-    } finally conn.close()
+    }
+    tx.connect {
+      Frag
+        .literal(
+          "CREATE TABLE IF NOT EXISTS user_unique (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE)"
+        )
+        .update
+    }
+    try f(tx)
+    finally conn.close()
   }
 
   private def withOnlyIdDb[A](f: JdbcTransactor => A): A = {
     val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
-    try {
-      val tx = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
-        override def connect[B](f: DbCon ?=> B): B = {
-          val dbConn       = new JdbcConnection(conn)
-          given con: DbCon = new DbCon {
-            val connection: DbConnection = dbConn
-            val dialect: SqlDialect      = SqlDialect.SQLite
-            val logger: SqlLogger        = SqlLogger.noop
-          }
-          f
+    val tx   = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+      override def connect[B](f: DbCon ?=> B): B = {
+        val dbConn       = new JdbcConnection(conn)
+        given con: DbCon = new DbCon {
+          val connection: DbConnection = dbConn
+          val dialect: SqlDialect      = SqlDialect.SQLite
+          val logger: SqlLogger        = SqlLogger.noop
         }
+        f
       }
-      tx.connect {
-        Frag.literal("CREATE TABLE IF NOT EXISTS only_id (id INTEGER PRIMARY KEY)").update
-      }
-      f(tx)
-    } finally conn.close()
+    }
+    tx.connect {
+      Frag.literal("CREATE TABLE IF NOT EXISTS only_id (id INTEGER PRIMARY KEY)").update
+    }
+    try f(tx)
+    finally conn.close()
   }
 
   private class CapturingLogger extends SqlLogger {

--- a/sql/jvm/src/test/scala/zio/blocks/sql/RepoUpsertSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/RepoUpsertSpec.scala
@@ -58,88 +58,96 @@ object RepoUpsertSpec extends ZIOSpecDefault {
 
   private def withFreshDb[A](f: JdbcTransactor => A): A = {
     val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
-    val tx   = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
-      override def connect[B](f: DbCon ?=> B): B = {
-        val dbConn       = new JdbcConnection(conn)
-        given con: DbCon = new DbCon {
-          val connection: DbConnection = dbConn
-          val dialect: SqlDialect      = SqlDialect.SQLite
-          val logger: SqlLogger        = SqlLogger.noop
+    try {
+      val tx = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+        override def connect[B](f: DbCon ?=> B): B = {
+          val dbConn       = new JdbcConnection(conn)
+          given con: DbCon = new DbCon {
+            val connection: DbConnection = dbConn
+            val dialect: SqlDialect      = SqlDialect.SQLite
+            val logger: SqlLogger        = SqlLogger.noop
+          }
+          f
         }
-        f
       }
-    }
-    tx.connect {
-      Frag
-        .literal("CREATE TABLE IF NOT EXISTS user (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)")
-        .update
-    }
-    f(tx)
+      tx.connect {
+        Frag
+          .literal("CREATE TABLE IF NOT EXISTS user (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)")
+          .update
+      }
+      f(tx)
+    } finally conn.close()
   }
 
   private def withFreshDbAndLogger[A](f: (JdbcTransactor, CapturingLogger) => A): A = {
     val conn       = DriverManager.getConnection("jdbc:sqlite::memory:")
     val testLogger = new CapturingLogger
-    val tx         = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
-      override def connect[B](f: DbCon ?=> B): B = {
-        val dbConn       = new JdbcConnection(conn)
-        given con: DbCon = new DbCon {
-          val connection: DbConnection = dbConn
-          val dialect: SqlDialect      = SqlDialect.SQLite
-          val logger: SqlLogger        = testLogger
+    try {
+      val tx = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+        override def connect[B](f: DbCon ?=> B): B = {
+          val dbConn       = new JdbcConnection(conn)
+          given con: DbCon = new DbCon {
+            val connection: DbConnection = dbConn
+            val dialect: SqlDialect      = SqlDialect.SQLite
+            val logger: SqlLogger        = testLogger
+          }
+          f
         }
-        f
       }
-    }
-    tx.connect {
-      Frag
-        .literal("CREATE TABLE IF NOT EXISTS user (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)")
-        .update
-    }
-    testLogger.clear()
-    f(tx, testLogger)
+      tx.connect {
+        Frag
+          .literal("CREATE TABLE IF NOT EXISTS user (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)")
+          .update
+      }
+      testLogger.clear()
+      f(tx, testLogger)
+    } finally conn.close()
   }
 
   private def withUniqueDb[A](f: JdbcTransactor => A): A = {
     val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
-    val tx   = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
-      override def connect[B](f: DbCon ?=> B): B = {
-        val dbConn       = new JdbcConnection(conn)
-        given con: DbCon = new DbCon {
-          val connection: DbConnection = dbConn
-          val dialect: SqlDialect      = SqlDialect.SQLite
-          val logger: SqlLogger        = SqlLogger.noop
+    try {
+      val tx = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+        override def connect[B](f: DbCon ?=> B): B = {
+          val dbConn       = new JdbcConnection(conn)
+          given con: DbCon = new DbCon {
+            val connection: DbConnection = dbConn
+            val dialect: SqlDialect      = SqlDialect.SQLite
+            val logger: SqlLogger        = SqlLogger.noop
+          }
+          f
         }
-        f
       }
-    }
-    tx.connect {
-      Frag
-        .literal(
-          "CREATE TABLE IF NOT EXISTS user_unique (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE)"
-        )
-        .update
-    }
-    f(tx)
+      tx.connect {
+        Frag
+          .literal(
+            "CREATE TABLE IF NOT EXISTS user_unique (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE)"
+          )
+          .update
+      }
+      f(tx)
+    } finally conn.close()
   }
 
   private def withOnlyIdDb[A](f: JdbcTransactor => A): A = {
     val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
-    val tx   = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
-      override def connect[B](f: DbCon ?=> B): B = {
-        val dbConn       = new JdbcConnection(conn)
-        given con: DbCon = new DbCon {
-          val connection: DbConnection = dbConn
-          val dialect: SqlDialect      = SqlDialect.SQLite
-          val logger: SqlLogger        = SqlLogger.noop
+    try {
+      val tx = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+        override def connect[B](f: DbCon ?=> B): B = {
+          val dbConn       = new JdbcConnection(conn)
+          given con: DbCon = new DbCon {
+            val connection: DbConnection = dbConn
+            val dialect: SqlDialect      = SqlDialect.SQLite
+            val logger: SqlLogger        = SqlLogger.noop
+          }
+          f
         }
-        f
       }
-    }
-    tx.connect {
-      Frag.literal("CREATE TABLE IF NOT EXISTS only_id (id INTEGER PRIMARY KEY)").update
-    }
-    f(tx)
+      tx.connect {
+        Frag.literal("CREATE TABLE IF NOT EXISTS only_id (id INTEGER PRIMARY KEY)").update
+      }
+      f(tx)
+    } finally conn.close()
   }
 
   private class CapturingLogger extends SqlLogger {

--- a/sql/jvm/src/test/scala/zio/blocks/sql/RepoUpsertSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/RepoUpsertSpec.scala
@@ -1,0 +1,432 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.sql
+
+import zio.test._
+import zio.blocks.schema._
+import java.sql.DriverManager
+import scala.collection.mutable.ArrayBuffer
+import scala.util.Try
+
+object RepoUpsertSpec extends ZIOSpecDefault {
+  private val _ = Class.forName("org.sqlite.JDBC")
+
+  case class User(id: Int, name: String, email: String)
+  object User {
+    implicit val schema: Schema[User] = Schema.derived
+  }
+
+  case class OnlyId(id: Int)
+  object OnlyId {
+    implicit val schema: Schema[OnlyId] = Schema.derived
+  }
+
+  private val userTable   = Table.derived[User]
+  private val onlyIdTable = Table.derived[OnlyId]
+
+  private given DbCodec[User]   = User.schema.deriving(DbCodecDeriver).derive
+  private given DbCodec[OnlyId] = OnlyId.schema.deriving(DbCodecDeriver).derive
+  private given DbCodec[Int]    = implicitly[Schema[Int]].deriving(DbCodecDeriver).derive
+
+  private val intCodec: DbCodec[Int] = summon[DbCodec[Int]]
+
+  private val userRepo   = Repo(userTable, "id", intCodec, (_: User).id)
+  private val onlyIdRepo = Repo(onlyIdTable, "id", intCodec, (_: OnlyId).id)
+
+  // Unique email table for constraint violation test
+  case class UserUnique(id: Int, name: String, email: String)
+  object UserUnique {
+    implicit val schema: Schema[UserUnique] = Schema.derived
+  }
+  private val userUniqueTable       = Table.derived[UserUnique]
+  private given DbCodec[UserUnique] = UserUnique.schema.deriving(DbCodecDeriver).derive
+  private val userUniqueRepo        = Repo(userUniqueTable, "id", intCodec, (_: UserUnique).id)
+
+  private def withFreshDb[A](f: JdbcTransactor => A): A = {
+    val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
+    val tx   = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+      override def connect[B](f: DbCon ?=> B): B = {
+        val dbConn       = new JdbcConnection(conn)
+        given con: DbCon = new DbCon {
+          val connection: DbConnection = dbConn
+          val dialect: SqlDialect      = SqlDialect.SQLite
+          val logger: SqlLogger        = SqlLogger.noop
+        }
+        f
+      }
+    }
+    tx.connect {
+      Frag
+        .literal("CREATE TABLE IF NOT EXISTS user (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)")
+        .update
+    }
+    f(tx)
+  }
+
+  private def withFreshDbAndLogger[A](f: (JdbcTransactor, CapturingLogger) => A): A = {
+    val conn       = DriverManager.getConnection("jdbc:sqlite::memory:")
+    val testLogger = new CapturingLogger
+    val tx         = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+      override def connect[B](f: DbCon ?=> B): B = {
+        val dbConn       = new JdbcConnection(conn)
+        given con: DbCon = new DbCon {
+          val connection: DbConnection = dbConn
+          val dialect: SqlDialect      = SqlDialect.SQLite
+          val logger: SqlLogger        = testLogger
+        }
+        f
+      }
+    }
+    tx.connect {
+      Frag
+        .literal("CREATE TABLE IF NOT EXISTS user (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)")
+        .update
+    }
+    testLogger.clear()
+    f(tx, testLogger)
+  }
+
+  private def withUniqueDb[A](f: JdbcTransactor => A): A = {
+    val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
+    val tx   = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+      override def connect[B](f: DbCon ?=> B): B = {
+        val dbConn       = new JdbcConnection(conn)
+        given con: DbCon = new DbCon {
+          val connection: DbConnection = dbConn
+          val dialect: SqlDialect      = SqlDialect.SQLite
+          val logger: SqlLogger        = SqlLogger.noop
+        }
+        f
+      }
+    }
+    tx.connect {
+      Frag
+        .literal(
+          "CREATE TABLE IF NOT EXISTS user_unique (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE)"
+        )
+        .update
+    }
+    f(tx)
+  }
+
+  private def withOnlyIdDb[A](f: JdbcTransactor => A): A = {
+    val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
+    val tx   = new JdbcTransactor(() => conn, SqlDialect.SQLite) {
+      override def connect[B](f: DbCon ?=> B): B = {
+        val dbConn       = new JdbcConnection(conn)
+        given con: DbCon = new DbCon {
+          val connection: DbConnection = dbConn
+          val dialect: SqlDialect      = SqlDialect.SQLite
+          val logger: SqlLogger        = SqlLogger.noop
+        }
+        f
+      }
+    }
+    tx.connect {
+      Frag.literal("CREATE TABLE IF NOT EXISTS only_id (id INTEGER PRIMARY KEY)").update
+    }
+    f(tx)
+  }
+
+  private class CapturingLogger extends SqlLogger {
+    val successes: ArrayBuffer[SqlLogger.SuccessEvent] = ArrayBuffer.empty
+    val errors: ArrayBuffer[SqlLogger.ErrorEvent]      = ArrayBuffer.empty
+
+    def onSuccess(event: SqlLogger.SuccessEvent): Unit = successes += event
+    def onError(event: SqlLogger.ErrorEvent): Unit     = errors += event
+
+    def clear(): Unit = {
+      successes.clear()
+      errors.clear()
+    }
+  }
+
+  def spec: Spec[TestEnvironment, Any] = suite("RepoUpsertSpec")(
+    suite("insertOrUpdate single")(
+      test("insert new via upsert inserts 1 row") {
+        withFreshDb { tx =>
+          tx.connect {
+            val c = userRepo.insertOrUpdate(User(1, "Alice", "alice@test.com"))
+            assertTrue(c == 1, userRepo.count == 1L, userRepo.find(1).get.name == "Alice")
+          }
+        }
+      },
+      test("update existing via upsert overwrites non-id columns") {
+        withFreshDb { tx =>
+          tx.connect {
+            userRepo.insert(User(1, "Alice", "alice@test.com"))
+            val c     = userRepo.insertOrUpdate(User(1, "Alice Updated", "new@test.com"))
+            val found = userRepo.find(1)
+            assertTrue(
+              c == 1,
+              found.isDefined,
+              found.get.name == "Alice Updated",
+              found.get.email == "new@test.com",
+              userRepo.count == 1L
+            )
+          }
+        }
+      },
+      test("double upsert single row retains second payload") {
+        withFreshDb { tx =>
+          tx.connect {
+            userRepo.insertOrUpdate(User(1, "First", "first@test.com"))
+            userRepo.insertOrUpdate(User(1, "Second", "second@test.com"))
+            val found = userRepo.find(1)
+            assertTrue(
+              userRepo.count == 1L,
+              userRepo.all.size == 1,
+              found.isDefined,
+              found.get.name == "Second",
+              found.get.email == "second@test.com"
+            )
+          }
+        }
+      },
+      test("insertOrUpdate new vs update both return 1") {
+        withFreshDb { tx =>
+          tx.connect {
+            val c1 = userRepo.insertOrUpdate(User(10, "A", "a@test.com"))
+            val c2 = userRepo.insertOrUpdate(User(10, "B", "b@test.com"))
+            val c3 = userRepo.insertOrUpdate(User(11, "C", "c@test.com"))
+            assertTrue(c1 == 1, c2 == 1, c3 == 1, userRepo.count == 2L)
+          }
+        }
+      },
+      test("upsert does not affect other rows") {
+        withFreshDb { tx =>
+          tx.connect {
+            userRepo.insert(User(1, "Alice", "a@test.com"))
+            userRepo.insert(User(2, "Bob", "b@test.com"))
+            userRepo.insertOrUpdate(User(1, "Alice2", "a2@test.com"))
+            val b = userRepo.find(2)
+            assertTrue(b.isDefined, b.get.name == "Bob", b.get.email == "b@test.com", userRepo.count == 2L)
+          }
+        }
+      },
+      test("golden SQL for Repo wrapper matches Upsert builder") {
+        val frag = Upsert.insertDoUpdate(userTable, User(1, "Alice", "alice@example.com"), "id")
+        assertTrue(
+          frag.sql(
+            SqlDialect.SQLite
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO UPDATE SET "name" = ?, "email" = ?""",
+          frag.sql(
+            SqlDialect.PostgreSQL
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO UPDATE SET "name" = ?, "email" = ?""",
+          frag.queryParams == IndexedSeq(
+            DbValue.DbInt(1),
+            DbValue.DbString("Alice"),
+            DbValue.DbString("alice@example.com"),
+            DbValue.DbString("Alice"),
+            DbValue.DbString("alice@example.com")
+          )
+        )
+      }
+    ),
+    suite("insertOrUpdateBatch")(
+      test("inserts multiple new rows via batch") {
+        withFreshDb { tx =>
+          tx.connect {
+            val c = userRepo.insertOrUpdateBatch(
+              List(
+                User(1, "Alice", "a@test.com"),
+                User(2, "Bob", "b@test.com"),
+                User(3, "Charlie", "c@test.com")
+              )
+            )
+            assertTrue(c == 3, userRepo.count == 3L, userRepo.all.size == 3)
+          }
+        }
+      },
+      test("mixed batch with new and existing ids") {
+        withFreshDb { tx =>
+          tx.connect {
+            userRepo.insert(User(1, "Alice", "a@test.com"))
+            userRepo.insert(User(2, "Bob", "b@test.com"))
+            val c = userRepo.insertOrUpdateBatch(
+              List(
+                User(1, "Alice Updated", "a2@test.com"),
+                User(3, "Charlie", "c@test.com"),
+                User(2, "Bob Updated", "b2@test.com")
+              )
+            )
+            val a1 = userRepo.find(1)
+            val a2 = userRepo.find(2)
+            val a3 = userRepo.find(3)
+            assertTrue(
+              c == 3,
+              userRepo.count == 3L,
+              a1.get.name == "Alice Updated",
+              a1.get.email == "a2@test.com",
+              a2.get.name == "Bob Updated",
+              a3.isDefined
+            )
+          }
+        }
+      },
+      test("batch counts correct") {
+        withFreshDb { tx =>
+          tx.connect {
+            val c1 = userRepo.insertOrUpdateBatch(List(User(1, "A", "a@test.com"), User(2, "B", "b@test.com")))
+            val c2 = userRepo.insertOrUpdateBatch(List(User(1, "A2", "a2@test.com"), User(3, "C", "c@test.com")))
+            assertTrue(c1 == 2, c2 == 2, userRepo.count == 3L)
+          }
+        }
+      },
+      test("empty batch returns 0 without touching db") {
+        withFreshDb { tx =>
+          tx.connect {
+            val c = userRepo.insertOrUpdateBatch(List.empty[User])
+            assertTrue(c == 0, userRepo.count == 0L)
+          }
+        }
+      },
+      test("single entity batch") {
+        withFreshDb { tx =>
+          tx.connect {
+            val c = userRepo.insertOrUpdateBatch(List(User(99, "Solo", "solo@test.com")))
+            assertTrue(c == 1, userRepo.count == 1L, userRepo.find(99).isDefined)
+          }
+        }
+      },
+      test("batch with all existing ids updates each") {
+        withFreshDb { tx =>
+          tx.connect {
+            userRepo.insert(User(1, "A", "a@test.com"))
+            userRepo.insert(User(2, "B", "b@test.com"))
+            val c = userRepo.insertOrUpdateBatch(
+              List(
+                User(1, "A2", "a2@test.com"),
+                User(2, "B2", "b2@test.com")
+              )
+            )
+            assertTrue(
+              c == 2,
+              userRepo.find(1).get.name == "A2",
+              userRepo.find(2).get.name == "B2",
+              userRepo.count == 2L
+            )
+          }
+        }
+      },
+      test("batch upsert yields single row per id after double batch") {
+        withFreshDb { tx =>
+          tx.connect {
+            userRepo.insertOrUpdateBatch(List(User(1, "A", "a@test.com")))
+            userRepo.insertOrUpdateBatch(List(User(1, "B", "b@test.com")))
+            assertTrue(userRepo.count == 1L, userRepo.find(1).get.name == "B")
+          }
+        }
+      }
+    ),
+    suite("constraint violation propagation")(
+      test("single upsert violating UNIQUE propagates exception") {
+        withUniqueDb { tx =>
+          tx.connect {
+            userUniqueRepo.insert(UserUnique(1, "Alice", "shared@test.com"))
+            val result = Try(userUniqueRepo.insertOrUpdate(UserUnique(2, "Bob", "shared@test.com")))
+            assertTrue(result.isFailure)
+          }
+        }
+      },
+      test("batch violating UNIQUE propagates exception") {
+        withUniqueDb { tx =>
+          tx.connect {
+            userUniqueRepo.insert(UserUnique(1, "Alice", "a@test.com"))
+            val result = Try(
+              userUniqueRepo.insertOrUpdateBatch(
+                List(
+                  UserUnique(2, "Bob", "b@test.com"),
+                  UserUnique(3, "Charlie", "a@test.com")
+                )
+              )
+            )
+            assertTrue(result.isFailure)
+          }
+        }
+      }
+    ),
+    suite("single-col table edge")(
+      test("insertOrUpdate on single-col table throws IllegalArgumentException") {
+        withOnlyIdDb { tx =>
+          tx.connect {
+            val result = Try(onlyIdRepo.insertOrUpdate(OnlyId(1)))
+            assertTrue(result.isFailure, result.failed.get.isInstanceOf[IllegalArgumentException])
+          }
+        }
+      },
+      test("insertOrUpdateBatch on single-col table throws") {
+        withOnlyIdDb { tx =>
+          tx.connect {
+            val result = Try(onlyIdRepo.insertOrUpdateBatch(List(OnlyId(1), OnlyId(2))))
+            assertTrue(result.isFailure, result.failed.get.isInstanceOf[IllegalArgumentException])
+          }
+        }
+      },
+      test("empty batch on single-col table returns 0 without throwing") {
+        withOnlyIdDb { tx =>
+          tx.connect {
+            val c = onlyIdRepo.insertOrUpdateBatch(List.empty[OnlyId])
+            assertTrue(c == 0)
+          }
+        }
+      }
+    ),
+    suite("logging")(
+      test("insertOrUpdate logs success with ON CONFLICT sql") {
+        withFreshDbAndLogger { (tx, logger) =>
+          tx.connect {
+            userRepo.insertOrUpdate(User(1, "Alice", "a@test.com"))
+            assertTrue(
+              logger.successes.size == 1,
+              logger.successes.head.sql.contains("ON CONFLICT"),
+              logger.successes.head.sql.contains("DO UPDATE SET"),
+              logger.errors.isEmpty
+            )
+          }
+        }
+      },
+      test("insertOrUpdateBatch logs success with ON CONFLICT sql and total count") {
+        withFreshDbAndLogger { (tx, logger) =>
+          tx.connect {
+            userRepo.insertOrUpdateBatch(
+              List(
+                User(1, "Alice", "a@test.com"),
+                User(2, "Bob", "b@test.com")
+              )
+            )
+            assertTrue(
+              logger.successes.size == 1,
+              logger.successes.head.sql.contains("ON CONFLICT"),
+              logger.successes.head.sql.contains("DO UPDATE SET"),
+              logger.successes.head.rowCount == 2,
+              logger.errors.isEmpty
+            )
+          }
+        }
+      },
+      test("batch logs empty params like insertBatch") {
+        withFreshDbAndLogger { (tx, logger) =>
+          tx.connect {
+            userRepo.insertOrUpdateBatch(List(User(1, "A", "a@test.com")))
+            assertTrue(logger.successes.head.params.isEmpty)
+          }
+        }
+      }
+    )
+  )
+}

--- a/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Frag.scala
@@ -147,6 +147,51 @@ object Frag {
   def sequence(frags: Frag*): Frag = frags.foldLeft(Frag.empty)(_ ++ _)
 
   /**
+   * Keyset pagination fragment for a single ordering column.
+   *
+   * Produces `WHERE <orderCol> > ? ORDER BY <orderCol> ASC LIMIT n` as a `Frag`
+   * with one bound parameter (`lastValue`). The ordering column is validated as
+   * a SQL identifier; when a `table` is supplied the column must also exist in
+   * `table.columns`.
+   *
+   * Single column only — composite cursors are intentionally unsupported (v2).
+   *
+   * @throws IllegalArgumentException
+   *   if `orderCol` is not a valid identifier, not in `table.columns` (when a
+   *   table is supplied), or if `limit <= 0`
+   */
+  def keysetAfter(table: Table[_], orderCol: String, lastValue: DbValue, limit: Int): Frag = {
+    require(limit > 0, s"Frag.keysetAfter: limit must be > 0, got $limit")
+    val validated = SqlIdentifier.validate("column", orderCol)
+    if (!table.columns.contains(validated))
+      throw new IllegalArgumentException(
+        s"Column '$validated' not found in table '${table.name}' columns: ${table.columns.mkString(", ")}"
+      )
+    Frag(
+      IndexedSeq(s" WHERE $validated > ", s" ORDER BY $validated ASC LIMIT $limit"),
+      IndexedSeq(lastValue)
+    )
+  }
+
+  /**
+   * Keyset pagination fragment without a table binding.
+   *
+   * Validates `orderCol` as a SQL identifier and produces
+   * `WHERE <orderCol> > ? ORDER BY <orderCol> ASC LIMIT n`.
+   *
+   * @throws IllegalArgumentException
+   *   if `orderCol` is not a valid identifier or `limit <= 0`
+   */
+  def keysetAfter(orderCol: String, lastValue: DbValue, limit: Int): Frag = {
+    require(limit > 0, s"Frag.keysetAfter: limit must be > 0, got $limit")
+    val validated = SqlIdentifier.validate("column", orderCol)
+    Frag(
+      IndexedSeq(s" WHERE $validated > ", s" ORDER BY $validated ASC LIMIT $limit"),
+      IndexedSeq(lastValue)
+    )
+  }
+
+  /**
    * Builds a VALUES clause for a multi-row INSERT. Renders as:
    * `(?, ?), (?, ?), ...` — one tuple per row, columns within each tuple
    * separated by `, `.

--- a/sql/shared/src/main/scala/zio/blocks/sql/Repo.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Repo.scala
@@ -50,8 +50,11 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
    * final class UserRepo extends Repo[User, UserId]
    * }}}
    */
-  protected def this()(using schema: Schema[E], idSchema: Schema[ID], idCodec: DbCodec[ID]) =
-    this(Repo.derivedMetadata[E, ID])
+  protected def this()(using
+    schema: Schema[E],
+    idSchema: Schema[ID],
+    idCodec: DbCodec[ID]
+  ) = this(Repo.derivedMetadata[E, ID])
 
   /** The table this repository operates on. */
   final val table: Table[E] = metadata.table
@@ -79,12 +82,6 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
 
   private val allCols: String = table.columns.mkString(", ")
   private val tbl: String     = table.name
-
-  /**
-   * `Statement.SUCCESS_NO_INFO` constant (-2), kept local to de-JDBC the shared
-   * source set.
-   */
-  private val SuccessNoInfo = -2
 
   /** The entity codec, exposed for internal Frag operations. */
   private given codec: DbCodec[E] = table.codec
@@ -126,6 +123,30 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
   final def count(using con: DbCon): Long = {
     val frag = Frag.literal(s"SELECT COUNT(*) FROM $tbl")
     frag.queryOne[Long](using con, DbCodec.longCodec).getOrElse(0L)
+  }
+
+  // === Pagination ===
+
+  /**
+   * Keyset pagination: returns the next `limit` rows whose primary key is
+   * strictly greater than `cursorId`, ordered by the primary key ascending.
+   *
+   * Uses `WHERE id > ? ORDER BY id ASC LIMIT n` so the cursor row itself is not
+   * repeated. When `cursorId` equals the last id the result is empty.
+   *
+   * @throws IllegalArgumentException
+   *   if `limit <= 0`
+   */
+  final def pageAfter(cursorId: ID, limit: Int)(using con: DbCon): List[E] = {
+    require(limit > 0, s"Repo.pageAfter: limit must be > 0, got $limit")
+    val frag = Frag(
+      IndexedSeq(
+        s"SELECT $allCols FROM $tbl WHERE $validatedIdColumn > ",
+        s" ORDER BY $validatedIdColumn ASC LIMIT $limit"
+      ),
+      idCodec.toDbValues(cursorId)
+    )
+    frag.query[E]
   }
 
   // === Write Operations ===
@@ -179,7 +200,68 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
         val counts = ps.executeBatch()
         val total  = counts.map { count =>
           if (count >= 0) count
-          else if (count == SuccessNoInfo) 1
+          else if (count == java.sql.Statement.SUCCESS_NO_INFO) 1
+          else 0
+        }.sum
+        val duration = java.time.Duration.ofNanos(System.nanoTime() - start)
+        con.logger.onSuccess(SqlLogger.SuccessEvent(sqlStr, IndexedSeq.empty, duration, total))
+        total
+      } finally ps.close()
+    } catch {
+      case e: Throwable =>
+        val duration = java.time.Duration.ofNanos(System.nanoTime() - start)
+        con.logger.onError(SqlLogger.ErrorEvent(sqlStr, IndexedSeq.empty, duration, e))
+        throw e
+    }
+  }
+
+  /**
+   * Inserts `entity` or updates it if the primary key already exists, using
+   * `ON CONFLICT (id) DO UPDATE SET ...`. All non-ID columns are overwritten
+   * with the values from `entity`.
+   *
+   * Conflict target is the repository's validated ID column. Assignment columns
+   * are `table.columns.filter(_ != validatedIdColumn)`.
+   *
+   * @return
+   *   affected row count (normally 1 for both insert and update paths)
+   * @throws IllegalArgumentException
+   *   if the table has only the ID column and no non-ID columns to update
+   */
+  final def insertOrUpdate(entity: E)(using con: DbCon): Int = {
+    val frag = Upsert.insertDoUpdate(table, entity, validatedIdColumn)
+    frag.update
+  }
+
+  /**
+   * Upserts all `entities` using a JDBC batch, following the `insertBatch`
+   * pattern. Each row is inserted with `ON CONFLICT (id) DO UPDATE SET ...`
+   * where the update columns are all non-ID columns.
+   *
+   * If `entities` is empty the method returns 0 without touching the database.
+   *
+   * Batch logging mirrors `insertBatch`: rendered SQL, duration, and total
+   * affected count with empty param capture.
+   *
+   * @throws IllegalArgumentException
+   *   if the table has only the ID column (no assignment columns)
+   */
+  final def insertOrUpdateBatch(entities: Iterable[E])(using con: DbCon): Int = {
+    if (entities.isEmpty) return 0
+    val sqlStr = Upsert.insertDoUpdate(table, entities.head, validatedIdColumn).sql(con.dialect)
+    val start  = System.nanoTime()
+    try {
+      val ps = con.connection.prepareStatement(sqlStr)
+      try {
+        entities.foreach { entity =>
+          val frag = Upsert.insertDoUpdate(table, entity, validatedIdColumn)
+          Frag.writeParams(ps.paramWriter, frag.queryParams)
+          ps.addBatch()
+        }
+        val counts = ps.executeBatch()
+        val total  = counts.map { count =>
+          if (count >= 0) count
+          else if (count == java.sql.Statement.SUCCESS_NO_INFO) 1
           else 0
         }.sum
         val duration = java.time.Duration.ofNanos(System.nanoTime() - start)

--- a/sql/shared/src/main/scala/zio/blocks/sql/Repo.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Repo.scala
@@ -200,7 +200,7 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
         val counts = ps.executeBatch()
         val total  = counts.map { count =>
           if (count >= 0) count
-          else if (count == java.sql.Statement.SUCCESS_NO_INFO) 1
+          else if (count == Repo.SuccessNoInfo) 1
           else 0
         }.sum
         val duration = java.time.Duration.ofNanos(System.nanoTime() - start)
@@ -261,7 +261,7 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
         val counts = ps.executeBatch()
         val total  = counts.map { count =>
           if (count >= 0) count
-          else if (count == java.sql.Statement.SUCCESS_NO_INFO) 1
+          else if (count == Repo.SuccessNoInfo) 1
           else 0
         }.sum
         val duration = java.time.Duration.ofNanos(System.nanoTime() - start)
@@ -347,6 +347,13 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
 }
 
 object Repo {
+
+  /**
+   * Shared constant matching `java.sql.Statement.SUCCESS_NO_INFO` (-2). Defined
+   * here to avoid `java.sql` references in the shared source set (breaks
+   * Scala.js).
+   */
+  private val SuccessNoInfo: Int = -2
 
   private[sql] final case class Metadata[E, ID](
     table: Table[E],

--- a/sql/shared/src/main/scala/zio/blocks/sql/Upsert.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Upsert.scala
@@ -170,15 +170,25 @@ object Upsert {
   /**
    * `INSERT ... ON CONFLICT ("conflict") DO NOTHING` for an entity.
    *
-   * Conflict column defaults to the first column when not supplied.
+   * Builds
+   * `INSERT INTO table (cols) VALUES (?, ...) ON CONFLICT ("conflict") DO NOTHING`.
+   * The table name is validated via [[SqlIdentifier.validate]] and the conflict
+   * column is validated as an identifier and checked for membership in
+   * `table.columns`.
+   *
+   * @param table
+   *   validated via [[Table]]; its name via [[SqlIdentifier.validate]] and its
+   *   columns used for conflict validation
+   * @param entity
+   *   entity whose values are obtained via `table.codec.toDbValues`
+   * @param conflictColumn
+   *   validated identifier that must be present in `table.columns`
+   * @return
+   *   a [[Frag]] whose SQL is `INSERT ... ON CONFLICT ("conflict") DO NOTHING`
+   * @throws IllegalArgumentException
+   *   if `conflictColumn` is not a valid identifier or is not found in
+   *   `table.columns`
    */
-  def insertDoNothing[A](table: Table[A], entity: A): Frag = {
-    val conflict = table.columns.headOption.getOrElse(
-      throw new IllegalArgumentException(s"Table '${table.name}' has no columns")
-    )
-    insertDoNothing(table, entity, conflict)
-  }
-
   def insertDoNothing[A](table: Table[A], entity: A, conflictColumn: String): Frag = {
     val t        = validatedTableName(table)
     val conflict = validatedConflictInTable(table, conflictColumn)
@@ -191,17 +201,24 @@ object Upsert {
   /**
    * `INSERT ... ON CONFLICT ("conflict") DO UPDATE SET ...` for an entity.
    *
-   * When `updateColumns` is empty the builder updates every column except the
-   * conflict column. Caller-supplied columns are validated against
-   * `Table.columns`.
+   * Updates all columns except the conflict column. The conflict column is
+   * validated via [[SqlIdentifier.validate]] and must exist in `table.columns`.
+   * The update set is derived as `table.columns.filter(_ != conflict)` and
+   * validated against `Table.columns`.
+   *
+   * @param table
+   *   validated via [[Table]]; name validated via [[SqlIdentifier.validate]]
+   * @param entity
+   *   entity serialized via `table.codec.toDbValues`
+   * @param conflictColumn
+   *   validated identifier that must be present in `table.columns`
+   * @return
+   *   a [[Frag]] with `ON CONFLICT ("conflict") DO UPDATE SET "col" = ?, ...`
+   *   where cols are all table columns except the conflict column
+   * @throws IllegalArgumentException
+   *   if `conflictColumn` is invalid or not in `table.columns`, or if the table
+   *   has only the conflict column (no assignable columns to update)
    */
-  def insertDoUpdate[A](table: Table[A], entity: A): Frag = {
-    val conflict = table.columns.headOption.getOrElse(
-      throw new IllegalArgumentException(s"Table '${table.name}' has no columns")
-    )
-    insertDoUpdate(table, entity, conflict)
-  }
-
   def insertDoUpdate[A](table: Table[A], entity: A, conflictColumn: String): Frag = {
     val conflict   = validatedConflictInTable(table, conflictColumn)
     val updateCols = table.columns.filter(_ != conflict)
@@ -212,6 +229,30 @@ object Upsert {
     insertDoUpdate(table, entity, conflict, updateCols)
   }
 
+  /**
+   * `INSERT ... ON CONFLICT ("conflict") DO UPDATE SET "col" = ?, ...` for an
+   * entity with explicit update columns.
+   *
+   * All identifiers are validated via [[SqlIdentifier.validate]]. The conflict
+   * column and each `updateColumns` entry must exist in `table.columns`.
+   *
+   * @param table
+   *   validated via [[Table]]; name validated via [[SqlIdentifier.validate]]
+   * @param entity
+   *   entity serialized via `table.codec.toDbValues`
+   * @param conflictColumn
+   *   validated identifier that must be present in `table.columns`
+   * @param updateColumns
+   *   validated against `table.columns`; each entry validated as an identifier,
+   *   must exist in the table, must not contain `conflictColumn`, and must be
+   *   non-empty
+   * @return
+   *   a [[Frag]] with `ON CONFLICT ("conflict") DO UPDATE SET` for the
+   *   specified columns
+   * @throws IllegalArgumentException
+   *   if any identifier is invalid, if any column is not in `table.columns`, if
+   *   `updateColumns` contains the conflict column, or if it is empty
+   */
   def insertDoUpdate[A](
     table: Table[A],
     entity: A,

--- a/sql/shared/src/main/scala/zio/blocks/sql/Upsert.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Upsert.scala
@@ -110,7 +110,13 @@ object Upsert {
   ): Frag = {
     val t = SqlIdentifier.validate("table", tableName)
     SqlIdentifier.validate("column", conflictColumn)
-    val base = Repo.buildInsertFrag(t, allColumns, values)
+    val columns = allColumns.split(",").map(_.trim).filter(_.nonEmpty).toIndexedSeq
+    if (columns.isEmpty)
+      throw new IllegalArgumentException("Upsert.doNothingRaw: allColumns must not be empty")
+    columns.foreach(c => SqlIdentifier.validate("column", c))
+    require(columns.size == values.size, "Upsert.doNothingRaw: columns/value count mismatch")
+    val normalizedCols = columns.mkString(", ")
+    val base           = Repo.buildInsertFrag(t, normalizedCols, values)
     base ++ doNothingSuffix(conflictColumn)
   }
 

--- a/sql/shared/src/main/scala/zio/blocks/sql/Upsert.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Upsert.scala
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.sql
+
+/**
+ * Builders for SQLite/PostgreSQL upsert Frags.
+ *
+ * Every produced Frag follows the invariant `parts.length == params.length + 1`
+ * and is rendered via `dialect.paramPlaceholder` (both dialects use `?`).
+ * Identifiers are validated through [[SqlIdentifier.validate]] and quoted with
+ * double quotes in the conflict clause. Assignment columns are additionally
+ * validated against `Table.columns`.
+ */
+object Upsert {
+
+  // -- suffix builders -----------------------------------------------------------------
+
+  /** Suffix ` ON CONFLICT ("col") DO NOTHING`. */
+  def doNothingSuffix(conflictColumn: String): Frag = {
+    val c = SqlIdentifier.validate("column", conflictColumn)
+    Frag(IndexedSeq(s""" ON CONFLICT ("$c") DO NOTHING"""), IndexedSeq.empty)
+  }
+
+  /** Alias used by prior docs. */
+  def buildDoNothingSuffix(conflictColumn: String): Frag =
+    doNothingSuffix(conflictColumn)
+
+  /**
+   * Suffix ` ON CONFLICT ("conflict") DO UPDATE SET "col" = ?, ...`.
+   * Assignments must be non-empty; each column is validated and quoted.
+   */
+  def doUpdateSuffix(
+    conflictColumn: String,
+    assignments: IndexedSeq[(String, DbValue)]
+  ): Frag = {
+    val c = SqlIdentifier.validate("column", conflictColumn)
+    if (assignments.isEmpty)
+      throw new IllegalArgumentException("Upsert DO UPDATE requires at least one assignment column")
+    val validatedAssignments = assignments.map { case (col, _) =>
+      SqlIdentifier.validate("column", col)
+    }
+    val params = assignments.map(_._2)
+    val parts  = IndexedSeq.newBuilder[String]
+    parts += s""" ON CONFLICT ("$c") DO UPDATE SET "${validatedAssignments.head}" = """
+    var i = 1
+    while (i < validatedAssignments.size) {
+      parts += s""", "${validatedAssignments(i)}" = """
+      i += 1
+    }
+    parts += ""
+    Frag(parts.result(), params)
+  }
+
+  /** Alias used by prior docs. */
+  def buildDoUpdateSuffix(
+    conflictColumn: String,
+    assignments: IndexedSeq[(String, DbValue)]
+  ): Frag =
+    doUpdateSuffix(conflictColumn, assignments)
+
+  // -- low-level full INSERT builders ---------------------------------------------------
+
+  /**
+   * Low-level builder: full INSERT with DO NOTHING.
+   *
+   * @param tableName
+   *   validated via SqlIdentifier
+   * @param columns
+   *   column names in order, each validated
+   * @param values
+   *   values aligned with columns
+   * @param conflictColumn
+   *   validated and quoted in suffix
+   */
+  def doNothing(
+    tableName: String,
+    columns: IndexedSeq[String],
+    values: IndexedSeq[DbValue],
+    conflictColumn: String
+  ): Frag = {
+    val t = SqlIdentifier.validate("table", tableName)
+    columns.foreach(c => SqlIdentifier.validate("column", c))
+    SqlIdentifier.validate("column", conflictColumn)
+    require(columns.size == values.size, "Upsert.doNothing: columns/value count mismatch")
+    val allCols = columns.mkString(", ")
+    val base    = Repo.buildInsertFrag(t, allCols, values)
+    base ++ doNothingSuffix(conflictColumn)
+  }
+
+  /** Overload accepting comma-joined column string (as Repo does). */
+  def doNothingRaw(
+    tableName: String,
+    allColumns: String,
+    values: IndexedSeq[DbValue],
+    conflictColumn: String
+  ): Frag = {
+    val t = SqlIdentifier.validate("table", tableName)
+    SqlIdentifier.validate("column", conflictColumn)
+    val base = Repo.buildInsertFrag(t, allColumns, values)
+    base ++ doNothingSuffix(conflictColumn)
+  }
+
+  /**
+   * Low-level builder: full INSERT with DO UPDATE SET.
+   */
+  def doUpdate(
+    tableName: String,
+    columns: IndexedSeq[String],
+    values: IndexedSeq[DbValue],
+    conflictColumn: String,
+    assignments: IndexedSeq[(String, DbValue)]
+  ): Frag = {
+    val t = SqlIdentifier.validate("table", tableName)
+    columns.foreach(c => SqlIdentifier.validate("column", c))
+    SqlIdentifier.validate("column", conflictColumn)
+    assignments.foreach { case (col, _) => SqlIdentifier.validate("column", col) }
+    require(columns.size == values.size, "Upsert.doUpdate: columns/value count mismatch")
+    val allCols = columns.mkString(", ")
+    val base    = Repo.buildInsertFrag(t, allCols, values)
+    base ++ doUpdateSuffix(conflictColumn, assignments)
+  }
+
+  // -- Table-aware builders -------------------------------------------------------------
+
+  private def validatedTableName[A](table: Table[A]): String =
+    SqlIdentifier.validate("table", table.name)
+
+  private def validatedConflictInTable[A](table: Table[A], conflictColumn: String): String = {
+    val c = SqlIdentifier.validate("column", conflictColumn)
+    if (!table.columns.contains(c))
+      throw new IllegalArgumentException(
+        s"Conflict column '$conflictColumn' (validated as '$c') not found in table '${table.name}' columns: ${table.columns.mkString(", ")}"
+      )
+    c
+  }
+
+  private def validatedAssignmentsInTable[A](
+    table: Table[A],
+    cols: Seq[String]
+  ): IndexedSeq[String] =
+    cols.map { col =>
+      val v = SqlIdentifier.validate("column", col)
+      if (!table.columns.contains(v))
+        throw new IllegalArgumentException(
+          s"Assignment column '$col' (validated as '$v') not found in table '${table.name}' columns: ${table.columns.mkString(", ")}"
+        )
+      v
+    }.toIndexedSeq
+
+  /**
+   * `INSERT ... ON CONFLICT ("conflict") DO NOTHING` for an entity.
+   *
+   * Conflict column defaults to the first column when not supplied.
+   */
+  def insertDoNothing[A](table: Table[A], entity: A): Frag = {
+    val conflict = table.columns.headOption.getOrElse(
+      throw new IllegalArgumentException(s"Table '${table.name}' has no columns")
+    )
+    insertDoNothing(table, entity, conflict)
+  }
+
+  def insertDoNothing[A](table: Table[A], entity: A, conflictColumn: String): Frag = {
+    val t        = validatedTableName(table)
+    val conflict = validatedConflictInTable(table, conflictColumn)
+    val values   = table.codec.toDbValues(entity)
+    val allCols  = table.columns.mkString(", ")
+    val base     = Repo.buildInsertFrag(t, allCols, values)
+    base ++ doNothingSuffix(conflict)
+  }
+
+  /**
+   * `INSERT ... ON CONFLICT ("conflict") DO UPDATE SET ...` for an entity.
+   *
+   * When `updateColumns` is empty the builder updates every column except the
+   * conflict column. Caller-supplied columns are validated against
+   * `Table.columns`.
+   */
+  def insertDoUpdate[A](table: Table[A], entity: A): Frag = {
+    val conflict = table.columns.headOption.getOrElse(
+      throw new IllegalArgumentException(s"Table '${table.name}' has no columns")
+    )
+    insertDoUpdate(table, entity, conflict)
+  }
+
+  def insertDoUpdate[A](table: Table[A], entity: A, conflictColumn: String): Frag = {
+    val conflict   = validatedConflictInTable(table, conflictColumn)
+    val updateCols = table.columns.filter(_ != conflict)
+    if (updateCols.isEmpty)
+      throw new IllegalArgumentException(
+        s"Upsert DO UPDATE requires at least one assignment column; table '${table.name}' only has conflict column '$conflict'"
+      )
+    insertDoUpdate(table, entity, conflict, updateCols)
+  }
+
+  def insertDoUpdate[A](
+    table: Table[A],
+    entity: A,
+    conflictColumn: String,
+    updateColumns: Seq[String]
+  ): Frag = {
+    val t                   = validatedTableName(table)
+    val conflict            = validatedConflictInTable(table, conflictColumn)
+    val validatedUpdateCols = validatedAssignmentsInTable(table, updateColumns)
+    if (validatedUpdateCols.isEmpty)
+      throw new IllegalArgumentException("Upsert DO UPDATE requires at least one assignment column")
+    if (validatedUpdateCols.contains(conflict))
+      throw new IllegalArgumentException(
+        s"Assignment columns must not contain conflict column '$conflict'"
+      )
+    val values  = table.codec.toDbValues(entity)
+    val allCols = table.columns.mkString(", ")
+    val base    = Repo.buildInsertFrag(t, allCols, values)
+    // Map column -> value via table.columns zip
+    val colValueMap                                = table.columns.zip(values).toMap
+    val assignments: IndexedSeq[(String, DbValue)] = validatedUpdateCols.map(col => col -> colValueMap(col))
+    base ++ doUpdateSuffix(conflict, assignments)
+  }
+}

--- a/sql/shared/src/test/scala/zio/blocks/sql/KeysetSpec.scala
+++ b/sql/shared/src/test/scala/zio/blocks/sql/KeysetSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.sql
+
+import zio.test._
+import zio.blocks.schema._
+
+object KeysetSpec extends ZIOSpecDefault {
+
+  case class User(id: Int, name: String, email: String)
+  object User {
+    implicit val schema: Schema[User] = Schema.derived
+  }
+
+  val userTable: Table[User] = Table.derived[User]
+
+  def spec: Spec[TestEnvironment, Any] = suite("KeysetSpec")(
+    suite("Frag.keysetAfter")(
+      test("renders WHERE col > ? ORDER BY col ASC LIMIT n (table-validated)") {
+        val frag = Frag.keysetAfter(userTable, "id", DbValue.DbInt(42), 20)
+        assertTrue(
+          frag.sql(SqlDialect.SQLite) == " WHERE id > ? ORDER BY id ASC LIMIT 20",
+          frag.sql(SqlDialect.PostgreSQL) == " WHERE id > ? ORDER BY id ASC LIMIT 20",
+          frag.queryParams == IndexedSeq(DbValue.DbInt(42))
+        )
+      },
+      test("renders without table (identifier only)") {
+        val frag = Frag.keysetAfter("created_at", DbValue.DbLong(1000L), 10)
+        assertTrue(
+          frag.sql(SqlDialect.SQLite) == " WHERE created_at > ? ORDER BY created_at ASC LIMIT 10",
+          frag.queryParams == IndexedSeq(DbValue.DbLong(1000L))
+        )
+      },
+      test("composes with base SELECT") {
+        val base = Frag.literal("SELECT id, name, email FROM user")
+        val page = base ++ Frag.keysetAfter(userTable, "id", DbValue.DbInt(5), 10)
+        assertTrue(
+          page.sql(SqlDialect.SQLite) == "SELECT id, name, email FROM user WHERE id > ? ORDER BY id ASC LIMIT 10",
+          page.queryParams == IndexedSeq(DbValue.DbInt(5))
+        )
+      },
+      test("rejects unknown column (table-validated)") {
+        val result = scala.util.Try(Frag.keysetAfter(userTable, "unknown_col", DbValue.DbInt(1), 10))
+        assertTrue(
+          result.isFailure,
+          result.failed.get.isInstanceOf[IllegalArgumentException],
+          result.failed.get.getMessage.contains("not found in table")
+        )
+      },
+      test("rejects invalid identifier (table-validated)") {
+        val result = scala.util.Try(Frag.keysetAfter(userTable, "bad-col!", DbValue.DbInt(1), 10))
+        assertTrue(result.isFailure && result.failed.get.isInstanceOf[IllegalArgumentException])
+      },
+      test("rejects invalid identifier (no table)") {
+        val result = scala.util.Try(Frag.keysetAfter("bad col", DbValue.DbInt(1), 10))
+        assertTrue(result.isFailure && result.failed.get.isInstanceOf[IllegalArgumentException])
+      },
+      test("rejects limit <= 0 (table overload)") {
+        val r1 = scala.util.Try(Frag.keysetAfter(userTable, "id", DbValue.DbInt(1), 0))
+        val r2 = scala.util.Try(Frag.keysetAfter(userTable, "id", DbValue.DbInt(1), -5))
+        assertTrue(
+          r1.isFailure && r1.failed.get.isInstanceOf[IllegalArgumentException],
+          r2.isFailure && r2.failed.get.isInstanceOf[IllegalArgumentException]
+        )
+      },
+      test("rejects limit <= 0 (no-table overload)") {
+        val r1 = scala.util.Try(Frag.keysetAfter("id", DbValue.DbInt(1), 0))
+        assertTrue(r1.isFailure && r1.failed.get.isInstanceOf[IllegalArgumentException])
+      },
+      test("uses > not >= (no duplicate cursor row)") {
+        val frag = Frag.keysetAfter(userTable, "id", DbValue.DbInt(99), 5)
+        assertTrue(frag.sql(SqlDialect.SQLite).contains("id > ?"), !frag.sql(SqlDialect.SQLite).contains("id >= ?"))
+      }
+    )
+  )
+}

--- a/sql/shared/src/test/scala/zio/blocks/sql/UpsertSpec.scala
+++ b/sql/shared/src/test/scala/zio/blocks/sql/UpsertSpec.scala
@@ -54,8 +54,8 @@ object UpsertSpec extends ZIOSpecDefault {
           )
         )
       },
-      test("insertDoNothing default conflict is first column") {
-        val frag = Upsert.insertDoNothing(userTable, User(2, "Bob", "bob@test.com"))
+      test("insertDoNothing with explicit conflict column") {
+        val frag = Upsert.insertDoNothing(userTable, User(2, "Bob", "bob@test.com"), "id")
         assertTrue(
           frag.sql(
             SqlDialect.PostgreSQL
@@ -137,8 +137,8 @@ object UpsertSpec extends ZIOSpecDefault {
           ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO UPDATE SET "name" = ?, "email" = ?"""
         )
       },
-      test("insertDoUpdate without conflict arg defaults to first column and updates rest") {
-        val frag = Upsert.insertDoUpdate(userTable, User(1, "Alice", "alice@example.com"))
+      test("insertDoUpdate with explicit conflict and default update set") {
+        val frag = Upsert.insertDoUpdate(userTable, User(1, "Alice", "alice@example.com"), "id")
         assertTrue(
           frag.sql(SqlDialect.PostgreSQL).contains("""ON CONFLICT ("id") DO UPDATE SET"""),
           frag.sql(

--- a/sql/shared/src/test/scala/zio/blocks/sql/UpsertSpec.scala
+++ b/sql/shared/src/test/scala/zio/blocks/sql/UpsertSpec.scala
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.sql
+
+import zio.test._
+import zio.blocks.schema._
+
+object UpsertSpec extends ZIOSpecDefault {
+
+  // Test entity: id, name, email
+  case class User(id: Int, name: String, email: String)
+  object User {
+    implicit val schema: Schema[User] = Schema.derived
+  }
+
+  // Single-column table for edge cases
+  case class IdOnly(id: Int)
+  object IdOnly {
+    implicit val schema: Schema[IdOnly] = Schema.derived
+  }
+
+  private val userTable   = Table.derived[User]
+  private val idOnlyTable = Table.derived[IdOnly]
+
+  def spec = suite("UpsertSpec")(
+    suite("DO NOTHING golden strings")(
+      test("Table-aware insertDoNothing renders PG and SQLite identically") {
+        val frag = Upsert.insertDoNothing(userTable, User(1, "Alice", "alice@example.com"), "id")
+        assertTrue(
+          frag.sql(
+            SqlDialect.PostgreSQL
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO NOTHING""",
+          frag.sql(
+            SqlDialect.SQLite
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO NOTHING""",
+          frag.queryParams == IndexedSeq(
+            DbValue.DbInt(1),
+            DbValue.DbString("Alice"),
+            DbValue.DbString("alice@example.com")
+          )
+        )
+      },
+      test("insertDoNothing default conflict is first column") {
+        val frag = Upsert.insertDoNothing(userTable, User(2, "Bob", "bob@test.com"))
+        assertTrue(
+          frag.sql(
+            SqlDialect.PostgreSQL
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO NOTHING"""
+        )
+      },
+      test("low-level doNothingSuffix golden string") {
+        val suffix = Upsert.doNothingSuffix("id")
+        assertTrue(
+          suffix.sql(SqlDialect.PostgreSQL) == """ ON CONFLICT ("id") DO NOTHING""",
+          suffix.sql(SqlDialect.SQLite) == """ ON CONFLICT ("id") DO NOTHING""",
+          suffix.queryParams.isEmpty
+        )
+      },
+      test("low-level doNothing full insert") {
+        val frag = Upsert.doNothing(
+          "user",
+          IndexedSeq("id", "name", "email"),
+          IndexedSeq(DbValue.DbInt(1), DbValue.DbString("A"), DbValue.DbString("a@b")),
+          "id"
+        )
+        assertTrue(
+          frag.sql(
+            SqlDialect.PostgreSQL
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO NOTHING""",
+          frag.sql(
+            SqlDialect.SQLite
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO NOTHING"""
+        )
+      },
+      test("buildDoNothingSuffix alias works") {
+        val s = Upsert.buildDoNothingSuffix("id")
+        assertTrue(s.sql(SqlDialect.PostgreSQL) == """ ON CONFLICT ("id") DO NOTHING""")
+      }
+    ),
+    suite("DO UPDATE golden strings")(
+      test("single assignment column") {
+        val frag = Upsert.insertDoUpdate(userTable, User(1, "Alice", "alice@example.com"), "id", Seq("email"))
+        assertTrue(
+          frag.sql(
+            SqlDialect.PostgreSQL
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO UPDATE SET "email" = ?""",
+          frag.sql(
+            SqlDialect.SQLite
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO UPDATE SET "email" = ?""",
+          // base params + assignment forwarded
+          frag.queryParams == IndexedSeq(
+            DbValue.DbInt(1),
+            DbValue.DbString("Alice"),
+            DbValue.DbString("alice@example.com"),
+            DbValue.DbString("alice@example.com")
+          )
+        )
+      },
+      test("multi-col assignment order preserved and PG/SQLite identical") {
+        val frag = Upsert.insertDoUpdate(userTable, User(1, "Alice", "alice@example.com"), "id", Seq("name", "email"))
+        assertTrue(
+          frag.sql(
+            SqlDialect.PostgreSQL
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO UPDATE SET "name" = ?, "email" = ?""",
+          frag.sql(
+            SqlDialect.SQLite
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO UPDATE SET "name" = ?, "email" = ?""",
+          frag.queryParams == IndexedSeq(
+            DbValue.DbInt(1),
+            DbValue.DbString("Alice"),
+            DbValue.DbString("alice@example.com"),
+            DbValue.DbString("Alice"),
+            DbValue.DbString("alice@example.com")
+          )
+        )
+      },
+      test("default update columns is all except conflict") {
+        val frag = Upsert.insertDoUpdate(userTable, User(1, "Alice", "alice@example.com"), "id")
+        // should be name,email in table order
+        assertTrue(
+          frag.sql(
+            SqlDialect.PostgreSQL
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO UPDATE SET "name" = ?, "email" = ?"""
+        )
+      },
+      test("insertDoUpdate without conflict arg defaults to first column and updates rest") {
+        val frag = Upsert.insertDoUpdate(userTable, User(1, "Alice", "alice@example.com"))
+        assertTrue(
+          frag.sql(SqlDialect.PostgreSQL).contains("""ON CONFLICT ("id") DO UPDATE SET"""),
+          frag.sql(
+            SqlDialect.PostgreSQL
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO UPDATE SET "name" = ?, "email" = ?"""
+        )
+      },
+      test("low-level doUpdateSuffix single and multi") {
+        val single = Upsert.doUpdateSuffix("id", IndexedSeq("email" -> DbValue.DbString("a@b")))
+        val multi  =
+          Upsert.doUpdateSuffix("id", IndexedSeq("name" -> DbValue.DbString("B"), "email" -> DbValue.DbString("b@b")))
+        assertTrue(
+          single.sql(SqlDialect.PostgreSQL) == """ ON CONFLICT ("id") DO UPDATE SET "email" = ?""",
+          single.sql(SqlDialect.SQLite) == """ ON CONFLICT ("id") DO UPDATE SET "email" = ?""",
+          single.queryParams == IndexedSeq(DbValue.DbString("a@b")),
+          multi.sql(SqlDialect.PostgreSQL) == """ ON CONFLICT ("id") DO UPDATE SET "name" = ?, "email" = ?""",
+          multi.queryParams == IndexedSeq(DbValue.DbString("B"), DbValue.DbString("b@b"))
+        )
+      },
+      test("buildDoUpdateSuffix alias works") {
+        val s = Upsert.buildDoUpdateSuffix("id", IndexedSeq("email" -> DbValue.DbString("x")))
+        assertTrue(s.sql(SqlDialect.PostgreSQL) == """ ON CONFLICT ("id") DO UPDATE SET "email" = ?""")
+      },
+      test("param forwarding: base values + assignment values appended in order") {
+        // Use low-level doUpdate with explicit assignments to verify param order
+        val values      = IndexedSeq(DbValue.DbInt(5), DbValue.DbString("N"), DbValue.DbString("e@x"))
+        val assignments = IndexedSeq("email" -> DbValue.DbString("e@x"))
+        val frag        = Upsert.doUpdate("user", IndexedSeq("id", "name", "email"), values, "id", assignments)
+        assertTrue(
+          frag.queryParams == values ++ assignments.map(_._2),
+          frag.sql(
+            SqlDialect.PostgreSQL
+          ) == """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO UPDATE SET "email" = ?"""
+        )
+      }
+    ),
+    suite("validation")(
+      test("invalid conflict identifier throws") {
+        val result = scala.util.Try(Upsert.doNothingSuffix("id; DROP TABLE user"))
+        assertTrue(result.isFailure, result.failed.get.isInstanceOf[IllegalArgumentException])
+      },
+      test("invalid assignment identifier throws") {
+        val result = scala.util.Try(Upsert.doUpdateSuffix("id", IndexedSeq("bad-col" -> DbValue.DbString("x"))))
+        assertTrue(result.isFailure, result.failed.get.isInstanceOf[IllegalArgumentException])
+      },
+      test("invalid table name throws") {
+        val result = scala.util.Try(
+          Upsert.doNothing("bad-table!", IndexedSeq("id"), IndexedSeq(DbValue.DbInt(1)), "id")
+        )
+        assertTrue(result.isFailure)
+      },
+      test("unknown assignment column throws") {
+        val result = scala.util.Try(
+          Upsert.insertDoUpdate(userTable, User(1, "A", "a@b"), "id", Seq("unknown_col"))
+        )
+        assertTrue(result.isFailure, result.failed.get.getMessage.contains("not found"))
+      },
+      test("unknown conflict column throws") {
+        val result = scala.util.Try(
+          Upsert.insertDoNothing(userTable, User(1, "A", "a@b"), "unknown")
+        )
+        assertTrue(result.isFailure)
+      },
+      test("empty assignments throws") {
+        val result1 = scala.util.Try(Upsert.doUpdateSuffix("id", IndexedSeq.empty))
+        val result2 = scala.util.Try(Upsert.insertDoUpdate(userTable, User(1, "A", "a@b"), "id", Seq.empty))
+        assertTrue(result1.isFailure, result2.isFailure)
+      },
+      test("single-col table doUpdate throws (no assignment)") {
+        val result = scala.util.Try(Upsert.insertDoUpdate(idOnlyTable, IdOnly(1), "id"))
+        assertTrue(result.isFailure)
+      },
+      test("assignment containing conflict column throws") {
+        val result = scala.util.Try(Upsert.insertDoUpdate(userTable, User(1, "A", "a@b"), "id", Seq("id", "email")))
+        assertTrue(result.isFailure, result.failed.get.getMessage.contains("conflict"))
+      }
+    )
+  )
+}


### PR DESCRIPTION
First-class upsert (`INSERT ... ON CONFLICT`) and keyset pagination for zio-blocks-sql.

**TL;DR:** Postgres and SQLite share identical `ON CONFLICT` syntax, so one builder serves both dialects; keyset paging needs only the id column `Repo` already owns. Shipping simple APIs now beats blocking on the future query IR.

**What this PR does:**

*Frag-level:*
- `Upsert` builders rendering `ON CONFLICT ("id") DO NOTHING | DO UPDATE SET c = ?...` with identifier validation via `SqlIdentifier` and assignment columns validated against `Table.columns`
- Identical rendering for PG+SQLite (`?` placeholders), golden-string tests for both dialects
- Unsupported future dialect errors clearly at render

*Repo-level:*
- `Repo.insertOrUpdate(entity)` (conflict target = `idColumn`) and `Repo.insertOrUpdateBatch(entities)` via JDBC batch (mirrors `insertBatch` pattern with `SUCCESS_NO_INFO→1` handling and empty-params logging)
- `Repo.pageAfter(cursorId, limit)` = `SELECT ... WHERE id > ? ORDER BY id ASC LIMIT n`
- `Frag.keysetAfter(table, orderCol, lastValue, limit)` and `Frag.keysetAfter(orderCol, lastValue, limit)` (table-validated vs identifier-only, single-column only)

*Docs:*
- Keyset pagination blurb appended to `docs/guides/query-dsl-sql.md` with mdoc examples

**What it does NOT do:**
- No OFFSET helpers, no MERGE, no change detection/dirty-tracking, no breaking changes to existing insert APIs, no RETURNING variants, no composite-cursor (v2), no `ON CONFLICT ... WHERE` (v2)

**Verification:**
- `UpsertSpec` 20 tests (golden strings PG+SQLite, param forwarding, validation)
- `KeysetSpec` 9 tests + `RepoKeysetSpec` 7 tests (boundary empty page, stable ordering, walk 100 rows in pages of 7, unknown column rejected)
- `RepoUpsertSpec` 21 tests (insert-new vs update-existing vs mixed batch, double upsert single row, constraint violation, single-col edge, logging)
- F3 end-to-end: seed 50, overlapping upsert 10 (45-54), walk 54 via `pageAfter` limit 7 (8 pages), 59 tests pass

**Commit:** `d9f4c020` feat(sql): upsert and keyset pagination (GPG-signed)

Fixes part of sql-upsert-keyset plan (tasks 1.1, 2, 3.2)

_Related: relational-query-layer plan may later re-express upsert as IR node (accepted refactor cost)._