### PR TITLE
Document the html selector ADT, argument encoding, and modifiers

### DIFF
--- a/docs/reference/html.md
+++ b/docs/reference/html.md
@@ -3,6 +3,9 @@ id: html
 title: "HTML"
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 `zio-blocks-html` is a **type-safe HTML templating library** providing immutable data structures and a fluent DSL for building HTML, CSS, and JavaScript. It offers compile-time safety, automatic XSS protection, and zero-dependency simplicity across Scala 2.13, 3.x, and both JVM and Scala.js platforms.
 
 Core types: `Dom` (HTML tree), `CssSelector` (CSS queries), `DomSelection` (DOM navigation), `Css` (stylesheets), `Js` (JavaScript expressions).
@@ -457,6 +460,88 @@ val card = div(
 ))
 ```
 
+### DomModifier and the Conversion Type Classes
+
+Everything passed to an element factory becomes a `DomModifier` — a deferred description of one modification, collected during construction and applied in a batch. The ADT has four cases:
+
+```scala
+sealed trait DomModifier {
+  def applyTo(element: Dom.Element): Dom.Element
+}
+
+object DomModifier {
+  final case class AddAttr(attr: Dom.Attribute)            extends DomModifier
+  final case class AddChild(child: Dom)                    extends DomModifier
+  final case class AddChildren(children: Chunk[Dom])       extends DomModifier
+  final case class AddEffects(effects: Chunk[DomModifier]) extends DomModifier
+}
+```
+
+`AddEffects` is what makes the ADT recursive, so a group of modifications can be passed as one value and applied as a unit.
+
+`DomModifier#applyTo` applies a single effect and returns the modified element. It is the direct path, and the one to avoid in a loop:
+
+```scala mdoc:silent
+import zio.blocks.html._
+
+val withId = DomModifier.AddAttr(id := "main").applyTo(div)
+```
+
+Each call produces a fresh element, so applying effects one at a time allocates an intermediate per effect:
+
+```scala mdoc
+withId.render
+```
+
+:::note[Prefer the factory for multiple effects]
+`ToModifier.buildFromEffects` — what `div(a, b, c)` calls internally — applies every effect in one pass. Reaching for `DomModifier#applyTo` repeatedly rebuilds the element each time. Use `DomModifier#applyTo` for a single effect computed at runtime, and the factory syntax for everything else.
+:::
+
+`DomModifierConversions` supplies the implicit that turns any `A` with a `ToModifier[A]` instance into a `DomModifier`, which is why strings, elements, and collections can be passed to a factory interchangeably.
+
+#### ToDom
+
+`ToDom[A]` converts a value into a `Dom` node. It is contravariant, and the instance set covers `Dom` itself, `Dom.Element`, `Dom.Text`, `String`, `Int`, `Long`, `Double`, `Boolean`, plus derived instances for `Option` and `Iterable`.
+
+The two derived instances have behaviour worth knowing, because both can produce a node you did not write. `None` becomes `Dom.Empty`, which renders as nothing:
+
+```scala mdoc:silent:reset
+import zio.blocks.html._
+
+val absent  = ToDom[Option[String]].toDom(None)
+val present = ToDom[Option[String]].toDom(Some("hello"))
+```
+
+That is what lets an optional value be dropped into a template without a conditional:
+
+```scala mdoc
+absent.render
+present.render
+```
+
+`Iterable` is the surprising one. An empty collection becomes `Dom.Empty` and a single-element collection becomes that element, but **two or more elements are wrapped in a `<span>`**:
+
+```scala mdoc
+ToDom[Iterable[String]].toDom(Nil).render
+ToDom[Iterable[String]].toDom(List("a")).render
+ToDom[Iterable[String]].toDom(List("a", "b")).render
+```
+
+:::warning[Collections of two or more get a wrapper element]
+`ToDom` has to return a single `Dom`, so a multi-element `Iterable` is wrapped in a `<span>`. That inserts an element into your markup which is invalid inside `<ul>`, `<table>`, and `<select>`, and which affects CSS descendant selectors. To splice a collection without a wrapper, pass it to a factory — `ul(items.map(li(_)))` uses the collection overload and adds the children directly.
+:::
+
+#### ToText
+
+`ToText[A]` converts a value to a plain `String` rather than a DOM node, and is what attribute values and text interpolation use. Instances cover `String`, `Int`, `Long`, `Double`, `Float`, `Boolean`, `Char`, `Byte`, `Short`, `BigInt`, and `BigDecimal`:
+
+```scala mdoc
+ToText[Int].toText(42)
+ToText[BigDecimal].toText(BigDecimal("1.50"))
+```
+
+There is deliberately no `ToText[Dom]`: rendering an element to text is `Dom#render`, which escapes, whereas `ToText` is for values that are already scalar. Providing your own instance is how a domain type becomes usable as an attribute value.
+
 ### Dom.Element.Void
 
 Void HTML elements (`br`, `hr`, `img`, `input`, `meta`, `link`, `area`, `base`, `col`, `embed`, `param`, `source`, `track`, `wbr`) are a **separate type** from `Dom.Element` — they extend `Dom.Element.Void` which extends `Dom` directly (not `Dom.Element`). This means they **structurally cannot have children** — passing a modifier like a string or another element to a void element factory is a **compile-time error**:
@@ -541,6 +626,117 @@ construction path. Elements with permissive content models (`li`, `th`, `td`,
 yet, so tables containing them cannot be built with the `table(...)`
 factory. Compose those tables with the `html""` interpolator or generic
 elements.
+:::
+
+### How the Constraint Is Encoded
+
+The guarantee is the same on both Scala versions, but the signature achieving it is not. Scala 3 uses a union type directly; Scala 2 has no unions, so each constrained factory takes a sealed argument trait with implicit conversions into it:
+
+<Tabs groupId="scala-version" defaultValue="scala2">
+  <TabItem value="scala2" label="Scala 2">
+
+```scala
+sealed trait ListArg
+object ListArg {
+  final case class Attribute(value: Dom.Attribute) extends ListArg
+  final case class Item(value: Dom.Element.Li)     extends ListArg
+
+  implicit def fromAttribute(attribute: Dom.Attribute): ListArg = Attribute(attribute)
+  implicit def fromLi(item: Dom.Element.Li): ListArg            = Item(item)
+}
+
+def ul(effect: ListArg, effects: ListArg*): Dom.Element
+```
+
+  </TabItem>
+  <TabItem value="scala3" label="Scala 3">
+
+```scala
+def ul(
+  effect: Dom.Attribute | Dom.Element.Li,
+  effects: (Dom.Attribute | Dom.Element.Li)*
+): Dom.Element
+```
+
+  </TabItem>
+</Tabs>
+
+Call sites are identical — `ul(id := "menu", li("Home"))` compiles unchanged on both — because the Scala 2 conversions are implicit. The encoding only becomes visible when you name the argument type, which is why these traits exist at all:
+
+| Factory                | Scala 2 argument type | Scala 3 union                                  |
+| ---------------------- | --------------------- | ---------------------------------------------- |
+| `ul(...)`, `ol(...)`   | `ListArg`             | `Dom.Attribute \| Dom.Element.Li`               |
+| `tr(...)`              | `CellArg`             | `Dom.Attribute \| Dom.Element.Cell`             |
+| `table(...)`           | `RowArg`              | `Dom.Attribute \| Dom.Element.Tr`               |
+| `select(...)`          | `SelectArg`           | `Dom.Attribute \| Dom.Element.SelectChild`      |
+| `optgroup(...)`        | `OptgroupArg`         | `Dom.Attribute \| Dom.Element.Opt`              |
+| `script(...)`          | `ScriptArg`           | `Dom.Attribute \| Js`                           |
+| `style(...)`           | `StyleArg`            | `Dom.Attribute \| Css`                          |
+
+`ScriptArg` and `StyleArg` follow the same shape for a different purpose: they admit typed inline source rather than a constrained child, so `script(js"...")` and `style(css"...")` embed a `Js` or `Css` value instead of a string.
+
+Writing a function that forwards to one of these factories is where the difference surfaces. On Scala 2 the parameter type is the argument trait; on Scala 3 it is the union:
+
+<Tabs groupId="scala-version" defaultValue="scala2">
+  <TabItem value="scala2" label="Scala 2">
+
+```scala
+def menu(items: ListArg*): Dom.Element = ul(items.head, items.tail: _*)
+```
+
+  </TabItem>
+  <TabItem value="scala3" label="Scala 3">
+
+```scala
+def menu(items: (Dom.Attribute | Dom.Element.Li)*): Dom.Element =
+  ul(items.head, items.tail*)
+```
+
+  </TabItem>
+</Tabs>
+
+Taking `Iterable[Dom.Element.Li]` avoids the difference entirely, since every constrained factory also has a collection overload that is spelled the same on both versions.
+
+### Concrete Element Classes
+
+The marker traits are implemented by case classes named after their tag: `LiElement`, `ThElement`, `TdElement`, `TrElement`, `OptElement`, and `OptgroupElement`. Each holds `attributes` and `children` and hard-codes its `tag`, which is what makes a value typed `Dom.Element.Li` guaranteed to render as `<li>`.
+
+You do not normally name them — the factories return the marker trait, not the implementation — but they appear in pattern matches over a DOM tree and in `toString` output. Because equality is structural, matching on `Dom.Element.Generic` will *not* catch a factory-produced `li`, even though the two are equal:
+
+```scala mdoc:silent
+import zio.blocks.html._
+
+val item = li("Home")
+```
+
+The factory returns the marker type, and the runtime class is the implementation behind it:
+
+```scala mdoc
+item.getClass.getSimpleName
+```
+
+Matching against `Generic` at that static type does not merely fail — it does not compile. `Dom.Element.Li` and `Generic` are disjoint, so the compiler reports the case as unreachable:
+
+```scala mdoc:fail
+item match {
+  case _: Dom.Element.Generic => "matched Generic"
+  case _                      => "no match"
+}
+```
+
+Widening to `Dom.Element` makes the match legal, and then `Generic` simply does not match:
+
+```scala mdoc
+val widened: Dom.Element = item
+widened match {
+  case _: Dom.Element.Generic => "matched Generic"
+  case _: Dom.Element.Li      => "matched Li"
+  case _                      => "no match"
+}
+```
+
+:::note[Structural equality, disjoint types]
+`li("Home") == Generic("li", ...)` is `true`, but `LiElement` is not a `Generic` and never matches one. Equality is structural and crosses classes; the types do not. Match on the marker trait, or on `Dom.Element` plus `tag`, rather than on a concrete class.
 :::
 
 ### Equality Across Element Classes
@@ -745,6 +941,80 @@ val containsClass = input.withAttributeContaining("class", "btn")  // input[clas
 val startsWithHref = a.withAttributeStarting("href", "https")      // a[href^="https"]
 val endsWithPng = img.withAttributeEnding("src", ".png")           // img[src$=".png"]
 ```
+
+### The Selector ADT
+
+The DSL operators are constructors: each one builds a `CssSelector` node, and the result is an ordinary sealed ADT you can pattern match on. That matters when a selector arrives from elsewhere — a stylesheet you are rewriting, a rule you are inspecting — rather than being written inline.
+
+Every operator and its node:
+
+| Expression                              | Node                                    | Renders as        |
+| --------------------------------------- | --------------------------------------- | ----------------- |
+| `CssSelector.Element("div")`            | `Element(tag)`                           | `div`             |
+| `CssSelector.Class("active")`           | `Class(name)`                            | `.active`         |
+| `CssSelector.Id("header")`              | `Id(name)`                               | `#header`         |
+| `CssSelector.Universal`                 | `Universal`                              | `*`               |
+| `div > span`                            | `Child(parent, child)`                   | `div > span`      |
+| `div >> span`                           | `Descendant(parent, descendant)`         | `div span`        |
+| `div + span`                            | `AdjacentSibling(previous, next)`        | `div + span`      |
+| `div ~ span`                            | `GeneralSibling(previous, sibling)`      | `div ~ span`      |
+| `div & CssSelector.Class("active")`     | `And(left, right)`                       | `div.active`      |
+| `div \| span`                           | `Or(left, right)`                        | `div, span`       |
+| `a.hover`                               | `PseudoClass(inner, pseudoClass)`        | `a:hover`         |
+| `div.before`                            | `PseudoElement(inner, pseudoElement)`    | `div::before`     |
+| `input.withAttribute("type")`           | `Attribute(inner, attribute, matcher)`   | `input[type]`     |
+| `CssSelector.Not(inner, negated)`       | `Not(inner, negated)`                    | `div:not(.hidden)`|
+| `CssSelector.Raw("...")`                | `Raw(value)`                             | verbatim          |
+
+Because the nodes are recursive, a selector built with operators nests rather than flattening:
+
+```scala mdoc:silent
+import zio.blocks.html._
+
+val selector = div >> span & CssSelector.Class("active")
+```
+
+Matching on the outermost node tells you which operator produced it:
+
+```scala mdoc
+selector.render
+selector match {
+  case CssSelector.And(left, right) => s"And(${left.render}, ${right.render})"
+  case other                        => other.getClass.getSimpleName
+}
+```
+
+`CssSelector.Raw` is the escape hatch for syntax the ADT does not model. It renders verbatim, so nothing validates it:
+
+```scala mdoc
+CssSelector.Raw("div:has(> img)").render
+```
+
+#### Attribute Matchers
+
+`CssSelector.Attribute` carries an `Option[AttributeMatch]`. `None` tests for presence alone; the six matchers correspond to the CSS attribute operators:
+
+| Builder                                    | Matcher                        | Renders as              |
+| ------------------------------------------ | ------------------------------ | ----------------------- |
+| `withAttribute(name)`                      | `None`                          | `[name]`                |
+| `withAttribute(name, value)`               | `Exact(value)`                  | `[name="value"]`        |
+| `withAttributeContaining(name, value)`     | `Contains(value)`               | `[name*="value"]`       |
+| `withAttributeStarting(name, value)`       | `StartsWith(value)`             | `[name^="value"]`       |
+| `withAttributeEnding(name, value)`         | `EndsWith(value)`               | `[name$="value"]`       |
+| —                                          | `WhitespaceContains(value)`     | `[name~="value"]`       |
+| —                                          | `HyphenPrefix(value)`           | `[name\|="value"]`      |
+
+`WhitespaceContains` and `HyphenPrefix` have no builder method, so construct them through `CssSelector.Attribute` directly:
+
+```scala mdoc
+CssSelector.Attribute(
+  CssSelector.Element("div"),
+  "class",
+  Some(CssSelector.AttributeMatch.WhitespaceContains("card"))
+).render
+```
+
+`WhitespaceContains` matches one word in a space-separated list, which is the correct matcher for a single class among several; `HyphenPrefix` matches a value or that value followed by a hyphen, which is what `lang` attributes need.
 
 ## DOM Querying with DomSelection
 

--- a/docs/undocumented-report.md
+++ b/docs/undocumented-report.md
@@ -28,15 +28,15 @@ Every figure in this revision, including those four, is restated under the priva
 | Declarations found (`class` / `trait` / `object` / `enum`) | 2,662 |
 | — of which public | 1,811 |
 | — of which private or nested in a private scope | 864 |
-| Public types never named anywhere in `docs/` | **325** |
-| Public types with no prose or heading reference | **637** |
-| Name-mention coverage | **82%** |
-| Explained-type coverage | **65%** |
+| Public types never named anywhere in `docs/` | **294** |
+| Public types with no prose or heading reference | **615** |
+| Name-mention coverage | **84%** |
+| Explained-type coverage | **66%** |
 
 Two coverage numbers are reported because they answer different questions.
 
-- **Name-mention coverage** counts a type as covered if its name appears anywhere in `docs/`, including inside an example code block. Its complement — 325 types — is entirely absent from the documentation.
-- **Explained-type coverage** is stricter: it requires the name in prose (inline code) or in a heading. Its complement — 637 types — additionally captures the 312 types that appear only as tokens inside examples and are never explained.
+- **Name-mention coverage** counts a type as covered if its name appears anywhere in `docs/`, including inside an example code block. Its complement — 294 types — is entirely absent from the documentation.
+- **Explained-type coverage** is stricter: it requires the name in prose (inline code) or in a heading. Its complement — 615 types — additionally captures the 321 types that appear only as tokens inside examples and are never explained.
 
 Only **public** types are counted. A type is public when neither it nor any enclosing declaration is `private` or `protected` — 864 declarations fail that test and are excluded, which is roughly a third of everything declared. Earlier revisions of this report counted many of them as API and mis-scoped work as a result; see *Methodology*.
 
@@ -51,7 +51,7 @@ This report file is excluded from the scan, so listing a type here does not make
 | Module | public | internal | absent | unexpl | cov | srcLOC | docLOC | ratio |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
 | mediatype | 16 | 2 | 2 | 11 | 31% | 12,676 | 460 | 0.04 |
-| **html** | 110 | 13 | 40 | 68 | **38%** | 5,591 | 1,300 | 0.23 |
+| html | 110 | 13 | 9 | 47 | 57% | 5,591 | 1,570 | 0.28 |
 | maybe | 10 | 0 | 6 | 6 | 40% | 595 | 943 | 1.58 |
 | context | 2 | 7 | 1 | 1 | 50% | 865 | 553 | 0.64 |
 | **typeid** | 90 | 14 | 26 | 43 | **52%** | 6,493 | 2,124 | 0.33 |
@@ -317,15 +317,16 @@ Actions:
 
 ### 12. Smaller module gaps
 
-- **`html`** (68 unexplained, 40 absent) — **the rank-1 justification in the table above was wrong and is corrected here.** An earlier revision of this entry claimed the typed content model was "entirely unnamed"; it is not. `html.md` has had a `## Typed Content Models` section since #1536 landed, naming every marker type (`Dom.Element.Li`, `Cell`, `Tr`, `SelectChild`, `Opt`, `Optgroup`), demonstrating compile-time rejection with an `mdoc:fail` block, and documenting structural equality across element classes and the `caption`/`thead` limitation. The 40 absent types break down as follows, and only two groups are conceptual gaps:
-  - **Real: CSS values — resolved.** `CssLength`'s unit set and numeric extension methods, and four of `CssColor`'s five cases, had no mention anywhere. The page's one example used the verbose `CssLength(300.0, "px")` while `300.px` existed unmentioned, so the docs actively steered readers to the clunkier API. A `### Typed Values: Lengths and Colors` section now covers the 15 valid units, `CssLengthIntOps`/`CssLengthDoubleOps` and the second import they require, all five `CssColor` cases, and the `Hex` versus `Hex.unsafe` validation split.
-  - **Real: the Scala 2 argument encoding.** `ListArg` ✗, `CellArg` ✗, `RowArg` ✗, `SelectArg` ✗, `OptgroupArg` ✗, `ScriptArg` ✗, and `StyleArg` ✗ are how the content model is expressed on 2.13 — sealed traits plus implicit conversions, where Scala 3 uses union types (`Dom.Attribute | Dom.Element.Li`). The content-model table writes the Scala 3 form only, and no page mentions that the encodings differ. This needs tabbed examples per the writing-style rule on version-specific syntax.
-  - **Real: extension points.** `DomModifier` ✗ and its four cases (`AddAttr` ✗, `AddChild` ✗, `AddChildren` ✗, `AddEffects` ✗), plus the `ToDom` ✗ and `ToText` ✗ conversion type classes. `ToModifier` is named in the page; these are not.
-  - **Naming only: selector ADT nodes.** `Descendant` ✗, `AdjacentSibling` ✗, `GeneralSibling` ✗, `AttributeMatch` ✗, `StartsWith` ✗, `EndsWith` ✗, `WhitespaceContains` ✗, `HyphenPrefix` ✗, `PseudoClass` ✗, `PseudoElement` ✗. Every one is reachable and demonstrated through the DSL (`div >> span`, `a.hover`, `input.withAttributeStarting(...)`); only the resulting node types are unnamed. Worth a short table for readers pattern matching on a built selector, not a section.
-  - **Naming only: concrete element classes.** `LiElement` ✗, `ThElement` ✗, `TdElement` ✗, `TrElement` ✗, `OptElement` ✗, `OptgroupElement` ✗ — the implementations behind the documented marker traits.
-  - **Skip: interpolator plumbing.** `CssStringContext` ✗, `HtmlStringContext` ✗, `JsStringContext` ✗, `SelectorStringContext` ✗, `TemplateInterpolators` ✗, `InterpolatorRuntime` ✗, `HtmlElements` ✗, `DomModifierConversions` ✗, `LowPriorityToJs` ✗, `JsValue` ✗. These match the naming patterns in *Deliberately Undocumented*; the interpolator syntax is documented, its machinery should not be.
-  - [ ] Add an ADT reference section naming the selector, colour, and modifier types behind the DSL
-- **`datastar`** (28 unexplained) — same shape: `EventModifier` ✗, `CaseModifier` ✗, `InitModifier` ✗, `IntersectModifier` ✗, `OnIntervalModifier` ✗, `OnSignalPatchModifier` ✗, `DataOn` ✗, `PatchSignals` ✗, `PatchElements` ✗, `DatastarAttributes` ✗, `DatastarAttrKey` ✗, `ToDatastarExpr` ✗, `DataSignalsBuilder` ✗, `EventType` ✗. The 0.18 ratio is the bigger problem: 346 lines for 1,881 source lines.
+- **`html`** — **RESOLVED.** An earlier revision of this entry claimed the typed content model was "entirely unnamed"; it was not, and checking that before writing changed the scope. `html.md` has had a `## Typed Content Models` section since #1536 landed, naming every marker type and demonstrating compile-time rejection with an `mdoc:fail` block. The genuine gaps were elsewhere, and all four are now closed:
+  - **CSS values.** `### Typed Values: Lengths and Colors` covers the 15 valid `CssLength` units, `CssLengthIntOps`/`CssLengthDoubleOps` and the second import they require, all five `CssColor` cases, and the `Hex` versus `Hex.unsafe` validation split.
+  - **The Scala 2 argument encoding.** `### How the Constraint Is Encoded` shows the sealed argument traits (`ListArg`, `CellArg`, `RowArg`, `SelectArg`, `OptgroupArg`, `ScriptArg`, `StyleArg`) beside the Scala 3 unions in tabs, and the forwarding function where the difference actually surfaces.
+  - **The selector ADT.** `### The Selector ADT` maps every DSL operator to the node it constructs and documents the six `AttributeMatch` matchers, including that `WhitespaceContains` and `HyphenPrefix` have no builder method.
+  - **Modifiers and conversions.** `### DomModifier and the Conversion Type Classes` covers the four `DomModifier` cases, `applyTo` versus the batched `buildFromEffects`, and the `ToDom`/`ToText` instance sets — including that a multi-element `Iterable` is wrapped in a `<span>`, which is invalid inside `ul`, `table`, and `select`.
+
+  Also documented: the concrete `*Element` classes, and that equality is structural across classes while the *types* are disjoint — matching a factory-produced `li` against `Generic` is rejected by the compiler as unreachable, not merely unmatched.
+
+  The module went from 46 absent at 32% to **9 absent at 57%**. All nine remaining are interpolator plumbing — `CssStringContext` ✗, `HtmlStringContext` ✗, `JsStringContext` ✗, `SelectorStringContext` ✗, `TemplateInterpolators` ✗, `InterpolatorRuntime` ✗, `HtmlElements` ✗, `LowPriorityToJs` ✗, `JsValue` ✗ — which match the patterns in *Deliberately Undocumented*. The interpolator syntax is documented; its machinery should not be.
+- **`datastar`** (28 unexplained) — a type-naming gap of the same kind html had: `EventModifier` ✗, `CaseModifier` ✗, `InitModifier` ✗, `IntersectModifier` ✗, `OnIntervalModifier` ✗, `OnSignalPatchModifier` ✗, `DataOn` ✗, `PatchSignals` ✗, `PatchElements` ✗, `DatastarAttributes` ✗, `DatastarAttrKey` ✗, `ToDatastarExpr` ✗, `DataSignalsBuilder` ✗, `EventType` ✗. The 0.18 ratio is the bigger problem: 346 lines for 1,881 source lines.
   - [ ] Expand `datastar.md` — each SSE event type needs a worked example; add an attribute-DSL type reference
 - **`schema-xml`** (15 unexplained) — `XmlCodecError` ✗, `XmlWriter` ✗, `XmlCodecDeriver` ✗ (657 lines), `SetAttribute` ✗, `RemoveAttribute` ✗, `ElementBuilder` ✗
   - [ ] Add error-handling and deriver/customization sections to `built-in-codecs/xml.md`
@@ -401,14 +402,14 @@ Ordered by user impact per unit of writing effort. The ranking below predates th
 
 | Rank | Module | absent / public | cov | Why |
 | ---- | ------ | --------------- | ---- | --- |
-| 1 | `html` | 40 / 110 | **38%** | Selector and modifier ADTs unnamed, and the Scala 2 argument encoding is undocumented |
-| 2 | `maybe` | 6 / 10 | 40% | Small surface, but more than half of it unnamed |
-| 3 | `typeid` | 26 / 90 | 52% | `Member` ADT and owner segments |
-| 4 | `schema-xml` | 9 / 38 | 53% | Error types and the deriver |
-| 5 | `schema` | 156 / 466 | 56% | Largest absolute, but six separable subsystems remain |
+| 1 | `typeid` | 26 / 90 | **52%** | `Member` ADT and owner segments |
+| 2 | `schema-xml` | 9 / 38 | **53%** | Error types and the deriver |
+| 3 | `schema` | 156 / 466 | 56% | Largest absolute, but six separable subsystems remain |
+| 4 | `scope` | 6 / 23 | 61% | `WireInfo`, `WireKind` |
+| 5 | `codegen` | 6 / 46 | 63% | Import forms, `ExtensionBlock`, `NestedType` |
 | 6 | `endpoint` | 18 / 60 | 67% | `Alternator`, `CanCombine`, segment shortcuts |
 
-`smithy` has left the list — the shape catalog took it from 24% to 86% with no absent types. `streams` and `async` drop out entirely once internal declarations are excluded. `htmx` and `datastar` left earlier: #1619 took `htmx` to 77%, and the five-page datastar split took it to 98%.
+`smithy` and `html` have both left the list — the shape catalog took `smithy` from 24% to 86% with no absent types, and the CSS-value, selector-ADT, argument-encoding, and modifier sections took `html` from 32% to 57% with 9 absent types, all of them interpolator plumbing that is deliberately undocumented. `maybe` stays off the list as permanently skippable. `streams` and `async` drop out entirely once internal declarations are excluded. `htmx` and `datastar` left earlier: #1619 took `htmx` to 77%, and the five-page datastar split took it to 98%.
 
 `html` grew from 100 public types to 110 between revisions while its documentation did not, which is the one row where waiting makes the work larger.
 
@@ -447,7 +448,7 @@ Ordered by user impact per unit of writing effort. The ranking below predates th
 25. - [ ] Expand `datastar.md` (ratio 0.18)
 26. - [ ] Expand `async.md` (ratio 0.20) — the user-facing direct-style surface, not the CPS internals
 27. - [x] Expand `smithy.md` — **done**: ratio 0.21 → 0.34 (533 → 881 lines)
-28. - [ ] Expand `html.md` with the Scala 2 argument encoding, the `DomModifier`/`ToDom`/`ToText` extension points, and a selector-node table — CSS values done
+28. - [x] Expand `html.md` — **done**: CSS values, the Scala 2 argument encoding in tabs, the selector ADT with its attribute matchers, and the `DomModifier`/`ToDom`/`ToText` extension points; module went from 32% to 57% with only interpolator plumbing absent
 
 **Tier 4 — conceptual documents**
 


### PR DESCRIPTION
## What

Closes the remaining `html` documentation gaps identified in #1643, which corrected the module's coverage entry after finding its rank-1 justification was wrong. That entry split the absent types into six groups and named four as genuine gaps; this PR closes three of them (the fourth, CSS values, landed in #1643).

The module goes from **40 absent types at 38% coverage to 9 at 57%**, and all nine remaining are interpolator plumbing already listed as deliberately undocumented — which is exactly what the classification predicted.

## Changes

### `### The Selector ADT`

The DSL operators are constructors, and the `CssSelector` they build is an ordinary sealed ADT — but no page named the nodes, so a selector arriving from elsewhere (a stylesheet being rewritten, a rule being inspected) could not be matched on.

Adds a table mapping every operator and builder to the node it produces, plus a second table for the six `AttributeMatch` matchers. Two of those matchers, `WhitespaceContains` and `HyphenPrefix`, have no builder method on the fluent API and must be constructed through `CssSelector.Attribute` directly — easy to miss, and they are the correct matchers for "one class among several" and for `lang`-style values respectively.

### `### How the Constraint Is Encoded`

The content-model table wrote the Scala 3 union form only (`Th | Td`), and nothing said the encodings differ. Scala 2 has no union types, so each constrained factory takes a sealed argument trait with implicit conversions into it:

| Factory | Scala 2 | Scala 3 |
| --- | --- | --- |
| `ul` / `ol` | `ListArg` | `Dom.Attribute \| Dom.Element.Li` |
| `tr` | `CellArg` | `Dom.Attribute \| Dom.Element.Cell` |
| `table` | `RowArg` | `Dom.Attribute \| Dom.Element.Tr` |
| `select` | `SelectArg` | `Dom.Attribute \| Dom.Element.SelectChild` |
| `optgroup` | `OptgroupArg` | `Dom.Attribute \| Dom.Element.Opt` |
| `script` | `ScriptArg` | `Dom.Attribute \| Js` |
| `style` | `StyleArg` | `Dom.Attribute \| Css` |

Call sites are identical on both versions because the conversions are implicit. The difference surfaces only when writing a function that forwards to one of these factories, which is now shown in tabs.

### `### DomModifier and the Conversion Type Classes`

Documents the four `DomModifier` cases, `DomModifier#applyTo` versus the batched `ToModifier.buildFromEffects`, and the `ToDom` and `ToText` instance sets.

Two `ToDom` behaviours were previously invisible and both can produce markup you did not write. `None` becomes `Dom.Empty`, which is the mechanism that lets an optional value be dropped into a template without a conditional. And an `Iterable` of two or more elements is **wrapped in a `<span>`**:

```scala
ToDom[Iterable[String]].toDom(List("a", "b")).render
// "<span>ab</span>"
```

That wrapper is invalid inside `<ul>`, `<table>`, and `<select>`, and it changes descendant selectors. The collection overloads on the factories (`ul(items.map(li(_)))`) add children directly and avoid it — now stated in a warning.

### `### Concrete Element Classes`

Documents `LiElement` and friends, and a consequence of how they relate to `Generic` that is easy to get wrong: equality is structural and crosses classes, so `li("Home") == Generic("li", ...)` is `true` — but the *types* are disjoint, so matching a factory-produced `li` against `Generic` is rejected by the compiler as unreachable rather than merely not matching. Shown with an `mdoc:fail` block.

## Verification

- `sbt "docs/mdoc --in docs/reference/html.md"` — **0 errors**. Four runs; two intermediate failures shaped the content rather than just being fixed:
  - `div()` does not compile (`apply` requires at least one effect), so the example uses the bare `div` value.
  - The unreachable-case error above was the compiler making a stronger point than my original prose, which had claimed the match merely fails at runtime. The section now documents what the compiler actually does.
- `sbt "++2.13; check"` — **success**.
- Style checker: 20 violations against a baseline of 15, stash-verified. Four of the five new ones are inherent to the tabs structure the writing-style skill prescribes — a `<TabItem>` line precedes each fence, so Rule 15's "prose ending in a colon" cannot be satisfied. The fifth is a `.active` CSS class in a table's rendering column being read as a method reference. Every violation that was genuinely mine is fixed.

Also adds the `Tabs` and `TabItem` MDX imports the version-specific examples require.

## Report update

`html` is marked resolved with its four closed gaps enumerated, and the ranking is re-done: `html` and `smithy` both leave the list and `typeid` becomes rank 1 at 52%. The ranking table is also repaired — an earlier edit of mine left `schema` listed twice and the rows out of coverage order.

Repository totals move from 325 to 294 absent and 637 to 615 unexplained.
