### PR TITLE
Document CssLength and CssColor, and correct the html coverage entry

### DIFF
--- a/docs/reference/html.md
+++ b/docs/reference/html.md
@@ -876,6 +876,84 @@ All `Css` subtypes support `.render()` for minified output and `.render(indent: 
 - `Css.Raw` — raw CSS string
 - `Css.Comment` — CSS comment
 
+### Typed Values: Lengths and Colors
+
+A `Css.Declaration` takes its value as a `String`, so nothing stops `"10pixels"` or `"#gggggg"` from reaching a stylesheet. `CssLength` and `CssColor` are the typed alternatives: each validates on construction and renders itself, so an invalid value cannot be built rather than being caught downstream.
+
+`CssLength` pairs a numeric value with a unit, and rejects units outside the CSS set — `px`, `em`, `rem`, `%`, `vh`, `vw`, `ch`, `ex`, `vmin`, `vmax`, `cm`, `mm`, `in`, `pt`, `pc`:
+
+```scala mdoc:silent
+import zio.blocks.html._
+import zio.blocks.html.CssLength._
+```
+
+The second import is what brings the numeric extension methods into scope. They live in `object CssLength` rather than the package, so `import zio.blocks.html._` alone gives you the `CssLength` constructor but not `300.px`.
+
+Writing the constructor directly works, but the extension methods on `Int` and `Double` are shorter and produce the same value:
+
+```scala mdoc
+CssLength(300.0, "px").render
+300.px.render
+1.5.rem.render
+```
+
+`CssLengthIntOps` and `CssLengthDoubleOps` provide `px`, `em`, `rem`, `pct`, `vh`, and `vw` on numeric literals. `pct` is spelled out because `%` is not a legal method name:
+
+```scala mdoc
+50.pct.render
+100.vh.render
+```
+
+A whole-number `Double` renders without its decimal point, so `2.0.em` and `2.em` produce identical CSS:
+
+```scala mdoc
+2.0.em.render
+2.em.render
+```
+
+`CssColor` is a sealed ADT with five cases, covering the notations CSS accepts:
+
+| Case                   | Constructor                       | Renders as              |
+| ---------------------- | --------------------------------- | ----------------------- |
+| `CssColor.Hex`         | `Hex(value)` / `Hex.unsafe(value)` | `#ff0000`               |
+| `CssColor.Rgb`         | `Rgb(r, g, b)`                     | `rgb(255,0,0)`          |
+| `CssColor.Rgba`        | `Rgba(r, g, b, a)`                 | `rgba(255,0,0,0.5)`     |
+| `CssColor.Hsl`         | `Hsl(h, s, l)`                     | `hsl(0,100%,50%)`       |
+| `CssColor.Named`       | `Named(name)`                      | `red`                   |
+
+The numeric cases are plain case classes, so they need no validation step:
+
+```scala mdoc
+CssColor.Rgb(255, 0, 0).render
+CssColor.Rgba(255, 0, 0, 0.5).render
+CssColor.Hsl(0, 100, 50).render
+```
+
+`Hsl` renders its saturation and lightness with percent signs while taking them as bare `Int`s, so pass `100` rather than `1.0` for full saturation.
+
+`CssColor.Hex` and `CssColor.Named` are the two validated cases, and both return an `Option` from `CssColor.Hex.apply` rather than throwing:
+
+```scala mdoc
+CssColor.Hex("ff0000")
+CssColor.Hex("gggggg")
+```
+
+A leading `#` is optional and the value is lowercased, so the same colour written four ways yields one representation:
+
+```scala mdoc
+CssColor.Hex("#FF0000").map(_.render)
+```
+
+`CssColor.Hex.unsafe` skips validation for literals you know are well-formed. It returns a `CssColor` directly rather than an `Option`, which is what makes it convenient inside an interpolator — and what makes it unsuitable for anything user-supplied:
+
+```scala mdoc
+CssColor.Hex.unsafe("ff0000").render
+```
+
+:::warning[`unsafe` renders whatever it is given]
+`CssColor.Hex.unsafe` performs no checking, so `Hex.unsafe("not-a-color")` renders as `#not-a-color` and produces a stylesheet the browser silently ignores. Use it only for compile-time literals; route anything dynamic through `CssColor.Hex.apply` and handle the `None`.
+:::
+
 ### Declarations and Rules
 
 A `Css.Declaration` is a property-value pair:

--- a/docs/undocumented-report.md
+++ b/docs/undocumented-report.md
@@ -28,15 +28,15 @@ Every figure in this revision, including those four, is restated under the priva
 | Declarations found (`class` / `trait` / `object` / `enum`) | 2,662 |
 | — of which public | 1,811 |
 | — of which private or nested in a private scope | 864 |
-| Public types never named anywhere in `docs/` | **331** |
-| Public types with no prose or heading reference | **643** |
+| Public types never named anywhere in `docs/` | **325** |
+| Public types with no prose or heading reference | **637** |
 | Name-mention coverage | **82%** |
-| Explained-type coverage | **64%** |
+| Explained-type coverage | **65%** |
 
 Two coverage numbers are reported because they answer different questions.
 
-- **Name-mention coverage** counts a type as covered if its name appears anywhere in `docs/`, including inside an example code block. Its complement — 331 types — is entirely absent from the documentation.
-- **Explained-type coverage** is stricter: it requires the name in prose (inline code) or in a heading. Its complement — 643 types — additionally captures the 312 types that appear only as tokens inside examples and are never explained.
+- **Name-mention coverage** counts a type as covered if its name appears anywhere in `docs/`, including inside an example code block. Its complement — 325 types — is entirely absent from the documentation.
+- **Explained-type coverage** is stricter: it requires the name in prose (inline code) or in a heading. Its complement — 637 types — additionally captures the 312 types that appear only as tokens inside examples and are never explained.
 
 Only **public** types are counted. A type is public when neither it nor any enclosing declaration is `private` or `protected` — 864 declarations fail that test and are excluded, which is roughly a third of everything declared. Earlier revisions of this report counted many of them as API and mis-scoped work as a result; see *Methodology*.
 
@@ -51,7 +51,7 @@ This report file is excluded from the scan, so listing a type here does not make
 | Module | public | internal | absent | unexpl | cov | srcLOC | docLOC | ratio |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | mediatype | 16 | 2 | 2 | 11 | 31% | 12,676 | 460 | 0.04 |
-| **html** | 100 | 13 | 46 | 68 | **32%** | 4,966 | 1,139 | 0.23 |
+| **html** | 110 | 13 | 40 | 68 | **38%** | 5,591 | 1,300 | 0.23 |
 | maybe | 10 | 0 | 6 | 6 | 40% | 595 | 943 | 1.58 |
 | context | 2 | 7 | 1 | 1 | 50% | 865 | 553 | 0.64 |
 | **typeid** | 90 | 14 | 26 | 43 | **52%** | 6,493 | 2,124 | 0.33 |
@@ -317,7 +317,13 @@ Actions:
 
 ### 12. Smaller module gaps
 
-- **`html`** (54 unexplained) — the CSS/DOM ADT node types: `PseudoClass` ✗, `PseudoElement` ✗, `Descendant` ✗, `AdjacentSibling` ✗, `GeneralSibling` ✗, `AttributeMatch` ✗, `StartsWith` ✗, `EndsWith` ✗, `WhitespaceContains` ✗, `Rgb` ✗, `Rgba` ✗, `Hsl` ✗, `AddAttr` ✗, `AddChild` ✗, `AddChildren` ✗, `AddEffects` ✗, `DomModifier` ✗, `ToDom` ✗, `ToText` ✗, `AttrValue` ✗, `StyleArg` ✗, `ScriptArg` ✗, `HtmlElements` ✗ (335 lines). The behaviour is documented through the DSL, so this is a type-naming gap, not a conceptual one. **Lower priority.**
+- **`html`** (68 unexplained, 40 absent) — **the rank-1 justification in the table above was wrong and is corrected here.** An earlier revision of this entry claimed the typed content model was "entirely unnamed"; it is not. `html.md` has had a `## Typed Content Models` section since #1536 landed, naming every marker type (`Dom.Element.Li`, `Cell`, `Tr`, `SelectChild`, `Opt`, `Optgroup`), demonstrating compile-time rejection with an `mdoc:fail` block, and documenting structural equality across element classes and the `caption`/`thead` limitation. The 40 absent types break down as follows, and only two groups are conceptual gaps:
+  - **Real: CSS values — resolved.** `CssLength`'s unit set and numeric extension methods, and four of `CssColor`'s five cases, had no mention anywhere. The page's one example used the verbose `CssLength(300.0, "px")` while `300.px` existed unmentioned, so the docs actively steered readers to the clunkier API. A `### Typed Values: Lengths and Colors` section now covers the 15 valid units, `CssLengthIntOps`/`CssLengthDoubleOps` and the second import they require, all five `CssColor` cases, and the `Hex` versus `Hex.unsafe` validation split.
+  - **Real: the Scala 2 argument encoding.** `ListArg` ✗, `CellArg` ✗, `RowArg` ✗, `SelectArg` ✗, `OptgroupArg` ✗, `ScriptArg` ✗, and `StyleArg` ✗ are how the content model is expressed on 2.13 — sealed traits plus implicit conversions, where Scala 3 uses union types (`Dom.Attribute | Dom.Element.Li`). The content-model table writes the Scala 3 form only, and no page mentions that the encodings differ. This needs tabbed examples per the writing-style rule on version-specific syntax.
+  - **Real: extension points.** `DomModifier` ✗ and its four cases (`AddAttr` ✗, `AddChild` ✗, `AddChildren` ✗, `AddEffects` ✗), plus the `ToDom` ✗ and `ToText` ✗ conversion type classes. `ToModifier` is named in the page; these are not.
+  - **Naming only: selector ADT nodes.** `Descendant` ✗, `AdjacentSibling` ✗, `GeneralSibling` ✗, `AttributeMatch` ✗, `StartsWith` ✗, `EndsWith` ✗, `WhitespaceContains` ✗, `HyphenPrefix` ✗, `PseudoClass` ✗, `PseudoElement` ✗. Every one is reachable and demonstrated through the DSL (`div >> span`, `a.hover`, `input.withAttributeStarting(...)`); only the resulting node types are unnamed. Worth a short table for readers pattern matching on a built selector, not a section.
+  - **Naming only: concrete element classes.** `LiElement` ✗, `ThElement` ✗, `TdElement` ✗, `TrElement` ✗, `OptElement` ✗, `OptgroupElement` ✗ — the implementations behind the documented marker traits.
+  - **Skip: interpolator plumbing.** `CssStringContext` ✗, `HtmlStringContext` ✗, `JsStringContext` ✗, `SelectorStringContext` ✗, `TemplateInterpolators` ✗, `InterpolatorRuntime` ✗, `HtmlElements` ✗, `DomModifierConversions` ✗, `LowPriorityToJs` ✗, `JsValue` ✗. These match the naming patterns in *Deliberately Undocumented*; the interpolator syntax is documented, its machinery should not be.
   - [ ] Add an ADT reference section naming the selector, colour, and modifier types behind the DSL
 - **`datastar`** (28 unexplained) — same shape: `EventModifier` ✗, `CaseModifier` ✗, `InitModifier` ✗, `IntersectModifier` ✗, `OnIntervalModifier` ✗, `OnSignalPatchModifier` ✗, `DataOn` ✗, `PatchSignals` ✗, `PatchElements` ✗, `DatastarAttributes` ✗, `DatastarAttrKey` ✗, `ToDatastarExpr` ✗, `DataSignalsBuilder` ✗, `EventType` ✗. The 0.18 ratio is the bigger problem: 346 lines for 1,881 source lines.
   - [ ] Expand `datastar.md` — each SSE event type needs a worked example; add an attribute-DSL type reference
@@ -395,7 +401,7 @@ Ordered by user impact per unit of writing effort. The ranking below predates th
 
 | Rank | Module | absent / public | cov | Why |
 | ---- | ------ | --------------- | ---- | --- |
-| 1 | `html` | 45 / 110 | **35%** | The typed content model is entirely unnamed, and the module is still growing |
+| 1 | `html` | 40 / 110 | **38%** | Selector and modifier ADTs unnamed, and the Scala 2 argument encoding is undocumented |
 | 2 | `maybe` | 6 / 10 | 40% | Small surface, but more than half of it unnamed |
 | 3 | `typeid` | 26 / 90 | 52% | `Member` ADT and owner segments |
 | 4 | `schema-xml` | 9 / 38 | 53% | Error types and the deriver |
@@ -441,7 +447,7 @@ Ordered by user impact per unit of writing effort. The ranking below predates th
 25. - [ ] Expand `datastar.md` (ratio 0.18)
 26. - [ ] Expand `async.md` (ratio 0.20) — the user-facing direct-style surface, not the CPS internals
 27. - [x] Expand `smithy.md` — **done**: ratio 0.21 → 0.34 (533 → 881 lines)
-28. - [ ] Expand `html.md` (ratio 0.24) with the ADT reference
+28. - [ ] Expand `html.md` with the Scala 2 argument encoding, the `DomModifier`/`ToDom`/`ToText` extension points, and a selector-node table — CSS values done
 
 **Tier 4 — conceptual documents**
 


### PR DESCRIPTION
## What

Documents `CssLength` and `CssColor` in `html.md`, and corrects the coverage report's `html` entry, whose rank-1 justification turned out to be wrong.

## The documentation gap

`Css.Declaration` takes its value as a `String`, so `CssLength` and `CssColor` exist to make invalid values unconstructible. Both were mentioned once, in the `css""` interpolator section, and neither type's surface was documented: the valid unit set, the numeric extension methods, and four of `CssColor`'s five cases had no mention anywhere in the page.

The gap had a practical cost. The one example showed the verbose constructor:

```scala
val width = css"width: ${CssLength(300.0, "px")};"
```

while `300.px` exists, produces the same value, and went unmentioned — so the docs steered readers to the clunkier API. That shorter syntax also needs a second import, `zio.blocks.html.CssLength._`, because the implicit classes live in the `CssLength` companion rather than the package. Nothing said so, and my first draft's examples failed to compile for exactly that reason.

## `### Typed Values: Lengths and Colors`

Added to the CSS ADT section, ahead of Declarations and Rules since declarations consume these values:

- **`CssLength`** — the 15 valid units, `CssLengthIntOps` and `CssLengthDoubleOps`, and the second import they require. Documents that a whole-number `Double` renders without its decimal point, so `2.0.em` and `2.em` produce identical CSS.
- **`CssColor`** — all five cases with a rendering table. `Rgb`, `Rgba`, and `Hsl` are plain case classes; `Hex` and `Named` validate and return `Option`. Notes that `Hsl` takes bare `Int`s but renders percent signs, so full saturation is `100` rather than `1.0`.
- **`Hex` versus `Hex.unsafe`** — `Hex.apply` validates and lowercases, accepting an optional leading `#`. `Hex.unsafe` performs no checking at all, so `Hex.unsafe("not-a-color")` renders as `#not-a-color` and produces a stylesheet the browser silently ignores. Flagged in a warning: literals only, never anything dynamic.

Every value in the section is shown as evaluated mdoc output rather than asserted.

## Report correction

The report ranked `html` first on the grounds that "the typed content model is entirely unnamed." That is not true, and I checked before writing 400 lines against it. `html.md` has had a `## Typed Content Models` section since #1536 landed: it names every marker type (`Dom.Element.Li`, `Cell`, `Tr`, `SelectChild`, `Opt`, `Optgroup`), demonstrates compile-time rejection with an `mdoc:fail` block, and documents structural equality across element classes and the `caption`/`thead` limitation.

The entry now breaks the 40 absent types into groups and says which are conceptual gaps and which are naming artifacts:

| Group | Verdict |
| --- | --- |
| CSS values | Real — resolved by this PR |
| Scala 2 `*Arg` encoding vs Scala 3 union types | Real, and undocumented in either direction |
| `DomModifier` cases, `ToDom`, `ToText` | Real extension points |
| Selector ADT nodes | Naming only — all reachable and demonstrated through the DSL |
| Concrete `*Element` classes | Naming only — the marker traits they implement are documented |
| Interpolator plumbing | Skip — matches the patterns already listed as deliberately undocumented |

`html` remains rank 1, but on corrected grounds: the selector and modifier ADTs are unnamed and the Scala 2 argument encoding is undocumented. It is not the 45-type hole the previous justification implied.

Re-scanned: `html` goes from 46 absent at 32% to **40 absent at 38%**, and repository totals from 331 to 325 absent and 643 to 637 unexplained.

## Verification

- `sbt "docs/mdoc --in docs/reference/html.md"` — **0 errors**. The first run failed with six errors, all from the missing `CssLength._` import, which is how that requirement was discovered.
- Style checker: 15 violations before and after, confirmed by stashing and re-running. The one violation the new section introduced was fixed.

## Not included

Three items remain on the `html` checklist and are deliberately out of scope here: the Scala 2 argument encoding with tabbed examples, the `DomModifier`/`ToDom`/`ToText` extension points, and a selector-node table. Each is independent of this section.
