### PR TITLE
fix(config): close config review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,9 @@ jobs:
     - name: Run Scala 3 tests with test coverage (JDK 25, skip docs due to scaladoc bug)
       if: ${{ (startsWith(matrix.scala, '3.')) && (matrix.java >= 25) }}
       run: sbt ++${{ matrix.scala }} coverage test${{ matrix.platform }} coverageReport
+    - name: Run Scala 3 config adapter coverage (JDK 25, scoped)
+      if: ${{ (startsWith(matrix.scala, '3.')) && (matrix.java >= 25) }}
+      run: sbt ++${{ matrix.scala }} configCoverage
     - name: Run Scala Next tests
       if: ${{ matrix.scala == '3.8.x' }}
       run: sbt ++3.8.3 scalaNextTests${{ matrix.platform }}/test benchmarks/test

--- a/build.sbt
+++ b/build.sbt
@@ -912,6 +912,13 @@ lazy val `config-yaml` = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings("zio.blocks.config.yaml"))
   .enablePlugins(BuildInfoPlugin)
   .jvmSettings(mimaSettings(failOnProblem = false))
+  .jvmSettings(
+    // Forked JVM is required for scoverage to correctly write measurements after `clean`:
+    // with Test/fork := false the instrumented classes run in sbt's JVM and the
+    // measurements file is not flushed when `clean` is executed in project scope
+    // (e.g. `project config-yamlJVM; clean; coverage; test; coverageReport` reports 0%).
+    Test / fork := true
+  )
   .jsSettings(jsSettings)
   .settings(
     libraryDependencies ++= Seq(
@@ -919,7 +926,7 @@ lazy val `config-yaml` = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test-sbt" % "2.1.26" % Test
     ),
     // Measured 2026-08-31 Scala 3.8.3 JVM via `project config-yamlJVM; coverage; test; coverageReport`:
-    // Statement 72.22%, Branch 66.67%. Set just below with modest margin.
+    // Statement 72.22%, Branch 66.67% (clean 72.22% with fork). Set just below with modest margin.
     coverageMinimumStmtTotal   := 71,
     coverageMinimumBranchTotal := 65
   )
@@ -932,6 +939,10 @@ lazy val `config-json` = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings("zio.blocks.config.json"))
   .enablePlugins(BuildInfoPlugin)
   .jvmSettings(mimaSettings(failOnProblem = false))
+  .jvmSettings(
+    // Forked JVM required for clean coverage (see config-yaml comment).
+    Test / fork := true
+  )
   .jsSettings(jsSettings)
   .settings(
     libraryDependencies ++= Seq(
@@ -939,7 +950,7 @@ lazy val `config-json` = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test-sbt" % "2.1.26" % Test
     ),
     // Measured 2026-08-31 Scala 3.8.3 JVM via `project config-jsonJVM; coverage; test; coverageReport`:
-    // Statement 92.59%, Branch 86.67%. Set just below with modest margin.
+    // Statement 92.59%, Branch 86.67% (clean 92.59% with fork). Set just below with modest margin.
     coverageMinimumStmtTotal   := 91,
     coverageMinimumBranchTotal := 85
   )
@@ -952,6 +963,10 @@ lazy val `config-hocon` = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings("zio.blocks.config.hocon"))
   .enablePlugins(BuildInfoPlugin)
   .jvmSettings(mimaSettings(failOnProblem = false))
+  .jvmSettings(
+    // Forked JVM required for clean coverage (see config-yaml comment).
+    Test / fork := true
+  )
   .jsSettings(jsSettings)
   .settings(
     libraryDependencies ++= Seq(
@@ -959,7 +974,7 @@ lazy val `config-hocon` = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test-sbt" % "2.1.26" % Test
     ),
     // Measured 2026-08-31 Scala 3.8.3 JVM via `project config-hoconJVM; coverage; test; coverageReport`:
-    // Statement 77.58%, Branch 67.84%. Set just below with modest margin.
+    // Statement 76.30-77.58%, Branch 67.54-67.84% (clean 76.30/67.54 with fork). Set just below with modest margin.
     coverageMinimumStmtTotal   := 76,
     coverageMinimumBranchTotal := 66
   )

--- a/build.sbt
+++ b/build.sbt
@@ -918,8 +918,10 @@ lazy val `config-yaml` = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test"     % "2.1.26" % Test,
       "dev.zio" %%% "zio-test-sbt" % "2.1.26" % Test
     ),
-    coverageMinimumStmtTotal   := 0,
-    coverageMinimumBranchTotal := 0
+    // Measured 2026-08-31 Scala 3.8.3 JVM via `project config-yamlJVM; coverage; test; coverageReport`:
+    // Statement 72.22%, Branch 66.67%. Set just below with modest margin.
+    coverageMinimumStmtTotal   := 71,
+    coverageMinimumBranchTotal := 65
   )
 
 lazy val `config-json` = crossProject(JSPlatform, JVMPlatform)
@@ -936,8 +938,10 @@ lazy val `config-json` = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test"     % "2.1.26" % Test,
       "dev.zio" %%% "zio-test-sbt" % "2.1.26" % Test
     ),
-    coverageMinimumStmtTotal   := 0,
-    coverageMinimumBranchTotal := 0
+    // Measured 2026-08-31 Scala 3.8.3 JVM via `project config-jsonJVM; coverage; test; coverageReport`:
+    // Statement 92.59%, Branch 86.67%. Set just below with modest margin.
+    coverageMinimumStmtTotal   := 91,
+    coverageMinimumBranchTotal := 85
   )
 
 lazy val `config-hocon` = crossProject(JSPlatform, JVMPlatform)
@@ -954,8 +958,10 @@ lazy val `config-hocon` = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test"     % "2.1.26" % Test,
       "dev.zio" %%% "zio-test-sbt" % "2.1.26" % Test
     ),
-    coverageMinimumStmtTotal   := 0,
-    coverageMinimumBranchTotal := 0
+    // Measured 2026-08-31 Scala 3.8.3 JVM via `project config-hoconJVM; coverage; test; coverageReport`:
+    // Statement 77.58%, Branch 67.84%. Set just below with modest margin.
+    coverageMinimumStmtTotal   := 76,
+    coverageMinimumBranchTotal := 66
   )
 
 lazy val `http-model` = crossProject(JSPlatform, JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,23 @@ inThisBuild(
 
 com.github.sbt.git.SbtGit.useReadableConsoleGit
 
+addCommandAlias(
+  "configCoverage",
+  // Project-scoped coverage for config adapters only. Global `coverage` sets
+  // `ThisBuild / coverageEnabled := true`, which instruments the entire
+  // dependency graph including schema (136 sources) and OOMs at 12GB after a
+  // clean. This alias disables global instrumentation and enables it only for
+  // the three adapter JVM projects, then runs clean/test/report per adapter
+  // so each report is isolated and does not pull in schema instrumentation.
+  "; set ThisBuild / coverageEnabled := false" +
+    "; set LocalProject(\"config-yamlJVM\") / coverageEnabled := true" +
+    "; set LocalProject(\"config-jsonJVM\") / coverageEnabled := true" +
+    "; set LocalProject(\"config-hoconJVM\") / coverageEnabled := true" +
+    "; config-yamlJVM/clean; config-yamlJVM/test; config-yamlJVM/coverageReport" +
+    "; config-jsonJVM/clean; config-jsonJVM/test; config-jsonJVM/coverageReport" +
+    "; config-hoconJVM/clean; config-hoconJVM/test; config-hoconJVM/coverageReport" +
+    "; set ThisBuild / coverageEnabled := false"
+)
 addCommandAlias("build", "; fmt; coverage; root/test; coverageReport")
 addCommandAlias("fmt", "all root/scalafmtSbt root/scalafmtAll")
 addCommandAlias("fmtCheck", "all root/scalafmtSbtCheck root/scalafmtCheckAll")
@@ -925,6 +942,10 @@ lazy val `config-yaml` = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test"     % "2.1.26" % Test,
       "dev.zio" %%% "zio-test-sbt" % "2.1.26" % Test
     ),
+    // Skipped in global `coverage` aggregate to avoid OOM via schema
+    // instrumentation; `configCoverage` re-enables via `set` and enforces
+    // nonzero thresholds with forked clean tests.
+    coverageEnabled := false,
     // Measured 2026-08-31 Scala 3.8.3 JVM via `project config-yamlJVM; coverage; test; coverageReport`:
     // Statement 72.22%, Branch 66.67% (clean 72.22% with fork). Set just below with modest margin.
     coverageMinimumStmtTotal   := 71,
@@ -949,6 +970,8 @@ lazy val `config-json` = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test"     % "2.1.26" % Test,
       "dev.zio" %%% "zio-test-sbt" % "2.1.26" % Test
     ),
+    // Skipped in global `coverage` aggregate; `configCoverage` re-enables.
+    coverageEnabled := false,
     // Measured 2026-08-31 Scala 3.8.3 JVM via `project config-jsonJVM; coverage; test; coverageReport`:
     // Statement 92.59%, Branch 86.67% (clean 92.59% with fork). Set just below with modest margin.
     coverageMinimumStmtTotal   := 91,
@@ -973,6 +996,8 @@ lazy val `config-hocon` = crossProject(JSPlatform, JVMPlatform)
       "dev.zio" %%% "zio-test"     % "2.1.26" % Test,
       "dev.zio" %%% "zio-test-sbt" % "2.1.26" % Test
     ),
+    // Skipped in global `coverage` aggregate; `configCoverage` re-enables.
+    coverageEnabled := false,
     // Measured 2026-08-31 Scala 3.8.3 JVM via `project config-hoconJVM; coverage; test; coverageReport`:
     // Statement 76.30-77.58%, Branch 67.54-67.84% (clean 76.30/67.54 with fork). Set just below with modest margin.
     coverageMinimumStmtTotal   := 76,

--- a/config-hocon/jvm/src/main/scala/zio/blocks/config/hocon/ConfigSourceHoconPlatformSyntax.scala
+++ b/config-hocon/jvm/src/main/scala/zio/blocks/config/hocon/ConfigSourceHoconPlatformSyntax.scala
@@ -23,8 +23,9 @@ trait ConfigSourceHoconPlatformSyntax {
     def fromFile(
       path: String,
       allowedBase: Option[java.io.File] = None,
-      maxIncludeDepth: Int = 10
+      maxIncludeDepth: Int = 10,
+      maxFileBytes: Long = HoconConfigSourcePlatform.DefaultMaxFileBytes
     ): Either[ConfigError, ConfigSource] =
-      HoconConfigSourcePlatform.fromFile(path, allowedBase, maxIncludeDepth)
+      HoconConfigSourcePlatform.fromFile(path, allowedBase, maxIncludeDepth, maxFileBytes)
   }
 }

--- a/config-hocon/jvm/src/main/scala/zio/blocks/config/hocon/ConfigSourceHoconPlatformSyntax.scala
+++ b/config-hocon/jvm/src/main/scala/zio/blocks/config/hocon/ConfigSourceHoconPlatformSyntax.scala
@@ -20,12 +20,36 @@ import zio.blocks.config.{ConfigError, ConfigSource}
 
 trait ConfigSourceHoconPlatformSyntax {
   implicit final class ConfigSourceHoconPlatformOps(private val companion: ConfigSource.type) {
+
+    /** Original three-argument API – preserved for binary compatibility. */
     def fromFile(
+      path: String,
+      allowedBase: Option[java.io.File] = None,
+      maxIncludeDepth: Int = 10
+    ): Either[ConfigError, ConfigSource] =
+      HoconConfigSourcePlatform.fromFile(path, allowedBase, maxIncludeDepth)
+
+    /**
+     * Binary-compatible bridge for the intermediate four-argument signature.
+     */
+    def fromFile(
+      path: String,
+      allowedBase: Option[java.io.File],
+      maxIncludeDepth: Int,
+      maxFileBytes: Long
+    ): Either[ConfigError, ConfigSource] =
+      HoconConfigSourcePlatform.fromFile(path, allowedBase, maxIncludeDepth, maxFileBytes)
+
+    /**
+     * Configurable-limit API with distinct name to avoid overloaded-default
+     * ambiguity.
+     */
+    def fromFileWithLimits(
       path: String,
       allowedBase: Option[java.io.File] = None,
       maxIncludeDepth: Int = 10,
       maxFileBytes: Long = HoconConfigSourcePlatform.DefaultMaxFileBytes
     ): Either[ConfigError, ConfigSource] =
-      HoconConfigSourcePlatform.fromFile(path, allowedBase, maxIncludeDepth, maxFileBytes)
+      HoconConfigSourcePlatform.fromFileWithLimits(path, allowedBase, maxIncludeDepth, maxFileBytes)
   }
 }

--- a/config-hocon/jvm/src/main/scala/zio/blocks/config/hocon/HoconConfigSourcePlatform.scala
+++ b/config-hocon/jvm/src/main/scala/zio/blocks/config/hocon/HoconConfigSourcePlatform.scala
@@ -16,62 +16,173 @@
 
 package zio.blocks.config.hocon
 
+import scala.util.control.NonFatal
+
 import zio.blocks.config.{ConfigError, ConfigSource}
 
 private[hocon] object HoconConfigSourcePlatform {
 
-  private def readUtf8(file: java.io.File): String = {
-    val source = scala.io.Source.fromFile(file, "UTF-8")
-    try source.mkString
-    finally source.close()
+  /** Default maximum size for a single HOCON file (root or included), in bytes. */
+  val DefaultMaxFileBytes: Long = 1024L * 1024L // 1 MiB
+
+  private def readUtf8Bounded(file: java.io.File, maxFileBytes: Long): String = {
+    try {
+      val len = try file.length()
+      catch { case NonFatal(e) => throw toHoconError(e, "Failed to read file") }
+      if (len > maxFileBytes)
+        throw HoconError(s"File size exceeds limit ($maxFileBytes bytes)", 0, 0)
+      try {
+        if (!file.isFile)
+          throw HoconError("Not a regular file", 0, 0)
+      } catch { case NonFatal(e) => throw toHoconError(e, "Failed to read file") }
+      val in = try new java.io.FileInputStream(file)
+      catch { case NonFatal(e) => throw toHoconError(e, "Failed to open file") }
+      try {
+        val out = new java.io.ByteArrayOutputStream()
+        val buf = new Array[Byte](8192)
+        var total: Long = 0L
+        var n           = try in.read(buf)
+        catch { case NonFatal(e) => throw toHoconError(e, "Failed to read file") }
+        while (n != -1) {
+          total += n
+          if (total > maxFileBytes)
+            throw HoconError(s"File size exceeds limit ($maxFileBytes bytes)", 0, 0)
+          out.write(buf, 0, n)
+          n = try in.read(buf)
+          catch { case NonFatal(e) => throw toHoconError(e, "Failed to read file") }
+        }
+        new String(out.toByteArray, java.nio.charset.StandardCharsets.UTF_8)
+      } finally
+        try in.close()
+        catch { case NonFatal(_) => () }
+    } catch {
+      case e: HoconError => throw e
+      case NonFatal(e)   => throw toHoconError(e, "Failed to read file")
+    }
   }
+
+  private def toHoconError(cause: Throwable, message: String): HoconError = {
+    val e = HoconError(message, 0, 0)
+    e.initCause(cause)
+    e
+  }
+
+  private def toParseError(path: String, sourceId: String, cause: Throwable): ConfigError =
+    cause match {
+      case h: HoconError => ConfigError.ParseError(path, sourceId, "valid HOCON", Some(h))
+      case _             => ConfigError.ParseError(path, sourceId, "valid HOCON", Some(cause))
+    }
 
   private def isWithinBase(file: java.io.File, base: java.io.File): Boolean =
     file.toPath.startsWith(base.toPath)
 
+  /**
+   * Load a HOCON file from the filesystem, resolving `include` directives.
+   *
+   * @param maxFileBytes
+   *   Maximum allowed size in bytes for the root file and for each included file. Files larger than this are
+   *   rejected with a typed [[zio.blocks.config.ConfigError.ParseError]] and are never fully loaded into memory.
+   *   Defaults to 1 MiB ([[DefaultMaxFileBytes]]).
+   */
   def fromFile(
     path: String,
     allowedBase: Option[java.io.File] = None,
-    maxIncludeDepth: Int = 10
+    maxIncludeDepth: Int = 10,
+    maxFileBytes: Long = DefaultMaxFileBytes
   ): Either[ConfigError, ConfigSource] = {
-    val canonical        = new java.io.File(path).getCanonicalFile
-    val allowedBaseCanon = allowedBase.map(_.getCanonicalFile)
+    if (maxFileBytes <= 0)
+      Left(
+        ConfigError.ParseError(path, "hocon:file", s"positive maxFileBytes (got $maxFileBytes)", None)
+      )
+    else if (maxIncludeDepth < 0)
+      Left(
+        ConfigError.ParseError(path, "hocon:file", s"non-negative maxIncludeDepth (got $maxIncludeDepth)", None)
+      )
+    else
+      try {
+        val canonical        = new java.io.File(path).getCanonicalFile
+        val allowedBaseCanon = allowedBase.map(_.getCanonicalFile)
 
-    def includeResolver(baseDir: java.io.File, includeDepth: Int): String => Option[HoconParser.IncludedResource] = {
-      resource =>
-        val nextDepth = includeDepth + 1
-        if (nextDepth > maxIncludeDepth)
-          throw HoconError(s"Include depth exceeded ($maxIncludeDepth)", 0, 0)
+        def includeResolver(baseDir: java.io.File, includeDepth: Int): String => Option[HoconParser.IncludedResource] = {
+          resource =>
+            try {
+              val nextDepth = includeDepth + 1
+              if (nextDepth > maxIncludeDepth)
+                throw HoconError(s"Include depth exceeded ($maxIncludeDepth)", 0, 0)
 
-        val includeFile = new java.io.File(baseDir, resource).getCanonicalFile
+              val includeFile =
+                try new java.io.File(baseDir, resource).getCanonicalFile
+                catch { case NonFatal(e) => throw toHoconError(e, "Failed to resolve include") }
 
-        allowedBaseCanon.foreach { base =>
-          if (!isWithinBase(includeFile, base))
-            throw HoconError(s"Include path traversal: $resource resolves outside ${base.getPath}", 0, 0)
+              try {
+                allowedBaseCanon.foreach { base =>
+                  if (!isWithinBase(includeFile, base))
+                    throw HoconError(s"Include path traversal: $resource resolves outside ${base.getPath}", 0, 0)
+                }
+              } catch {
+                case e: HoconError => throw e
+                case NonFatal(e)   => throw toHoconError(e, "Failed to resolve include")
+              }
+
+              val exists =
+                try includeFile.exists()
+                catch { case NonFatal(e) => throw toHoconError(e, "Failed to read include") }
+
+              if (exists) {
+                try {
+                  if (!includeFile.isFile)
+                    throw HoconError("Not a regular file", 0, 0)
+                } catch {
+                  case e: HoconError => throw e
+                  case NonFatal(e)   => throw toHoconError(e, "Failed to read include")
+                }
+                Some(
+                  HoconParser.IncludedResource(
+                    readUtf8Bounded(includeFile, maxFileBytes),
+                    includeResolver(includeFile.getParentFile, nextDepth)
+                  )
+                )
+              } else None
+            } catch {
+              case e: HoconError => throw e
+              case NonFatal(e)   => throw toHoconError(e, "Failed to resolve include")
+            }
         }
 
-        if (includeFile.exists())
-          Some(
-            HoconParser.IncludedResource(readUtf8(includeFile), includeResolver(includeFile.getParentFile, nextDepth))
-          )
-        else None
-    }
+        val traversalError: Option[Either[ConfigError, ConfigSource]] =
+          allowedBaseCanon.flatMap { base =>
+            if (!isWithinBase(canonical, base))
+              Some(Left(ConfigError.ParseError(path, "hocon:file", s"path inside ${base.getPath}", None)))
+            else None
+          }
 
-    val traversalError = allowedBaseCanon.flatMap { base =>
-      if (!isWithinBase(canonical, base))
-        Some(Left(ConfigError.ParseError(path, "hocon:file", s"path inside ${base.getPath}", None)))
-      else None
-    }
-
-    traversalError.getOrElse {
-      if (!canonical.exists())
-        Left(ConfigError.ParseError(path, "hocon:file", "existing file", None))
-      else
-        HoconConfigSource.fromStringWithResolver(
-          readUtf8(canonical),
-          s"hocon:${canonical.getName}",
-          includeResolver(canonical.getParentFile, 0)
-        )
-    }
+        traversalError.getOrElse {
+          if (!canonical.exists())
+            Left(ConfigError.ParseError(path, "hocon:file", "existing file", None))
+          else if (!canonical.isFile)
+            Left(
+              ConfigError.ParseError(
+                canonical.getPath,
+                s"hocon:${canonical.getName}",
+                "regular file",
+                Some(HoconError("Not a regular file", 0, 0))
+              )
+            )
+          else
+            try
+              HoconConfigSource.fromStringWithResolver(
+                readUtf8Bounded(canonical, maxFileBytes),
+                s"hocon:${canonical.getName}",
+                includeResolver(canonical.getParentFile, 0)
+              )
+            catch {
+              case e: HoconError => Left(toParseError(canonical.getPath, s"hocon:${canonical.getName}", e))
+              case NonFatal(e)   => Left(toParseError(canonical.getPath, s"hocon:${canonical.getName}", e))
+            }
+        }
+      } catch {
+        case e: HoconError => Left(toParseError(path, "hocon:file", e))
+        case NonFatal(e)   => Left(toParseError(path, "hocon:file", e))
+      }
   }
 }

--- a/config-hocon/jvm/src/main/scala/zio/blocks/config/hocon/HoconConfigSourcePlatform.scala
+++ b/config-hocon/jvm/src/main/scala/zio/blocks/config/hocon/HoconConfigSourcePlatform.scala
@@ -22,34 +22,40 @@ import zio.blocks.config.{ConfigError, ConfigSource}
 
 private[hocon] object HoconConfigSourcePlatform {
 
-  /** Default maximum size for a single HOCON file (root or included), in bytes. */
+  /**
+   * Default maximum size for a single HOCON file (root or included), in bytes.
+   */
   val DefaultMaxFileBytes: Long = 1024L * 1024L // 1 MiB
 
-  private def readUtf8Bounded(file: java.io.File, maxFileBytes: Long): String = {
+  private def readUtf8Bounded(file: java.io.File, maxFileBytes: Long): String =
     try {
-      val len = try file.length()
-      catch { case NonFatal(e) => throw toHoconError(e, "Failed to read file") }
+      val len =
+        try file.length()
+        catch { case NonFatal(e) => throw toHoconError(e, "Failed to read file") }
       if (len > maxFileBytes)
         throw HoconError(s"File size exceeds limit ($maxFileBytes bytes)", 0, 0)
       try {
         if (!file.isFile)
           throw HoconError("Not a regular file", 0, 0)
       } catch { case NonFatal(e) => throw toHoconError(e, "Failed to read file") }
-      val in = try new java.io.FileInputStream(file)
-      catch { case NonFatal(e) => throw toHoconError(e, "Failed to open file") }
+      val in =
+        try new java.io.FileInputStream(file)
+        catch { case NonFatal(e) => throw toHoconError(e, "Failed to open file") }
       try {
-        val out = new java.io.ByteArrayOutputStream()
-        val buf = new Array[Byte](8192)
+        val out         = new java.io.ByteArrayOutputStream()
+        val buf         = new Array[Byte](8192)
         var total: Long = 0L
-        var n           = try in.read(buf)
-        catch { case NonFatal(e) => throw toHoconError(e, "Failed to read file") }
+        var n           =
+          try in.read(buf)
+          catch { case NonFatal(e) => throw toHoconError(e, "Failed to read file") }
         while (n != -1) {
           total += n
           if (total > maxFileBytes)
             throw HoconError(s"File size exceeds limit ($maxFileBytes bytes)", 0, 0)
           out.write(buf, 0, n)
-          n = try in.read(buf)
-          catch { case NonFatal(e) => throw toHoconError(e, "Failed to read file") }
+          n =
+            try in.read(buf)
+            catch { case NonFatal(e) => throw toHoconError(e, "Failed to read file") }
         }
         new String(out.toByteArray, java.nio.charset.StandardCharsets.UTF_8)
       } finally
@@ -59,7 +65,6 @@ private[hocon] object HoconConfigSourcePlatform {
       case e: HoconError => throw e
       case NonFatal(e)   => throw toHoconError(e, "Failed to read file")
     }
-  }
 
   private def toHoconError(cause: Throwable, message: String): HoconError = {
     val e = HoconError(message, 0, 0)
@@ -80,16 +85,17 @@ private[hocon] object HoconConfigSourcePlatform {
    * Load a HOCON file from the filesystem, resolving `include` directives.
    *
    * @param maxFileBytes
-   *   Maximum allowed size in bytes for the root file and for each included file. Files larger than this are
-   *   rejected with a typed [[zio.blocks.config.ConfigError.ParseError]] and are never fully loaded into memory.
-   *   Defaults to 1 MiB ([[DefaultMaxFileBytes]]).
+   *   Maximum allowed size in bytes for the root file and for each included
+   *   file. Files larger than this are rejected with a typed
+   *   [[zio.blocks.config.ConfigError.ParseError]] and are never fully loaded
+   *   into memory. Defaults to 1 MiB ([[DefaultMaxFileBytes]]).
    */
-  def fromFile(
+  def fromFileWithLimits(
     path: String,
     allowedBase: Option[java.io.File] = None,
     maxIncludeDepth: Int = 10,
     maxFileBytes: Long = DefaultMaxFileBytes
-  ): Either[ConfigError, ConfigSource] = {
+  ): Either[ConfigError, ConfigSource] =
     if (maxFileBytes <= 0)
       Left(
         ConfigError.ParseError(path, "hocon:file", s"positive maxFileBytes (got $maxFileBytes)", None)
@@ -103,50 +109,52 @@ private[hocon] object HoconConfigSourcePlatform {
         val canonical        = new java.io.File(path).getCanonicalFile
         val allowedBaseCanon = allowedBase.map(_.getCanonicalFile)
 
-        def includeResolver(baseDir: java.io.File, includeDepth: Int): String => Option[HoconParser.IncludedResource] = {
-          resource =>
+        def includeResolver(
+          baseDir: java.io.File,
+          includeDepth: Int
+        ): String => Option[HoconParser.IncludedResource] = { resource =>
+          try {
+            val nextDepth = includeDepth + 1
+            if (nextDepth > maxIncludeDepth)
+              throw HoconError(s"Include depth exceeded ($maxIncludeDepth)", 0, 0)
+
+            val includeFile =
+              try new java.io.File(baseDir, resource).getCanonicalFile
+              catch { case NonFatal(e) => throw toHoconError(e, "Failed to resolve include") }
+
             try {
-              val nextDepth = includeDepth + 1
-              if (nextDepth > maxIncludeDepth)
-                throw HoconError(s"Include depth exceeded ($maxIncludeDepth)", 0, 0)
-
-              val includeFile =
-                try new java.io.File(baseDir, resource).getCanonicalFile
-                catch { case NonFatal(e) => throw toHoconError(e, "Failed to resolve include") }
-
-              try {
-                allowedBaseCanon.foreach { base =>
-                  if (!isWithinBase(includeFile, base))
-                    throw HoconError(s"Include path traversal: $resource resolves outside ${base.getPath}", 0, 0)
-                }
-              } catch {
-                case e: HoconError => throw e
-                case NonFatal(e)   => throw toHoconError(e, "Failed to resolve include")
+              allowedBaseCanon.foreach { base =>
+                if (!isWithinBase(includeFile, base))
+                  throw HoconError(s"Include path traversal: $resource resolves outside ${base.getPath}", 0, 0)
               }
-
-              val exists =
-                try includeFile.exists()
-                catch { case NonFatal(e) => throw toHoconError(e, "Failed to read include") }
-
-              if (exists) {
-                try {
-                  if (!includeFile.isFile)
-                    throw HoconError("Not a regular file", 0, 0)
-                } catch {
-                  case e: HoconError => throw e
-                  case NonFatal(e)   => throw toHoconError(e, "Failed to read include")
-                }
-                Some(
-                  HoconParser.IncludedResource(
-                    readUtf8Bounded(includeFile, maxFileBytes),
-                    includeResolver(includeFile.getParentFile, nextDepth)
-                  )
-                )
-              } else None
             } catch {
               case e: HoconError => throw e
               case NonFatal(e)   => throw toHoconError(e, "Failed to resolve include")
             }
+
+            val exists =
+              try includeFile.exists()
+              catch { case NonFatal(e) => throw toHoconError(e, "Failed to read include") }
+
+            if (exists) {
+              try {
+                if (!includeFile.isFile)
+                  throw HoconError("Not a regular file", 0, 0)
+              } catch {
+                case e: HoconError => throw e
+                case NonFatal(e)   => throw toHoconError(e, "Failed to read include")
+              }
+              Some(
+                HoconParser.IncludedResource(
+                  readUtf8Bounded(includeFile, maxFileBytes),
+                  includeResolver(includeFile.getParentFile, nextDepth)
+                )
+              )
+            } else None
+          } catch {
+            case e: HoconError => throw e
+            case NonFatal(e)   => throw toHoconError(e, "Failed to resolve include")
+          }
         }
 
         val traversalError: Option[Either[ConfigError, ConfigSource]] =
@@ -184,5 +192,26 @@ private[hocon] object HoconConfigSourcePlatform {
         case e: HoconError => Left(toParseError(path, "hocon:file", e))
         case NonFatal(e)   => Left(toParseError(path, "hocon:file", e))
       }
-  }
+
+  /**
+   * Binary-compatible bridge: preserves the original three-argument signature.
+   */
+  def fromFile(
+    path: String,
+    allowedBase: Option[java.io.File] = None,
+    maxIncludeDepth: Int = 10
+  ): Either[ConfigError, ConfigSource] =
+    fromFileWithLimits(path, allowedBase, maxIncludeDepth, DefaultMaxFileBytes)
+
+  /**
+   * Binary-compatible bridge for the intermediate four-argument signature (no
+   * defaults to avoid overload ambiguity).
+   */
+  def fromFile(
+    path: String,
+    allowedBase: Option[java.io.File],
+    maxIncludeDepth: Int,
+    maxFileBytes: Long
+  ): Either[ConfigError, ConfigSource] =
+    fromFileWithLimits(path, allowedBase, maxIncludeDepth, maxFileBytes)
 }

--- a/config-hocon/jvm/src/test/scala/zio/blocks/config/hocon/HoconConfigSourcePlatformSpec.scala
+++ b/config-hocon/jvm/src/test/scala/zio/blocks/config/hocon/HoconConfigSourcePlatformSpec.scala
@@ -170,8 +170,15 @@ object HoconConfigSourcePlatformSpec extends ZIOSpecDefault {
           result.isLeft,
           result.left.exists {
             case e: zio.blocks.config.ConfigError.ParseError =>
-              e.message.contains("exceeds limit") && !e.message.contains(secretContent) &&
-              !e.getMessage.contains(secretContent)
+              !e.message.contains(secretContent) &&
+              !e.getMessage.contains(secretContent) &&
+              !e.message.contains("exceeds limit") &&
+              !e.getMessage.contains("exceeds limit") &&
+              e.cause.exists {
+                case h: HoconError =>
+                  h.getMessage.contains("exceeds limit") && !h.getMessage.contains(secretContent)
+                case _ => false
+              }
             case _ => false
           }
         )
@@ -297,7 +304,14 @@ object HoconConfigSourcePlatformSpec extends ZIOSpecDefault {
           result.isLeft,
           result.left.exists {
             case e: zio.blocks.config.ConfigError.ParseError =>
-              e.message.contains("regular file") || e.message.contains("Failed")
+              !e.message.contains("Not a regular file") &&
+              !e.getMessage.contains("Not a regular file") &&
+              !e.message.contains("Failed") &&
+              !e.getMessage.contains("Failed") &&
+              e.cause.exists {
+                case h: HoconError => h.getMessage.contains("Not a regular file")
+                case _             => false
+              }
             case _ => false
           }
         )

--- a/config-hocon/jvm/src/test/scala/zio/blocks/config/hocon/HoconConfigSourcePlatformSpec.scala
+++ b/config-hocon/jvm/src/test/scala/zio/blocks/config/hocon/HoconConfigSourcePlatformSpec.scala
@@ -134,6 +134,207 @@ object HoconConfigSourcePlatformSpec extends ZIOSpecDefault {
           }
         )
       } finally deleteRecursively(root)
+    },
+    test("fromFile rejects root file exceeding maxFileBytes with typed error without leaking content") {
+      val root = Files.createTempDirectory("hocon-platform-limit-root-")
+      try {
+        val base = root.resolve("conf")
+        Files.createDirectories(base)
+        val secretContent = "x" * 2048
+        val largeContent  = s"""db.secret = "$secretContent"""" // > 1k bytes
+        val file          = writeFile(base.resolve("app.conf"), largeContent)
+        val result        = HoconConfigSourcePlatform.fromFile(file.toString, Some(base.toFile), maxFileBytes = 1024)
+        assertTrue(
+          result.isLeft,
+          result.left.exists {
+            case e: zio.blocks.config.ConfigError.ParseError =>
+              e.message.contains("exceeds limit") && !e.message.contains(secretContent) &&
+                !e.getMessage.contains(secretContent)
+            case _ => false
+          }
+        )
+      } finally deleteRecursively(root)
+    },
+    test("fromFile rejects included file exceeding maxFileBytes with typed error without leaking content") {
+      val root = Files.createTempDirectory("hocon-platform-limit-include-")
+      try {
+        val base = root.resolve("conf")
+        Files.createDirectories(base)
+        val secretContent = "y" * 2048
+        writeFile(base.resolve("large.conf"), s"""secret.value = "$secretContent"""")
+        val main   = writeFile(base.resolve("app.conf"), """include "large.conf"""")
+        val result = HoconConfigSourcePlatform.fromFile(main.toString, Some(base.toFile), maxFileBytes = 1024)
+        assertTrue(
+          result.isLeft,
+          result.left.exists {
+            case e: zio.blocks.config.ConfigError.ParseError =>
+              e.message.contains("exceeds limit") && !e.message.contains(secretContent) &&
+                !e.getMessage.contains(secretContent)
+            case _ => false
+          }
+        )
+      } finally deleteRecursively(root)
+    },
+    test("fromFile accepts file within maxFileBytes") {
+      val root = Files.createTempDirectory("hocon-platform-limit-ok-")
+      try {
+        val base = root.resolve("conf")
+        Files.createDirectories(base)
+        val main   = writeFile(base.resolve("app.conf"), "db.host = \"ok\"")
+        val result = HoconConfigSourcePlatform.fromFile(main.toString, Some(base.toFile), maxFileBytes = 1024)
+        assertTrue(
+          result.toOption.exists(_.get("db.host").exists(_.value == "ok"))
+        )
+      } finally deleteRecursively(root)
+    },
+    test("ConfigSource.fromFile respects maxFileBytes for root file") {
+      val root = Files.createTempDirectory("hocon-platform-limit-cfgsrc-")
+      try {
+        val base = root.resolve("conf")
+        Files.createDirectories(base)
+        val secretContent = "z" * 2048
+        val file          = writeFile(base.resolve("app.conf"), s"""db.secret = "$secretContent"""")
+        val result = zio.blocks.config.ConfigSource.fromFile(
+          file.toString,
+          Some(base.toFile),
+          maxFileBytes = 1024
+        )
+        assertTrue(
+          result.isLeft,
+          result.left.exists {
+            case e: zio.blocks.config.ConfigError.ParseError =>
+              e.message.contains("exceeds limit") && !e.message.contains(secretContent)
+            case _ => false
+          }
+        )
+      } finally deleteRecursively(root)
+    },
+    test("fromFile accepts included file within limit") {
+      val root = Files.createTempDirectory("hocon-platform-limit-include-ok-")
+      try {
+        val base = root.resolve("conf")
+        Files.createDirectories(base)
+        writeFile(base.resolve("small.conf"), "small.value = 1")
+        val main   = writeFile(base.resolve("app.conf"), """include "small.conf"""")
+        val result = HoconConfigSourcePlatform.fromFile(main.toString, Some(base.toFile), maxFileBytes = 1024)
+        assertTrue(
+          result.toOption.exists(_.get("small.value").exists(_.value == "1"))
+        )
+      } finally deleteRecursively(root)
+    },
+    test("fromFile returns typed error for non-positive maxFileBytes") {
+      val root = Files.createTempDirectory("hocon-platform-limit-invalid-")
+      try {
+        val base = root.resolve("conf")
+        Files.createDirectories(base)
+        val file = writeFile(base.resolve("app.conf"), "db.host = \"ok\"")
+        val resultZero = HoconConfigSourcePlatform.fromFile(file.toString, Some(base.toFile), maxFileBytes = 0)
+        val resultNeg  = HoconConfigSourcePlatform.fromFile(file.toString, Some(base.toFile), maxFileBytes = -1)
+        assertTrue(
+          resultZero.isLeft,
+          resultNeg.isLeft,
+          resultZero.left.exists {
+            case e: zio.blocks.config.ConfigError.ParseError => e.message.contains("maxFileBytes")
+            case _                                            => false
+          },
+          resultNeg.left.exists {
+            case e: zio.blocks.config.ConfigError.ParseError => e.message.contains("maxFileBytes")
+            case _                                            => false
+          }
+        )
+      } finally deleteRecursively(root)
+    },
+    test("fromFile returns typed error for negative maxIncludeDepth") {
+      val root = Files.createTempDirectory("hocon-platform-depth-invalid-")
+      try {
+        val base = root.resolve("conf")
+        Files.createDirectories(base)
+        val file   = writeFile(base.resolve("app.conf"), "db.host = \"ok\"")
+        val result = HoconConfigSourcePlatform.fromFile(file.toString, Some(base.toFile), maxIncludeDepth = -1)
+        assertTrue(
+          result.isLeft,
+          result.left.exists {
+            case e: zio.blocks.config.ConfigError.ParseError => e.message.contains("maxIncludeDepth")
+            case _                                            => false
+          }
+        )
+      } finally deleteRecursively(root)
+    },
+    test("fromFile returns typed error when root path is a directory") {
+      val root = Files.createTempDirectory("hocon-platform-dir-root-")
+      try {
+        val base = root.resolve("conf")
+        Files.createDirectories(base)
+        val result = HoconConfigSourcePlatform.fromFile(base.toString, Some(base.toFile))
+        assertTrue(
+          result.isLeft,
+          result.left.exists {
+            case e: zio.blocks.config.ConfigError.ParseError =>
+              e.message.contains("regular file") && !e.message.contains("secret")
+            case _ => false
+          }
+        )
+      } finally deleteRecursively(root)
+    },
+    test("fromFile returns typed error when included path is a directory") {
+      val root = Files.createTempDirectory("hocon-platform-dir-include-")
+      try {
+        val base = root.resolve("conf")
+        Files.createDirectories(base.resolve("subdir"))
+        val main   = writeFile(base.resolve("app.conf"), """include "subdir"""")
+        val result = HoconConfigSourcePlatform.fromFile(main.toString, Some(base.toFile))
+        assertTrue(
+          result.isLeft,
+          result.left.exists {
+            case e: zio.blocks.config.ConfigError.ParseError => e.message.contains("regular file") || e.message.contains("Failed")
+            case _                                            => false
+          }
+        )
+      } finally deleteRecursively(root)
+    },
+    test("ConfigSource.fromFile returns typed error for non-positive maxFileBytes") {
+      val root = Files.createTempDirectory("hocon-platform-cfgsrc-invalid-")
+      try {
+        val base = root.resolve("conf")
+        Files.createDirectories(base)
+        val file   = writeFile(base.resolve("app.conf"), "db.host = \"ok\"")
+        val result = zio.blocks.config.ConfigSource.fromFile(file.toString, Some(base.toFile), maxFileBytes = 0)
+        assertTrue(
+          result.isLeft,
+          result.left.exists {
+            case e: zio.blocks.config.ConfigError.ParseError => e.message.contains("maxFileBytes")
+            case _                                            => false
+          }
+        )
+      } finally deleteRecursively(root)
+    },
+    test("ConfigSource.fromFile returns typed error when root is a directory") {
+      val root = Files.createTempDirectory("hocon-platform-cfgsrc-dir-")
+      try {
+        val base = root.resolve("conf")
+        Files.createDirectories(base)
+        val result = zio.blocks.config.ConfigSource.fromFile(base.toString, Some(base.toFile))
+        assertTrue(
+          result.isLeft,
+          result.left.exists {
+            case e: zio.blocks.config.ConfigError.ParseError => e.message.contains("regular file")
+            case _                                            => false
+          }
+        )
+      } finally deleteRecursively(root)
+    },
+    test("fromFile never leaks exception for unreadable filesystem state") {
+      val root = Files.createTempDirectory("hocon-platform-unreadable-")
+      try {
+        val base = root.resolve("conf")
+        Files.createDirectories(base)
+        val missing = base.resolve("missing.conf")
+        val result  = HoconConfigSourcePlatform.fromFile(missing.toString, Some(base.toFile))
+        assertTrue(
+          result.isLeft,
+          result.left.exists { case _: zio.blocks.config.ConfigError.ParseError => true; case _ => false }
+        )
+      } finally deleteRecursively(root)
     }
   )
 }

--- a/config-hocon/jvm/src/test/scala/zio/blocks/config/hocon/HoconConfigSourcePlatformSpec.scala
+++ b/config-hocon/jvm/src/test/scala/zio/blocks/config/hocon/HoconConfigSourcePlatformSpec.scala
@@ -143,13 +143,14 @@ object HoconConfigSourcePlatformSpec extends ZIOSpecDefault {
         val secretContent = "x" * 2048
         val largeContent  = s"""db.secret = "$secretContent"""" // > 1k bytes
         val file          = writeFile(base.resolve("app.conf"), largeContent)
-        val result        = HoconConfigSourcePlatform.fromFile(file.toString, Some(base.toFile), maxFileBytes = 1024)
+        val result        =
+          HoconConfigSourcePlatform.fromFileWithLimits(file.toString, Some(base.toFile), maxFileBytes = 1024)
         assertTrue(
           result.isLeft,
           result.left.exists {
             case e: zio.blocks.config.ConfigError.ParseError =>
               e.message.contains("exceeds limit") && !e.message.contains(secretContent) &&
-                !e.getMessage.contains(secretContent)
+              !e.getMessage.contains(secretContent)
             case _ => false
           }
         )
@@ -163,13 +164,14 @@ object HoconConfigSourcePlatformSpec extends ZIOSpecDefault {
         val secretContent = "y" * 2048
         writeFile(base.resolve("large.conf"), s"""secret.value = "$secretContent"""")
         val main   = writeFile(base.resolve("app.conf"), """include "large.conf"""")
-        val result = HoconConfigSourcePlatform.fromFile(main.toString, Some(base.toFile), maxFileBytes = 1024)
+        val result =
+          HoconConfigSourcePlatform.fromFileWithLimits(main.toString, Some(base.toFile), maxFileBytes = 1024)
         assertTrue(
           result.isLeft,
           result.left.exists {
             case e: zio.blocks.config.ConfigError.ParseError =>
               e.message.contains("exceeds limit") && !e.message.contains(secretContent) &&
-                !e.getMessage.contains(secretContent)
+              !e.getMessage.contains(secretContent)
             case _ => false
           }
         )
@@ -181,7 +183,8 @@ object HoconConfigSourcePlatformSpec extends ZIOSpecDefault {
         val base = root.resolve("conf")
         Files.createDirectories(base)
         val main   = writeFile(base.resolve("app.conf"), "db.host = \"ok\"")
-        val result = HoconConfigSourcePlatform.fromFile(main.toString, Some(base.toFile), maxFileBytes = 1024)
+        val result =
+          HoconConfigSourcePlatform.fromFileWithLimits(main.toString, Some(base.toFile), maxFileBytes = 1024)
         assertTrue(
           result.toOption.exists(_.get("db.host").exists(_.value == "ok"))
         )
@@ -194,7 +197,7 @@ object HoconConfigSourcePlatformSpec extends ZIOSpecDefault {
         Files.createDirectories(base)
         val secretContent = "z" * 2048
         val file          = writeFile(base.resolve("app.conf"), s"""db.secret = "$secretContent"""")
-        val result = zio.blocks.config.ConfigSource.fromFile(
+        val result        = zio.blocks.config.ConfigSource.fromFileWithLimits(
           file.toString,
           Some(base.toFile),
           maxFileBytes = 1024
@@ -216,7 +219,8 @@ object HoconConfigSourcePlatformSpec extends ZIOSpecDefault {
         Files.createDirectories(base)
         writeFile(base.resolve("small.conf"), "small.value = 1")
         val main   = writeFile(base.resolve("app.conf"), """include "small.conf"""")
-        val result = HoconConfigSourcePlatform.fromFile(main.toString, Some(base.toFile), maxFileBytes = 1024)
+        val result =
+          HoconConfigSourcePlatform.fromFileWithLimits(main.toString, Some(base.toFile), maxFileBytes = 1024)
         assertTrue(
           result.toOption.exists(_.get("small.value").exists(_.value == "1"))
         )
@@ -227,19 +231,21 @@ object HoconConfigSourcePlatformSpec extends ZIOSpecDefault {
       try {
         val base = root.resolve("conf")
         Files.createDirectories(base)
-        val file = writeFile(base.resolve("app.conf"), "db.host = \"ok\"")
-        val resultZero = HoconConfigSourcePlatform.fromFile(file.toString, Some(base.toFile), maxFileBytes = 0)
-        val resultNeg  = HoconConfigSourcePlatform.fromFile(file.toString, Some(base.toFile), maxFileBytes = -1)
+        val file       = writeFile(base.resolve("app.conf"), "db.host = \"ok\"")
+        val resultZero =
+          HoconConfigSourcePlatform.fromFileWithLimits(file.toString, Some(base.toFile), maxFileBytes = 0)
+        val resultNeg =
+          HoconConfigSourcePlatform.fromFileWithLimits(file.toString, Some(base.toFile), maxFileBytes = -1)
         assertTrue(
           resultZero.isLeft,
           resultNeg.isLeft,
           resultZero.left.exists {
             case e: zio.blocks.config.ConfigError.ParseError => e.message.contains("maxFileBytes")
-            case _                                            => false
+            case _                                           => false
           },
           resultNeg.left.exists {
             case e: zio.blocks.config.ConfigError.ParseError => e.message.contains("maxFileBytes")
-            case _                                            => false
+            case _                                           => false
           }
         )
       } finally deleteRecursively(root)
@@ -250,12 +256,16 @@ object HoconConfigSourcePlatformSpec extends ZIOSpecDefault {
         val base = root.resolve("conf")
         Files.createDirectories(base)
         val file   = writeFile(base.resolve("app.conf"), "db.host = \"ok\"")
-        val result = HoconConfigSourcePlatform.fromFile(file.toString, Some(base.toFile), maxIncludeDepth = -1)
+        val result = HoconConfigSourcePlatform.fromFileWithLimits(
+          file.toString,
+          Some(base.toFile),
+          maxIncludeDepth = -1
+        )
         assertTrue(
           result.isLeft,
           result.left.exists {
             case e: zio.blocks.config.ConfigError.ParseError => e.message.contains("maxIncludeDepth")
-            case _                                            => false
+            case _                                           => false
           }
         )
       } finally deleteRecursively(root)
@@ -286,8 +296,9 @@ object HoconConfigSourcePlatformSpec extends ZIOSpecDefault {
         assertTrue(
           result.isLeft,
           result.left.exists {
-            case e: zio.blocks.config.ConfigError.ParseError => e.message.contains("regular file") || e.message.contains("Failed")
-            case _                                            => false
+            case e: zio.blocks.config.ConfigError.ParseError =>
+              e.message.contains("regular file") || e.message.contains("Failed")
+            case _ => false
           }
         )
       } finally deleteRecursively(root)
@@ -298,12 +309,13 @@ object HoconConfigSourcePlatformSpec extends ZIOSpecDefault {
         val base = root.resolve("conf")
         Files.createDirectories(base)
         val file   = writeFile(base.resolve("app.conf"), "db.host = \"ok\"")
-        val result = zio.blocks.config.ConfigSource.fromFile(file.toString, Some(base.toFile), maxFileBytes = 0)
+        val result =
+          zio.blocks.config.ConfigSource.fromFileWithLimits(file.toString, Some(base.toFile), maxFileBytes = 0)
         assertTrue(
           result.isLeft,
           result.left.exists {
             case e: zio.blocks.config.ConfigError.ParseError => e.message.contains("maxFileBytes")
-            case _                                            => false
+            case _                                           => false
           }
         )
       } finally deleteRecursively(root)
@@ -318,23 +330,46 @@ object HoconConfigSourcePlatformSpec extends ZIOSpecDefault {
           result.isLeft,
           result.left.exists {
             case e: zio.blocks.config.ConfigError.ParseError => e.message.contains("regular file")
-            case _                                            => false
+            case _                                           => false
           }
         )
       } finally deleteRecursively(root)
     },
-    test("fromFile never leaks exception for unreadable filesystem state") {
-      val root = Files.createTempDirectory("hocon-platform-unreadable-")
-      try {
-        val base = root.resolve("conf")
-        Files.createDirectories(base)
-        val missing = base.resolve("missing.conf")
-        val result  = HoconConfigSourcePlatform.fromFile(missing.toString, Some(base.toFile))
-        assertTrue(
-          result.isLeft,
-          result.left.exists { case _: zio.blocks.config.ConfigError.ParseError => true; case _ => false }
-        )
-      } finally deleteRecursively(root)
+    test("fromFile captures canonicalization failure via NonFatal as typed ParseError without leaking") {
+      val badPath = "invalid\u0000path.conf"
+      val direct  = HoconConfigSourcePlatform.fromFile(badPath)
+      val syntax  = zio.blocks.config.ConfigSource.fromFile(badPath)
+      assertTrue(
+        direct.isLeft,
+        syntax.isLeft,
+        direct.left.exists {
+          case e: zio.blocks.config.ConfigError.ParseError =>
+            e.message.contains("valid HOCON") && e.cause.isDefined
+          case _ => false
+        },
+        syntax.left.exists {
+          case e: zio.blocks.config.ConfigError.ParseError =>
+            e.message.contains("valid HOCON") && e.cause.isDefined
+          case _ => false
+        }
+      )
+    },
+    test("fromFileWithLimits captures canonicalization failure via NonFatal as typed ParseError") {
+      val badPath = "invalid\u0000path.conf"
+      val direct  = HoconConfigSourcePlatform.fromFileWithLimits(badPath, maxFileBytes = 1024)
+      val syntax  = zio.blocks.config.ConfigSource.fromFileWithLimits(badPath, maxFileBytes = 1024)
+      assertTrue(
+        direct.isLeft,
+        syntax.isLeft,
+        direct.left.exists {
+          case e: zio.blocks.config.ConfigError.ParseError => e.cause.isDefined
+          case _                                           => false
+        },
+        syntax.left.exists {
+          case e: zio.blocks.config.ConfigError.ParseError => e.cause.isDefined
+          case _                                           => false
+        }
+      )
     }
   )
 }

--- a/config-hocon/shared/src/main/scala/zio/blocks/config/hocon/HoconParser.scala
+++ b/config-hocon/shared/src/main/scala/zio/blocks/config/hocon/HoconParser.scala
@@ -259,12 +259,38 @@ object HoconParser {
     private def parseArray(includeResolver: String => Option[IncludedResource]): RawArr = {
       expect('[')
       val buf = new scala.collection.mutable.ArrayBuffer[RawValue]()
+      skipWhitespaceAndComments()
+      if (eof) error("Unterminated array, expected ']'")
+      if (ch == ']') { pos += 1; return RawArr(buf.toSeq) }
       while (true) {
         skipWhitespaceAndComments()
-        if (eof) error("Unexpected end of input in array")
+        if (eof) error("Unterminated array, expected ']'")
         if (ch == ']') { pos += 1; return RawArr(buf.toSeq) }
-        buf += parseValue(includeResolver)
-        skipComma()
+        if (ch == '}') error("Unexpected '}' in array, expected ']'")
+        if (ch == ',') error("Unexpected ',' in array")
+        val before = pos
+        // Use single-value parsing to avoid concatenating whitespace-separated tokens
+        // into a single element; array elements are delimited by ',' or newline.
+        val value = parseSingleValue(includeResolver)
+        if (pos == before) error("Failed to parse array element")
+        buf += value
+        skipWhitespaceAndComments()
+        if (eof) error("Unterminated array, expected ']'")
+        if (ch == ']') { pos += 1; return RawArr(buf.toSeq) }
+        if (ch == '}') error("Unexpected '}' in array, expected ']' or ','")
+        if (ch == ',') {
+          pos += 1
+          skipWhitespaceAndComments()
+          if (eof) error("Unterminated array, expected ']' after ','")
+          if (ch == ']') { pos += 1; return RawArr(buf.toSeq) }
+          // trailing comma handled; otherwise loop to parse next element
+        } else {
+          // No comma: newline/comment separated. `skipWhitespaceAndComments` already
+          // consumed newlines and comments, so if next is ']' we will handle at top.
+          // Otherwise continue to parse next element without explicit separator.
+          // If next char starts a value, the loop will parse it; whitespace-only
+          // separation without comma is permissively allowed.
+        }
       }
       // `while(true)` is intentional here; this return is only present to satisfy
       // the type checker after the early returns above.

--- a/config-hocon/shared/src/test/scala/zio/blocks/config/hocon/HoconParserSpec.scala
+++ b/config-hocon/shared/src/test/scala/zio/blocks/config/hocon/HoconParserSpec.scala
@@ -51,7 +51,6 @@ object HoconParserSpec extends ZIOSpecDefault {
       }
     ),
     suite("arrays")(
-      // TODO: fix array parsing bug — tracked in PR #1426 review
       test("parses simple array") {
         val result = parsed("""{ arr = [1, 2, 3] }""")
         assertTrue(
@@ -67,8 +66,7 @@ object HoconParserSpec extends ZIOSpecDefault {
             )
           )
         )
-      } @@ TestAspect.ignore,
-      // TODO: fix array parsing bug — tracked in PR #1426 review
+      },
       test("parses array of strings") {
         val result = parsed("""{ arr = ["a", "b"] }""")
         assertTrue(
@@ -83,13 +81,11 @@ object HoconParserSpec extends ZIOSpecDefault {
             )
           )
         )
-      } @@ TestAspect.ignore,
-      // TODO: fix array parsing bug — tracked in PR #1426 review
+      },
       test("parses empty array") {
         val result = parsed("{ arr = [] }")
         assertTrue(result == HoconValue.Obj(Map("arr" -> HoconValue.Arr(Seq.empty))))
-      } @@ TestAspect.ignore,
-      // TODO: fix array parsing bug — tracked in PR #1426 review
+      },
       test("parses newline-separated array elements") {
         val input =
           """{
@@ -113,7 +109,83 @@ object HoconParserSpec extends ZIOSpecDefault {
             )
           )
         )
-      } @@ TestAspect.ignore
+      }
+    ),
+    suite("arrays edge")(
+      test("parses nested arrays") {
+        val result = parsed("""{ arr = [[1, 2], [3, 4]] }""")
+        assertTrue(
+          result == HoconValue.Obj(
+            Map(
+              "arr" -> HoconValue.Arr(
+                Seq(
+                  HoconValue.Arr(Seq(HoconValue.Num(1.0), HoconValue.Num(2.0))),
+                  HoconValue.Arr(Seq(HoconValue.Num(3.0), HoconValue.Num(4.0)))
+                )
+              )
+            )
+          )
+        )
+      },
+      test("parses array after substitution") {
+        val result = parsed(
+          """{
+            |  x = 1
+            |  arr = [${x}, 2]
+            |}""".stripMargin
+        )
+        assertTrue(
+          result == HoconValue.Obj(
+            Map(
+              "x"   -> HoconValue.Num(1.0),
+              "arr" -> HoconValue.Arr(Seq(HoconValue.Num(1.0), HoconValue.Num(2.0)))
+            )
+          )
+        )
+      },
+      test("parses array of objects") {
+        val result = parsed("""{ arr = [{a = 1}, {b = 2}] }""")
+        assertTrue(
+          result == HoconValue.Obj(
+            Map(
+              "arr" -> HoconValue.Arr(
+                Seq(
+                  HoconValue.Obj(Map("a" -> HoconValue.Num(1.0))),
+                  HoconValue.Obj(Map("b" -> HoconValue.Num(2.0)))
+                )
+              )
+            )
+          )
+        )
+      },
+      test("parses array followed by object field") {
+        val result = parsed("""{ arr = [1, 2], obj = {x = 1} }""")
+        assertTrue(
+          result == HoconValue.Obj(
+            Map(
+              "arr" -> HoconValue.Arr(Seq(HoconValue.Num(1.0), HoconValue.Num(2.0))),
+              "obj" -> HoconValue.Obj(Map("x" -> HoconValue.Num(1.0)))
+            )
+          )
+        )
+      },
+      test("parses array with trailing comma") {
+        val result = parsed("""{ arr = [1, 2,] }""")
+        assertTrue(
+          result == HoconValue.Obj(
+            Map("arr" -> HoconValue.Arr(Seq(HoconValue.Num(1.0), HoconValue.Num(2.0))))
+          )
+        )
+      },
+      test("fails on unclosed array") {
+        assertTrue(parseFails("{ arr = [1, 2 }"))
+      },
+      test("fails on array with stray closing brace") {
+        assertTrue(parseFails("{ arr = [ }"))
+      },
+      test("fails on array without closing bracket") {
+        assertTrue(parseFails("{ arr = [1, 2 "))
+      }
     ),
     suite("strings")(
       test("parses quoted strings with escapes") {

--- a/config-json/shared/src/main/scala/zio/blocks/config/json/JsonConfigSource.scala
+++ b/config-json/shared/src/main/scala/zio/blocks/config/json/JsonConfigSource.scala
@@ -40,9 +40,8 @@ private[json] object JsonConfigSource {
       case Right(jsonValue) =>
         val flatMap = flatten(jsonValue, "")
         Right(ConfigSource.fromMap(flatMap, sourceId))
-      case Left(schemaError) =>
-        val excerpt = if (json.length > 100) json.take(100) + "..." else json
-        Left(ConfigError.InvalidValue("", excerpt, "valid JSON", sourceId, Some(schemaError)))
+      case Left(_) =>
+        Left(ConfigError.ParseError("", sourceId, "valid JSON"))
     }
 
   /**

--- a/config-json/shared/src/test/scala/zio/blocks/config/json/JsonConfigSourceSpec.scala
+++ b/config-json/shared/src/test/scala/zio/blocks/config/json/JsonConfigSourceSpec.scala
@@ -16,7 +16,7 @@
 
 package zio.blocks.config.json
 
-import zio.blocks.config.ConfigSource
+import zio.blocks.config.{ConfigError, ConfigSource}
 import zio.test._
 
 object JsonConfigSourceSpec extends ZIOSpecDefault {
@@ -147,6 +147,62 @@ object JsonConfigSourceSpec extends ZIOSpecDefault {
       assertTrue(result.toOption.get.get("path").get.value == "/home/user/file.txt") &&
       assertTrue(result.toOption.get.get("url").isDefined) &&
       assertTrue(result.toOption.get.get("url").get.value == "https://example.com?key=value")
-    }
+    },
+    suite("parse error redaction")(
+      test("invalid JSON does not leak document excerpt or cause, contains source and expected format") {
+        val secret   = "SENTINEL_JSON_SECRET_9f3b8a7c2e1d4f6a93b8c1d2e3f4a5b6c7d8e9f0a1b2"
+        val badJson  = s"""{"secret": "$secret", invalid}"""
+        val sourceId = "test-json-source"
+        val result   = JsonConfigSource.fromString(badJson, sourceId)
+        assertTrue(result.isLeft) &&
+        assertTrue(result.left.toOption.get.isInstanceOf[ConfigError.ParseError]) &&
+        assertTrue(!result.left.toOption.get.message.contains(secret)) &&
+        assertTrue(!result.left.toOption.get.getMessage.contains(secret)) &&
+        assertTrue(result.left.toOption.get.message.contains(sourceId)) &&
+        assertTrue(result.left.toOption.get.message.contains("valid JSON")) &&
+        assertTrue(!result.left.toOption.get.message.contains(badJson.take(20)))
+      },
+      test("invalid JSON with long document does not leak first 100 chars") {
+        val secret  = "SENTINEL_JSON_LONG_aaaaaaaaabbbbbbbbbccccccccddddddddeeeeeeeeffffffff111111222222333333444444555555"
+        val badJson = s"""{"k":"$secret" """ + ("x" * 200) // missing closing brace, long
+        val result  = JsonConfigSource.fromString(badJson, "json:long")
+        assertTrue(result.isLeft) &&
+        assertTrue(!result.left.toOption.get.message.contains(secret)) &&
+        assertTrue(!result.left.toOption.get.getMessage.contains(secret)) &&
+        assertTrue(result.left.toOption.get.message.contains("valid JSON")) &&
+        assertTrue(result.left.toOption.get.message.contains("json:long"))
+      },
+      test("invalid JSON error wrapped in Composite still redacted") {
+        val secret  = "SENTINEL_JSON_COMPOSITE_zzz111yyy222xxx333www444vvv555uuu666ttt777"
+        val badJson = s"""not-json-at-all $secret [[[ """
+        val result  = JsonConfigSource.fromString(badJson, "json:composite")
+        assertTrue(result.isLeft) &&
+        assertTrue({
+                 val composite = ConfigError.Composite(new ::(result.left.toOption.get, Nil))
+                 !composite.message.contains(secret) && !composite.getMessage.contains(secret) &&
+                 composite.message.contains("valid JSON") && composite.message.contains("json:composite")
+               })
+      },
+      test("invalid JSON error retains structured fields without leak via getMessage") {
+        val secret  = "SENTINEL_JSON_STRUCT_cccccddddd1111122222333334444455555"
+        val badJson = s"""{"a": "$secret" invalid}"""
+        val error   = JsonConfigSource.fromString(badJson, "src-json-struct").left.toOption.get.asInstanceOf[ConfigError.ParseError]
+        assertTrue(error.path == "") &&
+        assertTrue(error.source == "src-json-struct") &&
+        assertTrue(error.expectedType == "valid JSON") &&
+        assertTrue(!error.message.contains(secret)) &&
+        assertTrue(!error.getMessage.contains(secret))
+      },
+      test("ParseError with empty path hides cause text even if cause contains secret") {
+        val secret = "SENTINEL_PARSE_CAUSE_JSON_abcdef1234567890abcdef1234567890"
+        val cause  = new RuntimeException(s"unexpected token near '$secret'")
+        val err    = ConfigError.ParseError("", "json:string", "valid JSON", Some(cause))
+        assertTrue(!err.message.contains(secret)) &&
+        assertTrue(!err.getMessage.contains(secret)) &&
+        assertTrue(err.message.contains("valid JSON")) &&
+        assertTrue(err.message.contains("json:string")) &&
+        assertTrue(err.cause.exists(_.getMessage.contains(secret)))
+      }
+    )
   )
 }

--- a/config-json/shared/src/test/scala/zio/blocks/config/json/JsonConfigSourceSpec.scala
+++ b/config-json/shared/src/test/scala/zio/blocks/config/json/JsonConfigSourceSpec.scala
@@ -163,7 +163,8 @@ object JsonConfigSourceSpec extends ZIOSpecDefault {
         assertTrue(!result.left.toOption.get.message.contains(badJson.take(20)))
       },
       test("invalid JSON with long document does not leak first 100 chars") {
-        val secret  = "SENTINEL_JSON_LONG_aaaaaaaaabbbbbbbbbccccccccddddddddeeeeeeeeffffffff111111222222333333444444555555"
+        val secret =
+          "SENTINEL_JSON_LONG_aaaaaaaaabbbbbbbbbccccccccddddddddeeeeeeeeffffffff111111222222333333444444555555"
         val badJson = s"""{"k":"$secret" """ + ("x" * 200) // missing closing brace, long
         val result  = JsonConfigSource.fromString(badJson, "json:long")
         assertTrue(result.isLeft) &&
@@ -177,16 +178,17 @@ object JsonConfigSourceSpec extends ZIOSpecDefault {
         val badJson = s"""not-json-at-all $secret [[[ """
         val result  = JsonConfigSource.fromString(badJson, "json:composite")
         assertTrue(result.isLeft) &&
-        assertTrue({
-                 val composite = ConfigError.Composite(new ::(result.left.toOption.get, Nil))
-                 !composite.message.contains(secret) && !composite.getMessage.contains(secret) &&
-                 composite.message.contains("valid JSON") && composite.message.contains("json:composite")
-               })
+        assertTrue {
+          val composite = ConfigError.Composite(new ::(result.left.toOption.get, Nil))
+          !composite.message.contains(secret) && !composite.getMessage.contains(secret) &&
+          composite.message.contains("valid JSON") && composite.message.contains("json:composite")
+        }
       },
       test("invalid JSON error retains structured fields without leak via getMessage") {
         val secret  = "SENTINEL_JSON_STRUCT_cccccddddd1111122222333334444455555"
         val badJson = s"""{"a": "$secret" invalid}"""
-        val error   = JsonConfigSource.fromString(badJson, "src-json-struct").left.toOption.get.asInstanceOf[ConfigError.ParseError]
+        val error   =
+          JsonConfigSource.fromString(badJson, "src-json-struct").left.toOption.get.asInstanceOf[ConfigError.ParseError]
         assertTrue(error.path == "") &&
         assertTrue(error.source == "src-json-struct") &&
         assertTrue(error.expectedType == "valid JSON") &&

--- a/config-yaml/shared/src/main/scala/zio/blocks/config/yaml/YamlConfigSource.scala
+++ b/config-yaml/shared/src/main/scala/zio/blocks/config/yaml/YamlConfigSource.scala
@@ -45,9 +45,8 @@ object YamlConfigSource {
       val flatMap = flatten(parsed)
       Right(ConfigSource.MapSource(flatMap, sourceId))
     } catch {
-      case e: Exception =>
-        val excerpt = if (yaml.length > 100) yaml.take(100) + "..." else yaml
-        Left(ConfigError.InvalidValue("", excerpt, "valid YAML", sourceId, Some(e)))
+      case _: Throwable =>
+        Left(ConfigError.ParseError("", sourceId, "valid YAML"))
     }
 
   /**

--- a/config-yaml/shared/src/test/scala/zio/blocks/config/yaml/YamlConfigSourceSpec.scala
+++ b/config-yaml/shared/src/test/scala/zio/blocks/config/yaml/YamlConfigSourceSpec.scala
@@ -200,11 +200,11 @@ object YamlConfigSourceSpec extends ZIOSpecDefault {
         val badYaml = s"secretKey: $secret\nbad: \""
         val result  = YamlConfigSource.fromString(badYaml, "yaml:composite")
         assertTrue(result.isLeft) &&
-        assertTrue({
-                 val composite = ConfigError.Composite(new ::(result.left.toOption.get, Nil))
-                 !composite.message.contains(secret) && !composite.getMessage.contains(secret) &&
-                 composite.message.contains("valid YAML") && composite.message.contains("yaml:composite")
-               })
+        assertTrue {
+          val composite = ConfigError.Composite(new ::(result.left.toOption.get, Nil))
+          !composite.message.contains(secret) && !composite.getMessage.contains(secret) &&
+          composite.message.contains("valid YAML") && composite.message.contains("yaml:composite")
+        }
       },
       test("ParseError with empty path hides cause text even if cause contains secret") {
         val secret = "SENTINEL_PARSE_CAUSE_YAML_123456abcdef123456abcdef123456abcdef"

--- a/config-yaml/shared/src/test/scala/zio/blocks/config/yaml/YamlConfigSourceSpec.scala
+++ b/config-yaml/shared/src/test/scala/zio/blocks/config/yaml/YamlConfigSourceSpec.scala
@@ -101,7 +101,10 @@ object YamlConfigSourceSpec extends ZIOSpecDefault {
     test("handles flow sequence value") {
       val yaml   = "key: [a, b, c]"
       val result = YamlConfigSource.fromString(yaml)
-      assertTrue(result.isRight || result.isLeft)
+      assertTrue(result.isRight) &&
+      assertTrue(result.toOption.get.get("key.0").map(_.value) == Maybe.present("a")) &&
+      assertTrue(result.toOption.get.get("key.1").map(_.value) == Maybe.present("b")) &&
+      assertTrue(result.toOption.get.get("key.2").map(_.value) == Maybe.present("c"))
     },
     test("uses custom sourceId in provenance") {
       val yaml   = "key: value"
@@ -143,7 +146,8 @@ object YamlConfigSourceSpec extends ZIOSpecDefault {
     },
     test("malformed YAML treated as scalar value") {
       val result = YamlConfigSource.fromString("key: ]]][[[")
-      assertTrue(result.isRight)
+      assertTrue(result.isRight) &&
+      assertTrue(result.toOption.get.get("key").map(_.value) == Maybe.present("]]][[["))
     },
     test("triple-nested object keys accessible via dot notation") {
       val yaml = """

--- a/config-yaml/shared/src/test/scala/zio/blocks/config/yaml/YamlConfigSourceSpec.scala
+++ b/config-yaml/shared/src/test/scala/zio/blocks/config/yaml/YamlConfigSourceSpec.scala
@@ -16,7 +16,7 @@
 
 package zio.blocks.config.yaml
 
-import zio.blocks.config.ConfigSource
+import zio.blocks.config.{ConfigError, ConfigSource}
 import zio.blocks.maybe.Maybe
 import zio.test._
 
@@ -170,6 +170,58 @@ object YamlConfigSourceSpec extends ZIOSpecDefault {
       val result = YamlConfigSource.fromString(yaml)
       assertTrue(result.isRight) &&
       assertTrue(result.toOption.get.get("count").map(_.value) == Maybe.present("42"))
-    }
+    },
+    suite("parse error redaction")(
+      test("invalid YAML does not leak document excerpt or cause, contains source and expected format") {
+        // `bad: "` triggers StringIndexOutOfBounds via unquoteDouble substring bounds, while secret is in prior line
+        val secret   = "SENTINEL_YAML_SECRET_7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0"
+        val badYaml  = s"secretKey: $secret\nbad: \""
+        val sourceId = "test-yaml-source"
+        val result   = YamlConfigSource.fromString(badYaml, sourceId)
+        assertTrue(result.isLeft) &&
+        assertTrue(result.left.toOption.get.isInstanceOf[ConfigError.ParseError]) &&
+        assertTrue(!result.left.toOption.get.message.contains(secret)) &&
+        assertTrue(!result.left.toOption.get.getMessage.contains(secret)) &&
+        assertTrue(result.left.toOption.get.message.contains(sourceId)) &&
+        assertTrue(result.left.toOption.get.message.contains("valid YAML"))
+      },
+      test("invalid YAML with secret in long document does not leak") {
+        val secret  = "SENTINEL_YAML_LONG_ffffffffeeeeeeeeddddddddccccccccbbbbbbbb111111222222333333444444"
+        val badYaml = s"secretKey: $secret\nbad: \"\n" + ("x" * 120)
+        val result  = YamlConfigSource.fromString(badYaml, "yaml:long")
+        assertTrue(result.isLeft) &&
+        assertTrue(!result.left.toOption.get.message.contains(secret)) &&
+        assertTrue(!result.left.toOption.get.getMessage.contains(secret)) &&
+        assertTrue(result.left.toOption.get.message.contains("valid YAML")) &&
+        assertTrue(result.left.toOption.get.message.contains("yaml:long"))
+      },
+      test("invalid YAML error wrapped in Composite still redacted") {
+        val secret  = "SENTINEL_YAML_COMPOSITE_aaa111bbb222ccc333ddd444eee555fff666ggg777hhh888"
+        val badYaml = s"secretKey: $secret\nbad: \""
+        val result  = YamlConfigSource.fromString(badYaml, "yaml:composite")
+        assertTrue(result.isLeft) &&
+        assertTrue({
+                 val composite = ConfigError.Composite(new ::(result.left.toOption.get, Nil))
+                 !composite.message.contains(secret) && !composite.getMessage.contains(secret) &&
+                 composite.message.contains("valid YAML") && composite.message.contains("yaml:composite")
+               })
+      },
+      test("ParseError with empty path hides cause text even if cause contains secret") {
+        val secret = "SENTINEL_PARSE_CAUSE_YAML_123456abcdef123456abcdef123456abcdef"
+        val cause  = new RuntimeException(s"yaml parse error near '$secret'")
+        val err    = ConfigError.ParseError("", "yaml:string", "valid YAML", Some(cause))
+        assertTrue(!err.message.contains(secret)) &&
+        assertTrue(!err.getMessage.contains(secret)) &&
+        assertTrue(err.message.contains("valid YAML")) &&
+        assertTrue(err.message.contains("yaml:string")) &&
+        assertTrue(err.cause.exists(_.getMessage.contains(secret)))
+      },
+      test("non-empty path ParseError still includes cause for diagnostics") {
+        val cause = new RuntimeException("unexpected end")
+        val err   = ConfigError.ParseError("some.key", "yaml:string", "valid YAML", Some(cause))
+        assertTrue(err.message.contains("unexpected end")) &&
+        assertTrue(err.getMessage.contains("unexpected end"))
+      }
+    )
   )
 }

--- a/config/shared/src/main/scala/zio/blocks/config/ConfigError.scala
+++ b/config/shared/src/main/scala/zio/blocks/config/ConfigError.scala
@@ -164,10 +164,12 @@ object ConfigError {
   ) extends ConfigParseError {
     def message: String = {
       val base = s"Parse error for key '$path' (expected $expectedType) in source '$source'"
-      cause match {
-        case Some(t) => s"$base: ${t.getMessage}"
-        case None    => base
-      }
+      if (path.isEmpty) base
+      else
+        cause match {
+          case Some(t) => s"$base: ${t.getMessage}"
+          case None    => base
+        }
     }
   }
 }

--- a/config/shared/src/main/scala/zio/blocks/config/ConfigError.scala
+++ b/config/shared/src/main/scala/zio/blocks/config/ConfigError.scala
@@ -93,11 +93,15 @@ object ConfigError {
     cause: Option[Throwable] = None
   ) extends ConfigParseError {
     def message: String = {
-      val base = s"Invalid value '$value' for key '$path' (expected $expectedType) in source '$source'"
-      cause match {
-        case Some(t) => s"$base: ${t.getMessage}"
-        case None    => base
-      }
+      val isSensitive = Sensitive.isSensitive(path)
+      val display     = if (isSensitive) "<secret>" else value
+      val base        = s"Invalid value '$display' for key '$path' (expected $expectedType) in source '$source'"
+      if (isSensitive) base
+      else
+        cause match {
+          case Some(t) => s"$base: ${t.getMessage}"
+          case None    => base
+        }
     }
   }
 

--- a/config/shared/src/main/scala/zio/blocks/config/FlagException.scala
+++ b/config/shared/src/main/scala/zio/blocks/config/FlagException.scala
@@ -64,8 +64,11 @@ object FlagException {
     cause: Option[Throwable] = None
   ) extends FlagException {
     override def getMessage: String = {
-      val base = s"Failed to parse value '$rawValue' for flag '$flagName' (expected $expectedType)"
-      cause.fold(base)(t => s"$base: ${t.getMessage}")
+      val isSensitive = Sensitive.isSensitive(flagName)
+      val display     = if (isSensitive) "<secret>" else rawValue
+      val base        = s"Failed to parse value '$display' for flag '$flagName' (expected $expectedType)"
+      if (isSensitive) base
+      else cause.fold(base)(t => s"$base: ${t.getMessage}")
     }
   }
 

--- a/config/shared/src/main/scala/zio/blocks/config/FlagReader.scala
+++ b/config/shared/src/main/scala/zio/blocks/config/FlagReader.scala
@@ -164,8 +164,8 @@ object Flag extends Flag {
 
   /**
    * Authoritative global registry of all resolved flag instances (static and
-   * dynamic), keyed by flag name. Stored only here; [[Flag]] trait delegates
-   * to this instance so no separate map can exist.
+   * dynamic), keyed by flag name. Stored only here; [[Flag]] trait delegates to
+   * this instance so no separate map can exist.
    */
   override val registry: ConcurrentHashMap[String, Any] = new ConcurrentHashMap[String, Any]()
 

--- a/config/shared/src/main/scala/zio/blocks/config/FlagReader.scala
+++ b/config/shared/src/main/scala/zio/blocks/config/FlagReader.scala
@@ -22,135 +22,18 @@ import scala.concurrent.duration.{FiniteDuration, DAYS, HOURS, MINUTES, SECONDS,
 import scala.util.Try
 
 /** Global registry and diagnostics helpers for resolved flags. */
-trait Flag {
+sealed trait Flag {
 
   /**
    * Global registry of all resolved flag instances (static and dynamic), keyed
-   * by flag name.
+   * by flag name. Delegates to the authoritative store in [[Flag.registry]] so
+   * that arbitrary `Flag` mix-ins cannot receive an independent map.
    */
-  val registry: ConcurrentHashMap[String, Any] = new ConcurrentHashMap[String, Any]()
+  def registry: ConcurrentHashMap[String, Any] = Flag.registry
 
-  def dump(): String = {
-    import scala.jdk.CollectionConverters._
-    val entries = registry.entrySet().asScala.toList.sortBy(_.getKey)
-    if (entries.isEmpty) return "(no flags registered)"
+  def dump(): String = Flag.dump()
 
-    val rows: List[(String, String, String, String)] = entries.map { entry =>
-      val name = entry.getKey
-      val flag = entry.getValue
-      flag match {
-        case sf: StaticFlag[_] =>
-          (name, sf.source.toString, sf.displayValue, sf.provenance.sourceId)
-        case df: DynamicFlag[_] =>
-          (name, "DynamicFlag", df.expression, "dynamic")
-        case other =>
-          (name, "Unknown", other.toString, "unknown")
-      }
-    }
-
-    val nameWidth  = math.max("Name".length, rows.map(_._1.length).max)
-    val typeWidth  = math.max("Type".length, rows.map(_._2.length).max)
-    val valueWidth = math.max("Value".length, rows.map(_._3.length).max)
-    val srcWidth   = math.max("Source".length, rows.map(_._4.length).max)
-
-    val sb = new StringBuilder
-    sb.append("\u250c")
-    sb.append("\u2500" * (nameWidth + 2))
-    sb.append("\u252c")
-    sb.append("\u2500" * (typeWidth + 2))
-    sb.append("\u252c")
-    sb.append("\u2500" * (valueWidth + 2))
-    sb.append("\u252c")
-    sb.append("\u2500" * (srcWidth + 2))
-    sb.append("\u2510\n")
-
-    sb.append("\u2502 ")
-    sb.append("Name".padTo(nameWidth, ' '))
-    sb.append(" \u2502 ")
-    sb.append("Type".padTo(typeWidth, ' '))
-    sb.append(" \u2502 ")
-    sb.append("Value".padTo(valueWidth, ' '))
-    sb.append(" \u2502 ")
-    sb.append("Source".padTo(srcWidth, ' '))
-    sb.append(" \u2502\n")
-
-    sb.append("\u251c")
-    sb.append("\u2500" * (nameWidth + 2))
-    sb.append("\u253c")
-    sb.append("\u2500" * (typeWidth + 2))
-    sb.append("\u253c")
-    sb.append("\u2500" * (valueWidth + 2))
-    sb.append("\u253c")
-    sb.append("\u2500" * (srcWidth + 2))
-    sb.append("\u2524\n")
-
-    rows.foreach { case (name, tpe, value, src) =>
-      sb.append("\u2502 ")
-      sb.append(name.padTo(nameWidth, ' '))
-      sb.append(" \u2502 ")
-      sb.append(tpe.padTo(typeWidth, ' '))
-      sb.append(" \u2502 ")
-      sb.append(value.padTo(valueWidth, ' '))
-      sb.append(" \u2502 ")
-      sb.append(src.padTo(srcWidth, ' '))
-      sb.append(" \u2502\n")
-    }
-
-    sb.append("\u2514")
-    sb.append("\u2500" * (nameWidth + 2))
-    sb.append("\u2534")
-    sb.append("\u2500" * (typeWidth + 2))
-    sb.append("\u2534")
-    sb.append("\u2500" * (valueWidth + 2))
-    sb.append("\u2534")
-    sb.append("\u2500" * (srcWidth + 2))
-    sb.append("\u2518")
-
-    sb.toString
-  }
-
-  def nearMissWarnings(flagName: String): List[String] = {
-    val lowerName = flagName.toLowerCase
-    val envName   = flagName.replace('.', '_').toUpperCase
-    val warnings  = scala.collection.mutable.LinkedHashSet.empty[String]
-
-    val props    = System.getProperties
-    val propIter = props.stringPropertyNames().iterator()
-    while (propIter.hasNext) {
-      val prop = propIter.next()
-      if (prop.toLowerCase == lowerName && prop != flagName)
-        warnings += s"Near-miss: system property '$prop' looks similar to flag '$flagName' (case mismatch)"
-    }
-
-    val envIter = System.getenv().entrySet().iterator()
-    while (envIter.hasNext) {
-      val envVar = envIter.next().getKey
-      if (envVar.equalsIgnoreCase(envName) && envVar != envName)
-        warnings += s"Near-miss: environment variable '$envVar' looks similar to flag '$flagName' (case mismatch)"
-    }
-
-    val candidates = List(
-      flagName,
-      lowerName,
-      flagName.toUpperCase,
-      flagName.replace('.', '_'),
-      flagName.replace('.', '_').toLowerCase,
-      envName,
-      flagName.replace('_', '.'),
-      flagName.replace('_', '.').toLowerCase,
-      flagName.replace('_', '.').toUpperCase
-    ).distinct
-
-    FlagSource.Registry.all.foreach { source =>
-      candidates.foreach { candidate =>
-        if (candidate != flagName && source.get(candidate).isPresent)
-          warnings +=
-            s"Near-miss: FlagSource '${source.sourceId}' contains key '$candidate' similar to flag '$flagName'"
-      }
-    }
-
-    warnings.toList
-  }
+  def nearMissWarnings(flagName: String): List[String] = Flag.nearMissWarnings(flagName)
 
   trait Reader[A] {
 
@@ -278,6 +161,135 @@ trait Flag {
 }
 
 object Flag extends Flag {
+
+  /**
+   * Authoritative global registry of all resolved flag instances (static and
+   * dynamic), keyed by flag name. Stored only here; [[Flag]] trait delegates
+   * to this instance so no separate map can exist.
+   */
+  override val registry: ConcurrentHashMap[String, Any] = new ConcurrentHashMap[String, Any]()
+
+  override def dump(): String = {
+    import scala.jdk.CollectionConverters._
+    val entries = registry.entrySet().asScala.toList.sortBy(_.getKey)
+    if (entries.isEmpty) return "(no flags registered)"
+
+    val rows: List[(String, String, String, String)] = entries.map { entry =>
+      val name = entry.getKey
+      val flag = entry.getValue
+      flag match {
+        case sf: StaticFlag[_] =>
+          (name, sf.source.toString, sf.displayValue, sf.provenance.sourceId)
+        case df: DynamicFlag[_] =>
+          (name, "DynamicFlag", df.expression, "dynamic")
+        case other =>
+          (name, "Unknown", other.toString, "unknown")
+      }
+    }
+
+    val nameWidth  = math.max("Name".length, rows.map(_._1.length).max)
+    val typeWidth  = math.max("Type".length, rows.map(_._2.length).max)
+    val valueWidth = math.max("Value".length, rows.map(_._3.length).max)
+    val srcWidth   = math.max("Source".length, rows.map(_._4.length).max)
+
+    val sb = new StringBuilder
+    sb.append("\u250c")
+    sb.append("\u2500" * (nameWidth + 2))
+    sb.append("\u252c")
+    sb.append("\u2500" * (typeWidth + 2))
+    sb.append("\u252c")
+    sb.append("\u2500" * (valueWidth + 2))
+    sb.append("\u252c")
+    sb.append("\u2500" * (srcWidth + 2))
+    sb.append("\u2510\n")
+
+    sb.append("\u2502 ")
+    sb.append("Name".padTo(nameWidth, ' '))
+    sb.append(" \u2502 ")
+    sb.append("Type".padTo(typeWidth, ' '))
+    sb.append(" \u2502 ")
+    sb.append("Value".padTo(valueWidth, ' '))
+    sb.append(" \u2502 ")
+    sb.append("Source".padTo(srcWidth, ' '))
+    sb.append(" \u2502\n")
+
+    sb.append("\u251c")
+    sb.append("\u2500" * (nameWidth + 2))
+    sb.append("\u253c")
+    sb.append("\u2500" * (typeWidth + 2))
+    sb.append("\u253c")
+    sb.append("\u2500" * (valueWidth + 2))
+    sb.append("\u253c")
+    sb.append("\u2500" * (srcWidth + 2))
+    sb.append("\u2524\n")
+
+    rows.foreach { case (name, tpe, value, src) =>
+      sb.append("\u2502 ")
+      sb.append(name.padTo(nameWidth, ' '))
+      sb.append(" \u2502 ")
+      sb.append(tpe.padTo(typeWidth, ' '))
+      sb.append(" \u2502 ")
+      sb.append(value.padTo(valueWidth, ' '))
+      sb.append(" \u2502 ")
+      sb.append(src.padTo(srcWidth, ' '))
+      sb.append(" \u2502\n")
+    }
+
+    sb.append("\u2514")
+    sb.append("\u2500" * (nameWidth + 2))
+    sb.append("\u2534")
+    sb.append("\u2500" * (typeWidth + 2))
+    sb.append("\u2534")
+    sb.append("\u2500" * (valueWidth + 2))
+    sb.append("\u2534")
+    sb.append("\u2500" * (srcWidth + 2))
+    sb.append("\u2518")
+
+    sb.toString
+  }
+
+  override def nearMissWarnings(flagName: String): List[String] = {
+    val lowerName = flagName.toLowerCase
+    val envName   = flagName.replace('.', '_').toUpperCase
+    val warnings  = scala.collection.mutable.LinkedHashSet.empty[String]
+
+    val props    = System.getProperties
+    val propIter = props.stringPropertyNames().iterator()
+    while (propIter.hasNext) {
+      val prop = propIter.next()
+      if (prop.toLowerCase == lowerName && prop != flagName)
+        warnings += s"Near-miss: system property '$prop' looks similar to flag '$flagName' (case mismatch)"
+    }
+
+    val envIter = System.getenv().entrySet().iterator()
+    while (envIter.hasNext) {
+      val envVar = envIter.next().getKey
+      if (envVar.equalsIgnoreCase(envName) && envVar != envName)
+        warnings += s"Near-miss: environment variable '$envVar' looks similar to flag '$flagName' (case mismatch)"
+    }
+
+    val candidates = List(
+      flagName,
+      lowerName,
+      flagName.toUpperCase,
+      flagName.replace('.', '_'),
+      flagName.replace('.', '_').toLowerCase,
+      envName,
+      flagName.replace('_', '.'),
+      flagName.replace('_', '.').toLowerCase,
+      flagName.replace('_', '.').toUpperCase
+    ).distinct
+
+    FlagSource.Registry.all.foreach { source =>
+      candidates.foreach { candidate =>
+        if (candidate != flagName && source.get(candidate).isPresent)
+          warnings +=
+            s"Near-miss: FlagSource '${source.sourceId}' contains key '$candidate' similar to flag '$flagName'"
+      }
+    }
+
+    warnings.toList
+  }
 
   /**
    * Identifies where a flag's value was resolved from.

--- a/config/shared/src/main/scala/zio/blocks/config/FlagReader.scala
+++ b/config/shared/src/main/scala/zio/blocks/config/FlagReader.scala
@@ -22,7 +22,7 @@ import scala.concurrent.duration.{FiniteDuration, DAYS, HOURS, MINUTES, SECONDS,
 import scala.util.Try
 
 /** Global registry and diagnostics helpers for resolved flags. */
-sealed trait Flag {
+trait Flag {
 
   /**
    * Global registry of all resolved flag instances (static and dynamic), keyed

--- a/config/shared/src/main/scala/zio/blocks/config/ProvenanceMap.scala
+++ b/config/shared/src/main/scala/zio/blocks/config/ProvenanceMap.scala
@@ -24,25 +24,7 @@ import zio.blocks.maybe.Maybe
  */
 final case class ProvenanceMap[A](value: A, private val source: ConfigSource) {
 
-  private val sensitiveKeyMarkers = List(
-    "secret",
-    "password",
-    "passwd",
-    "token",
-    "apikey",
-    "api_key",
-    "accesskey",
-    "access_key",
-    "privatekey",
-    "private_key",
-    "credential",
-    "credentials"
-  )
-
-  private def shouldRedact(path: String): Boolean = {
-    val normalized = path.toLowerCase.replace('-', '_')
-    sensitiveKeyMarkers.exists(normalized.contains)
-  }
+  private def shouldRedact(path: String): Boolean = Sensitive.isSensitive(path)
 
   private def displayValue(key: String, rawValue: String): String =
     if (shouldRedact(key)) "<secret>" else rawValue

--- a/config/shared/src/main/scala/zio/blocks/config/Secret.scala
+++ b/config/shared/src/main/scala/zio/blocks/config/Secret.scala
@@ -16,6 +16,8 @@
 
 package zio.blocks.config
 
+import zio.blocks.schema.Schema
+
 final class Secret private (private val value: String) {
   override def toString: String = "<secret>"
 
@@ -33,4 +35,6 @@ object Secret {
   def unwrap(secret: Secret): String = secret.value
 
   def displayable: Displayable[Secret] = Displayable.instance(_ => "<secret>")
+
+  implicit val schema: Schema[Secret] = Schema[String].transform(Secret.apply, Secret.unwrap)
 }

--- a/config/shared/src/main/scala/zio/blocks/config/Sensitive.scala
+++ b/config/shared/src/main/scala/zio/blocks/config/Sensitive.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.config
+
+private[config] object Sensitive {
+
+  private val markers = List(
+    "secret",
+    "password",
+    "passwd",
+    "token",
+    "apikey",
+    "api_key",
+    "accesskey",
+    "access_key",
+    "privatekey",
+    "private_key",
+    "credential",
+    "credentials"
+  )
+
+  def isSensitive(path: String): Boolean = {
+    val normalized = path.toLowerCase.replace('-', '_')
+    markers.exists(normalized.contains)
+  }
+}

--- a/config/shared/src/test/scala/zio/blocks/config/ConfigErrorSpec.scala
+++ b/config/shared/src/test/scala/zio/blocks/config/ConfigErrorSpec.scala
@@ -198,6 +198,116 @@ object ConfigErrorSpec extends ConfigBaseSpec {
             error.message.contains("JDBC URL")
         )
       }
+    ),
+    suite("InvalidValue sensitive redaction")(
+      test("redacts password key") {
+        val err = ConfigError.InvalidValue("db.password", "hunter2", "Int", "src")
+        assertTrue(
+          err.message.contains("<secret>"),
+          !err.message.contains("hunter2"),
+          err.value == "hunter2",
+          err.getMessage.contains("<secret>"),
+          !err.getMessage.contains("hunter2")
+        )
+      },
+      test("redacts token key case-insensitive") {
+        val err = ConfigError.InvalidValue("apiToken", "tok123", "Int", "src")
+        assertTrue(
+          err.message.contains("<secret>"),
+          !err.message.contains("tok123"),
+          err.value == "tok123"
+        )
+      },
+      test("redacts api-key kebab variant") {
+        val err = ConfigError.InvalidValue("api-key", "secret123", "Int", "src")
+        assertTrue(
+          err.message.contains("<secret>"),
+          !err.message.contains("secret123")
+        )
+      },
+      test("redacts private-key underscore and hyphen variants") {
+        val err1 = ConfigError.InvalidValue("private_key", "priv1", "Int", "src")
+        val err2 = ConfigError.InvalidValue("private-key", "priv2", "Int", "src")
+        val err3 = ConfigError.InvalidValue("myPrivateKey", "priv3", "Int", "src")
+        assertTrue(
+          err1.message.contains("<secret>"),
+          !err1.message.contains("priv1"),
+          err2.message.contains("<secret>"),
+          !err2.message.contains("priv2"),
+          err3.message.contains("<secret>"),
+          !err3.message.contains("priv3")
+        )
+      },
+      test("redacts secret and credentials markers") {
+        val err1 = ConfigError.InvalidValue("mySecret", "s1", "Int", "src")
+        val err2 = ConfigError.InvalidValue("db.credentials", "s2", "Int", "src")
+        val err3 = ConfigError.InvalidValue("access_key", "s3", "Int", "src")
+        assertTrue(
+          err1.message.contains("<secret>"),
+          !err1.message.contains("s1"),
+          err2.message.contains("<secret>"),
+          !err2.message.contains("s2"),
+          err3.message.contains("<secret>"),
+          !err3.message.contains("s3")
+        )
+      },
+      test("does not redact non-sensitive value") {
+        val err = ConfigError.InvalidValue("db.host", "not-an-int", "Int", "src")
+        assertTrue(
+          err.message.contains("not-an-int"),
+          !err.message.contains("<secret>"),
+          err.value == "not-an-int"
+        )
+      },
+      test("redacts with cause but still hides value") {
+        val cause = new RuntimeException("cause msg")
+        val err   = ConfigError.InvalidValue("db.password", "hunter2", "Int", "src", Some(cause))
+        assertTrue(
+          err.message.contains("<secret>"),
+          !err.message.contains("hunter2"),
+          !err.message.contains("cause msg"),
+          !err.getMessage.contains("cause msg"),
+          err.value == "hunter2",
+          err.cause.exists(_.getMessage == "cause msg"),
+          err.message == "Invalid value '<secret>' for key 'db.password' (expected Int) in source 'src'",
+          err.getMessage == err.message
+        )
+      },
+      test("redacts cause text that echoes secret") {
+        val cause = new RuntimeException("For input string: \"hunter2\"")
+        val err   = ConfigError.InvalidValue("db.password", "hunter2", "Int", "src", Some(cause))
+        assertTrue(
+          !err.message.contains("hunter2"),
+          !err.getMessage.contains("hunter2"),
+          err.value == "hunter2",
+          err.cause.exists(_.getMessage.contains("hunter2")),
+          err.message == "Invalid value '<secret>' for key 'db.password' (expected Int) in source 'src'",
+          err.getMessage == err.message
+        )
+      },
+      test("Composite with sensitive InvalidValue keeps redaction") {
+        val sensitive    = ConfigError.InvalidValue("db.password", "hunter2", "Int", "src")
+        val nonSensitive = ConfigError.InvalidValue("db.port", "abc", "Int", "src")
+        val composite    = ConfigError.Composite(new ::(sensitive, List(nonSensitive)))
+        assertTrue(
+          composite.message.contains("<secret>"),
+          !composite.message.contains("hunter2"),
+          !composite.getMessage.contains("hunter2"),
+          composite.message.contains("abc")
+        )
+      },
+      test("Composite with sensitive cause does not leak through message") {
+        val cause     = new RuntimeException("For input string: \"hunter2\"")
+        val sensitive = ConfigError.InvalidValue("api.token", "hunter2", "Int", "src", Some(cause))
+        val composite = ConfigError.Composite(new ::(sensitive, Nil))
+        assertTrue(
+          !composite.message.contains("hunter2"),
+          !composite.getMessage.contains("hunter2"),
+          composite.message.contains("<secret>"),
+          sensitive.value == "hunter2",
+          sensitive.cause.exists(_.getMessage.contains("hunter2"))
+        )
+      }
     )
   )
 }

--- a/config/shared/src/test/scala/zio/blocks/config/ConfigSourceSpec.scala
+++ b/config/shared/src/test/scala/zio/blocks/config/ConfigSourceSpec.scala
@@ -26,6 +26,7 @@ object ConfigSourceSpec extends ConfigBaseSpec {
     orElseSuite,
     prefixSuite,
     keyMapperSuite,
+    keyMapperNestedSuite,
     envSourceSuite,
     sysPropSourceSuite
   )
@@ -240,6 +241,82 @@ object ConfigSourceSpec extends ConfigBaseSpec {
         result.keySet == Set("databaseUrl", "maxRetries"),
         result("databaseUrl").value == "jdbc:postgres://localhost",
         result("maxRetries").value == "3"
+      )
+    }
+  )
+
+  private val keyMapperNestedSuite = suite("keyMapper nested prefix")(
+    test("all with UpperSnakeCase returns prefix-relative canonical full keys consistently") {
+      val source = ConfigSource.fromMap(
+        Map(
+          "DATABASE_URL_A" -> "1",
+          "DATABASE_URL_B" -> "2",
+          "DATABASE_URL.A" -> "10",
+          "DATABASE_URL.B" -> "20"
+        )
+      )
+      val mapped    = source.keyMapper(KeyMapper.default, KeyFormat.UpperSnakeCase)
+      val allEmpty  = mapped.all("")
+      val allPrefix = mapped.all("databaseUrl")
+      assertTrue(
+        allEmpty.keySet == Set("databaseUrlA", "databaseUrlB", "databaseUrl.a", "databaseUrl.b"),
+        allPrefix.keySet == Set("databaseUrl.a", "databaseUrl.b"),
+        allPrefix("databaseUrl.a").value == "10",
+        allPrefix("databaseUrl.b").value == "20",
+        !allPrefix.contains("databaseUrlA")
+      )
+    },
+    test("distinguishes mapped prefix, full keys, and relative keys") {
+      val source = ConfigSource.fromMap(
+        Map(
+          "APP_DB.HOST"       -> "localhost",
+          "APP_DB.PORT"       -> "5432",
+          "APP_HTTP.HOST"     -> "0.0.0.0",
+          "APP_DB.HOST_EXTRA" -> "extra"
+        )
+      )
+      val mapped = source.keyMapper(KeyMapper.default, KeyFormat.UpperSnakeCase)
+      // mapped prefix "appDb" maps to "APP_DB" and all returns full canonical keys with prefix
+      val dbAll = mapped.all("appDb")
+      // prefix wrapper returns relative keys stripped of the prefix
+      val prefixed = source.keyMapper(KeyMapper.default, KeyFormat.UpperSnakeCase).prefix("appDb")
+      val relative = prefixed.all("")
+      assertTrue(
+        dbAll.keySet == Set("appDb.host", "appDb.port", "appDb.hostExtra"),
+        dbAll.contains("appDb.host"),
+        !dbAll.contains("appHttp.host"),
+        relative.keySet == Set("host", "port", "hostExtra"),
+        relative.contains("host"),
+        relative("host").value == "localhost"
+      )
+    },
+    test("nested map decoding through keyFormat with UpperSnakeCase and dot prefix") {
+      val source = ConfigSource
+        .fromMap(Map("DATABASE_URL.A" -> "1", "DATABASE_URL.B" -> "2"))
+        .keyFormat(KeyFormat.UpperSnakeCase)
+      val mappedAll = source.all("databaseUrl")
+      assertTrue(
+        mappedAll.keySet == Set("databaseUrl.a", "databaseUrl.b"),
+        mappedAll("databaseUrl.a").value == "1",
+        mappedAll("databaseUrl.b").value == "2"
+      )
+    },
+    test("prefix and keyMapper compose: all returns prefix-relative canonical keys") {
+      val source = ConfigSource.fromMap(
+        Map(
+          "APP_DB.HOST" -> "localhost",
+          "APP_DB.PORT" -> "5432",
+          "OTHER"       -> "x"
+        )
+      )
+      val composed = source.keyMapper(KeyMapper.default, KeyFormat.UpperSnakeCase).prefix("appDb")
+      val result   = composed.all("")
+      assertTrue(
+        result.keySet == Set("host", "port"),
+        result("host").value == "localhost",
+        result("port").value == "5432",
+        !result.contains("appDb.host"),
+        !result.contains("other")
       )
     }
   )

--- a/config/shared/src/test/scala/zio/blocks/config/ConfigSpec.scala
+++ b/config/shared/src/test/scala/zio/blocks/config/ConfigSpec.scala
@@ -37,6 +37,16 @@ object ConfigSpec extends ConfigBaseSpec {
 
   final class DbService(val config: Db)
 
+  case class WithSecret(token: Secret, name: String)
+  object WithSecret {
+    implicit val schema: Schema[WithSecret] = Schema.derived[WithSecret]
+  }
+
+  case class NestedSecret(dbPassword: Secret, host: String)
+  object NestedSecret {
+    implicit val schema: Schema[NestedSecret] = Schema.derived[NestedSecret]
+  }
+
   def spec = suite("ConfigSpec")(
     suite("Config.load")(
       test("loads a simple case class from MapSource") {
@@ -177,6 +187,45 @@ object ConfigSpec extends ConfigBaseSpec {
           dumped.contains("db.password"),
           dumped.contains("<secret>"),
           !dumped.contains("super-secret-password")
+        )
+      }
+    ),
+    suite("Secret integration")(
+      test("loads case class containing Secret via Config.load") {
+        val source = ConfigSource.fromMap(Map("token" -> "s3cr3t", "name" -> "myapp"))
+        val result = Config.load[WithSecret](source)
+        assertTrue(
+          result.isRight,
+          result.toOption.get.name == "myapp",
+          Secret.unwrap(result.toOption.get.token) == "s3cr3t",
+          result.toOption.get.token.toString == "<secret>"
+        )
+      },
+      test("loads case class containing Secret via ConfigDecoder") {
+        val source  = ConfigSource.fromMap(Map("token" -> "tok123", "name" -> "svc"))
+        val decoder = ConfigDecoder.derive[WithSecret]
+        val result  = decoder.decode(source, "")
+        assertTrue(
+          result.isRight,
+          Secret.unwrap(result.toOption.get.token) == "tok123"
+        )
+      },
+      test("loads nested Secret field with prefix") {
+        val source = ConfigSource.fromMap(Map("dbPassword" -> "pwd123", "host" -> "localhost"))
+        val result = Config.load[NestedSecret](source)
+        assertTrue(
+          result.isRight,
+          Secret.unwrap(result.toOption.get.dbPassword) == "pwd123",
+          result.toOption.get.host == "localhost"
+        )
+      },
+      test("Secret decoder respects missing key error") {
+        val source = ConfigSource.fromMap(Map("name" -> "myapp"))
+        val result = Config.load[WithSecret](source)
+        assertTrue(
+          result.isLeft,
+          result.swap.toOption.get.head.isInstanceOf[ConfigError.MissingKey] ||
+            result.swap.toOption.get.head.isInstanceOf[ConfigError.Composite]
         )
       }
     )

--- a/config/shared/src/test/scala/zio/blocks/config/FlagExceptionSpec.scala
+++ b/config/shared/src/test/scala/zio/blocks/config/FlagExceptionSpec.scala
@@ -260,6 +260,86 @@ object FlagExceptionSpec extends ZIOSpecDefault {
         assertTrue(result.isRight) &&
         assertTrue(result.toOption.get.getCause.isInstanceOf[FlagExpressionParseException])
       }
-    ) @@ TestAspect.sequential
+    ) @@ TestAspect.sequential,
+    suite("FlagValueParseException sensitive redaction")(
+      test("sensitive flag redacts rawValue and cause, retains structured fields") {
+        val secret = "SENTINEL_FLAG_SECRET_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8"
+        val cause  = new RuntimeException(s"For input string: \"$secret\"")
+        val ex     = FlagValueParseException("my.secret.token", secret, "Int", Some(cause))
+        assertTrue(!ex.getMessage.contains(secret)) &&
+        assertTrue(!ex.getMessage.contains("For input string")) &&
+        assertTrue(ex.getMessage.contains("<secret>")) &&
+        assertTrue(ex.getMessage.contains("my.secret.token")) &&
+        assertTrue(ex.getMessage.contains("Int")) &&
+        assertTrue(ex.rawValue == secret) &&
+        assertTrue(ex.cause.exists(_.getMessage.contains(secret))) &&
+        assertTrue(ex.flagName == "my.secret.token")
+      },
+      test("sensitive flag with password marker redacts") {
+        val secret = "SENTINEL_FLAG_PWD_zzz111yyy222xxx333www444vvv555uuu666ttt777sss888"
+        val ex     = FlagValueParseException("db.password", secret, "Int", Some(new RuntimeException(secret)))
+        assertTrue(!ex.getMessage.contains(secret)) &&
+        assertTrue(ex.getMessage.contains("<secret>")) &&
+        assertTrue(ex.rawValue == secret)
+      },
+      test("sensitive flag api-key kebab and credential markers redact") {
+        val s1 = "SENTINEL_FLAG_APIKEY_aaa111bbb222ccc333ddd444"
+        val s2 = "SENTINEL_FLAG_CRED_eee555fff666ggg777hhh888"
+        val ex1 = FlagValueParseException("service.api-key", s1, "Int", Some(new RuntimeException(s"bad $s1")))
+        val ex2 = FlagValueParseException("my.credentials", s2, "Int", Some(new RuntimeException(s2)))
+        assertTrue(!ex1.getMessage.contains(s1)) &&
+        assertTrue(ex1.getMessage.contains("<secret>")) &&
+        assertTrue(ex1.rawValue == s1) &&
+        assertTrue(!ex2.getMessage.contains(s2)) &&
+        assertTrue(ex2.getMessage.contains("<secret>")) &&
+        assertTrue(ex2.rawValue == s2)
+      },
+      test("non-sensitive flag retains rawValue and cause details") {
+        val ex = FlagValueParseException("service.timeout", "badValue123", "Int", Some(new RuntimeException("For input string: \"badValue123\"")))
+        assertTrue(ex.getMessage.contains("badValue123")) &&
+        assertTrue(ex.getMessage.contains("For input string")) &&
+        assertTrue(!ex.getMessage.contains("<secret>")) &&
+        assertTrue(ex.getMessage.contains("service.timeout")) &&
+        assertTrue(ex.getMessage.contains("Int"))
+      },
+      test("sensitive flag Composite wrapper does not leak") {
+        val secret = "SENTINEL_FLAG_COMP_999888777666555444333222111000aaaabbbbccccdddd"
+        val cause  = new RuntimeException(secret)
+        val ex     = FlagValueParseException("auth.token", secret, "Int", Some(cause))
+        // Flag exceptions are typically wrapped in ExceptionInInitializerError; simulate via Composite-like concatenation
+        val wrapperMsg = new ExceptionInInitializerError(ex).getCause.getMessage
+        assertTrue(!wrapperMsg.contains(secret)) &&
+        assertTrue(wrapperMsg.contains("<secret>")) &&
+        assertTrue(ex.rawValue == secret) &&
+        assertTrue(ex.cause.exists(_.getMessage.contains(secret)))
+      },
+      test("Sensitive.isSensitive covers all markers for flag names") {
+        val secret = "SENTINEL_GENERIC_abc123"
+        val sensitiveNames = List(
+          "my.secret",
+          "db.password",
+          "svc.passwd",
+          "auth.token",
+          "api.apiKey",
+          "x.api_key",
+          "svc.accessKey",
+          "svc.access_key",
+          "m.privateKey",
+          "m.private_key",
+          "svc.credential",
+          "svc.credentials"
+        )
+        assertTrue(sensitiveNames.forall { name =>
+          val ex = FlagValueParseException(name, secret, "Int", Some(new RuntimeException(secret)))
+          !ex.getMessage.contains(secret) && ex.getMessage.contains("<secret>")
+        })
+      },
+      test("non-sensitive flag with long secret value still shows value") {
+        val raw = "SENTINEL_NON_SENSITIVE_LONG_" + ("x" * 150)
+        val ex  = FlagValueParseException("app.port", raw, "Int", Some(new RuntimeException(raw)))
+        assertTrue(ex.getMessage.contains(raw)) &&
+        assertTrue(ex.rawValue == raw)
+      }
+    )
   )
 }

--- a/config/shared/src/test/scala/zio/blocks/config/FlagExceptionSpec.scala
+++ b/config/shared/src/test/scala/zio/blocks/config/FlagExceptionSpec.scala
@@ -283,8 +283,8 @@ object FlagExceptionSpec extends ZIOSpecDefault {
         assertTrue(ex.rawValue == secret)
       },
       test("sensitive flag api-key kebab and credential markers redact") {
-        val s1 = "SENTINEL_FLAG_APIKEY_aaa111bbb222ccc333ddd444"
-        val s2 = "SENTINEL_FLAG_CRED_eee555fff666ggg777hhh888"
+        val s1  = "SENTINEL_FLAG_APIKEY_aaa111bbb222ccc333ddd444"
+        val s2  = "SENTINEL_FLAG_CRED_eee555fff666ggg777hhh888"
         val ex1 = FlagValueParseException("service.api-key", s1, "Int", Some(new RuntimeException(s"bad $s1")))
         val ex2 = FlagValueParseException("my.credentials", s2, "Int", Some(new RuntimeException(s2)))
         assertTrue(!ex1.getMessage.contains(s1)) &&
@@ -295,7 +295,12 @@ object FlagExceptionSpec extends ZIOSpecDefault {
         assertTrue(ex2.rawValue == s2)
       },
       test("non-sensitive flag retains rawValue and cause details") {
-        val ex = FlagValueParseException("service.timeout", "badValue123", "Int", Some(new RuntimeException("For input string: \"badValue123\"")))
+        val ex = FlagValueParseException(
+          "service.timeout",
+          "badValue123",
+          "Int",
+          Some(new RuntimeException("For input string: \"badValue123\""))
+        )
         assertTrue(ex.getMessage.contains("badValue123")) &&
         assertTrue(ex.getMessage.contains("For input string")) &&
         assertTrue(!ex.getMessage.contains("<secret>")) &&
@@ -314,7 +319,7 @@ object FlagExceptionSpec extends ZIOSpecDefault {
         assertTrue(ex.cause.exists(_.getMessage.contains(secret)))
       },
       test("Sensitive.isSensitive covers all markers for flag names") {
-        val secret = "SENTINEL_GENERIC_abc123"
+        val secret         = "SENTINEL_GENERIC_abc123"
         val sensitiveNames = List(
           "my.secret",
           "db.password",

--- a/config/shared/src/test/scala/zio/blocks/config/FlagRegistrySpec.scala
+++ b/config/shared/src/test/scala/zio/blocks/config/FlagRegistrySpec.scala
@@ -20,7 +20,7 @@ import zio.test._
 
 object FlagRegistrySpec extends ZIOSpecDefault {
 
-  object TopStatic extends StaticFlag[Int](1)
+  object TopStatic  extends StaticFlag[Int](1)
   object TopDynamic extends DynamicFlag[Int](0, "5")
 
   def spec = suite("FlagRegistrySpec")(
@@ -41,30 +41,32 @@ object FlagRegistrySpec extends ZIOSpecDefault {
       } finally Flag.registry.remove("repro.singleton.flag")
     },
     test("anonymous Flag mixins share authoritative registry and dump state") {
-      val mixin1 = new Flag {}
-      val mixin2 = new Flag {}
+      val mixin1                     = new Flag {}
+      val mixin2                     = new Flag {}
       val mixin1DelegatesToSingleton = mixin1.registry eq Flag.registry
       val mixin2DelegatesToSingleton = mixin2.registry eq Flag.registry
       val mixinsShareRegistry        = mixin1.registry eq mixin2.registry
-      val sentinel = new Object()
+      val sentinel                   = new Object()
       mixin1.registry.put("repro.mixin.flag", sentinel)
       try {
-        val flagDump  = Flag.dump()
-        val dump1     = mixin1.dump()
-        val dump2     = mixin2.dump()
-        val viaFlag   = Flag.registry.get("repro.mixin.flag").asInstanceOf[AnyRef] eq sentinel.asInstanceOf[AnyRef]
-        val viaMixin2 = mixin2.registry.get("repro.mixin.flag").asInstanceOf[AnyRef] eq sentinel.asInstanceOf[AnyRef]
+        val flagDump   = Flag.dump()
+        val dump1      = mixin1.dump()
+        val dump2      = mixin2.dump()
+        val viaFlag    = Flag.registry.get("repro.mixin.flag").asInstanceOf[AnyRef] eq sentinel.asInstanceOf[AnyRef]
+        val viaMixin2  = mixin2.registry.get("repro.mixin.flag").asInstanceOf[AnyRef] eq sentinel.asInstanceOf[AnyRef]
         val dumpsEqual = flagDump == dump1 && dump1 == dump2
-        val contains = flagDump.contains("repro.mixin.flag") && dump1.contains("repro.mixin.flag") && dump2.contains(
+        val contains   = flagDump.contains("repro.mixin.flag") && dump1.contains("repro.mixin.flag") && dump2.contains(
           "repro.mixin.flag"
         )
-        val wFlag    = Flag.nearMissWarnings("repro.mixin.flag")
-        val w1       = mixin1.nearMissWarnings("repro.mixin.flag")
-        val w2       = mixin2.nearMissWarnings("repro.mixin.flag")
+        val wFlag         = Flag.nearMissWarnings("repro.mixin.flag")
+        val w1            = mixin1.nearMissWarnings("repro.mixin.flag")
+        val w2            = mixin2.nearMissWarnings("repro.mixin.flag")
         val warningsEqual = wFlag == w1 && w1 == w2
         assertTrue(mixin1DelegatesToSingleton) && assertTrue(mixin2DelegatesToSingleton) && assertTrue(
           mixinsShareRegistry
-        ) && assertTrue(viaFlag) && assertTrue(viaMixin2) && assertTrue(dumpsEqual) && assertTrue(contains) && assertTrue(
+        ) && assertTrue(viaFlag) && assertTrue(viaMixin2) && assertTrue(dumpsEqual) && assertTrue(
+          contains
+        ) && assertTrue(
           warningsEqual
         )
       } finally Flag.registry.remove("repro.mixin.flag")

--- a/config/shared/src/test/scala/zio/blocks/config/FlagRegistrySpec.scala
+++ b/config/shared/src/test/scala/zio/blocks/config/FlagRegistrySpec.scala
@@ -18,13 +18,12 @@ package zio.blocks.config
 
 import zio.test._
 
-object FlagRegistrySplitReproSpec extends ZIOSpecDefault {
+object FlagRegistrySpec extends ZIOSpecDefault {
 
-  // Top-level objects for registration tests: must be Scala objects (class name ends with $)
   object TopStatic extends StaticFlag[Int](1)
   object TopDynamic extends DynamicFlag[Int](0, "5")
 
-  def spec = suite("FlagRegistrySplitReproSpec")(
+  def spec = suite("FlagRegistrySpec")(
     test("authoritative registry is singleton across accesses") {
       val r1 = Flag.registry
       val r2 = Flag.registry
@@ -34,21 +33,43 @@ object FlagRegistrySplitReproSpec extends ZIOSpecDefault {
       val sentinel = new Object()
       Flag.registry.put("repro.singleton.flag", sentinel)
       try {
-        val dumped   = Flag.dump()
-        val contains = dumped.contains("repro.singleton.flag")
+        val dumped    = Flag.dump()
+        val contains  = dumped.contains("repro.singleton.flag")
         val retrieved = Flag.registry.get("repro.singleton.flag")
-        val same     = retrieved.asInstanceOf[AnyRef] eq sentinel.asInstanceOf[AnyRef]
+        val same      = retrieved.asInstanceOf[AnyRef] eq sentinel.asInstanceOf[AnyRef]
         assertTrue(contains) && assertTrue(same)
       } finally Flag.registry.remove("repro.singleton.flag")
     },
-    test("trait Flag is sealed so external mixin cannot obtain separate registry") {
-      // Sealed trait can only be extended in FlagReader.scala; `new Flag {}` in
-      // a different file fails to compile (proven by compilation error after fix).
-      // Cross-platform check: Flag is an interface and registry is singleton.
-      assertTrue(classOf[Flag].isInterface) && assertTrue(Flag.registry ne null)
+    test("anonymous Flag mixins share authoritative registry and dump state") {
+      val mixin1 = new Flag {}
+      val mixin2 = new Flag {}
+      val mixin1DelegatesToSingleton = mixin1.registry eq Flag.registry
+      val mixin2DelegatesToSingleton = mixin2.registry eq Flag.registry
+      val mixinsShareRegistry        = mixin1.registry eq mixin2.registry
+      val sentinel = new Object()
+      mixin1.registry.put("repro.mixin.flag", sentinel)
+      try {
+        val flagDump  = Flag.dump()
+        val dump1     = mixin1.dump()
+        val dump2     = mixin2.dump()
+        val viaFlag   = Flag.registry.get("repro.mixin.flag").asInstanceOf[AnyRef] eq sentinel.asInstanceOf[AnyRef]
+        val viaMixin2 = mixin2.registry.get("repro.mixin.flag").asInstanceOf[AnyRef] eq sentinel.asInstanceOf[AnyRef]
+        val dumpsEqual = flagDump == dump1 && dump1 == dump2
+        val contains = flagDump.contains("repro.mixin.flag") && dump1.contains("repro.mixin.flag") && dump2.contains(
+          "repro.mixin.flag"
+        )
+        val wFlag    = Flag.nearMissWarnings("repro.mixin.flag")
+        val w1       = mixin1.nearMissWarnings("repro.mixin.flag")
+        val w2       = mixin2.nearMissWarnings("repro.mixin.flag")
+        val warningsEqual = wFlag == w1 && w1 == w2
+        assertTrue(mixin1DelegatesToSingleton) && assertTrue(mixin2DelegatesToSingleton) && assertTrue(
+          mixinsShareRegistry
+        ) && assertTrue(viaFlag) && assertTrue(viaMixin2) && assertTrue(dumpsEqual) && assertTrue(contains) && assertTrue(
+          warningsEqual
+        )
+      } finally Flag.registry.remove("repro.mixin.flag")
     },
     test("StaticFlag and DynamicFlag share same authoritative registry") {
-      // TopStatic/TopDynamic are initialized on first access; force init
       val _ = (TopStatic.value, TopDynamic.expression)
       assertTrue(Flag.registry.containsKey(TopStatic.name)) &&
       assertTrue(Flag.registry.containsKey(TopDynamic.name)) &&

--- a/config/shared/src/test/scala/zio/blocks/config/FlagRegistrySplitReproSpec.scala
+++ b/config/shared/src/test/scala/zio/blocks/config/FlagRegistrySplitReproSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.config
+
+import zio.test._
+
+object FlagRegistrySplitReproSpec extends ZIOSpecDefault {
+
+  // Top-level objects for registration tests: must be Scala objects (class name ends with $)
+  object TopStatic extends StaticFlag[Int](1)
+  object TopDynamic extends DynamicFlag[Int](0, "5")
+
+  def spec = suite("FlagRegistrySplitReproSpec")(
+    test("authoritative registry is singleton across accesses") {
+      val r1 = Flag.registry
+      val r2 = Flag.registry
+      assertTrue(r1 eq r2)
+    },
+    test("Flag.registry mutation is visible via Flag.dump") {
+      val sentinel = new Object()
+      Flag.registry.put("repro.singleton.flag", sentinel)
+      try {
+        val dumped   = Flag.dump()
+        val contains = dumped.contains("repro.singleton.flag")
+        val retrieved = Flag.registry.get("repro.singleton.flag")
+        val same     = retrieved.asInstanceOf[AnyRef] eq sentinel.asInstanceOf[AnyRef]
+        assertTrue(contains) && assertTrue(same)
+      } finally Flag.registry.remove("repro.singleton.flag")
+    },
+    test("trait Flag is sealed so external mixin cannot obtain separate registry") {
+      // Sealed trait can only be extended in FlagReader.scala; `new Flag {}` in
+      // a different file fails to compile (proven by compilation error after fix).
+      // Cross-platform check: Flag is an interface and registry is singleton.
+      assertTrue(classOf[Flag].isInterface) && assertTrue(Flag.registry ne null)
+    },
+    test("StaticFlag and DynamicFlag share same authoritative registry") {
+      // TopStatic/TopDynamic are initialized on first access; force init
+      val _ = (TopStatic.value, TopDynamic.expression)
+      assertTrue(Flag.registry.containsKey(TopStatic.name)) &&
+      assertTrue(Flag.registry.containsKey(TopDynamic.name)) &&
+      assertTrue(Flag.registry.get(TopStatic.name).asInstanceOf[AnyRef] eq TopStatic.asInstanceOf[AnyRef]) &&
+      assertTrue(Flag.registry.get(TopDynamic.name).asInstanceOf[AnyRef] eq TopDynamic.asInstanceOf[AnyRef]) &&
+      assertTrue(Flag.dump().contains(TopStatic.name)) &&
+      assertTrue(Flag.dump().contains(TopDynamic.name))
+    }
+  ) @@ TestAspect.sequential
+}

--- a/project/CiWorkflow.scala
+++ b/project/CiWorkflow.scala
@@ -266,6 +266,11 @@ object CiWorkflow {
           run = Some("sbt ++${{ matrix.scala }} coverage test${{ matrix.platform }} coverageReport")
         ),
         SingleStep(
+          name = "Run Scala 3 config adapter coverage (JDK 25, scoped)",
+          condition = Some(expr("startsWith(matrix.scala, '3.')") && expr("matrix.java >= 25")),
+          run = Some("sbt ++${{ matrix.scala }} configCoverage")
+        ),
+        SingleStep(
           name = "Run Scala Next tests",
           condition = Some(expr("matrix.scala == '3.8.x'")),
           run = Some("sbt ++3.8.3 scalaNextTests${{ matrix.platform }}/test benchmarks/test")


### PR DESCRIPTION
## Summary
- fix HOCON array parsing, malformed-array hangs, and ignored array tests
- bound HOCON root/include file reads while preserving the existing JVM API descriptor
- centralize Flag registry ownership without breaking external trait extension
- add Secret schema decoding and mapped nested-source regression coverage
- redact sensitive config, flag, JSON, and YAML parse diagnostics
- replace weak YAML assertions and enforce measured adapter coverage in a scoped CI gate

## Verification
- Scala 3.8 JVM/JS config matrix: green
- Scala 2.13 JVM/JS config matrix: green
- Scala 3.3 JVM/JS core and HOCON matrix: green
- configCoverage: YAML 89.80/81.25, JSON 95.92/92.31, HOCON 76.69/67.87
- sbt fmt: green

Closes all actionable findings from the post-merge review of #1426.