### PR TITLE
Correct the AcceptEncoding defect citation in the header docs

### DIFF
--- a/docs/reference/http-model/headers.md
+++ b/docs/reference/http-model/headers.md
@@ -198,7 +198,7 @@ Header.AcceptEncoding.parse("!!!")
 ```
 
 :::warning[`AcceptEncoding` falls back to `GZip` on unknown values]
-`Header.AcceptEncoding` matches a fixed set of encoding names and returns `GZip` for anything it does not recognize, rather than reporting a parse failure. A request with `accept-encoding: bogus` — or a typo like `identityy` — reads as if the client asked for gzip. Its `parse` fails only on an empty value, so a server choosing a response encoding from this header should compare against `Header.AcceptEncoding.render` output or read the raw value instead.
+`Header.AcceptEncoding` matches a fixed set of encoding names and returns `GZip` for anything it does not recognize, rather than reporting a parse failure. A request with `accept-encoding: bogus` — or a typo like `identityy` — reads as if the client asked for gzip. `Header.AcceptEncoding.parse` rejects only values with no non-empty comma-separated part, so almost any string succeeds. A server choosing a response encoding from this header should read the raw value instead of trusting the parsed variant. Tracked as [zio/zio-blocks#1618](https://github.com/zio/zio-blocks/issues/1618).
 :::
 
 ### `Headers#getLast` — last parseable match

--- a/docs/undocumented-report.md
+++ b/docs/undocumented-report.md
@@ -151,7 +151,7 @@ Three behaviours the source made non-obvious, now stated with worked output:
 
 Writing the catalog also surfaced a genuine defect, documented in a warning admonition and worth fixing in the source:
 
-- [ ] `Header.AcceptEncoding.parseSingle` ends with `case _ => GZip(weight)` (`Header.scala:1252`), so any unrecognized encoding name silently parses as `GZip` — `accept-encoding: bogus` reads as a gzip request. Its `parse` fails only on an empty value. The sibling ADTs handle the same situation correctly: `Authorization` has an `Unparsed` case and `Connection` has `Other`. `AcceptEncoding` should either gain an equivalent case or return `Left`.
+- [ ] `Header.AcceptEncoding.parseSingle` ends with `case _ => GZip(weight)` (`Header.scala:1250`), so any unrecognized encoding name silently parses as `GZip` — `accept-encoding: bogus` reads as a gzip request. `Header.AcceptEncoding.parse` rejects only values with no non-empty comma-separated part, so `""`, `","`, and `"   "` are the only failing inputs. The sibling ADTs handle the same situation correctly: `Authorization` has an `Unparsed` case and `Connection` has `Other`. `AcceptEncoding` should either gain an equivalent case or return `Left`. Tracked as [zio/zio-blocks#1618](https://github.com/zio/zio-blocks/issues/1618).
 
 What remains is the report's own items 4 and 5 rather than anything new:
 


### PR DESCRIPTION
## What

Three small corrections to the `AcceptEncoding` defect notes added in #1615. That PR merged on 2026-08-24, before these fixes were pushed, so they never landed.

Documentation only — no code block changed, and no source behaviour is altered. The defect itself is tracked in #1618 and is deliberately not fixed here.

## Corrections

**1. Wrong line citation.** `docs/undocumented-report.md` pointed at `Header.scala:1252`. The `case _ => GZip(weight)` arm is at line **1250**.

**2. Overly narrow failure condition.** Both the report and the warning admonition in `docs/reference/http-model/headers.md` said `parse` "fails only on an empty value". That is narrower than the truth:

```scala
val parts = value.split(',').map(_.trim).filter(_.nonEmpty)
if (parts.isEmpty) Left(s"Invalid accept-encoding: $value")
```

Parsing splits on commas, trims, and drops empty parts, so it reports a failure only when nothing survives that filter. `""`, `","`, and `"   "` are the only rejected inputs; essentially every other string succeeds. "Empty value" implied only the first of those.

**3. Poor remediation advice.** The admonition suggested comparing against `Header.AcceptEncoding.render` output. That does not work, because the fallback discards the original text — `render(parse("bogus").toOption.get)` returns `"gzip"`, as #1618 documents. The advice now points readers at the raw value instead.

Both places now link #1618 so a reader hitting the admonition can find the tracking issue.

## Also

Qualifies the bare `parse` reference on the line being rewritten, per the writing-style rule on method references. The one remaining style violation in `undocumented-report.md` is pre-existing and on an unrelated line, so it is left alone.

## Verification

No code block is touched, so mdoc is unaffected. The style checker is clean on `headers.md`; on `undocumented-report.md` the single remaining hit is the pre-existing one noted above, unchanged from `main`.

The line number and the parse behaviour were both re-verified against `origin/main` at `e34022ee` rather than from memory.
