### PR TITLE
feat(sql): transaction hardening — isolation, savepoints, Hikari docs

### DIFF
--- a/dataMigration/jvm/src/test/scala/zio/blocks/data/migration/MigrationIntegrationSpec.scala
+++ b/dataMigration/jvm/src/test/scala/zio/blocks/data/migration/MigrationIntegrationSpec.scala
@@ -69,9 +69,13 @@ object MigrationIntegrationSpec extends ZIOSpecDefault {
       conn.setAutoCommit(false)
       try {
         given tx: DbTx = new DbTx {
-          val connection: DbConnection = dbConn
-          val dialect: SqlDialect      = SqlDialect.SQLite
-          val logger: SqlLogger        = SqlLogger.noop
+          val connection: DbConnection                = dbConn
+          val dialect: SqlDialect                     = SqlDialect.SQLite
+          val logger: SqlLogger                       = SqlLogger.noop
+          override var currentDepth: Int              = 0
+          override def savepoint(name: String): Unit  = dbConn.savepoint(name)
+          override def release(name: String): Unit    = dbConn.release(name)
+          override def rollbackTo(name: String): Unit = dbConn.rollbackTo(name)
         }
         val result = f
         conn.commit()

--- a/dataMigration/shared/src/test/scala/zio/blocks/data/migration/LargeMigratorSpec.scala
+++ b/dataMigration/shared/src/test/scala/zio/blocks/data/migration/LargeMigratorSpec.scala
@@ -30,8 +30,12 @@ object LargeMigratorSpec extends ZIOSpecDefault {
   final class StubTransactor(pendingValue: Long) extends Transactor {
     var transactCalls: Int = 0
 
-    def connect[A](f: DbCon ?=> A): A = pendingValue.asInstanceOf[A]
-    def transact[A](f: DbTx ?=> A): A = {
+    override def connect[A](f: DbCon ?=> A): A = pendingValue.asInstanceOf[A]
+    override def transact[A](f: DbTx ?=> A): A = {
+      transactCalls += 1
+      0.asInstanceOf[A]
+    }
+    override def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A = {
       transactCalls += 1
       0.asInstanceOf[A]
     }

--- a/dataMigration/shared/src/test/scala/zio/blocks/data/migration/SmallMigratorSpec.scala
+++ b/dataMigration/shared/src/test/scala/zio/blocks/data/migration/SmallMigratorSpec.scala
@@ -28,8 +28,9 @@ object SmallMigratorSpec extends ZIOSpecDefault {
    * without a database.
    */
   final class StubTransactor(pendingValue: Long) extends Transactor {
-    def connect[A](f: DbCon ?=> A): A = pendingValue.asInstanceOf[A]
-    def transact[A](f: DbTx ?=> A): A = 0.asInstanceOf[A]
+    override def connect[A](f: DbCon ?=> A): A                                                     = pendingValue.asInstanceOf[A]
+    override def transact[A](f: DbTx ?=> A): A                                                     = 0.asInstanceOf[A]
+    override def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A = 0.asInstanceOf[A]
   }
 
   private val idColumns = IndexedSeq(ColumnMeta("id", DbValue.DbInt(0), nullable = false))

--- a/dataMigration/shared/src/test/scala/zio/blocks/data/migration/TinyMigratorSpec.scala
+++ b/dataMigration/shared/src/test/scala/zio/blocks/data/migration/TinyMigratorSpec.scala
@@ -39,9 +39,27 @@ object TinyMigratorSpec extends ZIOSpecDefault {
       transactCalled = true
       f(using
         new DbTx {
-          def connection: DbConnection = ???
-          def dialect: SqlDialect      = ???
-          def logger: SqlLogger        = ???
+          def connection: DbConnection                = ???
+          def dialect: SqlDialect                     = ???
+          def logger: SqlLogger                       = ???
+          override var currentDepth: Int              = 0
+          override def savepoint(name: String): Unit  = ()
+          override def release(name: String): Unit    = ()
+          override def rollbackTo(name: String): Unit = ()
+        }
+      )
+    }
+    override def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A = {
+      transactCalled = true
+      f(using
+        new DbTx {
+          def connection: DbConnection                = ???
+          def dialect: SqlDialect                     = ???
+          def logger: SqlLogger                       = ???
+          override var currentDepth: Int              = 0
+          override def savepoint(name: String): Unit  = ()
+          override def release(name: String): Unit    = ()
+          override def rollbackTo(name: String): Unit = ()
         }
       )
     }

--- a/docs/guides/sql-transactions.md
+++ b/docs/guides/sql-transactions.md
@@ -1,0 +1,286 @@
+---
+id: sql-transactions
+title: "SQL Transactions: Isolation, Savepoints & Hikari on Loom"
+---
+
+This guide covers ZIO Blocks' SQL transaction system: how `transact` works under the hood, which isolation levels are available on each database, how nested transactions use savepoints, and how to wire HikariCP into a `JdbcTransactor` for virtual-thread-friendly connection pooling.
+
+**What we'll cover:**
+
+- Opening transactions with `transactor.transact { ... }` and tuning isolation + readOnly
+- The `TransactionIsolation` enum and how SQLite vs PostgreSQL handle each level
+- Nested transactions via SQL savepoints (`zib_tx_1 .. zib_tx_N`)
+- Error semantics: inner rollback vs outer commit
+- HikariCP connection pooling with `JdbcTransactor.fromDataSource`
+- Virtual threads (JDK 25+ Loom): why blocking JDBC is fine, and what pinning caveats remain
+
+## Basic Usage
+
+Every database interaction goes through a `Transactor`. The simplest form opens a connection, disables auto-commit, runs your code, and commits on success (or rolls back on failure):
+
+```scala
+transactor.transact {
+  sql"INSERT INTO users (name) VALUES ('Alice')".update
+  sql"INSERT INTO orders (user_id, total) VALUES (1, 99.50)".update
+}
+```
+
+Both inserts run inside a single transaction. If either fails, both are rolled back.
+
+To control isolation level and read-only mode, pass them explicitly:
+
+```scala
+transactor.transact(TransactionIsolation.RepeatableRead, readOnly = false) {
+  val users = sql"SELECT * FROM users WHERE active = true".query[User].toList
+  // ... process users ...
+}
+```
+
+The default overload uses `Serializable` isolation with `readOnly = false`, which matches the standard SQL default for transactional databases.
+
+## TransactionIsolation
+
+The `TransactionIsolation` enum has four values, each mapping to the corresponding `java.sql.Connection.TRANSACTION_*` constant:
+
+| Enum value           | JDBC constant                        |
+|----------------------|--------------------------------------|
+| `ReadUncommitted`    | `TRANSACTION_READ_UNCOMMITTED`       |
+| `ReadCommitted`      | `TRANSACTION_READ_COMMITTED`         |
+| `RepeatableRead`     | `TRANSACTION_REPEATABLE_READ`        |
+| `Serializable`       | `TRANSACTION_SERIALIZABLE`           |
+
+When you pass a level to `transactor.transact`, it calls `Connection.setTransactionIsolation` before starting the transaction. The previous level is restored in a `finally` block after the transaction completes.
+
+### SQLite vs PostgreSQL
+
+The two supported dialects differ significantly in how they honor isolation levels:
+
+| Level              | PostgreSQL                        | SQLite                                    |
+|--------------------|-----------------------------------|-------------------------------------------|
+| `ReadUncommitted`  | Full support (dirty reads)        | Accepted, treated as `SERIALIZABLE`       |
+| `ReadCommitted`    | Full support (default PG level)   | Accepted, treated as `SERIALIZABLE`       |
+| `RepeatableRead`   | Full support (MVCC snapshot)      | Accepted, treated as `SERIALIZABLE`       |
+| `Serializable`     | Full support (SSI)                | Native (default and only true level)      |
+
+SQLite natively supports only `SERIALIZABLE`. The driver accepts the `setTransactionIsolation` call without error, but the engine ignores the requested level and behaves as serializable. This is a SQLite limitation, not a ZIO Blocks one. If your application relies on weaker isolation guarantees (e.g., `ReadCommitted` for higher concurrency), test on PostgreSQL where those semantics are real.
+
+PostgreSQL supports all four levels natively through its MVCC implementation. `ReadCommitted` is the default for non-transactional statements; `RepeatableRead` gives you a consistent snapshot for the duration of the transaction; `Serializable` adds serialization conflict detection via Snapshot Isolation (SSI).
+
+## Read-Only Transactions
+
+Passing `readOnly = true` marks the connection as read-only at the JDBC level:
+
+```scala
+transactor.transact(TransactionIsolation.ReadCommitted, readOnly = true) {
+  sql"SELECT COUNT(*) FROM users".query[Int].toOne
+}
+```
+
+PostgreSQL uses the read-only flag to enable optimization paths (e.g., avoiding WAL writes for read-only transactions). SQLite may ignore the flag depending on the driver version, but it's still set on the connection for consistency. The previous `readOnly` value is always restored after the transaction, regardless of dialect.
+
+## Nested Transactions via Savepoints
+
+Nested transactions are emulated via SQL savepoints on the same JDBC connection. When you're already inside `transactor.transact { ... }`, you can nest further work using the ambient `DbTx`:
+
+```scala
+transactor.transact {
+  sql"INSERT INTO orders (total) VALUES (100)".update
+
+  summon[DbTx].transact {
+    sql"INSERT INTO order_items (order_id, product_id) VALUES (1, 42)".update
+  }
+
+  sql"UPDATE inventory SET stock = stock - 1 WHERE product_id = 42".update
+}
+```
+
+The nested block runs inside a savepoint named `zib_tx_1`. If it fails, only the inner work is rolled back (via `ROLLBACK TO SAVEPOINT`). The outer transaction continues and can still commit.
+
+### How Savepoints Work
+
+Each nesting level gets a savepoint name derived from the current depth: `zib_tx_1`, `zib_tx_2`, and so on. The mechanism:
+
+1. **Depth increments** before creating the savepoint
+2. **`SAVEPOINT zib_tx_<depth>`** is issued on the connection
+3. The nested body executes with the ambient `DbTx` in scope
+4. On **success**: `RELEASE SAVEPOINT zib_tx_<depth>` is called
+5. On **failure**: `ROLLBACK TO SAVEPOINT zib_tx_<depth>` is called, then the exception is rethrown
+6. **Depth decrements** in a `finally` block, guaranteeing the counter resets even after exceptions
+
+The depth counter resets after each inner block finishes, so sibling nested transactions reuse the same name sequence without leaking savepoints.
+
+### Three-Level Example
+
+```scala
+transactor.transact {
+  // Depth 0: outer transaction (real COMMIT/ROLLBACK)
+  sql"INSERT INTO t VALUES (1)".update
+
+  summon[DbTx].transact {
+    // Depth 1: savepoint zib_tx_1
+    sql"INSERT INTO t VALUES (2)".update
+
+    summon[DbTx].transact {
+      // Depth 2: savepoint zib_tx_2
+      sql"INSERT INTO t VALUES (3)".update
+    }
+    // zib_tx_2 released here
+
+    sql"INSERT INTO t VALUES (4)".update
+  }
+  // zib_tx_1 released here
+
+  sql"INSERT INTO t VALUES (5)".update
+}
+// COMMIT (all 5 inserts)
+```
+
+If the depth-2 block fails, only `INSERT INTO t VALUES (3)` is rolled back. Inserts 1, 2, 4, and 5 remain and will be committed.
+
+### Error Semantics
+
+When an inner block throws:
+
+- The inner savepoint is rolled back via `ROLLBACK TO SAVEPOINT`
+- The exception is rethrown to the caller
+- The outer transaction is **not** rolled back automatically
+- The outer block can catch the exception and continue, or let it propagate (triggering a full rollback at the top level)
+
+```scala
+transactor.transact {
+  sql"INSERT INTO t VALUES (1)".update
+
+  try {
+    summon[DbTx].transact {
+      sql"INSERT INTO t VALUES (2)".update
+      throw new RuntimeException("inner failure")
+      sql"INSERT INTO t VALUES (3)".update  // never reached
+    }
+  } catch {
+    case _: RuntimeException => ()  // swallow inner failure
+  }
+
+  sql"INSERT INTO t VALUES (4)".update
+}
+// COMMIT: rows 1 and 4 only (row 2 rolled back by savepoint)
+```
+
+### The `transactNested` Helper
+
+For call sites that prefer `using` parameters over extension receivers, `transactNested` is available as an alias:
+
+```scala
+import zio.blocks.sql.DbTx
+
+transactor.transact {
+  DbTx.transactNested {
+    // same as summon[DbTx].transact { ... }
+    sql"INSERT INTO t VALUES (1)".update
+  }
+}
+```
+
+Both forms are equivalent. The extension method (`summon[DbTx].transact { ... }`) is more common in practice because it reads naturally inside a `transact` block.
+
+### Given-Priority Trick
+
+When a `DbTx` is already in scope (inside `transactor.transact`), the extension `summon[DbTx].transact { ... }` resolves via the more specific `DbTx` receiver and reuses the same connection with a savepoint. Using `transactor.transact { ... }` instead would open a **new** connection, which is almost never what you want inside an existing transaction. The explicit `summon[DbTx]` form keeps semantics clear without hidden implicit resolution.
+
+## HikariCP Recipe
+
+For production applications, use HikariCP for connection pooling. Create a `HikariDataSource` and pass it to `JdbcTransactor.fromDataSource`:
+
+```scala
+import com.zaxxer.hikari.HikariDataSource
+import zio.blocks.sql.{JdbcTransactor, SqlDialect}
+
+val ds = new HikariDataSource()
+ds.setJdbcUrl("jdbc:postgresql://localhost:5432/mydb")
+ds.setUsername("app_user")
+ds.setPassword("secret")
+ds.setMaximumPoolSize(10)
+
+val transactor = JdbcTransactor.fromDataSource(ds, SqlDialect.PostgreSQL)
+```
+
+Convenience helpers are available for the built-in dialects:
+
+```scala
+val pgTransactor   = JdbcTransactor.postgres(ds)   // shorthand for fromDataSource(ds, PostgreSQL)
+val sqliteTransactor = JdbcTransactor.sqlite(ds)    // shorthand for fromDataSource(ds, SQLite)
+```
+
+### Pool Sizing for Virtual Threads
+
+With virtual threads (JDK 25+), the pool size rule is straightforward: **pool size equals database max connections, not thread count**. Virtual threads are cheap to create and block, so you don't need a thread pool to limit concurrency. The HikariCP pool limits how many database connections are open simultaneously, which is the only resource that actually needs capping.
+
+A typical configuration:
+
+```scala
+ds.setMaximumPoolSize(20)   // match your DB's max_connections / app instances
+ds.setMinimumIdle(5)        // keep a few warm connections
+ds.setConnectionTimeout(3000) // fail fast if pool exhausted
+```
+
+Don't set `maximumPoolSize` to the number of CPU cores or virtual threads. Size it based on your database's connection limit and how many concurrent queries your application actually runs. Most applications need 10-30 connections, not thousands.
+
+Queue sizing via `connectionTimeout` (default 30 seconds) controls how long a request waits for a pooled connection when the pool is exhausted. With virtual threads, you can afford to wait longer since you're not blocking platform threads, but 30 seconds via `ds.setConnectionTimeout(30000)` is usually a good default.
+
+### Pinning Notes (Post-JEP491)
+
+JEP 491 (JDK 25+) eliminates virtual-thread pinning on most blocking I/O operations. Blocking JDBC calls like `Statement.executeQuery()` no longer pin the virtual thread to its carrier thread. This means you can run thousands of concurrent queries without needing an async JDBC wrapper.
+
+However, some drivers still have internal `synchronized` blocks or native calls that can pin:
+
+- **SQLite driver**: The `busy_timeout` implementation uses `synchronized` internally. Under high concurrency with short timeouts, this can still pin virtual threads. Set `busy_timeout` high (e.g., 5000ms) to reduce contention, or use PostgreSQL for concurrent workloads.
+
+- **PostgreSQL JDBC driver**: The driver's `Object.wait()` calls are safe on virtual threads post-JEP491. Earlier JDK versions (21-24) may pin during `Object.wait` in the driver's connection handshake, but this is resolved in JDK 25+.
+
+- **HikariCP itself**: HikariCP's internal `ConcurrentBag` uses `ThreadLocal`-based tracking, which works correctly with virtual threads. The pool doesn't need special configuration for Loom.
+
+If you're on JDK 25+, just use blocking JDBC directly. No need for `ZIO.attemptBlocking` or async wrappers to avoid pinning.
+
+## Virtual Threads (JDK 25+ Loom)
+
+JDK 25 brings Loom to general availability on the JVM-first path. Virtual threads handle blocking I/O naturally: when a JDBC call blocks, the virtual thread unmounts from its carrier thread and the carrier is free to run other work.
+
+This changes the connection-pooling calculus. Before Loom, you needed to size your thread pool and connection pool carefully to avoid thread starvation. With virtual threads, the thread pool concern disappears. Your only constraint is the database's connection limit.
+
+```scala
+// No special thread pool needed. Just use virtual threads directly.
+import java.util.concurrent.Executors
+import scala.concurrent.ExecutionContext
+
+val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()
+val ec = ExecutionContext.fromExecutor(vtExecutor)
+
+// Run hundreds of concurrent queries
+val results = Future.traverse(userIds) { id =>
+  Future {
+    transactor.transact {
+      sql"SELECT * FROM users WHERE id = $id".query[User].toOne
+    }
+  }(ec)
+}
+```
+
+With virtual threads, you don't need async JDBC drivers, reactive wrappers, or thread pool tuning. Blocking is fine. The database connection pool is the only thing you need to manage.
+
+## Summary
+
+| Concept                    | Key Point                                               |
+|----------------------------|---------------------------------------------------------|
+| `transactor.transact`      | Opens connection, disables auto-commit, commits/rollbacks |
+| `TransactionIsolation`     | Four levels; SQLite only true `SERIALIZABLE`            |
+| `readOnly` flag            | Sets JDBC read-only; PG optimizes, SQLite may ignore    |
+| Nested via `summon[DbTx]`  | Savepoints `zib_tx_1..N`, inner rollback isolated       |
+| `transactNested`           | Alias using `using` parameter instead of extension      |
+| HikariCP                   | `fromDataSource(ds, dialect)`, pool = DB connections     |
+| Virtual threads            | Blocking JDBC is fine on JDK 25+ Loom                   |
+| Pinning                    | Post-JEP491 mostly resolved; SQLite `busy_timeout` caveat |
+
+## Going Further
+
+- **[Query DSL with SQL](./query-dsl-sql.md)** -- Building parameterized SQL from `SchemaExpr` queries
+- **[Transactor Reference](../reference/sql/transactor)** -- `JdbcTransactor.fromDataSource` / `fromUrl` and `transact(isolation, readOnly)` overloads
+- **[DbTx Reference](../reference/sql/db-tx)** -- Savepoint API (`savepoint` / `release` / `rollbackTo`) and `summon[DbTx].transact`

--- a/docs/reference/sql/db-tx.md
+++ b/docs/reference/sql/db-tx.md
@@ -12,26 +12,28 @@ keywords:
   - "JDBC Transaction Lifecycle"
 ---
 
-`DbTx` is a marker trait in the `zio-blocks-sql` module that extends `DbCon` to signal a transactional execution scope. It declares no members of its own — its distinct type is what instructs `Transactor#transact` to disable auto-commit, commit the connection on success, and roll back on any thrown exception. You never construct a `DbTx` directly; the `Transactor` creates one and supplies it as a given context to the block passed to `transact`. The connection is always closed when the block exits, whether it commits, rolls back, or throws.
+`DbTx` is the transactional connection context supplied by `Transactor#transact`. It extends `DbCon` (so every `Frag`/`Repo` operation that needs `DbCon` also accepts `DbTx`) and adds savepoint-based nested transaction support. You never construct a `DbTx` directly; the `Transactor` creates one and supplies it as a given context to the block passed to `transact`. The connection is always closed when the outermost block exits, whether it commits, rolls back, or throws.
 
 Key properties:
-- **Transactional context marker** — A `DbTx` value in scope guarantees the underlying JDBC connection has auto-commit disabled.
-- **Commit-on-success semantics** — The `Transactor` commits the connection when the `transact` block returns normally.
-- **Rollback-on-failure semantics** — Any uncaught exception causes the `Transactor` to roll back the connection before re-throwing.
+- **Transactional context** — A `DbTx` value in scope guarantees the underlying JDBC connection has auto-commit disabled.
+- **Commit-on-success / rollback-on-failure** — The outermost `Transactor.transact` commits on normal return and rolls back on any uncaught exception (with suppressed rollback failures).
+- **Savepoint-based nesting** — Inner blocks reuse the same connection via SQL savepoints (`SAVEPOINT` / `RELEASE SAVEPOINT` / `ROLLBACK TO SAVEPOINT`).
+- **`transact(isolation, readOnly)`** — The two-arg `Transactor.transact` overload sets isolation level and `readOnly` before disabling auto-commit; `DbTx` nested blocks inherit those settings on the same connection.
 
 The structural declaration of `DbTx` is:
 
 ```scala
-trait DbTx extends DbCon
-```
+trait DbTx extends DbCon {
+  def savepoint(name: String): Unit
+  def release(name: String): Unit
+  def rollbackTo(name: String): Unit
+  def currentDepth: Int
+  private[sql] def currentDepth_=(depth: Int): Unit
 
-Every context member that `DbTx` exposes is inherited from `DbCon`, which declares the three fields every SQL operation consumes:
-
-```scala
-trait DbCon {
+  // inherited from DbCon
   def connection: DbConnection
-  def dialect:    SqlDialect
-  def logger:     SqlLogger
+  def dialect: SqlDialect
+  def logger: SqlLogger
 }
 ```
 
@@ -71,3 +73,33 @@ tx.transact {
   (all, custom)
 }
 ```
+
+## Nested Transactions via Savepoints
+
+Nested transactions reuse the same underlying JDBC connection via SQL savepoints. The `DbTx` given in scope exposes an extension `transact` and the `transactNested` helpers:
+
+```scala mdoc:compile-only
+import zio.blocks.sql._
+
+val transactor = JdbcTransactor.fromUrl("jdbc:sqlite::memory:", SqlDialect.SQLite)
+
+// Savepoint-based nesting — same connection, isolated rollback
+transactor.transact {
+  sql"INSERT INTO t VALUES (1)".update
+
+  // Inner block runs inside SAVEPOINT zib_tx_1
+  summon[DbTx].transact {
+    sql"INSERT INTO t VALUES (2)".update
+  }
+
+  // Equivalent using the `using` helper
+  // DbTx.transactNested { sql"INSERT INTO t VALUES (3)".update }
+  // transactNested { sql"INSERT INTO t VALUES (4)".update }
+}
+```
+
+Savepoint names are `zib_tx_1 .. zib_tx_N` where `N` is the nesting depth tracked in `currentDepth`. On success the savepoint is released via `RELEASE SAVEPOINT`; on failure it is rolled back via `ROLLBACK TO SAVEPOINT` and the exception is rethrown (with any rollback failure added as suppressed). Depth is decremented in `finally`, so sibling nested blocks reuse the same name sequence without leaking savepoints. `savepoint`/`release`/`rollbackTo` are also available directly for manual control and validate identifiers via `SqlIdentifier` to prevent injection.
+
+:::caution
+Only the outermost `Transactor.transact` issues a real `COMMIT`/`ROLLBACK`. Inner `summon[DbTx].transact` blocks are savepoint-scoped — outer commit still decides the final persistence of all work, including inner blocks that succeeded.
+:::

--- a/docs/reference/sql/transactor.md
+++ b/docs/reference/sql/transactor.md
@@ -25,8 +25,11 @@ The structural shape of the trait is:
 trait Transactor {
   def connect[A](f: DbCon ?=> A): A
   def transact[A](f: DbTx ?=> A): A
+  def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A
 }
 ```
+
+The no-arg `transact` preserves the driver’s default isolation level and `readOnly` flag, while the two-arg overload lets callers request an explicit `TransactionIsolation` (`ReadUncommitted(1)`, `ReadCommitted(2)`, `RepeatableRead(4)`, `Serializable(8)`) and read-only mode, plus the savepoint-based nested transaction support described in `DbTx`.
 
 `JdbcTransactor` is the concrete JDBC-backed implementation. Its companion object provides factory methods for all common connection strategies:
 
@@ -223,15 +226,18 @@ Inside `connect`, auto-commit is left at its default state (typically `true` for
 
 ### Transaction Management
 
-`Transactor#transact` builds on `connect` by adding full transaction semantics: it disables auto-commit before executing the body, commits when the body returns normally, and rolls back when the body throws. The connection is always closed after commit or rollback.
-
-It acquires a connection, sets `autoCommit = false`, synthesizes a `DbTx` given value, and runs the body. On success it calls `conn.commit()`. On any exception it calls `conn.rollback()`, adds any rollback failure as a suppressed exception, and rethrows the original. The connection is closed in the `finally` block regardless of outcome:
+`Transactor#transact` builds on `connect` by adding full transaction semantics: it disables auto-commit before executing the body, commits when the body returns normally, and rolls back when the body throws. The connection is always closed after commit or rollback. Two overloads are available — a no-arg form that preserves the driver’s defaults and a two-arg form that sets isolation and `readOnly` explicitly:
 
 ```scala
 trait Transactor {
   def transact[A](f: DbTx ?=> A): A
+  def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A
 }
 ```
+
+The two-arg overload acquires a connection, saves the previous isolation level and `readOnly` flag, calls `setTransactionIsolation(isolation.jdbcLevel)` (fail-fast — isolation failures propagate) and best-effort `setReadOnly(readOnly)` (SQLite may throw, which is swallowed), sets `autoCommit = false` (fail-fast), synthesizes a `DbTx` given value, and runs the body. On success it calls `conn.commit()`. On any exception it calls `conn.rollback()`, adds any rollback failure as a suppressed exception, and rethrows the original. Previous isolation, `readOnly`, and `autoCommit` are restored and the connection is closed in the `finally` block regardless of outcome. SQLite natively supports only `SERIALIZABLE` — other levels are accepted via `setTransactionIsolation` but the engine still behaves as serializable.
+
+The no-arg overload preserves driver defaults (e.g. PostgreSQL `READ_COMMITTED`) and does not force `SERIALIZABLE`; it simply sets `autoCommit = false` before running the body, with the same commit/rollback and cleanup guarantees.
 
 Because `DbTx extends DbCon`, the `DbTx` given satisfies any `DbCon ?=>` requirement inside the block. We can mix `Repo` CRUD calls with raw `sql"..."` fragments freely:
 
@@ -261,6 +267,10 @@ transactor.transact {
 :::caution
 If `commit` itself throws after a successful body, the transaction is rolled back and the commit exception propagates. The body's return value is discarded in that case.
 :::
+
+### Nested Transactions (Savepoints)
+
+Inside `transact`, nested work is emulated via SQL savepoints on the same JDBC connection through `DbTx` — `summon[DbTx].transact { ... }`, `DbTx.transactNested`, or the top-level `transactNested` helper. Savepoints are named `zib_tx_1 .. zib_tx_N` with depth tracked in `DbTx.currentDepth`; inner success issues `RELEASE SAVEPOINT`, failure issues `ROLLBACK TO SAVEPOINT` then rethrows. See [DbTx](db-tx) for full savepoint semantics.
 
 ## JdbcTransactor
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -380,7 +380,7 @@ const sidebars = {
         "guides/query-dsl-fluent-builder",
         "guides/query-dsl-reified-optics",
         "guides/query-dsl-sql",
-        "guides/sql-checked-interpolation",
+        "guides/sql-transactions",
         "guides/zio-schema-migration",
         "guides/telemetry-guide",
       ]

--- a/sql-zio/src/main/scala/zio/blocks/sql/zio/TransactorZIO.scala
+++ b/sql-zio/src/main/scala/zio/blocks/sql/zio/TransactorZIO.scala
@@ -77,6 +77,9 @@ class TransactorZIO(
   def transact[A](f: DbTx ?=> A): Task[A] =
     ZIO.attemptBlocking(underlying.transact(f))
 
+  def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): Task[A] =
+    ZIO.attemptBlocking(underlying.transact(isolation, readOnly)(f))
+
   /**
    * Acquires a connection via `ZIO.acquireRelease`, passes it to `f` as a
    * `DbCon`, and ensures the connection is closed when the scope exits (even on
@@ -107,28 +110,92 @@ class TransactorZIO(
    * Acquires a connection via `ZIO.acquireRelease`, disables auto-commit,
    * passes it to `f` as a `DbTx`, commits on success, rolls back on failure,
    * then closes the connection.
+   *
+   * Preserves the driver's default isolation level and `readOnly` flag — does
+   * not force `SERIALIZABLE` — matching [[JdbcTransactor.transact]]. Use the
+   * two-arg overload to request a specific isolation level or read-only flag.
    */
   // NEW: Effect-aware ZIO transaction management
   def transactZIO[R, E, A](f: DbTx ?=> ZIO[R, E, A]): ZIO[R, E | Throwable, A] =
+    transactZIOInternal(None, None)(f)
+
+  /**
+   * Acquires a connection via `ZIO.acquireRelease`, applies the requested
+   * isolation level and read-only flag, disables auto-commit, passes it to `f`
+   * as a `DbTx`, commits on success, rolls back on failure, then closes the
+   * connection. Previous `autoCommit`, isolation level and `readOnly` flag are
+   * restored after commit or rollback.
+   *
+   * Isolation-setup failures are propagated (fail fast, matching
+   * [[JdbcTransactor.transact]]); `setReadOnly` failures remain best-effort.
+   */
+  def transactZIO[R, E, A](isolation: TransactionIsolation, readOnly: Boolean)(
+    f: DbTx ?=> ZIO[R, E, A]
+  ): ZIO[R, E | Throwable, A] =
+    transactZIOInternal(Some(isolation), Some(readOnly))(f)
+
+  private def transactZIOInternal[R, E, A](
+    isolation: Option[TransactionIsolation],
+    readOnly: Option[Boolean]
+  )(f: DbTx ?=> ZIO[R, E, A]): ZIO[R, E | Throwable, A] =
     ZIO.scoped[R] {
       ZIO
         .acquireRelease(ZIO.attemptBlocking {
-          val conn           = connectionFactory()
-          val dbConn         = new JdbcConnection(conn)
-          val prevAutoCommit = conn.getAutoCommit
-          conn.setAutoCommit(false)
-          (conn, dbConn, prevAutoCommit)
-        }) { case (conn, dbConn, prevAutoCommit) =>
+          val conn   = connectionFactory()
+          val dbConn = new JdbcConnection(conn)
+          try {
+            val prevAutoCommit = conn.getAutoCommit
+            val prevIsolation  = isolation.map(_ => conn.getTransactionIsolation)
+            val prevReadOnly   = readOnly.map(_ =>
+              try conn.isReadOnly
+              catch { case _: Throwable => false }
+            )
+            // Fail fast: isolation failures must propagate (do not swallow); the
+            // release finalizer restores previous settings and closes the connection.
+            isolation.foreach(iso => conn.setTransactionIsolation(iso.jdbcLevel))
+            // Intentionally swallow readOnly failures: SQLite (and some other
+            // drivers) throw on setReadOnly even though transactions still work;
+            // keep best-effort semantics for this flag only, as in JdbcTransactor.
+            readOnly.foreach(ro =>
+              try conn.setReadOnly(ro)
+              catch { case _: Throwable => () }
+            )
+            // Fail fast: if autoCommit cannot be disabled, do not run the body
+            // outside a transaction.
+            conn.setAutoCommit(false)
+            (conn, dbConn, prevAutoCommit, prevIsolation, prevReadOnly)
+          } catch {
+            case e: Throwable =>
+              // Setup failed before the acquire completed, so the release
+              // finalizer is not registered; close the connection here.
+              try conn.close()
+              catch { case _: Throwable => () }
+              throw e
+          }
+        }) { case (conn, dbConn, prevAutoCommit, prevIsolation, prevReadOnly) =>
           ZIO.attemptBlocking {
-            conn.setAutoCommit(prevAutoCommit)
+            prevReadOnly.foreach(ro =>
+              try conn.setReadOnly(ro)
+              catch { case _: Throwable => () }
+            )
+            prevIsolation.foreach(iso =>
+              try conn.setTransactionIsolation(iso)
+              catch { case _: Throwable => () }
+            )
+            try conn.setAutoCommit(prevAutoCommit)
+            catch { case _: Throwable => () }
             dbConn.close()
           }.ignore
         }
-        .flatMap { case (conn, dbConn, _) =>
+        .flatMap { case (conn, dbConn, _, _, _) =>
           val tx = new DbTx {
-            val connection: DbConnection = dbConn
-            val dialect: SqlDialect      = TransactorZIO.this.dialect
-            val logger: SqlLogger        = TransactorZIO.this.logger
+            val connection: DbConnection                = dbConn
+            val dialect: SqlDialect                     = TransactorZIO.this.dialect
+            val logger: SqlLogger                       = TransactorZIO.this.logger
+            override var currentDepth: Int              = 0
+            override def savepoint(name: String): Unit  = dbConn.savepoint(name)
+            override def release(name: String): Unit    = dbConn.release(name)
+            override def rollbackTo(name: String): Unit = dbConn.rollbackTo(name)
           }
           f(using tx).exit.flatMap {
             case Exit.Success(value) =>

--- a/sql-zio/src/test/scala/zio/blocks/sql/zio/TransactorZIOSpec.scala
+++ b/sql-zio/src/test/scala/zio/blocks/sql/zio/TransactorZIOSpec.scala
@@ -33,14 +33,30 @@ object TransactorZIOSpec extends ZIOSpecDefault {
     var rollbackCalls: Int = 0,
     val autoCommitValues: ListBuffer[Boolean] = ListBuffer.empty,
     var failCommit: Boolean = false,
-    var failRollback: Boolean = false
+    var failRollback: Boolean = false,
+    var isolation: Int = Connection.TRANSACTION_READ_UNCOMMITTED,
+    var readOnly: Boolean = true,
+    var setTransactionIsolationCalls: Int = 0,
+    var setReadOnlyCalls: Int = 0,
+    var failSetTransactionIsolation: Boolean = false
   )
 
   private def connection(state: ConnectionState): Connection = {
     val handler = new InvocationHandler {
       override def invoke(proxy: Any, method: Method, args: Array[AnyRef] | Null): AnyRef =
         method.getName match {
-          case "getAutoCommit" => java.lang.Boolean.valueOf(state.autoCommit)
+          case "getAutoCommit"           => java.lang.Boolean.valueOf(state.autoCommit)
+          case "getTransactionIsolation" => Integer.valueOf(state.isolation)
+          case "isReadOnly"              => java.lang.Boolean.valueOf(state.readOnly)
+          case "setTransactionIsolation" =>
+            state.setTransactionIsolationCalls += 1
+            if (state.failSetTransactionIsolation) throw new java.sql.SQLException("isolation not supported")
+            state.isolation = args.nn(0).asInstanceOf[java.lang.Integer].intValue()
+            null
+          case "setReadOnly" =>
+            state.setReadOnlyCalls += 1
+            state.readOnly = args.nn(0).asInstanceOf[java.lang.Boolean].booleanValue()
+            null
           case "setAutoCommit" =>
             val value = args.nn(0).asInstanceOf[java.lang.Boolean].booleanValue()
             state.autoCommit = value
@@ -80,6 +96,12 @@ object TransactorZIOSpec extends ZIOSpecDefault {
     else if (returnType == java.lang.Byte.TYPE) java.lang.Byte.valueOf(0.toByte)
     else null
 
+  private def failedWith(exit: _root_.zio.Exit[Throwable, ?], message: String): Boolean =
+    exit match {
+      case _root_.zio.Exit.Failure(cause) => cause.failures.headOption.exists(_.getMessage == message)
+      case _root_.zio.Exit.Success(_)     => false
+    }
+
   def spec: Spec[TestEnvironment, Any] = suite("TransactorZIOSpec")(
     test("transactZIO rolls back when commit fails after a successful body") {
       val state                                               = ConnectionState(failCommit = true)
@@ -106,6 +128,47 @@ object TransactorZIOSpec extends ZIOSpecDefault {
         value <- transactor.transactZIO(program)
       } yield assertTrue(
         value == 42,
+        state.commitCalls == 1,
+        state.rollbackCalls == 0,
+        state.closed,
+        state.autoCommit,
+        state.autoCommitValues.toList == List(false, true)
+      )
+    },
+    test("transactZIO propagates isolation setup failure and closes the connection") {
+      val state                                               = ConnectionState(failSetTransactionIsolation = true)
+      val transactor                                          = new TransactorZIO(() => connection(state), SqlDialect.SQLite)
+      var bodyRan                                             = false
+      val program: DbTx ?=> _root_.zio.ZIO[Any, Nothing, Int] = {
+        bodyRan = true
+        _root_.zio.ZIO.succeed(42)
+      }
+
+      for {
+        exit <- transactor.transactZIO(TransactionIsolation.Serializable, readOnly = false)(program).exit
+      } yield assertTrue(
+        exit.isFailure,
+        !bodyRan,
+        state.closed,
+        state.commitCalls == 0,
+        state.rollbackCalls == 0,
+        state.setTransactionIsolationCalls == 1,
+        failedWith(exit, "isolation not supported")
+      )
+    },
+    test("transactZIO preserves driver isolation and readOnly defaults") {
+      val state                                                          = ConnectionState()
+      val conn                                                           = connection(state)
+      val transactor                                                     = new TransactorZIO(() => conn, SqlDialect.SQLite)
+      val program: DbTx ?=> _root_.zio.ZIO[Any, Nothing, (Int, Boolean)] =
+        _root_.zio.ZIO.succeed((conn.getTransactionIsolation, conn.isReadOnly))
+
+      for {
+        result <- transactor.transactZIO(program)
+      } yield assertTrue(
+        result == (Connection.TRANSACTION_READ_UNCOMMITTED, true),
+        state.setTransactionIsolationCalls == 0,
+        state.setReadOnlyCalls == 0,
         state.commitCalls == 1,
         state.rollbackCalls == 0,
         state.closed,

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcConnection.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcConnection.scala
@@ -37,6 +37,43 @@ private[sql] class JdbcConnection(val underlying: Connection) extends DbConnecti
   def commit(): Unit = underlying.commit()
 
   def rollback(): Unit = underlying.rollback()
+
+  /**
+   * Savepoint support via SQL strings for portability.
+   *
+   * Uses `SAVEPOINT <name>`, `RELEASE SAVEPOINT <name>`, and
+   * `ROLLBACK TO SAVEPOINT <name>` executed via a fresh Statement. This avoids
+   * tracking `java.sql.Savepoint` objects and works on both SQLite and
+   * PostgreSQL. The statement is closed in `finally` to avoid leaking
+   * resources. Names are expected to be simple identifiers like `zib_tx_1` so
+   * no quoting/escaping is needed.
+   *
+   * Cost: Each savepoint operation allocates a new JDBC `Statement` (two per
+   * nested transaction: one for `SAVEPOINT`, one for `RELEASE` or
+   * `ROLLBACK TO`). This is negligible for typical nesting depths (1-3) and
+   * avoids holding `Savepoint` objects, but very deep or high-frequency nesting
+   * should be benchmarked if it becomes hot.
+   */
+  override def savepoint(name: String): Unit = {
+    SqlIdentifier.validate("savepoint", name)
+    val stmt = underlying.createStatement()
+    try stmt.execute(s"SAVEPOINT $name")
+    finally stmt.close()
+  }
+
+  override def release(name: String): Unit = {
+    SqlIdentifier.validate("savepoint", name)
+    val stmt = underlying.createStatement()
+    try stmt.execute(s"RELEASE SAVEPOINT $name")
+    finally stmt.close()
+  }
+
+  override def rollbackTo(name: String): Unit = {
+    SqlIdentifier.validate("savepoint", name)
+    val stmt = underlying.createStatement()
+    try stmt.execute(s"ROLLBACK TO SAVEPOINT $name")
+    finally stmt.close()
+  }
 }
 
 private[sql] class JdbcPreparedStatement(val underlying: java.sql.PreparedStatement) extends DbPreparedStatement {

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
@@ -51,9 +51,112 @@ class JdbcTransactor(
   }
 
   /**
+   * Opens a connection, applies the requested isolation level and read-only
+   * flag, disables auto-commit, executes `f`, commits on success, and rolls
+   * back on exception. Previous `autoCommit`, isolation level and `readOnly`
+   * flag are restored and the connection is closed after commit or rollback.
+   *
+   * For `SqlDialect.SQLite`, `transact` runs with `busy_timeout=5000` and
+   * `IMMEDIATE` — `fromUrl` and `sqlite` create SQLite connections with
+   * `busy_timeout=5000` and `transaction_mode=IMMEDIATE`, and `transact` also
+   * configures any SQLite `Connection` (including pooled/wrapped via
+   * `isWrapperFor`/`unwrap`) per-transaction so queue workers reserve the write
+   * lock before the `SELECT` and wait on contention instead of failing the
+   * later `DELETE` with `SQLITE_BUSY`. See PR #1534 discussion_r3863454094;
+   * SQLite is single-consumer.
+   *
+   * SQLite note: SQLite natively supports only `SERIALIZABLE` (its default).
+   * Other levels are accepted and applied via
+   * `Connection.setTransactionIsolation` so behaviour is uniform across
+   * dialects, but on SQLite the engine still behaves as serializable — the
+   * requested level may be ignored by the engine even though it is set on the
+   * connection.
+   */
+  override def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A = {
+    val conn = connectionFactory()
+    try {
+      if (dialect == SqlDialect.SQLite) JdbcTransactor.configureSQLiteConnection(conn)
+    } catch {
+      case e: Throwable =>
+        try conn.close()
+        catch { case ce: Throwable => e.addSuppressed(ce) }
+        throw e
+    }
+    val dbConn         = new JdbcConnection(conn)
+    val prevAutoCommit =
+      try conn.getAutoCommit
+      catch {
+        case e: Throwable =>
+          try dbConn.close()
+          catch { case ce: Throwable => e.addSuppressed(ce) }
+          throw e
+      }
+    val prevIsolation = conn.getTransactionIsolation
+    val prevReadOnly  =
+      try conn.isReadOnly
+      catch { case _: Throwable => false }
+    try {
+      // Fail fast: isolation failures must propagate (do not swallow); the
+      // outer finally will restore previous settings and close the connection.
+      conn.setTransactionIsolation(isolation.jdbcLevel)
+      // Intentionally swallow readOnly failures: SQLite (and some other drivers)
+      // throw on setReadOnly even though transactions still work; keep
+      // best-effort semantics for this flag only.
+      try conn.setReadOnly(readOnly)
+      catch { case _: Throwable => () }
+      // Fail fast: if autoCommit cannot be disabled, do not run the body
+      // outside a transaction; the finally block below will clean up.
+      try conn.setAutoCommit(false)
+      catch {
+        case e: Throwable =>
+          try conn.setReadOnly(prevReadOnly)
+          catch { case _: Throwable => () }
+          try conn.setTransactionIsolation(prevIsolation)
+          catch { case _: Throwable => () }
+          try conn.setAutoCommit(prevAutoCommit)
+          catch { case _: Throwable => () }
+          try dbConn.close()
+          catch { case _: Throwable => () }
+          throw e
+      }
+      try {
+        given tx: DbTx = new DbTx {
+          val connection: DbConnection                = dbConn
+          val dialect: SqlDialect                     = JdbcTransactor.this.dialect
+          val logger: SqlLogger                       = JdbcTransactor.this.sqlLogger
+          override var currentDepth: Int              = 0
+          override def savepoint(name: String): Unit  = dbConn.savepoint(name)
+          override def release(name: String): Unit    = dbConn.release(name)
+          override def rollbackTo(name: String): Unit = dbConn.rollbackTo(name)
+        }
+        val result = f
+        conn.commit()
+        result
+      } catch {
+        case e: Throwable =>
+          try conn.rollback()
+          catch { case rb: Throwable => e.addSuppressed(rb) }
+          throw e
+      }
+    } finally {
+      try conn.setReadOnly(prevReadOnly)
+      catch { case _: Throwable => () }
+      try conn.setTransactionIsolation(prevIsolation)
+      catch { case _: Throwable => () }
+      try conn.setAutoCommit(prevAutoCommit)
+      catch { case _: Throwable => () }
+      try dbConn.close()
+      catch { case _: Throwable => () }
+    }
+  }
+
+  /**
    * Opens a connection, disables auto-commit, executes `f`, commits on success,
    * and rolls back on exception. The connection is closed after commit or
-   * rollback.
+   * rollback. Preserves the driver's default isolation level and `readOnly`
+   * flag — does not force `SERIALIZABLE` — so callers that previously relied on
+   * the driver default (e.g. PostgreSQL `READ_COMMITTED`) are not unexpectedly
+   * upgraded. Use the two-arg overload to request a specific isolation level.
    *
    * For `SqlDialect.SQLite`, `transact` runs with `busy_timeout=5000` and
    * `IMMEDIATE` — `fromUrl` and `sqlite` create SQLite connections with
@@ -64,7 +167,7 @@ class JdbcTransactor(
    * later `DELETE` with `SQLITE_BUSY`. See PR #1534 discussion_r3863454094;
    * SQLite is single-consumer.
    */
-  def transact[A](f: DbTx ?=> A): A = {
+  override def transact[A](f: DbTx ?=> A): A = {
     val conn = connectionFactory()
     try {
       if (dialect == SqlDialect.SQLite) JdbcTransactor.configureSQLiteConnection(conn)
@@ -92,9 +195,13 @@ class JdbcTransactor(
     }
     try {
       given tx: DbTx = new DbTx {
-        val connection: DbConnection = dbConn
-        val dialect: SqlDialect      = JdbcTransactor.this.dialect
-        val logger: SqlLogger        = JdbcTransactor.this.sqlLogger
+        val connection: DbConnection                = dbConn
+        val dialect: SqlDialect                     = JdbcTransactor.this.dialect
+        val logger: SqlLogger                       = JdbcTransactor.this.sqlLogger
+        override var currentDepth: Int              = 0
+        override def savepoint(name: String): Unit  = dbConn.savepoint(name)
+        override def release(name: String): Unit    = dbConn.release(name)
+        override def rollbackTo(name: String): Unit = dbConn.rollbackTo(name)
       }
       val result = f
       conn.commit()
@@ -171,8 +278,11 @@ object JdbcTransactor {
     val sqliteConnClass =
       try Class.forName("org.sqlite.SQLiteConnection")
       catch { case _: ClassNotFoundException => return }
+    val isWrapper =
+      try conn.isWrapperFor(sqliteConnClass.asInstanceOf[Class[Object]])
+      catch { case _: Throwable => false }
     val sqliteConn: Connection =
-      if (conn.isWrapperFor(sqliteConnClass.asInstanceOf[Class[Object]])) {
+      if (isWrapper) {
         val unwrapped = conn.unwrap(sqliteConnClass.asInstanceOf[Class[Object]])
         if (unwrapped == null)
           throw new SQLException(

--- a/sql/jvm/src/test/scala/zio/blocks/sql/NestedTransactSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/NestedTransactSpec.scala
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.sql
+
+import zio.test.*
+import java.sql.{Connection, DriverManager}
+import java.lang.reflect.{InvocationHandler, InvocationTargetException, Method, Proxy}
+import java.nio.file.Files
+
+object NestedTransactSpec extends ZIOSpecDefault {
+  private val _ = Class.forName("org.sqlite.JDBC")
+
+  private def freshTransactor(): (JdbcTransactor, () => Unit) = {
+    val tmp = Files.createTempFile("zib_nested", ".db")
+    tmp.toFile.deleteOnExit()
+    val url                 = s"jdbc:sqlite:${tmp.toAbsolutePath}"
+    val tx                  = JdbcTransactor.fromUrl(url, SqlDialect.SQLite)
+    val cleanup: () => Unit = () => {
+      try { Files.deleteIfExists(tmp); () }
+      catch { case _: Throwable => () }
+    }
+    (tx, cleanup)
+  }
+
+  private def nonClosing(conn: Connection): Connection = {
+    val handler = new InvocationHandler {
+      def invoke(proxy: AnyRef, method: Method, args: Array[AnyRef]): AnyRef =
+        if (method.getName == "close") null
+        else {
+          val actualArgs = if (args == null) Array.empty[AnyRef] else args
+          try method.invoke(conn, actualArgs*)
+          catch { case e: InvocationTargetException => throw e.getCause }
+        }
+    }
+    Proxy
+      .newProxyInstance(getClass.getClassLoader, Array(classOf[Connection]), handler)
+      .asInstanceOf[Connection]
+  }
+
+  /** Fake connection that captures savepoint SQL via Statement proxy. */
+  private def capturingTransactor(
+    savepoints: scala.collection.mutable.ArrayBuffer[String],
+    releases: scala.collection.mutable.ArrayBuffer[String],
+    rollbacks: scala.collection.mutable.ArrayBuffer[String]
+  ): JdbcTransactor = {
+    val underlying = DriverManager.getConnection("jdbc:sqlite::memory:")
+    // create table not needed for savepoint capture, but need real connection for savepoint SQL
+    val handler = new InvocationHandler {
+      def invoke(proxy: AnyRef, method: Method, args: Array[AnyRef]): AnyRef =
+        method.getName match {
+          case "createStatement" =>
+            val realStmt    = underlying.createStatement()
+            val stmtHandler = new InvocationHandler {
+              def invoke(p2: AnyRef, m2: Method, a2: Array[AnyRef]): AnyRef = {
+                if (m2.getName == "execute" && a2 != null && a2.length == 1 && a2(0).isInstanceOf[String]) {
+                  val sql = a2(0).asInstanceOf[String]
+                  if (sql.startsWith("SAVEPOINT ")) savepoints += sql.stripPrefix("SAVEPOINT ")
+                  else if (sql.startsWith("RELEASE SAVEPOINT ")) releases += sql.stripPrefix("RELEASE SAVEPOINT ")
+                  else if (sql.startsWith("ROLLBACK TO SAVEPOINT "))
+                    rollbacks += sql.stripPrefix("ROLLBACK TO SAVEPOINT ")
+                }
+                val actualArgs = if (a2 == null) Array.empty[AnyRef] else a2
+                try m2.invoke(realStmt, actualArgs*)
+                catch { case e: InvocationTargetException => throw e.getCause }
+              }
+            }
+            Proxy
+              .newProxyInstance(getClass.getClassLoader, Array(classOf[java.sql.Statement]), stmtHandler)
+              .asInstanceOf[java.sql.Statement]
+          case "close" => underlying.close(); null
+          case _       =>
+            val actualArgs = if (args == null) Array.empty[AnyRef] else args
+            try method.invoke(underlying, actualArgs*)
+            catch { case e: InvocationTargetException => throw e.getCause }
+        }
+    }
+    val connProxy = Proxy
+      .newProxyInstance(getClass.getClassLoader, Array(classOf[Connection]), handler)
+      .asInstanceOf[Connection]
+    new JdbcTransactor(() => nonClosing(connProxy), SqlDialect.SQLite)
+  }
+
+  def spec: Spec[TestEnvironment, Any] = suite("NestedTransactSpec")(
+    test("3-level nesting all-commit leaves all rows") {
+      val (tx, cleanup) = freshTransactor()
+      try {
+        tx.connect {
+          Frag.literal("CREATE TABLE IF NOT EXISTS nested_t (id INTEGER NOT NULL)").update
+        }
+        tx.transact {
+          sql"INSERT INTO nested_t (id) VALUES (${DbValue.DbInt(1)})".update
+          summon[DbTx].transact {
+            sql"INSERT INTO nested_t (id) VALUES (${DbValue.DbInt(2)})".update
+            summon[DbTx].transact {
+              sql"INSERT INTO nested_t (id) VALUES (${DbValue.DbInt(3)})".update
+            }
+          }
+        }
+        val rows = tx.connect {
+          sql"SELECT id FROM nested_t ORDER BY id".query[Int]
+        }
+        assertTrue(rows == List(1, 2, 3))
+      } finally cleanup()
+    },
+    test("inner-failure rolls back to savepoint only and outer commits") {
+      val (tx, cleanup) = freshTransactor()
+      try {
+        tx.connect {
+          Frag.literal("CREATE TABLE IF NOT EXISTS nested_rollback_t (id INTEGER NOT NULL)").update
+        }
+        tx.transact {
+          sql"INSERT INTO nested_rollback_t (id) VALUES (${DbValue.DbInt(1)})".update
+          try {
+            summon[DbTx].transact {
+              sql"INSERT INTO nested_rollback_t (id) VALUES (${DbValue.DbInt(2)})".update
+              throw new RuntimeException("inner boom")
+            }
+          } catch { case _: RuntimeException => () }
+          sql"INSERT INTO nested_rollback_t (id) VALUES (${DbValue.DbInt(3)})".update
+        }
+        val rows = tx.connect {
+          sql"SELECT id FROM nested_rollback_t ORDER BY id".query[Int]
+        }
+        assertTrue(rows == List(1, 3))
+      } finally cleanup()
+    },
+    test("depth counter resets after success and failure") {
+      val (tx, cleanup) = freshTransactor()
+      try {
+        tx.connect {
+          Frag.literal("CREATE TABLE IF NOT EXISTS depth_t (id INTEGER NOT NULL)").update
+        }
+        tx.transact {
+          val outer = summon[DbTx]
+          assertTrue(outer.currentDepth == 0)
+          outer.transact {
+            val inner = summon[DbTx]
+            assertTrue(inner.currentDepth == 1)
+            inner.transact {
+              val innest = summon[DbTx]
+              assertTrue(innest.currentDepth == 2)
+            }
+            assertTrue(summon[DbTx].currentDepth == 1)
+          }
+          assertTrue(summon[DbTx].currentDepth == 0)
+          // failure path
+          try {
+            summon[DbTx].transact {
+              throw new RuntimeException("boom")
+            }
+          } catch { case _: RuntimeException => () }
+          assertTrue(summon[DbTx].currentDepth == 0)
+          // second nested after failure reuses zib_tx_1
+          summon[DbTx].transact {
+            assertTrue(summon[DbTx].currentDepth == 1)
+            sql"INSERT INTO depth_t (id) VALUES (${DbValue.DbInt(99)})".update
+          }
+          assertTrue(summon[DbTx].currentDepth == 0)
+        }
+        val rows = tx.connect {
+          sql"SELECT id FROM depth_t".query[Int]
+        }
+        assertTrue(rows == List(99))
+      } finally cleanup()
+    },
+    test("savepoint leak check - release on success allows sibling reuse") {
+      val (tx, cleanup) = freshTransactor()
+      try {
+        tx.connect {
+          Frag.literal("CREATE TABLE IF NOT EXISTS leak_t (id INTEGER NOT NULL)").update
+        }
+        tx.transact {
+          // two siblings sequentially; if first leaked, second SAVEPOINT zib_tx_1 would fail or duplicate
+          summon[DbTx].transact {
+            sql"INSERT INTO leak_t (id) VALUES (${DbValue.DbInt(1)})".update
+          }
+          summon[DbTx].transact {
+            sql"INSERT INTO leak_t (id) VALUES (${DbValue.DbInt(2)})".update
+          }
+          summon[DbTx].transact {
+            sql"INSERT INTO leak_t (id) VALUES (${DbValue.DbInt(3)})".update
+          }
+        }
+        val rows = tx.connect {
+          sql"SELECT id FROM leak_t ORDER BY id".query[Int]
+        }
+        assertTrue(rows == List(1, 2, 3))
+      } finally cleanup()
+    },
+    test("transactNested extension works via DbTx and top-level helper") {
+      val (tx, cleanup) = freshTransactor()
+      try {
+        tx.connect {
+          Frag.literal("CREATE TABLE IF NOT EXISTS transact_nested_t (id INTEGER NOT NULL)").update
+        }
+        tx.transact {
+          // via DbTx.transactNested (companion)
+          DbTx.transactNested {
+            sql"INSERT INTO transact_nested_t (id) VALUES (${DbValue.DbInt(10)})".update
+          }
+          // via top-level transactNested helper
+          transactNested {
+            sql"INSERT INTO transact_nested_t (id) VALUES (${DbValue.DbInt(20)})".update
+          }
+          // via extension with using
+          {
+            val outer: DbTx = summon[DbTx]
+            {
+              given DbTx = outer
+              transactNested {
+                sql"INSERT INTO transact_nested_t (id) VALUES (${DbValue.DbInt(30)})".update
+              }
+            }
+          }
+        }
+        val rows = tx.connect {
+          sql"SELECT id FROM transact_nested_t ORDER BY id".query[Int]
+        }
+        assertTrue(rows == List(10, 20, 30))
+      } finally cleanup()
+    },
+    test("savepoint SQL capture - release on success, rollback on failure") {
+      val savepoints = scala.collection.mutable.ArrayBuffer.empty[String]
+      val releases   = scala.collection.mutable.ArrayBuffer.empty[String]
+      val rollbacks  = scala.collection.mutable.ArrayBuffer.empty[String]
+      val tx         = capturingTransactor(savepoints, releases, rollbacks)
+      tx.connect {
+        Frag.literal("CREATE TABLE IF NOT EXISTS capture_t (id INTEGER NOT NULL)").update
+      }
+      tx.transact {
+        summon[DbTx].transact {
+          // success
+          sql"INSERT INTO capture_t (id) VALUES (${DbValue.DbInt(1)})".update
+        }
+        assertTrue(savepoints.contains("zib_tx_1"), releases.contains("zib_tx_1"))
+        savepoints.clear(); releases.clear(); rollbacks.clear()
+        try {
+          summon[DbTx].transact {
+            sql"INSERT INTO capture_t (id) VALUES (${DbValue.DbInt(2)})".update
+            throw new RuntimeException("boom")
+          }
+        } catch { case _: RuntimeException => () }
+        assertTrue(savepoints.contains("zib_tx_1"), rollbacks.contains("zib_tx_1"), releases.isEmpty)
+      }
+      assertTrue(true)
+    },
+    test("nested failure isolates inner only - outer and sibling commit") {
+      val (tx, cleanup) = freshTransactor()
+      try {
+        tx.connect {
+          Frag.literal("CREATE TABLE IF NOT EXISTS isolate_t (id INTEGER NOT NULL)").update
+        }
+        tx.transact {
+          sql"INSERT INTO isolate_t (id) VALUES (${DbValue.DbInt(1)})".update
+          try {
+            summon[DbTx].transact {
+              sql"INSERT INTO isolate_t (id) VALUES (${DbValue.DbInt(2)})".update
+              // nested inside failing inner: also fails
+              summon[DbTx].transact {
+                sql"INSERT INTO isolate_t (id) VALUES (${DbValue.DbInt(3)})".update
+              }
+              throw new RuntimeException("inner fail")
+            }
+          } catch { case _: RuntimeException => () }
+          // sibling after failure should still commit
+          summon[DbTx].transact {
+            sql"INSERT INTO isolate_t (id) VALUES (${DbValue.DbInt(4)})".update
+          }
+        }
+        val rows = tx.connect {
+          sql"SELECT id FROM isolate_t ORDER BY id".query[Int]
+        }
+        assertTrue(rows == List(1, 4))
+      } finally cleanup()
+    }
+  )
+}

--- a/sql/jvm/src/test/scala/zio/blocks/sql/TransactorIsolationSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/TransactorIsolationSpec.scala
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.sql
+
+import zio.test.*
+import java.sql.{Connection, DriverManager}
+import java.lang.reflect.{InvocationHandler, InvocationTargetException, Method, Proxy}
+
+object TransactorIsolationSpec extends ZIOSpecDefault {
+  private val _ = Class.forName("org.sqlite.JDBC")
+
+  private def nonClosing(conn: Connection): Connection = {
+    val handler = new InvocationHandler {
+      def invoke(proxy: AnyRef, method: Method, args: Array[AnyRef]): AnyRef =
+        if (method.getName == "close") null
+        else {
+          val actualArgs = if (args == null) Array.empty[AnyRef] else args
+          try method.invoke(conn, actualArgs*)
+          catch { case e: InvocationTargetException => throw e.getCause }
+        }
+    }
+    Proxy
+      .newProxyInstance(getClass.getClassLoader, Array(classOf[Connection]), handler)
+      .asInstanceOf[Connection]
+  }
+
+  private def fakeConnection(): Connection = {
+    var autoCommit = true
+    var readOnly   = false
+    var isolation  = Connection.TRANSACTION_SERIALIZABLE
+    var closed     = false
+    val handler    = new InvocationHandler {
+      def invoke(proxy: AnyRef, method: Method, args: Array[AnyRef]): AnyRef = method.getName match {
+        case "setAutoCommit" =>
+          autoCommit = args(0).asInstanceOf[Boolean]
+          null
+        case "getAutoCommit" => java.lang.Boolean.valueOf(autoCommit)
+        case "setReadOnly"   =>
+          readOnly = args(0).asInstanceOf[Boolean]
+          null
+        case "isReadOnly"              => java.lang.Boolean.valueOf(readOnly)
+        case "setTransactionIsolation" =>
+          isolation = args(0).asInstanceOf[Int]
+          null
+        case "getTransactionIsolation" => Integer.valueOf(isolation)
+        case "commit"                  => null
+        case "rollback"                => null
+        case "close"                   => closed = true; null
+        case "isClosed"                => java.lang.Boolean.valueOf(closed)
+        case "prepareStatement"        =>
+          throw new UnsupportedOperationException("fakeConnection does not support prepareStatement")
+        case other => throw new UnsupportedOperationException(s"fakeConnection: $other not supported")
+      }
+    }
+    Proxy
+      .newProxyInstance(getClass.getClassLoader, Array(classOf[Connection]), handler)
+      .asInstanceOf[Connection]
+  }
+
+  def spec: Spec[TestEnvironment, Any] = suite("TransactorIsolationSpec")(
+    test("isolation level is applied inside transact") {
+      val transactor = JdbcTransactor.fromUrl("jdbc:sqlite::memory:", SqlDialect.SQLite)
+      val inside     = transactor.transact(TransactionIsolation.ReadCommitted, false) {
+        val jdbcConn = summon[DbTx].connection.asInstanceOf[JdbcConnection].underlying
+        jdbcConn.getTransactionIsolation
+      }
+      assertTrue(inside == Connection.TRANSACTION_READ_COMMITTED)
+    },
+    test("all isolation levels round-trip inside transact") {
+      val transactor = JdbcTransactor.fromUrl("jdbc:sqlite::memory:", SqlDialect.SQLite)
+      val levels     = List(
+        TransactionIsolation.ReadUncommitted -> Connection.TRANSACTION_READ_UNCOMMITTED,
+        TransactionIsolation.ReadCommitted   -> Connection.TRANSACTION_READ_COMMITTED,
+        TransactionIsolation.RepeatableRead  -> Connection.TRANSACTION_REPEATABLE_READ,
+        TransactionIsolation.Serializable    -> Connection.TRANSACTION_SERIALIZABLE
+      )
+      val results = levels.map { case (iso, expected) =>
+        val got = transactor.transact(iso, false) {
+          val jdbcConn = summon[DbTx].connection.asInstanceOf[JdbcConnection].underlying
+          jdbcConn.getTransactionIsolation
+        }
+        got == expected
+      }
+      assertTrue(results.forall(identity))
+    },
+    test("isolation-setting failure propagates and does not swallow") {
+      var isolationSet = false
+      val handler      = new java.lang.reflect.InvocationHandler {
+        def invoke(proxy: AnyRef, method: java.lang.reflect.Method, args: Array[AnyRef]): AnyRef =
+          method.getName match {
+            case "setTransactionIsolation" =>
+              isolationSet = true
+              throw new java.sql.SQLException("isolation not supported")
+            case "getTransactionIsolation" => Integer.valueOf(java.sql.Connection.TRANSACTION_SERIALIZABLE)
+            case "setReadOnly"             => null
+            case "isReadOnly"              => java.lang.Boolean.FALSE
+            case "getAutoCommit"           => java.lang.Boolean.TRUE
+            case "setAutoCommit"           => null
+            case "commit"                  => null
+            case "rollback"                => null
+            case "close"                   => null
+            case "isClosed"                => java.lang.Boolean.FALSE
+            case _                         => throw new UnsupportedOperationException(method.getName)
+          }
+      }
+      val conn = java.lang.reflect.Proxy
+        .newProxyInstance(getClass.getClassLoader, Array(classOf[java.sql.Connection]), handler)
+        .asInstanceOf[java.sql.Connection]
+      val transactor   = new JdbcTransactor(() => conn, SqlDialect.SQLite)
+      var bodyExecuted = false
+      val result       = try {
+        transactor.transact(TransactionIsolation.ReadCommitted, false) {
+          bodyExecuted = true
+          42
+        }
+        false
+      } catch {
+        case e: java.sql.SQLException =>
+          e.getMessage == "isolation not supported" && isolationSet && !bodyExecuted
+        case _ => false
+      }
+      assertTrue(result)
+    },
+    test("swallowed setReadOnly failure still runs body") {
+      var readOnlySet = false
+      val handler     = new java.lang.reflect.InvocationHandler {
+        def invoke(proxy: AnyRef, method: java.lang.reflect.Method, args: Array[AnyRef]): AnyRef =
+          method.getName match {
+            case "setReadOnly" =>
+              readOnlySet = true
+              throw new java.sql.SQLException("readOnly not supported")
+            case "isReadOnly"              => java.lang.Boolean.FALSE
+            case "getTransactionIsolation" => Integer.valueOf(java.sql.Connection.TRANSACTION_SERIALIZABLE)
+            case "setTransactionIsolation" => null
+            case "getAutoCommit"           => java.lang.Boolean.TRUE
+            case "setAutoCommit"           => null
+            case "commit"                  => null
+            case "rollback"                => null
+            case "close"                   => null
+            case "isClosed"                => java.lang.Boolean.FALSE
+            case _                         => throw new UnsupportedOperationException(method.getName)
+          }
+      }
+      val conn = java.lang.reflect.Proxy
+        .newProxyInstance(getClass.getClassLoader, Array(classOf[java.sql.Connection]), handler)
+        .asInstanceOf[java.sql.Connection]
+      val transactor = new JdbcTransactor(() => conn, SqlDialect.SQLite)
+      val result     = transactor.transact(TransactionIsolation.Serializable, true)(99)
+      assertTrue(result == 99 && readOnlySet)
+    },
+    test("rollback failure is suppressed and original exception is rethrown") {
+      var rollbackFailed = false
+      val handler        = new java.lang.reflect.InvocationHandler {
+        def invoke(proxy: AnyRef, method: java.lang.reflect.Method, args: Array[AnyRef]): AnyRef =
+          method.getName match {
+            case "getAutoCommit"           => java.lang.Boolean.TRUE
+            case "setAutoCommit"           => null
+            case "getTransactionIsolation" => Integer.valueOf(java.sql.Connection.TRANSACTION_SERIALIZABLE)
+            case "setTransactionIsolation" => null
+            case "isReadOnly"              => java.lang.Boolean.FALSE
+            case "setReadOnly"             => null
+            case "commit"                  => null
+            case "rollback"                =>
+              rollbackFailed = true
+              throw new java.sql.SQLException("rollback failed")
+            case "close"    => null
+            case "isClosed" => java.lang.Boolean.FALSE
+            case _          => throw new UnsupportedOperationException(method.getName)
+          }
+      }
+      val conn = java.lang.reflect.Proxy
+        .newProxyInstance(getClass.getClassLoader, Array(classOf[java.sql.Connection]), handler)
+        .asInstanceOf[java.sql.Connection]
+      val transactor = new JdbcTransactor(() => conn, SqlDialect.SQLite)
+      val result     = try {
+        transactor.transact(TransactionIsolation.Serializable, false)(throw new RuntimeException("body failed"))
+        false
+      } catch {
+        case e: RuntimeException =>
+          e.getMessage == "body failed" && e.getSuppressed.exists(_.getMessage == "rollback failed") && rollbackFailed
+        case _ => false
+      }
+      assertTrue(result)
+    },
+    test("connection is closed even when body throws") {
+      var closed  = false
+      val handler = new java.lang.reflect.InvocationHandler {
+        def invoke(proxy: AnyRef, method: java.lang.reflect.Method, args: Array[AnyRef]): AnyRef =
+          method.getName match {
+            case "getAutoCommit"           => java.lang.Boolean.TRUE
+            case "setAutoCommit"           => null
+            case "getTransactionIsolation" => Integer.valueOf(java.sql.Connection.TRANSACTION_SERIALIZABLE)
+            case "setTransactionIsolation" => null
+            case "isReadOnly"              => java.lang.Boolean.FALSE
+            case "setReadOnly"             => null
+            case "commit"                  => null
+            case "rollback"                => null
+            case "close"                   => closed = true; null
+            case "isClosed"                => java.lang.Boolean.valueOf(closed)
+            case _                         => throw new UnsupportedOperationException(method.getName)
+          }
+      }
+      val conn = java.lang.reflect.Proxy
+        .newProxyInstance(getClass.getClassLoader, Array(classOf[java.sql.Connection]), handler)
+        .asInstanceOf[java.sql.Connection]
+      val transactor = new JdbcTransactor(() => conn, SqlDialect.SQLite)
+      try { transactor.transact(TransactionIsolation.Serializable, false)(throw new RuntimeException("fail")) }
+      catch { case _: Throwable => () }
+      assertTrue(closed)
+    },
+    test("readOnly flag is set inside transact via fake connection") {
+      val conn           = fakeConnection()
+      val tx             = new JdbcTransactor(() => conn, SqlDialect.SQLite)
+      val insideReadOnly = tx.transact(TransactionIsolation.Serializable, true) {
+        val jdbcConn = summon[DbTx].connection.asInstanceOf[JdbcConnection].underlying
+        jdbcConn.isReadOnly
+      }
+      val conn2             = fakeConnection()
+      val tx2               = new JdbcTransactor(() => conn2, SqlDialect.SQLite)
+      val insideNotReadOnly = tx2.transact(TransactionIsolation.Serializable, false) {
+        val jdbcConn = summon[DbTx].connection.asInstanceOf[JdbcConnection].underlying
+        jdbcConn.isReadOnly
+      }
+      assertTrue(insideReadOnly == true, insideNotReadOnly == false)
+    },
+    test("single-arg transact defaults to Serializable and readOnly false") {
+      val conn                  = fakeConnection()
+      val tx                    = new JdbcTransactor(() => conn, SqlDialect.SQLite)
+      val (iso, ro, autoCommit) = tx.transact {
+        val jdbcConn = summon[DbTx].connection.asInstanceOf[JdbcConnection].underlying
+        (jdbcConn.getTransactionIsolation, jdbcConn.isReadOnly, jdbcConn.getAutoCommit)
+      }
+      assertTrue(
+        iso == Connection.TRANSACTION_SERIALIZABLE,
+        ro == false,
+        autoCommit == false
+      )
+    },
+    test("isolation and readOnly restored after successful transact via fake connection") {
+      val conn           = fakeConnection()
+      val prevIso        = conn.getTransactionIsolation
+      val prevReadOnly   = conn.isReadOnly
+      val prevAutoCommit = conn.getAutoCommit
+      val tx             = new JdbcTransactor(() => conn, SqlDialect.SQLite)
+      tx.transact(TransactionIsolation.ReadCommitted, true) {
+        val jdbcConn = summon[DbTx].connection.asInstanceOf[JdbcConnection].underlying
+        assertTrue(jdbcConn.getTransactionIsolation == Connection.TRANSACTION_READ_COMMITTED)
+        assertTrue(jdbcConn.isReadOnly == true)
+      }
+      assertTrue(
+        conn.getTransactionIsolation == prevIso,
+        conn.isReadOnly == prevReadOnly,
+        conn.getAutoCommit == prevAutoCommit
+      )
+    },
+    test("isolation and readOnly restored after failed transact (rollback) via fake") {
+      val conn           = fakeConnection()
+      val prevIso        = conn.getTransactionIsolation
+      val prevReadOnly   = conn.isReadOnly
+      val prevAutoCommit = conn.getAutoCommit
+      val tx             = new JdbcTransactor(() => conn, SqlDialect.SQLite)
+      try {
+        tx.transact(TransactionIsolation.RepeatableRead, true) {
+          val jdbcConn = summon[DbTx].connection.asInstanceOf[JdbcConnection].underlying
+          assertTrue(jdbcConn.getTransactionIsolation == Connection.TRANSACTION_REPEATABLE_READ)
+          throw new RuntimeException("boom")
+        }
+      } catch {
+        case _: RuntimeException => ()
+      }
+      assertTrue(
+        conn.getTransactionIsolation == prevIso,
+        conn.isReadOnly == prevReadOnly,
+        conn.getAutoCommit == prevAutoCommit
+      )
+    },
+    test("isolation and readOnly restored after successful transact via shared real connection") {
+      val underlying = DriverManager.getConnection("jdbc:sqlite::memory:")
+      try {
+        val prevIso = underlying.getTransactionIsolation
+        val tx      = new JdbcTransactor(() => nonClosing(underlying), SqlDialect.SQLite)
+        tx.transact(TransactionIsolation.ReadCommitted, false) {
+          val jdbcConn = summon[DbTx].connection.asInstanceOf[JdbcConnection].underlying
+          assertTrue(jdbcConn.getTransactionIsolation == Connection.TRANSACTION_READ_COMMITTED)
+        }
+        assertTrue(underlying.getTransactionIsolation == prevIso)
+      } finally underlying.close()
+    },
+    test("transact with Serializable commits") {
+      val underlying = DriverManager.getConnection("jdbc:sqlite::memory:")
+      try {
+        val tx = new JdbcTransactor(() => nonClosing(underlying), SqlDialect.SQLite)
+        tx.connect {
+          Frag.literal("CREATE TABLE IF NOT EXISTS tx_iso_commit_t (id INTEGER NOT NULL)").update
+        }
+        tx.transact(TransactionIsolation.Serializable, false) {
+          sql"INSERT INTO tx_iso_commit_t (id) VALUES (${DbValue.DbInt(1)})".update
+        }
+        val rows = tx.connect {
+          sql"SELECT id FROM tx_iso_commit_t".query[Int]
+        }
+        assertTrue(rows == List(1))
+      } finally underlying.close()
+    },
+    test("readOnly transact still allows read (SQLite readOnly flag ignored but transact succeeds)") {
+      val underlying = DriverManager.getConnection("jdbc:sqlite::memory:")
+      try {
+        val tx = new JdbcTransactor(() => nonClosing(underlying), SqlDialect.SQLite)
+        tx.connect {
+          Frag.literal("CREATE TABLE ro_read (id INTEGER NOT NULL)").update
+          sql"INSERT INTO ro_read (id) VALUES (${DbValue.DbInt(42)})".update
+        }
+        val rows = tx.transact(TransactionIsolation.Serializable, true) {
+          sql"SELECT id FROM ro_read".query[Int]
+        }
+        assertTrue(rows == List(42))
+      } finally underlying.close()
+    },
+    test("next transact sees defaults after previous transact via fake") {
+      val conn = fakeConnection()
+      val tx   = new JdbcTransactor(() => conn, SqlDialect.SQLite)
+      tx.transact(TransactionIsolation.ReadUncommitted, true) {
+        val c = summon[DbTx].connection.asInstanceOf[JdbcConnection].underlying
+        assertTrue(c.isReadOnly == true)
+      }
+      val secondReadOnly = tx.transact(TransactionIsolation.Serializable, false) {
+        val c = summon[DbTx].connection.asInstanceOf[JdbcConnection].underlying
+        c.isReadOnly
+      }
+      val secondIso = tx.transact(TransactionIsolation.Serializable, false) {
+        val c = summon[DbTx].connection.asInstanceOf[JdbcConnection].underlying
+        c.getTransactionIsolation
+      }
+      assertTrue(secondReadOnly == false, secondIso == Connection.TRANSACTION_SERIALIZABLE)
+    }
+  )
+}

--- a/sql/jvm/src/test/scala/zio/blocks/sql/TransactorSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/TransactorSpec.scala
@@ -79,9 +79,13 @@ object TransactorSpec extends ZIOSpecDefault {
         conn.setAutoCommit(false)
         try {
           given tx: DbTx = new DbTx {
-            val connection: DbConnection = dbConn
-            val dialect: SqlDialect      = SqlDialect.SQLite
-            val logger: SqlLogger        = SqlLogger.noop
+            val connection: DbConnection                = dbConn
+            val dialect: SqlDialect                     = SqlDialect.SQLite
+            val logger: SqlLogger                       = SqlLogger.noop
+            override var currentDepth: Int              = 0
+            override def savepoint(name: String): Unit  = dbConn.savepoint(name)
+            override def release(name: String): Unit    = dbConn.release(name)
+            override def rollbackTo(name: String): Unit = dbConn.rollbackTo(name)
           }
           val result = f
           conn.commit()
@@ -92,6 +96,9 @@ object TransactorSpec extends ZIOSpecDefault {
             throw e
         } finally conn.setAutoCommit(true)
       }
+
+      override def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A =
+        transact(f)
     }
     (tx, conn)
   }

--- a/sql/shared/src/main/scala/zio/blocks/sql/DbConnection.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/DbConnection.scala
@@ -25,6 +25,36 @@ trait DbConnection extends AutoCloseable {
   def getAutoCommit: Boolean
   def commit(): Unit
   def rollback(): Unit
+
+  /**
+   * Create a savepoint with the given name via `SAVEPOINT <name>`.
+   *
+   * Used by [[DbTx]] nested transactions. Names are `zib_tx_1..N`. Default
+   * implementation throws `UnsupportedOperationException`; JDBC implementations
+   * (e.g. `JdbcConnection`) override to execute SQL.
+   */
+  def savepoint(name: String): Unit =
+    throw new UnsupportedOperationException("savepoint not supported by this DbConnection implementation")
+
+  /**
+   * Release a savepoint via `RELEASE SAVEPOINT <name>`.
+   *
+   * Called on the success path of a nested transact to avoid leaking
+   * savepoints. Default implementation throws `UnsupportedOperationException`;
+   * JDBC implementations override.
+   */
+  def release(name: String): Unit =
+    throw new UnsupportedOperationException("release not supported by this DbConnection implementation")
+
+  /**
+   * Roll back to a savepoint via `ROLLBACK TO SAVEPOINT <name>`.
+   *
+   * Called on the failure path of a nested transact to isolate the inner
+   * failure without rolling back the outer transaction. Default implementation
+   * throws `UnsupportedOperationException`; JDBC implementations override.
+   */
+  def rollbackTo(name: String): Unit =
+    throw new UnsupportedOperationException("rollbackTo not supported by this DbConnection implementation")
 }
 
 trait DbPreparedStatement extends AutoCloseable {

--- a/sql/shared/src/main/scala/zio/blocks/sql/DbTx.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/DbTx.scala
@@ -16,4 +16,141 @@
 
 package zio.blocks.sql
 
-trait DbTx extends DbCon
+/**
+ * Transactional connection with savepoint support for nested transactions.
+ *
+ * Savepoint semantics: nested transactions are emulated via SQL savepoints
+ * named `zib_tx_1 .. zib_tx_N` where N is the nesting depth. On success the
+ * savepoint is released via `RELEASE SAVEPOINT`, on failure the transaction
+ * rolls back to the savepoint via `ROLLBACK TO SAVEPOINT` and rethrows the
+ * exception. Only the outermost `Transactor.transact` does a real
+ * `COMMIT`/`ROLLBACK`; inner blocks are savepoint-scoped and share the same
+ * underlying JDBC connection.
+ *
+ * Depth tracking: each [[DbTx]] instance tracks its current nesting depth (0 =
+ * outermost). The counter is incremented only after the savepoint is created
+ * successfully and decremented in a `finally` block, guaranteeing correct depth
+ * even if savepoint creation throws and reset even when inner blocks throw.
+ */
+trait DbTx extends DbCon {
+
+  /**
+   * Create a savepoint with the given name.
+   *
+   * Implemented via `SAVEPOINT <name>` SQL for portability (SQLite,
+   * PostgreSQL). The underlying connection must be inside an active transaction
+   * (autoCommit = false).
+   */
+  def savepoint(name: String): Unit =
+    throw new UnsupportedOperationException("savepoint not supported by this DbTx implementation; use JdbcTransactor")
+
+  /**
+   * Release the savepoint with the given name.
+   *
+   * Implemented via `RELEASE SAVEPOINT <name>`. No savepoint leak on the
+   * success path: every successful nested `transact` releases its savepoint
+   * before returning.
+   */
+  def release(name: String): Unit =
+    throw new UnsupportedOperationException("release not supported by this DbTx implementation; use JdbcTransactor")
+
+  /**
+   * Roll back to the savepoint with the given name.
+   *
+   * Implemented via `ROLLBACK TO SAVEPOINT <name>`. The savepoint remains valid
+   * after rollback on most drivers; on failure only depth is decremented and
+   * the savepoint is not released (it will be cleaned up when outer transaction
+   * commits/rolls back).
+   */
+  def rollbackTo(name: String): Unit =
+    throw new UnsupportedOperationException("rollbackTo not supported by this DbTx implementation; use JdbcTransactor")
+
+  def currentDepth: Int = 0
+
+  private[sql] def currentDepth_=(depth: Int): Unit = ()
+}
+
+object DbTx {
+
+  /**
+   * Nested transaction via savepoint using an ambient [[DbTx]].
+   *
+   * Example:
+   * {{{
+   * transactor.transact {
+   *   sql"INSERT INTO t VALUES (1)".update
+   *   summon[DbTx].transact {
+   *     sql"INSERT INTO t VALUES (2)".update
+   *   }
+   * }
+   * }}}
+   *
+   * Also available as `transactNested` for call sites that prefer a `using`
+   * parameter over an extension receiver.
+   */
+  def transactNested[A](f: DbTx ?=> A)(using outer: DbTx): A =
+    outer.transact(f)
+}
+
+/**
+ * Savepoint-based nested transaction support.
+ *
+ * Names are `zib_tx_1 .. zib_tx_N` where N is the nesting depth derived from
+ * [[DbTx.currentDepth]]. Success → `RELEASE SAVEPOINT`, failure →
+ * `ROLLBACK TO SAVEPOINT` then rethrow. Depth is decremented in `finally` so
+ * the counter resets even after failures, allowing subsequent nested blocks to
+ * reuse the same name sequence without leaking.
+ *
+ * Given-priority trick (documented): When a [[DbTx]] is already in scope
+ * (inside `Transactor.transact`), the extension `summon[DbTx].transact { ... }`
+ * is preferred over `transactor.transact { ... }` because it resolves via the
+ * more specific `DbTx` receiver and reuses the same connection with a
+ * savepoint. A transparent-inline `given` trick that would make
+ * `Transactor.transact` auto-delegate to the savepoint path when an ambient
+ * `DbTx` exists is possible (e.g. `transparent inline given DbTx` with
+ * priority), but is not required here: the explicit `summon[DbTx].transact`
+ * form is the supported nested path and `Transactor.transact` remains the
+ * top-level entry point that opens a new connection. This keeps semantics
+ * explicit and avoids implicit-resolution surprises. If desired, a future
+ * `given Conversion` or inline trick can delegate `transactor.transact` to
+ * `summon[DbTx].transact` when `summon[DbTx]` is available, but the current
+ * implementation documents the pattern instead of hiding it behind implicits.
+ */
+extension (outer: DbTx) {
+
+  /**
+   * Execute `f` inside a savepoint nested transaction.
+   *
+   * Creates savepoint `zib_tx_<depth>` where depth is `outer.currentDepth + 1`,
+   * runs `f` with the same underlying connection (given `DbTx` is `outer` with
+   * incremented depth), releases on success and rolls back to the savepoint on
+   * failure. Depth is always decremented in `finally`. On failure only depth is
+   * decremented and the savepoint is not released (it will be cleaned up when
+   * outer transaction commits/rolls back).
+   */
+  def transact[A](f: DbTx ?=> A): A = {
+    val depth = outer.currentDepth + 1
+    val name  = s"zib_tx_$depth"
+    outer.savepoint(name)
+    outer.currentDepth = depth
+    try {
+      given DbTx = outer
+      val result =
+        try f
+        catch {
+          case e: Throwable =>
+            try outer.rollbackTo(name)
+            catch { case rb: Throwable => e.addSuppressed(rb) }
+            throw e
+        }
+      outer.release(name)
+      result
+    } finally {
+      outer.currentDepth = depth - 1
+    }
+  }
+}
+
+/** Top-level helper that mirrors `DbTx.transactNested` with `using` syntax. */
+def transactNested[A](f: DbTx ?=> A)(using outer: DbTx): A =
+  outer.transact(f)

--- a/sql/shared/src/main/scala/zio/blocks/sql/Dump.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Dump.scala
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.sql
+
+import scala.quoted._
+import zio.blocks.schema.Schema
+
+/**
+ * Compile-time SQL dump utilities for debugging and inspection.
+ *
+ * `Dump` exposes transparent `inline` macros that, when enabled, write the
+ * generated SQL text to files **during compilation**. This is an opt-in
+ * diagnostic aid — by default the macros expand to `()` and perform no I/O.
+ *
+ * ==Opt-in mechanism==
+ *
+ * Set the system property `zib.sql.dumpDir` to a directory path before
+ * compilation, e.g. `-Dzib.sql.dumpDir=/tmp/sql-dump` on the `scalac`/`sbt`
+ * invocation or via `System.setProperty("zib.sql.dumpDir", "/tmp/sql-dump")` in
+ * the same JVM that runs the compiler. When the property is absent or `null`
+ * every `Dump` call is a no-op. No code changes are required beyond adding the
+ * `Dump` invocations where you want SQL inspected.
+ *
+ * ==Side effects==
+ *
+ * When `zib.sql.dumpDir` is set, each macro invocation may perform file I/O at
+ * compile time:
+ *   - Parent directories are created with `Files.createDirectories`.
+ *   - SQL is written as UTF-8 to `<sanitized-name>-<dialect>.sql` (e.g.
+ *     `users-postgresql.sql`, `users-sqlite.sql`) under the dump directory.
+ *   - Existing files are compared byte-for-byte and left untouched if
+ *     unchanged, to avoid spurious rebuilds.
+ *   - Any I/O failure is reported as a compiler warning at the macro expansion
+ *     site (`Position.ofMacroExpansion`) and never fails compilation.
+ *
+ * When the property is not set, the macros short-circuit to `'{ () }` without
+ * touching the file system — compilation is side-effect free.
+ *
+ * ==Intended usage==
+ *
+ * Intended for local debugging, SQL review, and documentation — not for
+ * production. Use `Dump` to inspect what DDL macros generate for each dialect
+ * (`PostgreSQL` vs `SQLite`), diff the output across schema changes, or check
+ * generated SQL into docs. Remove or gate `Dump` calls before release; they are
+ * compile-time only and have no runtime cost when `zib.sql.dumpDir` is unset.
+ *
+ * @see
+ *   [[SqlDialect]] for the dialects that are dumped (`PostgreSQL` and `SQLite`)
+ */
+object Dump {
+
+  private[sql] def emit(name: String, dialect: SqlDialect, sqlText: String)(using Quotes): Unit = {
+    import quotes.reflect._
+    val dirProp = System.getProperty("zib.sql.dumpDir")
+    if (dirProp == null) return
+    try {
+      val safe     = sanitize(name)
+      val suffix   = dialect.name.toLowerCase(java.util.Locale.ROOT)
+      val fileName = s"$safe-$suffix.sql"
+      val content  = if (sqlText.endsWith("\n")) sqlText else sqlText + "\n"
+      val dirPath  = java.nio.file.Paths.get(dirProp)
+      val filePath = dirPath.resolve(fileName)
+      val parent   = filePath.getParent
+      if (parent != null) java.nio.file.Files.createDirectories(parent)
+      val bytes = content.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+      if (java.nio.file.Files.exists(filePath)) {
+        val existing = java.nio.file.Files.readAllBytes(filePath)
+        if (java.util.Arrays.equals(existing, bytes)) return
+      }
+      java.nio.file.Files.write(
+        filePath,
+        bytes,
+        java.nio.file.StandardOpenOption.CREATE,
+        java.nio.file.StandardOpenOption.TRUNCATE_EXISTING,
+        java.nio.file.StandardOpenOption.WRITE
+      )
+    } catch {
+      case e: Throwable =>
+        report.warning(
+          s"[zib.sql.dumpDir] Failed to dump $name/${dialect.name}: ${e.getMessage}",
+          Position.ofMacroExpansion
+        )
+    }
+  }
+
+  private def sanitize(name: String): String =
+    try SqlIdentifier.validate("table", name)
+    catch {
+      case _: IllegalArgumentException =>
+        val s = name.replaceAll("[^A-Za-z0-9_]", "_")
+        if (s.isEmpty) "_"
+        else if (s.matches("^[A-Za-z_].*")) s
+        else "_" + s
+    }
+
+  /**
+   * Dump the DDL for the given `Table` to the dump directory.
+   *
+   * Inline macro that expands at compile time. When `zib.sql.dumpDir` is set,
+   * generates `CREATE TABLE` SQL for both `PostgreSQL` and `SQLite` and writes
+   * each to `<table>-<dialect>.sql` via [[emit]]; otherwise expands to `()`.
+   * Intended for debugging/inspection — see [[Dump]] for opt-in and side-effect
+   * details.
+   */
+  inline def dumpTable[A](inline table: Table[A])(using
+    @scala.annotation.unused schema: Schema[A]
+  ): Unit =
+    ${ dumpTableImpl[A]('table) }
+
+  def dumpTableImpl[A: Type](table: Expr[Table[A]])(using Quotes): Expr[Unit] = {
+    import quotes.reflect._
+    val dirProp = System.getProperty("zib.sql.dumpDir")
+    if (dirProp == null) '{ () }
+    else {
+      def dbValueForLocal(tpe: TypeRepr): DbValue =
+        if (tpe =:= TypeRepr.of[Int]) DbValue.DbInt(0)
+        else if (tpe =:= TypeRepr.of[Long]) DbValue.DbLong(0L)
+        else if (tpe =:= TypeRepr.of[String]) DbValue.DbString("")
+        else if (tpe =:= TypeRepr.of[Boolean]) DbValue.DbBoolean(false)
+        else if (tpe =:= TypeRepr.of[Short]) DbValue.DbShort(0)
+        else if (tpe =:= TypeRepr.of[Byte]) DbValue.DbByte(0)
+        else if (tpe =:= TypeRepr.of[Float]) DbValue.DbFloat(0f)
+        else if (tpe =:= TypeRepr.of[Double]) DbValue.DbDouble(0d)
+        else if (tpe =:= TypeRepr.of[Char]) DbValue.DbChar(' ')
+        else if (tpe =:= TypeRepr.of[BigDecimal]) DbValue.DbBigDecimal(BigDecimal(0))
+        else if (tpe =:= TypeRepr.of[Array[Byte]]) DbValue.DbBytes(Array.emptyByteArray)
+        else if (tpe =:= TypeRepr.of[java.time.LocalDate]) DbValue.DbLocalDate(java.time.LocalDate.ofEpochDay(0))
+        else if (tpe =:= TypeRepr.of[java.time.LocalDateTime])
+          DbValue.DbLocalDateTime(java.time.LocalDateTime.ofEpochSecond(0, 0, java.time.ZoneOffset.UTC))
+        else if (tpe =:= TypeRepr.of[java.time.LocalTime]) DbValue.DbLocalTime(java.time.LocalTime.MIDNIGHT)
+        else if (tpe =:= TypeRepr.of[java.time.Instant]) DbValue.DbInstant(java.time.Instant.EPOCH)
+        else if (tpe =:= TypeRepr.of[java.time.Duration]) DbValue.DbDuration(java.time.Duration.ZERO)
+        else if (tpe =:= TypeRepr.of[java.util.UUID]) DbValue.DbUUID(new java.util.UUID(0L, 0L))
+        else if (tpe =:= TypeRepr.of[java.math.BigDecimal]) DbValue.DbBigDecimal(BigDecimal(0))
+        else {
+          val full = tpe.typeSymbol.fullName
+          full match {
+            case "scala.Int"                         => DbValue.DbInt(0)
+            case "scala.Long"                        => DbValue.DbLong(0L)
+            case "scala.String" | "java.lang.String" => DbValue.DbString("")
+            case "scala.Boolean"                     => DbValue.DbBoolean(false)
+            case "scala.Short"                       => DbValue.DbShort(0)
+            case "scala.Byte"                        => DbValue.DbByte(0)
+            case "scala.Float"                       => DbValue.DbFloat(0f)
+            case "scala.Double"                      => DbValue.DbDouble(0d)
+            case "scala.Char"                        => DbValue.DbChar(' ')
+            case "scala.math.BigDecimal"             => DbValue.DbBigDecimal(BigDecimal(0))
+            case "java.time.LocalDate"               => DbValue.DbLocalDate(java.time.LocalDate.ofEpochDay(0))
+            case "java.time.LocalDateTime"           =>
+              DbValue.DbLocalDateTime(java.time.LocalDateTime.ofEpochSecond(0, 0, java.time.ZoneOffset.UTC))
+            case "java.time.LocalTime"                    => DbValue.DbLocalTime(java.time.LocalTime.MIDNIGHT)
+            case "java.time.Instant"                      => DbValue.DbInstant(java.time.Instant.EPOCH)
+            case "java.time.Duration"                     => DbValue.DbDuration(java.time.Duration.ZERO)
+            case "java.util.UUID"                         => DbValue.DbUUID(new java.util.UUID(0L, 0L))
+            case _ if tpe.typeSymbol.flags.is(Flags.Enum) => DbValue.DbString("")
+            case _                                        => DbValue.DbString("")
+          }
+        }
+
+      def dbValueAndNullableLocal(tpe: TypeRepr): (DbValue, Boolean) = {
+        val optSym   = TypeRepr.of[Option[Int]].typeSymbol
+        val maybeSym =
+          try TypeRepr.of[zio.blocks.maybe.Maybe[Int]].typeSymbol
+          catch { case _: Throwable => null }
+        def isOpt: Boolean = tpe match {
+          case AppliedType(tycon, _) => tycon.typeSymbol == optSym
+          case _                     => false
+        }
+        def isMaybe: Boolean =
+          if (maybeSym == null) false
+          else
+            tpe match {
+              case AppliedType(tycon, _) => tycon.typeSymbol == maybeSym
+              case _                     => false
+            }
+        if (isOpt || isMaybe) {
+          val inner = tpe match {
+            case AppliedType(_, List(arg)) => arg
+            case _                         => TypeRepr.of[String]
+          }
+          val (innerVal, _) = dbValueAndNullableLocal(inner)
+          (innerVal, true)
+        } else (dbValueForLocal(tpe), false)
+      }
+
+      def deriveColumnsLocal(tpe: TypeRepr): IndexedSeq[ColumnMeta] = {
+        val sym                  = tpe.typeSymbol
+        val fields: List[Symbol] =
+          try sym.caseFields
+          catch { case _: Throwable => Nil }
+        if (fields.nonEmpty) {
+          fields.flatMap { f =>
+            val fieldName          = f.name
+            val colName            = SqlNameMapper.SnakeCase(fieldName)
+            val fieldTpe: TypeRepr =
+              try tpe.memberType(f)
+              catch { case _: Throwable => TypeRepr.of[String] }
+            val (dbVal, nullable) = dbValueAndNullableLocal(fieldTpe)
+            IndexedSeq(ColumnMeta(colName, dbVal, nullable))
+          }.toIndexedSeq
+        } else {
+          val ctorParams = sym.primaryConstructor.paramSymss.flatten
+          if (ctorParams.nonEmpty) {
+            ctorParams.flatMap { p =>
+              val n = p.name
+              if (n.isEmpty || n == "x$0" || n.startsWith("$")) None
+              else Some(ColumnMeta(SqlNameMapper.SnakeCase(n), DbValue.DbString(""), false))
+            }.toIndexedSeq
+          } else IndexedSeq.empty
+        }
+      }
+
+      val tpe      = TypeRepr.of[A]
+      val sym      = tpe.typeSymbol
+      val typeName = if (sym.name == "<none>" || sym.name.isEmpty) "unknown" else sym.name
+
+      var explicit: Option[String] = None
+      def walk(t: Term): Unit      = t match {
+        case Literal(StringConstant(s)) if s.matches("[A-Za-z_][A-Za-z0-9_]*") =>
+          if (explicit.isEmpty) explicit = Some(s)
+        case Apply(fun, args)     => walk(fun); args.foreach(walk)
+        case Select(qual, _)      => walk(qual)
+        case Inlined(_, _, inner) => walk(inner)
+        case Block(_, inner)      => walk(inner)
+        case Typed(inner, _)      => walk(inner)
+        case _                    =>
+      }
+      walk(table.asTerm)
+      val tableName    = explicit.getOrElse(SqlNameMapper.SnakeCase(typeName))
+      val columns      = deriveColumnsLocal(tpe)
+      val finalColumns =
+        if (columns.nonEmpty) columns else IndexedSeq(ColumnMeta("value", DbValue.DbString(""), false))
+
+      for (dialect <- Seq(SqlDialect.PostgreSQL, SqlDialect.SQLite)) {
+        val colDefs = finalColumns.map { cm =>
+          ColumnDef(cm.name, dialect.typeName(cm.dbValue), cm.nullable)
+        }
+        val frag    = Ddl.createTable(tableName, colDefs)
+        val sqlText = frag.sql(dialect)
+        emit(tableName, dialect, sqlText)
+      }
+      '{ () }
+    }
+  }
+}

--- a/sql/shared/src/main/scala/zio/blocks/sql/TransactionIsolation.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/TransactionIsolation.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.sql
+
+/**
+ * Transaction isolation level.
+ *
+ * Each value maps to the standard JDBC isolation level via [[jdbcLevel]].
+ * Levels are defined as local `Int` constants matching the JDBC specification
+ * (1, 2, 4, 8) to avoid a `java.sql` dependency in the shared (JS) build. This
+ * keeps `sql/shared` free of `java.sql` — the JVM side interprets [[jdbcLevel]]
+ * via `Connection.setTransactionIsolation` — mirroring the convention in
+ * `DbCodec.scala:101` where shared sources keep `java.sql` constants local.
+ *
+ * SQLite semantics: SQLite natively supports only `SERIALIZABLE` (its default).
+ * Other levels are accepted by the driver and documented here but may be
+ * treated as `SERIALIZABLE` by the SQLite engine — the implementation still
+ * applies the requested level via `Connection.setTransactionIsolation` so
+ * behaviour is uniform across dialects, with the caveat that on SQLite the
+ * isolation guarantee remains serializable regardless of the requested level.
+ */
+enum TransactionIsolation(val jdbcLevel: Int) {
+  case ReadUncommitted extends TransactionIsolation(1) // JDBC TRANSACTION_READ_UNCOMMITTED = 1
+  case ReadCommitted   extends TransactionIsolation(2) // JDBC TRANSACTION_READ_COMMITTED = 2
+  case RepeatableRead  extends TransactionIsolation(4) // JDBC TRANSACTION_REPEATABLE_READ = 4
+  case Serializable    extends TransactionIsolation(8) // JDBC TRANSACTION_SERIALIZABLE = 8
+}

--- a/sql/shared/src/main/scala/zio/blocks/sql/Transactor.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Transactor.scala
@@ -21,6 +21,46 @@ package zio.blocks.sql
  *
  * Both methods acquire a connection, execute the provided body, and close the
  * connection upon return (whether the body succeeds or throws).
+ *
+ * ==Nested transactions (savepoints)==
+ *
+ * Top-level transactions are started via `transact { ... }`, which opens a new
+ * connection, disables auto-commit, and commits/rolls back on exit. Inner
+ * (nested) transactions are emulated via SQL savepoints on the *same*
+ * connection and are accessed through the ambient [[DbTx]]:
+ * {{{
+ * transactor.transact {
+ *   sql"INSERT INTO t VALUES (1)".update
+ *   summon[DbTx].transact {
+ *     sql"INSERT INTO t VALUES (2)".update
+ *   }
+ * }
+ * }}}
+ * Names are `zib_tx_1 .. zib_tx_N` where N is the nesting depth tracked in
+ * [[DbTx.currentDepth]]. Success → `RELEASE SAVEPOINT`, failure →
+ * `ROLLBACK TO SAVEPOINT` then rethrow; depth is decremented in `finally` so no
+ * savepoint leak occurs and the counter resets for subsequent siblings.
+ *
+ * ===Given-priority trick (documented)===
+ *
+ * When a [[DbTx]] is already in scope (inside `transact`), the extension
+ * `summon[DbTx].transact { ... }` is preferred over
+ * `transactor.transact { ... }` because it resolves via the more specific
+ * `DbTx` receiver and reuses the same connection with a savepoint. A
+ * transparent-inline `given` trick that would make `Transactor.transact`
+ * auto-delegate to the savepoint path when an ambient `DbTx` exists is possible
+ * (e.g. `transparent inline given DbTx` with priority), but is not required
+ * here: the explicit `summon[DbTx].transact` form is the supported nested path
+ * and `Transactor.transact` remains the top-level entry point that opens a new
+ * connection. This keeps semantics explicit and avoids implicit-resolution
+ * surprises. If desired, a future inline trick can delegate
+ * `transactor.transact` to `summon[DbTx].transact` when `summon[DbTx]` is
+ * available, but the current implementation documents the pattern instead of
+ * hiding it behind implicits.
+ *
+ * Additionally `transactNested { ... }` (both `DbTx.transactNested` and the
+ * top-level `transactNested` helper) is provided as an alias that takes the
+ * outer transaction as a `using` parameter.
  */
 trait Transactor {
 
@@ -30,7 +70,31 @@ trait Transactor {
   /**
    * Opens a connection, disables auto-commit, executes `f`, commits on success,
    * and rolls back on exception. The connection is closed after commit or
-   * rollback.
+   * rollback. Preserves the driver's default isolation level and `readOnly`
+   * flag (does not force `SERIALIZABLE`); use the overload with explicit
+   * `isolation`/`readOnly` to request a specific isolation level. This avoids
+   * unexpectedly upgrading PostgreSQL's default `READ_COMMITTED` to
+   * `SERIALIZABLE` for callers that used the no-arg form.
    */
   def transact[A](f: DbTx ?=> A): A
+
+  /**
+   * Opens a connection, applies the requested isolation level and read-only
+   * flag, disables auto-commit, executes `f`, commits on success, and rolls
+   * back on exception. The previous isolation level and read-only flag are
+   * restored and the connection is closed after commit or rollback.
+   *
+   * SQLite note: SQLite natively supports only `SERIALIZABLE`; other levels are
+   * accepted and the driver is asked to apply them, but the engine still
+   * behaves as serializable. See [[TransactionIsolation]] for details.
+   *
+   * Compatibility note: This is a new method added in 0.3.x. A concrete default
+   * is provided that delegates to `transact(f)` and ignores
+   * `isolation`/`readOnly` so existing external `Transactor` implementations
+   * continue to compile. Implementations that wish to honor isolation should
+   * override this method (as `JdbcTransactor` does). This default will be
+   * removed in a future major version.
+   */
+  @scala.annotation.nowarn("msg=unused")
+  def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A = transact(f)
 }

--- a/sql/shared/src/test/scala/zio/blocks/sql/RepoSpec.scala
+++ b/sql/shared/src/test/scala/zio/blocks/sql/RepoSpec.scala
@@ -238,6 +238,9 @@ object RepoSpec extends ZIOSpecDefault {
           def getAutoCommit: Boolean                   = true
           def commit(): Unit                           = ()
           def rollback(): Unit                         = ()
+          override def savepoint(name: String): Unit   = ()
+          override def release(name: String): Unit     = ()
+          override def rollbackTo(name: String): Unit  = ()
         }
 
         given DbCon = new DbCon {


### PR DESCRIPTION
Plan: **sql-tx-hardening** — transactions you can nest (savepoints) and tune (isolation, read-only), plus HikariCP on JDK 25+ virtual threads.

**What this PR does**
- `TransactionIsolation` enum (4 levels) in shared, `Transactor.transact(isolation, readOnly)` overload with save/restore around autocommit window (SQLite caveat: only SERIALIZABLE native, others accepted-and-documented)
- Re-entrant `transact` via savepoints `zib_tx_1..N` (`RELEASE` on success, `ROLLBACK TO` on failure) + public `DbTx.savepoint/release/rollbackTo` and `currentDepth`; `summon[DbTx].transact` / `transactNested` with given-priority docs
- `docs/guides/sql-transactions.md` (nesting semantics, per-dialect isolation matrix SQLite vs PG, error semantics, HikariCP recipe + virtual-thread notes, JEP491 pinning caveats) + sidebar registration

**Scope guardrails**
- No pooling implementation, no XA, no changes to `Frag`/`Repo`, no behavior change for top-level `transact`
- Zero new runtime deps, Scala 3 only, JDK 25+ / Loom first
- Includes required compilation fix from sibling plan: `Dump.scala` + `RelMacros.scala` for `d1dc17ed`

**Commits**
- `kkxmsxzn` feat(sql): isolation and read-only transact parameters (TransactionIsolation, Transactor overload, JdbcTransactor, TransactorIsolationSpec 10 tests)
- `snptwlxk` feat(sql): savepoint-nested transactions (DbTx, DbConnection, JdbcConnection, NestedTransactSpec 7 tests)
- `luzvppsw` docs(sql): transactions, savepoints, Hikari-on-Loom guide

**Verification**
- `sbt "++3.8.3; sqlJVM/testOnly NestedTransactSpec TransactorIsolationSpec"` 17 passed
- `sbt "++3.8.3; sqlJVM/test"` 456 passed, 1 failed (JdbcInstantTimezoneSpec PG docker, pre-existing gated)
- `sbt sqlJVM/scalafmtCheck` PASS, no `java.sql` leak into shared public API

Closes plan `sql-tx-hardening` (7/7 checkboxes, F1-F4 APPROVE)
