### PR TITLE
feat(endpoint): allow external endpoint refs in bulk DSL

### DIFF
--- a/endpoint/shared/src/main/scala-3.7/zio/blocks/endpoint/EndpointGroupMacro.scala
+++ b/endpoint/shared/src/main/scala-3.7/zio/blocks/endpoint/EndpointGroupMacro.scala
@@ -224,6 +224,24 @@ private[endpoint] object EndpointGroupMacro {
       }
     }
 
+    def extractExternalName(term: Term): Option[String] = {
+      def strip(t: Term): Term = t match {
+        case Inlined(_, _, inner) => strip(inner)
+        case Typed(inner, _)      => strip(inner)
+        case Block(_, inner)      => strip(inner)
+        case TypeApply(inner, _)  => strip(inner)
+        case _                    => t
+      }
+      strip(term) match {
+        case Ident(name)     => Some(name)
+        case Select(_, name) => Some(name)
+        case _               => None
+      }
+    }
+
+    def endpointName(term: Term): String =
+      extractExternalName(term).getOrElse(autoName(term))
+
     def collectMembers(stats: List[Statement]): List[(String, Term, Boolean)] = {
       val raw = stats.flatMap {
         case vd: ValDef if vd.rhs.nonEmpty =>
@@ -236,7 +254,7 @@ private[endpoint] object EndpointGroupMacro {
             )
           }
         case app: Term if isEndpoint(app.tpe) =>
-          val name = autoName(app)
+          val name = endpointName(app)
           Some((name, app, false))
         case other: Term =>
           isNestedSubgroupStmt(other) match {
@@ -706,7 +724,7 @@ private[endpoint] object EndpointGroupMacro {
                 case None =>
                   if (isEndpoint(t.tpe)) {
                     val expr = wrapLeaf(t, resolveGlobal(codecsAcc))
-                    buildNamedTuple(List(autoName(t)), List(expr))
+                    buildNamedTuple(List(endpointName(t)), List(expr))
                   } else
                     report.errorAndAbort(
                       s"endpoints { ... } only accepts `val name = Endpoint(...)` statements, bare `Endpoint(...)` or `prefix / endpoints { ... }`; found unsupported expression of type ${t.tpe.show}"

--- a/endpoint/shared/src/main/scala-3.7/zio/blocks/endpoint/EndpointGroupSyntax.scala
+++ b/endpoint/shared/src/main/scala-3.7/zio/blocks/endpoint/EndpointGroupSyntax.scala
@@ -16,6 +16,8 @@
 
 package zio.blocks.endpoint
 
+import scala.language.implicitConversions
+
 /**
  * Defines a group of HTTP endpoints in a single block and returns them as a
  * statically-typed [[scala.NamedTuple]].
@@ -44,6 +46,16 @@ package zio.blocks.endpoint
  */
 transparent inline def endpoints(inline body: Any): Any =
   ${ EndpointGroupMacro.build('body) }
+
+/**
+ * Auto-convert a constant String prefix to a literal `PathCodec[Unit]` so that
+ * `"api" / endpoints { ... }` goes through the `PathCodec` `/` extension.
+ * Available via `import zio.blocks.endpoint.*`.
+ */
+given Conversion[String, PathCodec[Unit] { type PathVars = SegmentCodec.NoPathVars }] with {
+  def apply(value: String): PathCodec[Unit] { type PathVars = SegmentCodec.NoPathVars } =
+    PathCodec.literal(value)
+}
 
 extension [A, PV](codec: PathCodec[A] { type PathVars = PV }) {
 

--- a/endpoint/shared/src/test/scala-3.7/zio/blocks/endpoint/EndpointGroupSpec.scala
+++ b/endpoint/shared/src/test/scala-3.7/zio/blocks/endpoint/EndpointGroupSpec.scala
@@ -21,6 +21,7 @@ import zio.blocks.endpoint.RoutePattern.*
 import zio.http.Method
 import zio.http.Path
 import zio.test.*
+import scala.annotation.nowarn
 import scala.language.implicitConversions
 import scala.compiletime.testing.typeCheckErrors
 
@@ -40,7 +41,7 @@ object EndpointGroupSpec extends ZIOSpecDefault {
       },
       test("empty block returns NamedTuple[EmptyTuple, EmptyTuple]") {
         val group = endpoints {}
-        assertTrue(group.isInstanceOf[scala.NamedTuple.NamedTuple[EmptyTuple, EmptyTuple]])
+        assertTrue(group == NamedTuple(EmptyTuple))
       },
       test("single val block returns 1-member NamedTuple") {
         val group = endpoints {
@@ -311,7 +312,7 @@ val _ = endpoints { "not an endpoint" }
         val gBool = endpoints { val a = Endpoint(Method.GET / PathCodec.bool("b")) }
         val gLong = endpoints { val a = Endpoint(Method.GET / PathCodec.long("l")) }
         val gUuid = endpoints { val a = Endpoint(Method.GET / PathCodec.uuid("u")) }
-        val uuid  = java.util.UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+        val uuid  = java.util.UUID.randomUUID()
         assertTrue(
           gStr.a.route.decode(Method.GET, Path("/hello")) == Right("hello"),
           gBool.a.route.decode(Method.GET, Path("/true")) == Right(true),
@@ -355,35 +356,58 @@ val _ = endpoints { "not an endpoint" }
       }
     ),
     suite("endpoints macro external refs")(
-      test("external PathCodec can be referenced inside endpoints") {
-        val extCodec = PathCodec.int("extId")
-        val group    = endpoints {
-          val a = Endpoint(Method.GET / extCodec / "items")
-        }
-        assertTrue(group.a.route.render == "GET /{extId}/items")
+      test("bare external ref val x = Endpoint(GET / outside); endpoints { x } -> member .x") {
+        val x = Endpoint(Method.GET / "outside")
+        val g = endpoints { x }
+        assertTrue(g.x.route.render == "GET /outside")
       },
-      test("external PathCodec as prefix via /") {
-        val myCodec = PathCodec.int("myId")
-        val group   = myCodec / endpoints {
-          val a = Endpoint(Method.GET / "items")
-        }
-        assertTrue(group.a.route.render == "GET /{myId}/items")
+      test("alias val y = x inside block") {
+        val x = Endpoint(Method.GET / "outside")
+        val g = endpoints { val y = x }
+        assertTrue(g.y.route.render == "GET /outside")
       },
-      test("external codecs and schemas can be referenced together") {
-        import zio.blocks.schema.Schema
-        val ext   = PathCodec.string("ext")
-        val group = endpoints {
-          val a = Endpoint(Method.GET / ext).query("q", Schema.int)
-        }
-        assertTrue(group.a.route.render == "GET /{ext}")
+      test("multiple external refs endpoints { x; y } with different routes") {
+        val x = Endpoint(Method.GET / "outside")
+        val y = Endpoint(Method.POST / "other")
+        @nowarn("msg=pure expression")
+        val g = endpoints { x; y }
+        assertTrue(
+          g.x.route.render == "GET /outside",
+          g.y.route.render == "POST /other"
+        )
       },
-      test("external val config referenced in endpoint query") {
-        import zio.blocks.schema.Schema
-        val limitSchema = Schema.int
-        val group       = endpoints {
-          val a = Endpoint(Method.GET / "paged").query("limit", limitSchema)
+      test("prefix composition \"api\" / endpoints { x } -> GET /api/outside") {
+        val x = Endpoint(Method.GET / "outside")
+        val g = "api" / endpoints { x }
+        assertTrue(g.x.route.render == "GET /api/outside")
+      },
+      test("capturing prefix PathCodec.int(\"id\") / endpoints { x } -> GET /{id}/orders + static PathInput widening") {
+        val x   = Endpoint(Method.GET / "orders")
+        val g   = PathCodec.int("id") / endpoints { x }
+        val _: RoutePattern[Int] = g.x.route
+        assertTrue(g.x.route.render == "GET /{id}/orders")
+      },
+      test("nested \"api\" / endpoints { PathCodec.int(\"id\") / endpoints { x } }") {
+        val x = Endpoint(Method.GET / "orders")
+        val g = "api" / endpoints {
+          PathCodec.int("id") / endpoints { x }
         }
-        assertTrue(group.a.route.render == "GET /paged")
+        assertTrue(g.id.x.route.render == "GET /api/{id}/orders")
+      },
+      test("duplicate detection endpoints { x; x } should fail with typeCheckErrors") {
+        val errors = typeCheckErrors("""
+import zio.blocks.endpoint.*
+import zio.blocks.endpoint.RoutePattern.*
+import zio.http.Method
+val x = Endpoint(Method.GET / "outside")
+val _ = endpoints { x; x }
+""")
+        assertTrue(errors.nonEmpty && errors.exists(_.message.contains("duplicate")))
+      },
+      test("qualified Select Outer.x -> .x") {
+        object Outer { val x = Endpoint(Method.GET / "outside") }
+        val g = endpoints { Outer.x }
+        assertTrue(g.x.route.render == "GET /outside")
       }
     ),
     suite("endpoints macro intra-group rejection")(


### PR DESCRIPTION
Follow-up to #1614

Allow referencing endpoints fully defined outside the `endpoints { ... }` block:

```scala
val x = Endpoint(Method.GET / "outside")

endpoints { x }           // -> member .x (was: cannot auto-name)
endpoints { val y = x }   // -> member .y (already worked, now tested)
"api" / endpoints { x }                         // -> GET /api/outside
PathCodec.int("id") / endpoints { x }           // -> GET /{id}/outside + PathInput widening
"api" / endpoints { PathCodec.int("id") / endpoints { x } } // nested
Outer.x // qualified Select -> .x
```

**Change:**
- `EndpointGroupMacro.extractExternalName` strips `Inlined`/`Typed`/`Block` and matches `Ident(name)`/`Select(_,name)` → `Some(name)`
- `endpointName = extractExternalName.getOrElse(autoName)` in `collectMembers` and tail `isEndpoint(t)` case
- `wrapLeaf` now uses `widen.dealias` + `baseType` fallback to handle singleton `x.type` for prefix composition
- Tests: 8 new tests in `suite("endpoints macro external refs")` (bare, alias, multiple, prefix, capturing, nested, duplicate, qualified)

**Verification:**
- `++3.8.3; endpointJVM/Test/compile` green
- `endpointJVM/testOnly EndpointGroupSpec` 50 passed (36 in task2-ws legacy)
