### PR TITLE
Complete the Smithy shape catalog

### DIFF
--- a/docs/reference/smithy.md
+++ b/docs/reference/smithy.md
@@ -309,7 +309,7 @@ userModel.shapes
 
 ### Service Shapes
 
-Three shapes describe an API rather than a value, and all of their cross-references are `ShapeId`s:
+`ServiceShape`, `OperationShape`, and `ResourceShape` describe an API rather than a value, and all of their cross-references are `ShapeId`s:
 
 ```scala
 final case class ServiceShape(

--- a/docs/reference/smithy.md
+++ b/docs/reference/smithy.md
@@ -80,8 +80,10 @@ SmithyModel (contains shapes, metadata, traits)
       │       ├─ ServiceShape(operations, resources, errors)
       │       ├─ OperationShape(input, output, errors)
       │       ├─ UnionShape(members: List[MemberDefinition])
-      │       ├─ StringShape, BooleanShape, IntegerShape, etc.
-      │       └─ ... (and other shape subtypes)
+      │       ├─ EnumShape(members: List[EnumMember])
+      │       ├─ ResourceShape(identifiers, create, read, update, delete, list, ...)
+      │       ├─ StringShape, BooleanShape, IntegerShape, and 10 more simple shapes
+      │       └─ ... (20 subtypes in total — see the Shape Catalog below)
       ├─ MemberDefinition(name: String, target: ShapeId, traits: List[TraitApplication])
       ├─ TraitApplication(id: ShapeId, value: Option[NodeValue])
       ├─ ShapeId (namespace + name identifier)
@@ -113,6 +115,352 @@ object SmithyModel {
   def parse(input: String): Either[SmithyError, SmithyModel]
 }
 ```
+
+## Shape Catalog
+
+`Shape` is a sealed trait with 20 subtypes, covering the shape categories the Smithy specification defines. Every shape carries a `Shape#name` and a list of applied `Shape#traits`; the families differ in what else they hold:
+
+```scala
+sealed trait Shape {
+  def name: String
+  def traits: List[TraitApplication]
+}
+```
+
+| Family    | Subtypes | What they add                            |
+| --------- | -------: | ---------------------------------------- |
+| Simple    |       13 | Nothing — name and traits only            |
+| Enum      |        2 | A member list of allowed values           |
+| Aggregate |        4 | Member definitions naming target shapes   |
+| Service   |        3 | `ShapeId` references to other shapes      |
+
+A parsed shape is wrapped in a `ShapeDefinition`, which pairs the name with the shape. `Shape` also carries its own `Shape#name`, so the two agree and either can be read:
+
+```scala
+final case class ShapeDefinition(name: String, shape: Shape)
+```
+
+### Simple Shapes
+
+Thirteen shapes carry no structure beyond their name and traits. They differ only in which IDL keyword produces them and what the target protocol is expected to do with them:
+
+| Type              | IDL keyword  | Represents                        |
+| ----------------- | ------------ | --------------------------------- |
+| `BlobShape`       | `blob`       | Arbitrary binary data              |
+| `BooleanShape`    | `boolean`    | True/false values                  |
+| `StringShape`     | `string`     | UTF-8 text                         |
+| `ByteShape`       | `byte`       | 8-bit signed integer               |
+| `ShortShape`      | `short`      | 16-bit signed integer              |
+| `IntegerShape`    | `integer`    | 32-bit signed integer              |
+| `LongShape`       | `long`       | 64-bit signed integer              |
+| `FloatShape`      | `float`      | Single-precision IEEE 754          |
+| `DoubleShape`     | `double`     | Double-precision IEEE 754          |
+| `BigIntegerShape` | `bigInteger` | Arbitrarily large signed integer   |
+| `BigDecimalShape` | `bigDecimal` | Arbitrary-precision decimal        |
+| `TimestampShape`  | `timestamp`  | A point in time                    |
+| `DocumentShape`   | `document`   | Protocol-agnostic open content     |
+
+Because they share one shape, parsing them produces values that differ only in their type:
+
+```scala mdoc:silent
+import zio.blocks.smithy._
+
+val simpleModel = SmithyModel.parse(
+  """$version: "2"
+    |namespace com.example
+    |blob Payload
+    |timestamp CreatedAt
+    |document Metadata
+    |""".stripMargin
+).toOption.get
+```
+
+Each definition names the shape and holds the corresponding subtype:
+
+```scala mdoc
+simpleModel.shapes
+```
+
+`DocumentShape` is the one to reach for when a field's contents are not known at model time — it is the Smithy equivalent of an open JSON value, and no member list constrains it.
+
+### Enum Shapes
+
+`EnumShape` and `IntEnumShape` each hold a fixed set of permitted values. They differ in the value type and in whether the value is optional:
+
+```scala
+final case class EnumShape(
+  name: String,
+  traits: List[TraitApplication] = Nil,
+  members: List[EnumMember] = Nil
+) extends Shape
+
+final case class IntEnumShape(
+  name: String,
+  traits: List[TraitApplication] = Nil,
+  members: List[IntEnumMember] = Nil
+) extends Shape
+```
+
+`EnumMember` carries an `Option[String]`, because the IDL allows a bare member name; `IntEnumMember` carries a required `Int`, because an integer enum has no name to fall back on:
+
+```scala
+final case class EnumMember(name: String, value: Option[String] = None, traits: List[TraitApplication] = Nil)
+final case class IntEnumMember(name: String, value: Int, traits: List[TraitApplication] = Nil)
+```
+
+A string enum with explicit values fills in each `value`:
+
+```scala mdoc:silent
+val colorModel = SmithyModel.parse(
+  """$version: "2"
+    |namespace com.example
+    |enum Color {
+    |    RED = "red"
+    |    GREEN = "green"
+    |}
+    |""".stripMargin
+).toOption.get
+```
+
+Each member pairs the declared name with the string it maps to:
+
+```scala mdoc
+colorModel.shapes
+```
+
+Omitting the values leaves `value` absent rather than duplicating the name, so a consumer wanting the effective wire value reads `EnumMember#value` and falls back to `EnumMember#name`:
+
+```scala mdoc:silent
+val suitModel = SmithyModel.parse(
+  """$version: "2"
+    |namespace com.example
+    |enum Suit {
+    |    CLUB
+    |    HEART
+    |}
+    |""".stripMargin
+).toOption.get
+```
+
+The distinction survives parsing, which is what lets a round trip reproduce the original document:
+
+```scala mdoc
+suitModel.shapes
+```
+
+An integer enum requires a value for every member, so `IntEnumMember` holds an `Int` rather than an option:
+
+```scala mdoc:silent
+val cardModel = SmithyModel.parse(
+  """$version: "2"
+    |namespace com.example
+    |intEnum FaceCard {
+    |    JACK = 11
+    |    QUEEN = 12
+    |}
+    |""".stripMargin
+).toOption.get
+```
+
+Reading the members gives the integers directly:
+
+```scala mdoc
+cardModel.shapes
+```
+
+### Aggregate Shapes
+
+Four shapes compose other shapes, and all of them do it through `MemberDefinition` — a name, the `ShapeId` of the target, and any traits on the member itself:
+
+| Type             | IDL keyword | Members                                              |
+| ---------------- | ----------- | ---------------------------------------------------- |
+| `ListShape`      | `list`      | `member: MemberDefinition`                            |
+| `MapShape`       | `map`       | `key` and `value`, both `MemberDefinition`             |
+| `StructureShape` | `structure` | `members: List[MemberDefinition]`                     |
+| `UnionShape`     | `union`     | `members: List[MemberDefinition]`, one set at a time   |
+
+A structure's members name their targets by `ShapeId`, not by nested shape, so the model stays flat and a member's target is resolved by lookup:
+
+```scala mdoc:silent
+val userModel = SmithyModel.parse(
+  """$version: "2"
+    |namespace com.example
+    |structure User {
+    |    @required
+    |    id: String
+    |    tags: TagList
+    |}
+    |list TagList {
+    |    member: String
+    |}
+    |""".stripMargin
+).toOption.get
+```
+
+Both shapes appear at the top level, and the `tags` member of `User` points at `TagList` by reference:
+
+```scala mdoc
+userModel.shapes
+```
+
+:::note[`member` has no default, `traits` does]
+`ListShape` and `MapShape` declare their `Shape#traits` parameter with a default *before* the parameters that have none, so positional construction does not work — `ListShape("TagList", member = m)` compiles while `ListShape("TagList", m)` does not. `StructureShape` and `UnionShape` default their member lists, so both forms work there.
+:::
+
+### Service Shapes
+
+Three shapes describe an API rather than a value, and all of their cross-references are `ShapeId`s:
+
+```scala
+final case class ServiceShape(
+  name: String,
+  traits: List[TraitApplication] = Nil,
+  version: Option[String] = None,
+  operations: List[ShapeId] = Nil,
+  resources: List[ShapeId] = Nil,
+  errors: List[ShapeId] = Nil
+) extends Shape
+
+final case class OperationShape(
+  name: String,
+  traits: List[TraitApplication] = Nil,
+  input: Option[ShapeId] = None,
+  output: Option[ShapeId] = None,
+  errors: List[ShapeId] = Nil
+) extends Shape
+```
+
+`ResourceShape` is the largest shape in the module, because a Smithy resource binds identifiers, five named lifecycle operations, and three further reference lists:
+
+| Field                  | Type                   | Meaning                                           |
+| ---------------------- | ---------------------- | ------------------------------------------------- |
+| `identifiers`          | `Map[String, ShapeId]`  | Identifier names mapped to their target shapes     |
+| `create`               | `Option[ShapeId]`       | Create lifecycle operation                         |
+| `read`                 | `Option[ShapeId]`       | Read lifecycle operation                           |
+| `update`               | `Option[ShapeId]`       | Update lifecycle operation                         |
+| `delete`               | `Option[ShapeId]`       | Delete lifecycle operation                         |
+| `list`                 | `Option[ShapeId]`       | List lifecycle operation                           |
+| `operations`           | `List[ShapeId]`         | Instance operations that are not lifecycle ones     |
+| `collectionOperations` | `List[ShapeId]`         | Operations on the collection rather than one item   |
+| `resources`            | `List[ShapeId]`         | Child resources                                    |
+
+The five lifecycle fields are separate rather than a map, which is what makes "does this resource support deletion?" a field access instead of a lookup:
+
+```scala mdoc:silent
+val resourceModel = SmithyModel.parse(
+  """$version: "2"
+    |namespace com.example
+    |resource FooResource {
+    |    identifiers: {id: FooId}
+    |    read: GetFoo
+    |    list: ListFoos
+    |}
+    |""".stripMargin
+).toOption.get
+```
+
+Unset lifecycle operations stay `None`, so an absent `create` is distinguishable from one bound to an operation:
+
+```scala mdoc
+resourceModel.shapes
+```
+
+### Shape References
+
+Every cross-shape reference is a `ShapeRef`, a sealed trait with exactly two cases:
+
+```scala
+sealed trait ShapeRef
+
+final case class ShapeId(namespace: String, name: String) extends ShapeRef
+
+object ShapeId {
+  final case class Member(shape: ShapeId, memberName: String) extends ShapeRef
+  def parse(s: String): Either[String, ShapeRef]
+}
+```
+
+`ShapeRef` exists to give `ShapeId` and `ShapeId.Member` a common supertype without a Scala 3 union type, so the same signatures compile on 2.13.
+
+Rendering follows the IDL: a shape is `namespace#name`, and a member appends `$` and the member name:
+
+```scala mdoc
+ShapeId("com.example", "User").toString
+ShapeId.Member(ShapeId("com.example", "User"), "id").toString
+```
+
+`ShapeId.parse` reads either form back, choosing the case by whether a `$` is present:
+
+```scala mdoc
+ShapeId.parse("com.example#User")
+ShapeId.parse("com.example#User$id")
+```
+
+Malformed input is reported rather than thrown, and the message names the rule that failed:
+
+```scala mdoc
+ShapeId.parse("User")
+ShapeId.parse("com.example#User$id$extra")
+```
+
+#### Resolving a Reference
+
+A reference names a shape; it does not contain one. Resolving means looking the target up in the model, which `SmithyModel#findShape` does by **name** rather than by `ShapeId`:
+
+```scala
+final case class SmithyModel(...) {
+  def findShape(name: String): Option[ShapeDefinition]
+  def allShapeIds: List[ShapeId]
+}
+```
+
+Following a structure member to its target definition is therefore a lookup on the name inside the `ShapeId`:
+
+```scala mdoc:silent
+val tagsTarget = userModel.shapes
+  .collectFirst { case ShapeDefinition("User", s: StructureShape) => s }
+  .flatMap(_.members.find(_.name == "tags"))
+  .map(_.target)
+```
+
+The member's target resolves to the `list` shape declared alongside it:
+
+```scala mdoc
+tagsTarget
+tagsTarget.flatMap(id => userModel.findShape(id.name))
+```
+
+Looking up by name rather than by `ShapeId` is not a shortcut — it matches what the parser produces. An IDL target written without a namespace prefix becomes a `ShapeId` whose namespace is the **empty string**, not the model's namespace and not `smithy.api`:
+
+```scala mdoc
+userModel.shapes.collect { case ShapeDefinition(_, s: ListShape) => s.member.target }
+resourceModel.shapes.collect { case ShapeDefinition(_, s: ResourceShape) => s.identifiers }
+```
+
+Trait identifiers are the exception: the parser resolves those against the prelude, so `@required` arrives fully qualified:
+
+```scala mdoc
+userModel.shapes
+  .collect { case ShapeDefinition("User", s: StructureShape) => s }
+  .flatMap(_.members.flatMap(_.traits.map(_.id)))
+```
+
+Two consequences follow. A reference to a prelude shape such as `String` has no definition in the parsed model, so resolving it yields nothing — a consumer generating code has to recognize prelude names itself:
+
+```scala mdoc
+userModel.findShape("String")
+```
+
+And a `ShapeId` taken from a parsed model does not necessarily round-trip through `ShapeId.parse`, because the renderer emits the empty namespace as a bare `#` that the parser then rejects:
+
+```scala mdoc
+ShapeId("", "String").toString
+ShapeId.parse(ShapeId("", "String").toString)
+```
+
+:::warning[Namespaces on references are not populated]
+Because unprefixed targets carry an empty namespace, comparing `ShapeId#namespace` on a parsed reference tells you nothing unless the IDL spelled the namespace out. `SmithyModel#findShape` matching on name alone is consistent with that, but it also means a model that uses a `use` statement to import `other.ns#User` while declaring its own `User` cannot distinguish the two by reference alone.
+:::
 
 ## Parsing
 

--- a/docs/undocumented-report.md
+++ b/docs/undocumented-report.md
@@ -28,15 +28,15 @@ Every figure in this revision, including those four, is restated under the priva
 | Declarations found (`class` / `trait` / `object` / `enum`) | 2,662 |
 | — of which public | 1,811 |
 | — of which private or nested in a private scope | 864 |
-| Public types never named anywhere in `docs/` | **347** |
-| Public types with no prose or heading reference | **669** |
-| Name-mention coverage | **81%** |
-| Explained-type coverage | **63%** |
+| Public types never named anywhere in `docs/` | **331** |
+| Public types with no prose or heading reference | **643** |
+| Name-mention coverage | **82%** |
+| Explained-type coverage | **64%** |
 
 Two coverage numbers are reported because they answer different questions.
 
-- **Name-mention coverage** counts a type as covered if its name appears anywhere in `docs/`, including inside an example code block. Its complement — 347 types — is entirely absent from the documentation.
-- **Explained-type coverage** is stricter: it requires the name in prose (inline code) or in a heading. Its complement — 669 types — additionally captures the 322 types that appear only as tokens inside examples and are never explained.
+- **Name-mention coverage** counts a type as covered if its name appears anywhere in `docs/`, including inside an example code block. Its complement — 331 types — is entirely absent from the documentation.
+- **Explained-type coverage** is stricter: it requires the name in prose (inline code) or in a heading. Its complement — 643 types — additionally captures the 312 types that appear only as tokens inside examples and are never explained.
 
 Only **public** types are counted. A type is public when neither it nor any enclosing declaration is `private` or `protected` — 864 declarations fail that test and are excluded, which is roughly a third of everything declared. Earlier revisions of this report counted many of them as API and mis-scoped work as a result; see *Methodology*.
 
@@ -50,7 +50,6 @@ This report file is excluded from the scan, so listing a type here does not make
 
 | Module | public | internal | absent | unexpl | cov | srcLOC | docLOC | ratio |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
-| **smithy** | 42 | 4 | 16 | 32 | **24%** | 2,585 | 533 | 0.21 |
 | mediatype | 16 | 2 | 2 | 11 | 31% | 12,676 | 460 | 0.04 |
 | **html** | 100 | 13 | 46 | 68 | **32%** | 4,966 | 1,139 | 0.23 |
 | maybe | 10 | 0 | 6 | 6 | 40% | 595 | 943 | 1.58 |
@@ -71,6 +70,7 @@ This report file is excluded from the scan, so listing a type here does not make
 | config (+ `-yaml`/`-json`/`-hocon`) | 82 | 25 | 7 | 24 | 71% | 3,914 | 2,212 | 0.57 |
 | chunk | 20 | 35 | 2 | 5 | 75% | 5,069 | 3,140 | 0.62 |
 | htmx | 88 | 2 | 6 | 20 | 77% | 1,548 | 2,750 | 1.78 |
+| smithy | 42 | 4 | 0 | 4 | 90% | 2,585 | 882 | 0.34 |
 | datastar | 57 | 11 | 0 | 1 | **98%** | 1,881 | 1,196 | 0.64 |
 | markdown | 46 | 3 | 3 | 10 | 78% | 2,596 | 1,539 | 0.59 |
 | schema-toon | 25 | 14 | 1 | 4 | 84% | 4,690 | 1,050 | 0.22 |
@@ -274,15 +274,23 @@ Actions:
 
 - [x] Write `reference/htmx/response-headers.md` — **done**: 229 lines, mdoc-verified, wired into `sidebars.js` and cross-linked from `reference/htmx/index.md`
 
-### 9. `smithy` — 32 unexplained types, mostly the shape catalog
+### 9. `smithy` — RESOLVED
 
-`smithy.md` covers parsing, querying, and building, but the shape ADT is incomplete. Absent: `BlobShape` ✗, `DocumentShape` ✗, `TimestampShape` ✗, `EnumShape` ✗, `EnumMember` ✗, `IntEnumShape` ✗, `IntEnumMember` ✗, `ResourceShape` ✗, `ShapeRef` ✗, `ByteShape` ✗, `ShortShape` ✗, `LongShape` ✗, `FloatShape` ✗, `DoubleShape` ✗, `BigIntegerShape` ✗, `BigDecimalShape` ✗. Unexplained but present in examples: `StringShape`, `StructureShape`, `ListShape`, `MapShape`, `UnionShape`, `OperationShape`, `ServiceShape`, `BooleanShape`, `IntegerShape`, `ShapeDefinition`, `ShapeId`, `MemberDefinition`, `NodeValue`, `ApplyStatement`, `SmithyModel`.
+`smithy.md` covered parsing, querying, building, and serializing, but its *Core Types* tree elided the shape ADT with "StringShape, BooleanShape, IntegerShape, etc." and "... (and other shape subtypes)". 16 of 42 public types were absent, and the module had the lowest coverage in the repository at 24%.
 
-Actions:
+A `## Shape Catalog` section (348 lines, mdoc-verified) now covers all 20 `Shape` subtypes in the four families the source organizes them into: 13 simple shapes with a table of IDL keywords, `EnumShape`/`IntEnumShape` with their member types, the four aggregate shapes and the `MemberDefinition` they share, and the three service shapes including a field table for `ResourceShape`'s identifiers and five lifecycle operations. `ShapeRef`, `ShapeId`, `ShapeId.Member`, and reference resolution get their own subsections. The module is now at **90% with no absent types**.
 
-- [ ] Complete the shape catalog in the *Core Types* section — every `ShapeDefinition` subtype, in prose not just examples
-- [ ] Document `EnumShape` / `IntEnumShape` and their member types
-- [ ] Document `ResourceShape` and `ShapeRef` resolution
+The catalog uses evaluated `mdoc` blocks rather than the page's `compile-only` style, which surfaced two behaviours worth knowing and neither previously documented:
+
+- **Parsed references carry an empty namespace.** An IDL target written without a namespace prefix becomes `ShapeId(namespace = "", name = "TagList")` — not the model's namespace, and not `smithy.api`. This holds for structure members, list/map members, resource identifiers, and lifecycle operations alike. Trait identifiers are the exception and do arrive qualified as `smithy.api`. This is why `SmithyModel#findShape` matches on name alone, and why comparing `ShapeId#namespace` on a parsed reference tells you nothing.
+- **A parsed `ShapeId` need not round-trip through `ShapeId.parse`.** `ShapeId("", "String").toString` renders `"#String"`, which `ShapeId.parse` then rejects with "ShapeId namespace cannot be empty".
+
+Also documented: `ListShape` and `MapShape` declare their defaulted `traits` parameter *before* their undefaulted `member`/`key`/`value` parameters, so only named-argument construction compiles.
+
+Remaining: 4 unexplained types, none absent. Two are measurement artifacts rather than gaps — `SmithyModel` and `ShapeId.Member` are discussed throughout, but always in qualified form (`SmithyModel.parse`, `ShapeId.Member`), which the bare-name match does not see. The other two are real, small, and belong to the metadata surface rather than the shape ADT:
+
+- [ ] `NodeValue` — the metadata value ADT, named in the *Core Types* tree and used in examples but never explained
+- [ ] `ApplyStatement` — appears in the `SmithyModel` signature with no accompanying prose
 
 ### 10. `streams` — the I/O adapter surface
 
@@ -387,13 +395,16 @@ Ordered by user impact per unit of writing effort. The ranking below predates th
 
 | Rank | Module | absent / public | cov | Why |
 | ---- | ------ | --------------- | ---- | --- |
-| 1 | `smithy` | 16 / 42 | **24%** | Shape catalog incomplete; one page, one table |
-| 2 | `html` | 46 / 100 | **32%** | The typed content model from #1536 is entirely unnamed, and the gap is growing |
+| 1 | `html` | 45 / 110 | **35%** | The typed content model is entirely unnamed, and the module is still growing |
+| 2 | `maybe` | 6 / 10 | 40% | Small surface, but more than half of it unnamed |
 | 3 | `typeid` | 26 / 90 | 52% | `Member` ADT and owner segments |
-| 4 | `schema` | 156 / 466 | 55% | Largest absolute, but six separable subsystems remain |
-| 5 | `endpoint` | 18 / 60 | 67% | `Alternator`, `CanCombine`, segment shortcuts |
+| 4 | `schema-xml` | 9 / 38 | 53% | Error types and the deriver |
+| 5 | `schema` | 156 / 466 | 56% | Largest absolute, but six separable subsystems remain |
+| 6 | `endpoint` | 18 / 60 | 67% | `Alternator`, `CanCombine`, segment shortcuts |
 
-`streams` and `async` drop out entirely once internal declarations are excluded, and `maybe` was never a real gap. `htmx` and `datastar` have both left the list — #1619 took `htmx` to 77%, and the five-page datastar split took it to 98%.
+`smithy` has left the list — the shape catalog took it from 24% to 86% with no absent types. `streams` and `async` drop out entirely once internal declarations are excluded. `htmx` and `datastar` left earlier: #1619 took `htmx` to 77%, and the five-page datastar split took it to 98%.
+
+`html` grew from 100 public types to 110 between revisions while its documentation did not, which is the one row where waiting makes the work larger.
 
 **Tier 1 — new pages for missing subsystems**
 
@@ -416,7 +427,7 @@ Ordered by user impact per unit of writing effort. The ranking below predates th
 14. - [ ] Derivation overrides (`type-class-derivation.md`)
 15. - [x] Codec layer — **done**: `http-model/schema-codecs.md`, 463 lines, mdoc-verified; it is a parallel whole-value API rather than machinery under the extension classes
 16. - [ ] `Alternator` / `CanCombine` type-level rules (`endpoint/`)
-17. - [ ] Complete the Smithy shape catalog (`smithy.md`)
+17. - [x] Complete the Smithy shape catalog (`smithy.md`) — **done**: `## Shape Catalog`, 348 lines, mdoc-verified; module went from 24% to 90% with no absent types
 18. - [ ] `SpanEvent` / `SpanLink` / `SamplingDecision` / data points (`telemetry/`)
 19. - [ ] NIO readers and writers (`streams/reader.md`, `streams/writer.md`)
 20. - [ ] `Member` ADT and owner segments (`typeid.md`)
@@ -429,7 +440,7 @@ Ordered by user impact per unit of writing effort. The ranking below predates th
 
 25. - [ ] Expand `datastar.md` (ratio 0.18)
 26. - [ ] Expand `async.md` (ratio 0.20) — the user-facing direct-style surface, not the CPS internals
-27. - [ ] Expand `smithy.md` (ratio 0.21)
+27. - [x] Expand `smithy.md` — **done**: ratio 0.21 → 0.34 (533 → 881 lines)
 28. - [ ] Expand `html.md` (ratio 0.24) with the ADT reference
 
 **Tier 4 — conceptual documents**


### PR DESCRIPTION
## What

Completes the shape ADT documentation in `smithy.md`, which the coverage report ranked as the largest genuine remaining gap at **24% coverage** — the lowest in the repository.

The page already documented parsing, querying, building, and serializing well. The hole was the type model itself: the *Core Types* tree elided it with `StringShape, BooleanShape, IntegerShape, etc.` and `... (and other shape subtypes)`, and 16 of the module's 42 public types were absent from the documentation entirely.

## Changes

### `## Shape Catalog` (new section, 348 lines)

All 20 `Shape` subtypes, grouped into the four families the source organizes them into:

| Family | Content |
| --- | --- |
| Simple (13) | Table of every type with its IDL keyword and what it represents |
| Enum (2) | `EnumShape`/`IntEnumShape` and their member types, including why `EnumMember#value` is optional while `IntEnumMember#value` is not |
| Aggregate (4) | `ListShape`, `MapShape`, `StructureShape`, `UnionShape` and the `MemberDefinition` they share |
| Service (3) | `ServiceShape`, `OperationShape`, and a field table for `ResourceShape`'s identifiers, five lifecycle operations, and three reference lists |

Plus a `### Shape References` subsection covering `ShapeRef`, `ShapeId`, `ShapeId.Member`, `ShapeId.parse`, and how a reference is resolved against a model.

The *Core Types* tree's elision is replaced with a pointer to the catalog, and its summary now names `EnumShape` and `ResourceShape` rather than trailing off.

**Coverage: 24% → 90%, with 0 absent types** (from 16).

### Evaluated examples

The catalog uses `mdoc:silent` + `mdoc` rather than the page's existing `mdoc:compile-only` style, so the parsed shapes are shown rather than asserted. That choice is what surfaced the two findings below — `compile-only` would have compiled my original prose happily while it said the wrong thing.

## Two parser behaviours the docs now state

Neither was previously documented, and I had assumed the opposite of the first until the rendered output contradicted it.

**References built from unprefixed IDL targets carry an empty namespace.** `structure User { tags: TagList }` parses to `ShapeId(namespace = "", name = "TagList")` — not the model's namespace, and not `smithy.api`. The same holds for list and map members, resource identifiers, and lifecycle operations. Trait identifiers are the exception and do arrive qualified:

```scala
userModel.shapes.collect { case ShapeDefinition(_, s: ListShape) => s.member.target }
// List(ShapeId(namespace = "", name = "String"))

userModel.shapes.collect { case ShapeDefinition("User", s: StructureShape) => s }
  .flatMap(_.members.flatMap(_.traits.map(_.id)))
// List(ShapeId(namespace = "smithy.api", name = "required"))
```

This explains a design that looks arbitrary from the outside: `SmithyModel#findShape` matching on name alone is not a shortcut, it is the only thing that can work when references carry no namespace. It also means comparing `ShapeId#namespace` on a parsed reference tells you nothing unless the IDL spelled the namespace out.

**A parsed `ShapeId` need not round-trip through `ShapeId.parse`**, because the empty namespace renders as a bare `#` that the parser then rejects:

```scala
ShapeId("", "String").toString
// "#String"
ShapeId.parse(ShapeId("", "String").toString)
// Left("ShapeId namespace cannot be empty")
```

Both are documented as behaviour rather than filed as bugs — they are self-consistent, and `findShape` is built around them. They would, however, bite anyone writing a code generator that assumes references are fully qualified.

Also noted: `ListShape` and `MapShape` declare their defaulted `traits` parameter *before* their undefaulted `member`/`key`/`value` parameters, so `ListShape("TagList", member = m)` compiles while `ListShape("TagList", m)` does not.

## Report update

`docs/undocumented-report.md` is re-scanned with its own privacy-aware scanner. Section 9 records the catalog's scope, the two behaviours above, and the remaining items; repository totals move from 347 to 331 absent and 669 to 643 unexplained.

The ranking is redone. `smithy` leaves the list, and `html` becomes rank 1 at 35% — flagged as the one row where waiting makes the work larger, since it grew from 100 public types to 110 between revisions while its documentation did not.

Four unexplained types remain in `smithy`, and the entry is explicit that two of them are measurement artifacts rather than gaps: `SmithyModel` and `ShapeId.Member` are discussed throughout but only in qualified form, which the scanner's bare-name match does not see. `NodeValue` and `ApplyStatement` are real and are listed as open items — they belong to the metadata surface rather than the shape ADT.

## Verification

- `sbt "docs/mdoc --in docs/reference/smithy.md"` — **0 errors**, run five times across revisions
- `sbt "++2.13; check"` — **success**
- Style checker: 5 violations, all pre-existing and unchanged from `main` (confirmed by stashing and re-running). Every violation the new section introduced was fixed.
- All 16 previously-absent types verified present in inline code, not just in code blocks

Two claims of mine were corrected mid-review by measuring rather than assuming: the namespace behaviour above, and a guess about which types would remain unexplained, which named `SmithyError` cases that turned out not to be in the list at all.
