### PR TITLE
fix(sql): PR2 widen-review fixes — positional decode, batch hoist, validation, dedup

### DIFF
--- a/docs/guides/query-dsl-sql.md
+++ b/docs/guides/query-dsl-sql.md
@@ -984,7 +984,7 @@ val q = SqlQuery
   .where(userTable, "name", DbValue.DbString("alice"))
 
 println(q.explain(SqlDialect.PostgreSQL))
-// SELECT t0.id, t0.name, t1.id, t1.owner_id, t1.name FROM user t0 INNER JOIN repo t1 ON t0.id = t1.owner_id WHERE t0.name = ?1
+// SELECT t0."id", t0."name", t1."id", t1."owner_id", t1."name" FROM "user" t0 INNER JOIN "repo" t1 ON t0."id" = t1."owner_id" WHERE t0."name" = ?1
 // -- params: 1:String
 ```
 

--- a/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
+++ b/sql/jvm/src/main/scala/zio/blocks/sql/JdbcTransactor.scala
@@ -27,20 +27,11 @@ class JdbcTransactor(
 ) extends Transactor {
 
   def connect[A](f: DbCon ?=> A): A = {
-    val conn = connectionFactory()
-    try {
-      if (dialect == SqlDialect.SQLite) JdbcTransactor.configureSQLiteConnection(conn)
-    } catch {
-      case e: Throwable =>
-        try conn.close()
-        catch { case ce: Throwable => e.addSuppressed(ce) }
-        throw e
-    }
-    val dbConn = new JdbcConnection(conn)
+    val dbConn = JdbcTransactor.openConnection(connectionFactory, dialect)
     try {
       if (dialect == SqlDialect.SQLite) {
         try {
-          val stmt = conn.createStatement()
+          val stmt = dbConn.underlying.createStatement()
           if (stmt != null) {
             try stmt.execute("PRAGMA busy_timeout = 5000")
             finally
@@ -84,16 +75,8 @@ class JdbcTransactor(
    * connection.
    */
   override def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A = {
-    val conn = connectionFactory()
-    try {
-      if (dialect == SqlDialect.SQLite) JdbcTransactor.configureSQLiteConnection(conn)
-    } catch {
-      case e: Throwable =>
-        try conn.close()
-        catch { case ce: Throwable => e.addSuppressed(ce) }
-        throw e
-    }
-    val dbConn         = new JdbcConnection(conn)
+    val dbConn         = JdbcTransactor.openConnection(connectionFactory, dialect)
+    val conn           = dbConn.underlying
     val prevAutoCommit =
       try conn.getAutoCommit
       catch {
@@ -179,16 +162,8 @@ class JdbcTransactor(
    * SQLite is single-consumer.
    */
   override def transact[A](f: DbTx ?=> A): A = {
-    val conn = connectionFactory()
-    try {
-      if (dialect == SqlDialect.SQLite) JdbcTransactor.configureSQLiteConnection(conn)
-    } catch {
-      case e: Throwable =>
-        try conn.close()
-        catch { case ce: Throwable => e.addSuppressed(ce) }
-        throw e
-    }
-    val dbConn         = new JdbcConnection(conn)
+    val dbConn         = JdbcTransactor.openConnection(connectionFactory, dialect)
+    val conn           = dbConn.underlying
     val prevAutoCommit =
       try conn.getAutoCommit
       catch {
@@ -232,6 +207,29 @@ class JdbcTransactor(
 }
 
 object JdbcTransactor {
+
+  /**
+   * Opens a raw connection, applies the per-dialect configuration (SQLite
+   * busy-timeout + IMMEDIATE), and wraps it in a [[JdbcConnection]].
+   * Configuration failures close the raw connection with the original error
+   * carrying any close failure as suppressed — shared by `connect` and both
+   * `transact` overloads so the setup/teardown sequence lives in one place.
+   */
+  private[sql] def openConnection(
+    connectionFactory: () => Connection,
+    dialect: SqlDialect
+  ): JdbcConnection = {
+    val conn = connectionFactory()
+    try {
+      if (dialect == SqlDialect.SQLite) configureSQLiteConnection(conn)
+    } catch {
+      case e: Throwable =>
+        try conn.close()
+        catch { case ce: Throwable => e.addSuppressed(ce) }
+        throw e
+    }
+    new JdbcConnection(conn)
+  }
 
   def fromUrl(url: String, dialect: SqlDialect): JdbcTransactor =
     if (dialect == SqlDialect.SQLite) {

--- a/sql/jvm/src/test/scala/zio/blocks/sql/ExplainDumpGoldenSpec.scala
+++ b/sql/jvm/src/test/scala/zio/blocks/sql/ExplainDumpGoldenSpec.scala
@@ -24,6 +24,8 @@ import zio.blocks.schema.Schema
 import zio.blocks.sql.query.{SortOrder => QSortOrder, SqlQuery => Qry, Rel}
 
 // Separate fixture objects ensure distinct dump fileBase per query (owner-derived).
+// Exercises the deprecated stringly builder (legacy dump goldens).
+@scala.annotation.nowarn("cat=deprecation")
 private object Legacy2JoinFixture {
   case class User(id: Int, name: String)
   object User { implicit val schema: Schema[User] = Schema.derived }
@@ -43,6 +45,8 @@ private object Legacy2JoinFixture {
       .where(repoTable, "name", DbValue.DbString("my-repo"))
   Dump.dump(query)
 }
+// Exercises the deprecated stringly builder (legacy dump goldens).
+@scala.annotation.nowarn("cat=deprecation")
 private object LegacyFullFixture {
   case class User(id: Int, name: String)
   object User { implicit val schema: Schema[User] = Schema.derived }
@@ -62,6 +66,8 @@ private object LegacyFullFixture {
       .offset(5)
   Dump.dump(query)
 }
+// Exercises the deprecated stringly builder (legacy dump goldens).
+@scala.annotation.nowarn("cat=deprecation")
 private object FourArgFixture {
   case class User(id: Int, name: String)
   object User { implicit val schema: Schema[User] = Schema.derived }
@@ -70,6 +76,8 @@ private object FourArgFixture {
     SqlQuery.from(userTable).where(userTable, "name", "=", DbValue.DbString("alice"))
   Dump.dump(query)
 }
+// Exercises the deprecated stringly builder (legacy dump goldens).
+@scala.annotation.nowarn("cat=deprecation")
 private object InQueryFixture {
   case class User(id: Int, name: String)
   object User { implicit val schema: Schema[User] = Schema.derived }
@@ -80,6 +88,8 @@ private object InQueryFixture {
       .where(SqlStatement.ColumnRef("t0", "id"), "IN", DbValue.DbArray("integer", IndexedSeq(1, 2, 3)))
   Dump.dump(query)
 }
+// Exercises the deprecated stringly builder (legacy dump goldens).
+@scala.annotation.nowarn("cat=deprecation")
 private object InSize1Fixture {
   case class User(id: Int, name: String)
   object User { implicit val schema: Schema[User] = Schema.derived }
@@ -88,6 +98,8 @@ private object InSize1Fixture {
     SqlQuery.from(userTable).where(SqlStatement.ColumnRef("t0", "id"), "IN", DbValue.DbArray("integer", IndexedSeq(1)))
   Dump.dump(query)
 }
+// Exercises the deprecated stringly builder (legacy dump goldens).
+@scala.annotation.nowarn("cat=deprecation")
 private object InSize2Fixture {
   case class User(id: Int, name: String)
   object User { implicit val schema: Schema[User] = Schema.derived }
@@ -98,6 +110,8 @@ private object InSize2Fixture {
       .where(SqlStatement.ColumnRef("t0", "id"), "IN", DbValue.DbArray("integer", IndexedSeq(1, 2)))
   Dump.dump(query)
 }
+// Exercises the deprecated stringly builder (legacy dump goldens).
+@scala.annotation.nowarn("cat=deprecation")
 private object InSize5Fixture {
   case class User(id: Int, name: String)
   object User { implicit val schema: Schema[User] = Schema.derived }
@@ -108,6 +122,8 @@ private object InSize5Fixture {
       .where(SqlStatement.ColumnRef("t0", "id"), "IN", DbValue.DbArray("integer", IndexedSeq(1, 2, 3, 4, 5)))
   Dump.dump(query)
 }
+// Exercises the deprecated stringly builder (legacy dump goldens).
+@scala.annotation.nowarn("cat=deprecation")
 private object InEmptyFixture {
   case class User(id: Int, name: String)
   object User { implicit val schema: Schema[User] = Schema.derived }
@@ -118,6 +134,8 @@ private object InEmptyFixture {
       .where(SqlStatement.ColumnRef("t0", "id"), "IN", DbValue.DbArray("integer", IndexedSeq.empty[Int]))
   Dump.dump(query)
 }
+// Exercises the deprecated stringly builder (legacy dump goldens).
+@scala.annotation.nowarn("cat=deprecation")
 private object InDynamicFixture {
   case class DynUser(id: Int, name: String)
   object DynUser { implicit val schema: Schema[DynUser] = Schema.derived }
@@ -150,6 +168,8 @@ private object IrFullFixture {
   Dump.dumpQuery(query)
 }
 
+// Exercises the deprecated stringly builder (legacy dump goldens).
+@scala.annotation.nowarn("cat=deprecation")
 object ExplainDumpGoldenSpec extends ZIOSpecDefault {
 
   case class User(id: Int, name: String)

--- a/sql/shared/src/main/scala/zio/blocks/sql/DbCodec.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/DbCodec.scala
@@ -17,7 +17,7 @@
 package zio.blocks.sql
 
 import zio.blocks.maybe.Maybe
-import zio.blocks.schema.{As, Schema}
+import zio.blocks.schema.{As, Schema, SchemaError}
 import zio.blocks.schema.derive.DerivationBuilder
 import zio.blocks.schema.json.{JsonCodec => JsonSchemaCodec}
 
@@ -102,10 +102,35 @@ object DbCodec extends DbCodecOpaquePriority {
   private val SqlNullType = 0
 
   private def decodeJsonb[A](input: String)(using jsonCodec: JsonSchemaCodec[A]): A =
-    jsonCodec.decode(input) match {
+    decodeJsonbEither[A](input) match {
       case Right(value) => value
       case Left(err)    => throw new RuntimeException(s"JSONB decode error: $err")
     }
+
+  /**
+   * Either-returning JSONB decode step. Prefer this over [[decodeJsonb]] when
+   * the caller can propagate the failure as a value: a single bad JSONB row no
+   * longer aborts the whole `Frag.query` list decode with an unactionable
+   * `RuntimeException`.
+   */
+  def decodeJsonbEither[A](input: String)(using jsonCodec: JsonSchemaCodec[A]): Either[SchemaError, A] =
+    jsonCodec.decode(input)
+
+  /**
+   * Either-returning `As` decode step used by [[dbCodecFromAs]]. Exposed so
+   * callers that can handle failure as a value do not have to go through the
+   * throwing given.
+   */
+  def decodeViaAs[A, B](conv: As[A, B], decoded: A): Either[SchemaError, B] =
+    conv.into(decoded)
+
+  /**
+   * Either-returning `As` encode step used by [[dbCodecFromAs]]. Exposed so
+   * callers that can handle failure as a value do not have to go through the
+   * throwing given.
+   */
+  def encodeViaAs[A, B](conv: As[A, B], value: B): Either[SchemaError, A] =
+    conv.from(value)
 
   private def unexpectedNull(typeName: String): Nothing =
     throw new IllegalStateException(
@@ -237,6 +262,7 @@ object DbCodec extends DbCodecOpaquePriority {
   given intCodec: DbCodec[Int] = new DbCodec[Int] {
     val columns: IndexedSeq[String]                                              = IndexedSeq("value")
     def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Int = reader.getInt(columnLabels.head)
+    override def readValue(reader: DbResultReader, startIndex: Int): Int         = reader.getInt(startIndex)
     def writeValue(writer: DbParamWriter, startIndex: Int, value: Int): Unit     = writer.setInt(startIndex, value)
     def toDbValues(value: Int): IndexedSeq[DbValue]                              = IndexedSeq(DbValue.DbInt(value))
   }
@@ -244,6 +270,7 @@ object DbCodec extends DbCodecOpaquePriority {
   given longCodec: DbCodec[Long] = new DbCodec[Long] {
     val columns: IndexedSeq[String]                                               = IndexedSeq("value")
     def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Long = reader.getLong(columnLabels.head)
+    override def readValue(reader: DbResultReader, startIndex: Int): Long         = reader.getLong(startIndex)
     def writeValue(writer: DbParamWriter, startIndex: Int, value: Long): Unit     = writer.setLong(startIndex, value)
     def toDbValues(value: Long): IndexedSeq[DbValue]                              = IndexedSeq(DbValue.DbLong(value))
   }
@@ -252,6 +279,8 @@ object DbCodec extends DbCodecOpaquePriority {
     val columns: IndexedSeq[String]                                                 = IndexedSeq("value")
     def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): String =
       reader.getString(columnLabels.head)
+    override def readValue(reader: DbResultReader, startIndex: Int): String =
+      reader.getString(startIndex)
     def writeValue(writer: DbParamWriter, startIndex: Int, value: String): Unit = writer.setString(startIndex, value)
     def toDbValues(value: String): IndexedSeq[DbValue]                          = IndexedSeq(DbValue.DbString(value))
   }
@@ -260,6 +289,8 @@ object DbCodec extends DbCodecOpaquePriority {
     val columns: IndexedSeq[String]                                                  = IndexedSeq("value")
     def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Boolean =
       reader.getBoolean(columnLabels.head)
+    override def readValue(reader: DbResultReader, startIndex: Int): Boolean =
+      reader.getBoolean(startIndex)
     def writeValue(writer: DbParamWriter, startIndex: Int, value: Boolean): Unit = writer.setBoolean(startIndex, value)
     def toDbValues(value: Boolean): IndexedSeq[DbValue]                          = IndexedSeq(DbValue.DbBoolean(value))
   }
@@ -268,6 +299,8 @@ object DbCodec extends DbCodecOpaquePriority {
     val columns: IndexedSeq[String]                                                 = IndexedSeq("value")
     def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Double =
       reader.getDouble(columnLabels.head)
+    override def readValue(reader: DbResultReader, startIndex: Int): Double =
+      reader.getDouble(startIndex)
     def writeValue(writer: DbParamWriter, startIndex: Int, value: Double): Unit = writer.setDouble(startIndex, value)
     def toDbValues(value: Double): IndexedSeq[DbValue]                          = IndexedSeq(DbValue.DbDouble(value))
   }
@@ -275,6 +308,7 @@ object DbCodec extends DbCodecOpaquePriority {
   given floatCodec: DbCodec[Float] = new DbCodec[Float] {
     val columns: IndexedSeq[String]                                                = IndexedSeq("value")
     def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Float = reader.getFloat(columnLabels.head)
+    override def readValue(reader: DbResultReader, startIndex: Int): Float         = reader.getFloat(startIndex)
     def writeValue(writer: DbParamWriter, startIndex: Int, value: Float): Unit     = writer.setFloat(startIndex, value)
     def toDbValues(value: Float): IndexedSeq[DbValue]                              = IndexedSeq(DbValue.DbFloat(value))
   }
@@ -282,6 +316,7 @@ object DbCodec extends DbCodecOpaquePriority {
   given shortCodec: DbCodec[Short] = new DbCodec[Short] {
     val columns: IndexedSeq[String]                                                = IndexedSeq("value")
     def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Short = reader.getShort(columnLabels.head)
+    override def readValue(reader: DbResultReader, startIndex: Int): Short         = reader.getShort(startIndex)
     def writeValue(writer: DbParamWriter, startIndex: Int, value: Short): Unit     = writer.setShort(startIndex, value)
     def toDbValues(value: Short): IndexedSeq[DbValue]                              = IndexedSeq(DbValue.DbShort(value))
   }
@@ -289,6 +324,7 @@ object DbCodec extends DbCodecOpaquePriority {
   given byteCodec: DbCodec[Byte] = new DbCodec[Byte] {
     val columns: IndexedSeq[String]                                               = IndexedSeq("value")
     def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Byte = reader.getByte(columnLabels.head)
+    override def readValue(reader: DbResultReader, startIndex: Int): Byte         = reader.getByte(startIndex)
     def writeValue(writer: DbParamWriter, startIndex: Int, value: Byte): Unit     = writer.setByte(startIndex, value)
     def toDbValues(value: Byte): IndexedSeq[DbValue]                              = IndexedSeq(DbValue.DbByte(value))
   }
@@ -297,6 +333,10 @@ object DbCodec extends DbCodecOpaquePriority {
     val columns: IndexedSeq[String]                                                     = IndexedSeq("value")
     def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): BigDecimal = {
       val jbd = reader.getBigDecimal(columnLabels.head)
+      if (jbd != null) scala.BigDecimal(jbd) else unexpectedNull("BigDecimal")
+    }
+    override def readValue(reader: DbResultReader, startIndex: Int): BigDecimal = {
+      val jbd = reader.getBigDecimal(startIndex)
       if (jbd != null) scala.BigDecimal(jbd) else unexpectedNull("BigDecimal")
     }
     def writeValue(writer: DbParamWriter, startIndex: Int, value: BigDecimal): Unit =
@@ -337,12 +377,12 @@ object DbCodec extends DbCodecOpaquePriority {
    */
   given dbCodecFromAs[A, B](using conv: As[A, B], base: DbCodec[A]): DbCodec[B] =
     base.transform(decoded =>
-      conv.into(decoded) match {
+      decodeViaAs(conv, decoded) match {
         case Right(b) => b
         case Left(e)  => throw new IllegalStateException(s"DbCodec decode via As failed: $e")
       }
     )(value =>
-      conv.from(value) match {
+      encodeViaAs(conv, value) match {
         case Right(a) => a
         case Left(e)  => throw new IllegalStateException(s"DbCodec encode via As failed: $e")
       }

--- a/sql/shared/src/main/scala/zio/blocks/sql/DbCodecDeriver.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/DbCodecDeriver.scala
@@ -164,6 +164,21 @@ class DbCodecDeriver(columnNameMapper: SqlNameMapper = SqlNameMapper.SnakeCase) 
       builder.result()
     }
 
+    // Starting column offset of each active field within `allColumns`, computed
+    // once at construction: field column counts are static, so label slicing
+    // below needs no per-row offset arithmetic.
+    val fieldLabelOffsets: Array[Int] = {
+      val offsets = new Array[Int](activeFieldIndices.length)
+      var acc     = 0
+      var fi      = 0
+      while (fi < activeFieldIndices.length) {
+        offsets(fi) = acc
+        acc += fieldCodecs(activeFieldIndices(fi)).columnCount
+        fi += 1
+      }
+      offsets
+    }
+
     new DbCodec[A] {
       val columns: IndexedSeq[String] = allColumns
 
@@ -191,16 +206,15 @@ class DbCodecDeriver(columnNameMapper: SqlNameMapper = SqlNameMapper.SnakeCase) 
       }
 
       private def readByLabels(reader: DbResultReader, columnLabels: IndexedSeq[String]): A = {
-        val regs = borrowRegs()
+        val regs   = borrowRegs()
+        val slices = fieldSlices(columnLabels)
         try {
-          var labelIdx = 0
-          var fi       = 0
+          var fi = 0
           while (fi < activeFieldIndices.length) {
             val i          = activeFieldIndices(fi)
             val codec      = fieldCodecs(i)
-            val fieldValue = codec.readValue(reader, columnLabels.slice(labelIdx, labelIdx + codec.columnCount))
+            val fieldValue = codec.readValue(reader, slices(fi))
             registers(i).set(regs, 0, fieldValue)
-            labelIdx += codec.columnCount
             fi += 1
           }
           var ti = 0
@@ -251,6 +265,32 @@ class DbCodecDeriver(columnNameMapper: SqlNameMapper = SqlNameMapper.SnakeCase) 
         else {
           pooled.startUse()
           pooled
+        }
+      }
+
+      // Per-field label slices, computed once per statement (per thread) instead
+      // of once per field per row. `Frag.rowDecoder` passes the same `labels`
+      // instance for every row of a statement, so a reference-equality hit
+      // reuses the slices; any other caller recomputes them (still correct,
+      // just not cached). Sound because `IndexedSeq` labels are immutable: an
+      // identical reference implies identical slice contents.
+      private val labelSlicesCache: ThreadLocal[(IndexedSeq[String], Array[IndexedSeq[String]])] =
+        new ThreadLocal[(IndexedSeq[String], Array[IndexedSeq[String]])]
+
+      private def fieldSlices(columnLabels: IndexedSeq[String]): Array[IndexedSeq[String]] = {
+        val cached = labelSlicesCache.get()
+        if (cached != null && (cached._1 eq columnLabels)) cached._2
+        else {
+          val slices = new Array[IndexedSeq[String]](activeFieldIndices.length)
+          var fi     = 0
+          while (fi < activeFieldIndices.length) {
+            val count  = fieldCodecs(activeFieldIndices(fi)).columnCount
+            val offset = fieldLabelOffsets(fi)
+            slices(fi) = columnLabels.slice(offset, offset + count)
+            fi += 1
+          }
+          labelSlicesCache.set((columnLabels, slices))
+          slices
         }
       }
 
@@ -598,133 +638,47 @@ class DbCodecDeriver(columnNameMapper: SqlNameMapper = SqlNameMapper.SnakeCase) 
     override def columnCount: Int                                                 = 0
   }
 
-  private val booleanCodec: DbCodec[Boolean] = new DbCodec[Boolean] {
-    val columns: IndexedSeq[String]                                                  = IndexedSeq("value")
-    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Boolean =
-      reader.getBoolean(columnLabels.head)
-    override def readValue(reader: DbResultReader, startIndex: Int): Boolean =
-      reader.getBoolean(startIndex)
-    def writeValue(writer: DbParamWriter, startIndex: Int, value: Boolean): Unit =
-      writer.setBoolean(startIndex, value)
-    def toDbValues(value: Boolean): IndexedSeq[DbValue] =
-      IndexedSeq(DbValue.DbBoolean(value))
-  }
-
-  private val byteCodec: DbCodec[Byte] = new DbCodec[Byte] {
-    val columns: IndexedSeq[String]                                               = IndexedSeq("value")
-    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Byte =
-      reader.getByte(columnLabels.head)
-    override def readValue(reader: DbResultReader, startIndex: Int): Byte =
-      reader.getByte(startIndex)
-    def writeValue(writer: DbParamWriter, startIndex: Int, value: Byte): Unit =
-      writer.setByte(startIndex, value)
-    def toDbValues(value: Byte): IndexedSeq[DbValue] =
-      IndexedSeq(DbValue.DbByte(value))
-  }
-
-  private val shortCodec: DbCodec[Short] = new DbCodec[Short] {
-    val columns: IndexedSeq[String]                                                = IndexedSeq("value")
-    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Short =
-      reader.getShort(columnLabels.head)
-    override def readValue(reader: DbResultReader, startIndex: Int): Short =
-      reader.getShort(startIndex)
-    def writeValue(writer: DbParamWriter, startIndex: Int, value: Short): Unit =
-      writer.setShort(startIndex, value)
-    def toDbValues(value: Short): IndexedSeq[DbValue] =
-      IndexedSeq(DbValue.DbShort(value))
-  }
-
-  private val intCodec: DbCodec[Int] = new DbCodec[Int] {
-    val columns: IndexedSeq[String]                                              = IndexedSeq("value")
-    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Int =
-      reader.getInt(columnLabels.head)
-    override def readValue(reader: DbResultReader, startIndex: Int): Int =
-      reader.getInt(startIndex)
-    def writeValue(writer: DbParamWriter, startIndex: Int, value: Int): Unit =
-      writer.setInt(startIndex, value)
-    def toDbValues(value: Int): IndexedSeq[DbValue] =
-      IndexedSeq(DbValue.DbInt(value))
-  }
-
-  private val longCodec: DbCodec[Long] = new DbCodec[Long] {
-    val columns: IndexedSeq[String]                                               = IndexedSeq("value")
-    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Long =
-      reader.getLong(columnLabels.head)
-    override def readValue(reader: DbResultReader, startIndex: Int): Long =
-      reader.getLong(startIndex)
-    def writeValue(writer: DbParamWriter, startIndex: Int, value: Long): Unit =
-      writer.setLong(startIndex, value)
-    def toDbValues(value: Long): IndexedSeq[DbValue] =
-      IndexedSeq(DbValue.DbLong(value))
-  }
-
-  private val floatCodec: DbCodec[Float] = new DbCodec[Float] {
-    val columns: IndexedSeq[String]                                                = IndexedSeq("value")
-    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Float =
-      reader.getFloat(columnLabels.head)
-    override def readValue(reader: DbResultReader, startIndex: Int): Float =
-      reader.getFloat(startIndex)
-    def writeValue(writer: DbParamWriter, startIndex: Int, value: Float): Unit =
-      writer.setFloat(startIndex, value)
-    def toDbValues(value: Float): IndexedSeq[DbValue] =
-      IndexedSeq(DbValue.DbFloat(value))
-  }
-
-  private val doubleCodec: DbCodec[Double] = new DbCodec[Double] {
-    val columns: IndexedSeq[String]                                                 = IndexedSeq("value")
-    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Double =
-      reader.getDouble(columnLabels.head)
-    override def readValue(reader: DbResultReader, startIndex: Int): Double =
-      reader.getDouble(startIndex)
-    def writeValue(writer: DbParamWriter, startIndex: Int, value: Double): Unit =
-      writer.setDouble(startIndex, value)
-    def toDbValues(value: Double): IndexedSeq[DbValue] =
-      IndexedSeq(DbValue.DbDouble(value))
-  }
+  // Primitive codecs shared with the `DbCodec` companion (single source of
+  // behavior: the companion givens carry the positional `readValue` overrides,
+  // so derivation inherits them). Codecs with no companion equivalent
+  // (char, duration, temporals, uuid, unit) keep their local definitions below.
+  private val booleanCodec: DbCodec[Boolean]           = DbCodec.booleanCodec
+  private val byteCodec: DbCodec[Byte]                 = DbCodec.byteCodec
+  private val shortCodec: DbCodec[Short]               = DbCodec.shortCodec
+  private val intCodec: DbCodec[Int]                   = DbCodec.intCodec
+  private val longCodec: DbCodec[Long]                 = DbCodec.longCodec
+  private val floatCodec: DbCodec[Float]               = DbCodec.floatCodec
+  private val doubleCodec: DbCodec[Double]             = DbCodec.doubleCodec
+  private val stringCodec: DbCodec[String]             = DbCodec.stringCodec
+  private val bigDecimalCodec: DbCodec[BigDecimal]     = DbCodec.bigDecimalCodec
+  private val instantCodec: DbCodec[java.time.Instant] = DbCodec.instantCodec
 
   private val charCodec: DbCodec[Char] = new DbCodec[Char] {
     val columns: IndexedSeq[String]                                               = IndexedSeq("value")
-    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Char = {
-      val s = reader.getString(columnLabels.head)
-      if (s != null && s.length > 0) s.charAt(0) else '\u0000'
-    }
-    override def readValue(reader: DbResultReader, startIndex: Int): Char = {
-      val s = reader.getString(startIndex)
-      if (s != null && s.length > 0) s.charAt(0) else '\u0000'
-    }
+    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): Char =
+      decodeChar(reader.getString(columnLabels.head))
+    override def readValue(reader: DbResultReader, startIndex: Int): Char =
+      decodeChar(reader.getString(startIndex))
     def writeValue(writer: DbParamWriter, startIndex: Int, value: Char): Unit =
       writer.setString(startIndex, value.toString)
     def toDbValues(value: Char): IndexedSeq[DbValue] =
       IndexedSeq(DbValue.DbChar(value))
   }
 
-  private val stringCodec: DbCodec[String] = new DbCodec[String] {
-    val columns: IndexedSeq[String]                                                 = IndexedSeq("value")
-    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): String =
-      reader.getString(columnLabels.head)
-    override def readValue(reader: DbResultReader, startIndex: Int): String =
-      reader.getString(startIndex)
-    def writeValue(writer: DbParamWriter, startIndex: Int, value: String): Unit =
-      writer.setString(startIndex, value)
-    def toDbValues(value: String): IndexedSeq[DbValue] =
-      IndexedSeq(DbValue.DbString(value))
-  }
-
-  private val bigDecimalCodec: DbCodec[BigDecimal] = new DbCodec[BigDecimal] {
-    val columns: IndexedSeq[String]                                                     = IndexedSeq("value")
-    def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): BigDecimal = {
-      val jbd = reader.getBigDecimal(columnLabels.head)
-      if (jbd != null) scala.BigDecimal(jbd) else unexpectedNull("BigDecimal")
-    }
-    override def readValue(reader: DbResultReader, startIndex: Int): BigDecimal = {
-      val jbd = reader.getBigDecimal(startIndex)
-      if (jbd != null) scala.BigDecimal(jbd) else unexpectedNull("BigDecimal")
-    }
-    def writeValue(writer: DbParamWriter, startIndex: Int, value: BigDecimal): Unit =
-      writer.setBigDecimal(startIndex, value.bigDecimal)
-    def toDbValues(value: BigDecimal): IndexedSeq[DbValue] =
-      IndexedSeq(DbValue.DbBigDecimal(value))
-  }
+  /**
+   * Decodes a `CHAR(1)` value. SQL NULL and the empty string both fail fast
+   * instead of collapsing to a `'\u0000'` sentinel: like every other
+   * non-optional primitive, a NULL Char column is a data error (use
+   * `Option[Char]`/`Maybe[Char]` for nullable columns), and an empty string has
+   * no first character to decode.
+   */
+  private def decodeChar(s: String): Char =
+    if (s == null) unexpectedNull("Char")
+    else if (s.isEmpty)
+      throw new IllegalStateException(
+        "Encountered empty string while decoding non-optional Char. Use Option[Char] or Maybe[Char] for nullable columns."
+      )
+    else s.charAt(0)
 
   private val durationCodec: DbCodec[java.time.Duration] =
     new DbCodec[java.time.Duration] {
@@ -737,19 +691,6 @@ class DbCodecDeriver(columnNameMapper: SqlNameMapper = SqlNameMapper.SnakeCase) 
         writer.setDuration(startIndex, value)
       def toDbValues(value: java.time.Duration): IndexedSeq[DbValue] =
         IndexedSeq(DbValue.DbDuration(value))
-    }
-
-  private val instantCodec: DbCodec[java.time.Instant] =
-    new DbCodec[java.time.Instant] {
-      val columns: IndexedSeq[String]                                                            = IndexedSeq("value")
-      def readValue(reader: DbResultReader, columnLabels: IndexedSeq[String]): java.time.Instant =
-        reader.getInstant(columnLabels.head)
-      override def readValue(reader: DbResultReader, startIndex: Int): java.time.Instant =
-        reader.getInstant(startIndex)
-      def writeValue(writer: DbParamWriter, startIndex: Int, value: java.time.Instant): Unit =
-        writer.setInstant(startIndex, value)
-      def toDbValues(value: java.time.Instant): IndexedSeq[DbValue] =
-        IndexedSeq(DbValue.DbInstant(value))
     }
 
   private val localDateCodec: DbCodec[java.time.LocalDate] =

--- a/sql/shared/src/main/scala/zio/blocks/sql/Dialect.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Dialect.scala
@@ -22,9 +22,10 @@ package zio.blocks.sql
  * All identifier parameters (`table`, `col`, `shadowName`, `sourceTable`,
  * `sourceIdColumn`, `queueKeyColumn`) must be bare, pre-validated SQL
  * identifiers — never user input, never schema-qualified, never quoted. Valid
- * identifiers match `[A-Za-z_][A-Za-z0-9_]*`; callers must enforce this
- * whitelist before passing values in. Implementations interpolate them into
- * DDL/DML as-is.
+ * identifiers match `[A-Za-z_][A-Za-z0-9_]*`. Each method enforces this
+ * whitelist up front via [[SqlIdentifier.validate]] (same package, no new API)
+ * so the documented contract holds mechanically rather than by convention.
+ * Implementations interpolate the validated identifiers into DDL/DML as-is.
  */
 trait SqlMigration {
 
@@ -91,14 +92,23 @@ object Dialect {
     val sqlDialect: SqlDialect = SqlDialect.PostgreSQL
     val supportsSkipLocked     = true
 
-    def createQueueTableDDL(table: String, col: String): String =
-      s"CREATE TABLE IF NOT EXISTS $table (\n  $col TEXT NOT NULL PRIMARY KEY,\n  op TEXT NOT NULL DEFAULT 'I',\n  payload TEXT\n)"
+    def createQueueTableDDL(table: String, col: String): String = {
+      val t = SqlIdentifier.validate("table", table)
+      val c = SqlIdentifier.validate("column", col)
+      s"CREATE TABLE IF NOT EXISTS $t (\n  $c TEXT NOT NULL PRIMARY KEY,\n  op TEXT NOT NULL DEFAULT 'I',\n  payload TEXT\n)"
+    }
 
-    def dequeueSQL(table: String, col: String, batchSize: Int): String =
-      s"SELECT $col FROM $table ORDER BY $col LIMIT $batchSize FOR UPDATE SKIP LOCKED"
+    def dequeueSQL(table: String, col: String, batchSize: Int): String = {
+      val t = SqlIdentifier.validate("table", table)
+      val c = SqlIdentifier.validate("column", col)
+      s"SELECT $c FROM $t ORDER BY $c LIMIT $batchSize FOR UPDATE SKIP LOCKED"
+    }
 
-    def createShadowTableDDL(shadowName: String, sourceTable: String): String =
-      s"CREATE TABLE IF NOT EXISTS $shadowName (LIKE $sourceTable INCLUDING ALL)"
+    def createShadowTableDDL(shadowName: String, sourceTable: String): String = {
+      val shadow = SqlIdentifier.validate("table", shadowName)
+      val source = SqlIdentifier.validate("table", sourceTable)
+      s"CREATE TABLE IF NOT EXISTS $shadow (LIKE $source INCLUDING ALL)"
+    }
 
     def createTriggerDDL(
       queueTable: String,
@@ -106,7 +116,11 @@ object Dialect {
       sourceIdColumn: String,
       queueKeyColumn: String
     ): List[String] = {
-      val funcName = s"${queueTable}_notify"
+      val queue    = SqlIdentifier.validate("table", queueTable)
+      val source   = SqlIdentifier.validate("table", sourceTable)
+      val idCol    = SqlIdentifier.validate("column", sourceIdColumn)
+      val keyCol   = SqlIdentifier.validate("column", queueKeyColumn)
+      val funcName = s"${queue}_notify"
       // s-interpolator renders $$ as one $, so build plpgsql dollar-quotes from a named value.
       val dollarQuote = "$$"
       val func        =
@@ -114,18 +128,18 @@ object Dialect {
            |RETURNS TRIGGER AS $dollarQuote
            |BEGIN
            |  IF TG_OP = 'DELETE' THEN
-           |    INSERT INTO $queueTable ($queueKeyColumn, op, payload) VALUES (OLD.$sourceIdColumn, 'D', row_to_json(OLD)::text) ON CONFLICT ($queueKeyColumn) DO UPDATE SET op = 'D', payload = EXCLUDED.payload;
+           |    INSERT INTO $queue ($keyCol, op, payload) VALUES (OLD.$idCol, 'D', row_to_json(OLD)::text) ON CONFLICT ($keyCol) DO UPDATE SET op = 'D', payload = EXCLUDED.payload;
            |  ELSIF TG_OP = 'INSERT' THEN
-           |    INSERT INTO $queueTable ($queueKeyColumn, op) VALUES (NEW.$sourceIdColumn, 'I') ON CONFLICT ($queueKeyColumn) DO NOTHING;
+           |    INSERT INTO $queue ($keyCol, op) VALUES (NEW.$idCol, 'I') ON CONFLICT ($keyCol) DO NOTHING;
            |  ELSIF TG_OP = 'UPDATE' THEN
-           |    INSERT INTO $queueTable ($queueKeyColumn, op) VALUES (NEW.$sourceIdColumn, 'U') ON CONFLICT ($queueKeyColumn) DO NOTHING;
+           |    INSERT INTO $queue ($keyCol, op) VALUES (NEW.$idCol, 'U') ON CONFLICT ($keyCol) DO NOTHING;
            |  END IF;
            |  RETURN NULL;
            |END;
            |$dollarQuote LANGUAGE plpgsql;""".stripMargin
       // CREATE OR REPLACE TRIGGER keeps re-running installTriggers idempotent (PG 14+).
       val trigger =
-        s"CREATE OR REPLACE TRIGGER trg_${queueTable}_mod AFTER INSERT OR UPDATE OR DELETE ON $sourceTable FOR EACH ROW EXECUTE FUNCTION $funcName();"
+        s"CREATE OR REPLACE TRIGGER trg_${queue}_mod AFTER INSERT OR UPDATE OR DELETE ON $source FOR EACH ROW EXECUTE FUNCTION $funcName();"
       List(func, trigger)
     }
   }
@@ -134,11 +148,17 @@ object Dialect {
     val sqlDialect: SqlDialect = SqlDialect.SQLite
     val supportsSkipLocked     = false
 
-    def createQueueTableDDL(table: String, col: String): String =
-      s"CREATE TABLE IF NOT EXISTS $table (\n  $col TEXT NOT NULL PRIMARY KEY,\n  op TEXT NOT NULL DEFAULT 'I',\n  payload TEXT\n)"
+    def createQueueTableDDL(table: String, col: String): String = {
+      val t = SqlIdentifier.validate("table", table)
+      val c = SqlIdentifier.validate("column", col)
+      s"CREATE TABLE IF NOT EXISTS $t (\n  $c TEXT NOT NULL PRIMARY KEY,\n  op TEXT NOT NULL DEFAULT 'I',\n  payload TEXT\n)"
+    }
 
-    def dequeueSQL(table: String, col: String, batchSize: Int): String =
-      s"SELECT $col FROM $table ORDER BY $col LIMIT $batchSize"
+    def dequeueSQL(table: String, col: String, batchSize: Int): String = {
+      val t = SqlIdentifier.validate("table", table)
+      val c = SqlIdentifier.validate("column", col)
+      s"SELECT $c FROM $t ORDER BY $c LIMIT $batchSize"
+    }
 
     def createShadowTableDDL(shadowName: String, sourceTable: String): String =
       throw new UnsupportedOperationException(
@@ -151,11 +171,16 @@ object Dialect {
       sourceTable: String,
       sourceIdColumn: String,
       queueKeyColumn: String
-    ): List[String] =
+    ): List[String] = {
+      val queue  = SqlIdentifier.validate("table", queueTable)
+      val source = SqlIdentifier.validate("table", sourceTable)
+      val idCol  = SqlIdentifier.validate("column", sourceIdColumn)
+      val keyCol = SqlIdentifier.validate("column", queueKeyColumn)
       List(
-        s"CREATE TRIGGER IF NOT EXISTS trg_${queueTable}_insert AFTER INSERT ON $sourceTable BEGIN INSERT OR IGNORE INTO $queueTable ($queueKeyColumn, op) VALUES (NEW.$sourceIdColumn, 'I'); END;",
-        s"CREATE TRIGGER IF NOT EXISTS trg_${queueTable}_update AFTER UPDATE ON $sourceTable BEGIN INSERT OR IGNORE INTO $queueTable ($queueKeyColumn, op) VALUES (NEW.$sourceIdColumn, 'U'); END;",
-        s"CREATE TRIGGER IF NOT EXISTS trg_${queueTable}_delete AFTER DELETE ON $sourceTable BEGIN INSERT OR REPLACE INTO $queueTable ($queueKeyColumn, op) VALUES (OLD.$sourceIdColumn, 'D'); END;"
+        s"CREATE TRIGGER IF NOT EXISTS trg_${queue}_insert AFTER INSERT ON $source BEGIN INSERT OR IGNORE INTO $queue ($keyCol, op) VALUES (NEW.$idCol, 'I'); END;",
+        s"CREATE TRIGGER IF NOT EXISTS trg_${queue}_update AFTER UPDATE ON $source BEGIN INSERT OR IGNORE INTO $queue ($keyCol, op) VALUES (NEW.$idCol, 'U'); END;",
+        s"CREATE TRIGGER IF NOT EXISTS trg_${queue}_delete AFTER DELETE ON $source BEGIN INSERT OR REPLACE INTO $queue ($keyCol, op) VALUES (OLD.$idCol, 'D'); END;"
       )
+    }
   }
 }

--- a/sql/shared/src/main/scala/zio/blocks/sql/Dump.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Dump.scala
@@ -610,6 +610,7 @@ object Dump {
    * source-only fallback. For full joins/filters use `inline val`/`inline def`
    * or construct the query directly at the call site.
    */
+  @scala.annotation.nowarn("cat=deprecation")
   inline def dump(inline query: SqlQuery[?]): Unit =
     ${ dumpQueryImpl('query) }
 
@@ -658,6 +659,7 @@ object Dump {
     }
   }
 
+  @scala.annotation.nowarn("cat=deprecation")
   def dumpQueryImpl(query: Expr[SqlQuery[?]])(using Quotes): Expr[Unit] = {
     import quotes.reflect._
     val dirProp = System.getProperty("zib.sql.dumpDir")

--- a/sql/shared/src/main/scala/zio/blocks/sql/JoinsDumpExample.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/JoinsDumpExample.scala
@@ -20,7 +20,11 @@ import zio.blocks.schema.Schema
 
 /**
  * Canonical User/Repo/Star example for task-4 compile-time dump verification.
+ *
+ * Uses the deprecated stringly builder intentionally (legacy dump coverage);
+ * new code should prefer `zio.blocks.sql.query.SqlQuery`.
  */
+@scala.annotation.nowarn("cat=deprecation")
 object JoinsDumpExample {
 
   case class User(id: Int, name: String)

--- a/sql/shared/src/main/scala/zio/blocks/sql/Repo.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Repo.scala
@@ -39,6 +39,17 @@ import zio.blocks.maybe.Maybe
  * `Repo` is immutable and safe for concurrent use. Individual operations
  * require a `DbCon` or `DbTx` given context which is not shared across threads
  * unless the caller arranges it.
+ *
+ * ==Empty-input policy==
+ *   - Builders throw on empty input (`require`): [[insertAll]] (empty rows),
+ *     `Frag.values` (empty rows). An empty multi-row VALUES list is invalid
+ *     SQL, so construction fails fast.
+ *   - Executors return `0` (or `List.empty` for reads) on empty input without
+ *     touching the database: [[insertBatch]], [[insertOrUpdateBatch]],
+ *     [[deleteAll]], [[findAll]].
+ *   - [[update]] returns `0` both when no row matches the ID and when the
+ *     entity carries only the ID column (nothing to set) — callers cannot
+ *     distinguish the two cases from the return value alone.
  */
 abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
 
@@ -94,14 +105,20 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
     frag.query[E]
   }
 
-  /** Returns the rows whose primary keys match the given IDs. */
+  /**
+   * Returns the rows whose primary keys match the given IDs.
+   *
+   * Renders one `IN (?, ..., ?)` shape per ID count; the rendered SQL is
+   * memoized per shape, so callers with varying batch sizes should keep arities
+   * stable (or prefer keyset paging via [[pageAfter]]) to avoid churning the
+   * fragment cache.
+   */
   final def findAll(ids: Iterable[ID])(using con: DbCon): List[E] = {
     val idList = ids.toList
     if (idList.isEmpty) List.empty
     else {
       val allValues = idList.flatMap(id => idCodec.toDbValues(id)).toIndexedSeq
-      val parts     = IndexedSeq(s"SELECT $allCols FROM $tbl WHERE ($validatedIdColumn) IN (") ++
-        IndexedSeq.fill(allValues.size - 1)(", ") :+ ")"
+      val parts     = Repo.inListParts(s"SELECT $allCols FROM $tbl WHERE ($validatedIdColumn) IN (", allValues.size)
       Frag(parts, allValues).query[E]
     }
   }
@@ -249,13 +266,20 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
   final def insertOrUpdateBatch(entities: Iterable[E])(using con: DbCon): Int = {
     if (entities.isEmpty) return 0
     val sqlStr = Upsert.insertDoUpdate(table, entities.head, validatedIdColumn).sql(con.dialect)
-    val start  = System.nanoTime()
+    // Hoisted once per batch: the upsert shape (columns, conflict target,
+    // assignments) is identical for every row, so per-row work is only
+    // `toDbValues` plus positional assignment projection. Param order matches
+    // `Upsert.insertDoUpdate`: all insert values, then the DO UPDATE SET
+    // assignment values in update-column order.
+    val updateIdx: Array[Int] = table.columns.filter(_ != validatedIdColumn).map(table.columns.indexOf).toArray
+    val start                 = System.nanoTime()
     try {
       val ps = con.connection.prepareStatement(sqlStr)
       try {
         entities.foreach { entity =>
-          val frag = Upsert.insertDoUpdate(table, entity, validatedIdColumn)
-          Frag.writeParams(ps.paramWriter, frag.queryParams)
+          val vals       = table.codec.toDbValues(entity)
+          val assignVals = updateIdx.map(i => vals(i)).toIndexedSeq
+          Frag.writeParams(ps.paramWriter, vals ++ assignVals)
           ps.addBatch()
         }
         val counts = ps.executeBatch()
@@ -329,14 +353,16 @@ abstract class Repo[E, ID] protected (metadata: Repo.Metadata[E, ID]) {
   /**
    * Deletes the rows with the given primary keys. Returns the total affected
    * row count.
+   *
+   * Like [[findAll]], renders one `IN (?, ..., ?)` shape per ID count; keep
+   * batch arities stable to avoid churning the memoized rendered-SQL cache.
    */
   final def deleteAll(ids: Iterable[ID])(using con: DbCon): Int = {
     val idList = ids.toList
     if (idList.isEmpty) 0
     else {
       val allValues = idList.flatMap(id => idCodec.toDbValues(id)).toIndexedSeq
-      val parts     = IndexedSeq(s"DELETE FROM $tbl WHERE ($validatedIdColumn) IN (") ++
-        IndexedSeq.fill(allValues.size - 1)(", ") :+ ")"
+      val parts     = Repo.inListParts(s"DELETE FROM $tbl WHERE ($validatedIdColumn) IN (", allValues.size)
       Frag(parts, allValues).update
     }
   }
@@ -514,11 +540,18 @@ object Repo {
     )
   }
 
-  private[sql] def buildInsertFrag(
-    tableName: String,
-    allColumns: String,
-    values: IndexedSeq[DbValue]
-  ): Frag =
+  /**
+   * Builds the literal parts for `prefix (?, ..., ?)` with `size` bound
+   * parameters: `prefix` followed by `size - 1` `", "` separators and a closing
+   * `")"`. Shared by the `IN`-list executors (`findAll`, `deleteAll`) so every
+   * call site mints the same shape for the same arity.
+   */
+  private[sql] def inListParts(prefix: String, size: Int): IndexedSeq[String] = {
+    require(size >= 1, s"Repo.inListParts: size must be >= 1, got $size")
+    IndexedSeq(prefix) ++ IndexedSeq.fill(size - 1)(", ") :+ ")"
+  }
+
+  private[sql] def buildInsertFrag(tableName: String, allColumns: String, values: IndexedSeq[DbValue]): Frag =
     if (values.isEmpty) Frag.literal(s"INSERT INTO $tableName DEFAULT VALUES")
     else {
       val parts =

--- a/sql/shared/src/main/scala/zio/blocks/sql/SqlDialect.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/SqlDialect.scala
@@ -45,6 +45,7 @@ object SqlDialect {
       case _: DbValue.DbInstant       => "TIMESTAMPTZ"
       case _: DbValue.DbDuration      => "INTERVAL"
       case _: DbValue.DbUUID          => "UUID"
+      case _: DbValue.DbArray         => "TEXT[]"
     }
 
     def paramPlaceholder(index: Int): String = "?"
@@ -72,6 +73,7 @@ object SqlDialect {
       case _: DbValue.DbInstant       => "TEXT"
       case _: DbValue.DbDuration      => "TEXT"
       case _: DbValue.DbUUID          => "TEXT"
+      case _: DbValue.DbArray         => "TEXT"
     }
 
     def paramPlaceholder(index: Int): String = "?"

--- a/sql/shared/src/main/scala/zio/blocks/sql/SqlQuery.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/SqlQuery.scala
@@ -28,7 +28,20 @@ import zio.blocks.sql.SqlStatement._
  *   - [[statement]] — structured [[SqlStatement]] for programmatic inspection
  *   - [[explain]] — single-line SQL with `?N` placeholders plus
  *     `-- params: ...` footer for logging
+ *
+ * Every identifier is validated and double-quoted at render time (like
+ * `zio.blocks.sql.query.QueryRenderer`), so mixed-case and reserved-word
+ * columns resolve correctly. `LIMIT`/`OFFSET` are literal-by-design (they are
+ * validated `Int`s, matching `QueryRenderer` and `Repo.pageAfter`); only filter
+ * values bind as `?` params.
  */
+@deprecated(
+  "Use zio.blocks.sql.query.SqlQuery for new queries: it validates joins through typed Rels and composes Frag throughout. This builder remains for SqlStatement/explain inspection until the full merge lands.",
+  "0.1.0"
+)
+// Self-references (method return types, `from` constructor call) would warn;
+// external users still get the deprecation warning at their call sites.
+@scala.annotation.nowarn("cat=deprecation")
 final class SqlQuery[A] private (
   private val source: Table[A],
   private val sourceAlias: String,
@@ -249,22 +262,27 @@ final class SqlQuery[A] private (
   }
 
   private def build(@scala.annotation.unused dialect: SqlDialect): (SqlStatement, Frag) = {
+    // `dialect` is currently informational: both dialects render `?`
+    // placeholders (see `Frag.renderSql`), so rendering is dialect-identical
+    // today. The parameter is kept (rather than removed) so a future `$N`-style
+    // dialect can thread through `toFrag`/`statement`/`explain` without an API
+    // break; revisit if such a dialect lands.
     val allTables: Vector[(String, IndexedSeq[String], String)] =
       Vector((source.name, columnsByAlias(sourceAlias), sourceAlias)) ++
         joins.map(j => (j.table, columnsByAlias.getOrElse(j.alias, IndexedSeq.empty), j.alias))
 
     val selectList = allTables.flatMap { case (_, cols, alias) =>
-      cols.map(c => s"$alias.$c")
+      cols.map(c => s"""$alias."$c"""")
     }.mkString(", ")
 
     val head = new StringBuilder
-    head.append(s"SELECT $selectList FROM ${source.name} $sourceAlias")
+    head.append(s"""SELECT $selectList FROM "${source.name}" $sourceAlias""")
     for (j <- joins) {
       val kindStr = j.kind match {
         case JoinKind.Inner => "INNER JOIN"
         case JoinKind.Left  => "LEFT JOIN"
       }
-      head.append(s" $kindStr ${j.table} ${j.alias} ON ${j.onLeft.qualified} = ${j.onRight.qualified}")
+      head.append(s""" $kindStr "${j.table}" ${j.alias} ON ${j.onLeft.qualified} = ${j.onRight.qualified}""")
     }
 
     val tailBuilder = new StringBuilder
@@ -320,6 +338,7 @@ final class SqlQuery[A] private (
 
 object SqlQuery {
 
+  @scala.annotation.nowarn("cat=deprecation")
   def from[A](table: Table[A]): SqlQuery[A] =
     new SqlQuery[A](table, "t0", Vector.empty, Vector.empty, None, Vector.empty, None, None, Map("t0" -> table.columns))
 

--- a/sql/shared/src/main/scala/zio/blocks/sql/SqlStatement.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/SqlStatement.scala
@@ -42,7 +42,10 @@ final case class SqlStatement(
 object SqlStatement {
 
   final case class ColumnRef(tableAlias: String, column: String) {
-    def qualified: String = s"$tableAlias.$column"
+    // Quote the column (validated at every builder entry): the alias is either
+    // a generated tN or a validated alias, while the column may be mixed-case
+    // or reserved. Mirrors QueryRenderer's `alias."col"` shape.
+    def qualified: String = s"""$tableAlias."$column""""
   }
 
   sealed trait JoinKind

--- a/sql/shared/src/main/scala/zio/blocks/sql/Table.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Table.scala
@@ -36,6 +36,14 @@ final case class Table[A](name: String, codec: DbCodec[A], columnsMeta: IndexedS
     column.copy(name = SqlIdentifier.validate("column", column.name))
   }
 
+  // Fail fast on duplicate columns: downstream builders (e.g.
+  // `Upsert.insertDoUpdate`) resolve column values by position, and a silently
+  // duplicated column would bind the wrong value to the wrong placeholder.
+  require(
+    validatedColumnsMeta.map(_.name).distinct.size == validatedColumnsMeta.size,
+    s"Table '$name' has duplicate columns: ${validatedColumnsMeta.map(_.name).mkString(", ")}"
+  )
+
   /** Column names in codec order (delegates to `codec.columns`). */
   def columns: IndexedSeq[String] = validatedColumnsMeta.map(_.name)
 

--- a/sql/shared/src/main/scala/zio/blocks/sql/Upsert.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/Upsert.scala
@@ -108,16 +108,25 @@ object Upsert {
     values: IndexedSeq[DbValue],
     conflictColumn: String
   ): Frag = {
-    val t = SqlIdentifier.validate("table", tableName)
+    val t       = SqlIdentifier.validate("table", tableName)
+    val columns = splitColumnList(allColumns, "Upsert.doNothingRaw")
+    columns.foreach(c => SqlIdentifier.validate("column", c))
     SqlIdentifier.validate("column", conflictColumn)
+    require(columns.size == values.size, "Upsert.doNothingRaw: columns/value count mismatch")
+    val base = Repo.buildInsertFrag(t, columns.mkString(", "), values)
+    base ++ doNothingSuffix(conflictColumn)
+  }
+
+  /**
+   * Splits a comma-joined column list (as `Repo` stores `allCols`) into
+   * validated, non-empty entries. Shared by the `*Raw` overloads so the
+   * normalize-then-validate step lives in one place.
+   */
+  private def splitColumnList(allColumns: String, where: String): IndexedSeq[String] = {
     val columns = allColumns.split(",").map(_.trim).filter(_.nonEmpty).toIndexedSeq
     if (columns.isEmpty)
-      throw new IllegalArgumentException("Upsert.doNothingRaw: allColumns must not be empty")
-    columns.foreach(c => SqlIdentifier.validate("column", c))
-    require(columns.size == values.size, "Upsert.doNothingRaw: columns/value count mismatch")
-    val normalizedCols = columns.mkString(", ")
-    val base           = Repo.buildInsertFrag(t, normalizedCols, values)
-    base ++ doNothingSuffix(conflictColumn)
+      throw new IllegalArgumentException(s"$where: allColumns must not be empty")
+    columns
   }
 
   /**
@@ -251,7 +260,8 @@ object Upsert {
    *   specified columns
    * @throws IllegalArgumentException
    *   if any identifier is invalid, if any column is not in `table.columns`, if
-   *   `updateColumns` contains the conflict column, or if it is empty
+   *   `updateColumns` contains the conflict column or contains duplicates, or
+   *   if it is empty
    */
   def insertDoUpdate[A](
     table: Table[A],
@@ -268,12 +278,19 @@ object Upsert {
       throw new IllegalArgumentException(
         s"Assignment columns must not contain conflict column '$conflict'"
       )
+    if (validatedUpdateCols.distinct.size != validatedUpdateCols.size)
+      throw new IllegalArgumentException(
+        s"Assignment columns must not contain duplicates: ${validatedUpdateCols.mkString(", ")}"
+      )
     val values  = table.codec.toDbValues(entity)
     val allCols = table.columns.mkString(", ")
     val base    = Repo.buildInsertFrag(t, allCols, values)
-    // Map column -> value via table.columns zip
-    val colValueMap                                = table.columns.zip(values).toMap
-    val assignments: IndexedSeq[(String, DbValue)] = validatedUpdateCols.map(col => col -> colValueMap(col))
+    // Index by position, not via `table.columns.zip(values).toMap`: a map keeps
+    // the LAST value on duplicate columns silently, while `indexOf` on a
+    // duplicate-checked `Table` (see `Table` constructor) resolves each column
+    // to its single position.
+    val assignments: IndexedSeq[(String, DbValue)] =
+      validatedUpdateCols.map(col => col -> values(table.columns.indexOf(col)))
     base ++ doUpdateSuffix(conflict, assignments)
   }
 }

--- a/sql/shared/src/main/scala/zio/blocks/sql/query/QueryRenderer.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/query/QueryRenderer.scala
@@ -20,6 +20,14 @@ import zio.blocks.sql.{Frag, SqlDialect, SqlIdentifier, Table}
 
 object QueryRenderer {
 
+  /**
+   * Renders a typed query IR to an executable [[Frag]].
+   *
+   * `dialect` is currently informational: both dialects render `?` placeholders
+   * (see `Frag.renderSql`), so rendering is dialect-identical today. The
+   * parameter is kept (rather than removed) so a future `$N`-style dialect can
+   * thread through without an API break; revisit if such a dialect lands.
+   */
   def render[A](query: SqlQuery[A], @scala.annotation.unused dialect: SqlDialect): Frag = {
     // SELECT clause: t0."col", t1."col", ...
     val allTables: Vector[(Table[_], String)] =

--- a/sql/shared/src/main/scala/zio/blocks/sql/query/SqlQuery.scala
+++ b/sql/shared/src/main/scala/zio/blocks/sql/query/SqlQuery.scala
@@ -21,6 +21,13 @@ import zio.blocks.sql.{Frag, SqlDialect, SqlIdentifier, Table}
 /**
  * Immutable query IR starting from a source table.
  *
+ * This is the blessed SELECT builder for new code (see the module decision
+ * below): joins are validated through typed [[Rel]]s, rendering is performed by
+ * [[QueryRenderer]] through `Frag.++` composition only, every identifier is
+ * validated and double-quoted, and values always bind as `?` params. The legacy
+ * stringly builder `zio.blocks.sql.SqlQuery` remains (deprecated) for
+ * `SqlStatement`/`explain` inspection flows until the full merge lands.
+ *
  * Alias allocation is deterministic: t0 = source, t1..tN in join order
  * (self-join safe — same Table joined twice gets distinct aliases). Rendering
  * is performed by [[QueryRenderer]] and produces a [[Frag]] via `Frag.++`

--- a/sql/shared/src/test/scala/zio/blocks/sql/DbCodecSpec.scala
+++ b/sql/shared/src/test/scala/zio/blocks/sql/DbCodecSpec.scala
@@ -151,6 +151,167 @@ object DbCodecSpec extends ZIOSpecDefault {
     implicit val schema: Schema[WithCustomLines] = Schema.derived
   }
 
+  case class WithChar(c: Char)
+  object WithChar {
+    implicit val schema: Schema[WithChar] = Schema.derived
+  }
+
+  /**
+   * Row-varying fake reader: every positional getter answers from the current
+   * `row` (1-based), so two simulated rows decode to different values. Label
+   * getters throw — any codec routing through labels on the positional path
+   * fails loudly — and `columnLabel` counts calls (each one hits result-set
+   * metadata on a real JDBC reader).
+   */
+  private final class RowReader extends DbResultReader {
+    var row: Int                                   = 1
+    var columnLabelCalls: Int                      = 0
+    private def unsupported(name: String): Nothing =
+      throw new UnsupportedOperationException(s"positional path must not call $name")
+    def getInt(index: Int): Int                                  = row * 100 + index
+    def getInt(label: String): Int                               = unsupported("getInt(label)")
+    def getLong(index: Int): Long                                = row * 100L + index
+    def getLong(label: String): Long                             = unsupported("getLong(label)")
+    def getDouble(index: Int): Double                            = row * 100.0 + index
+    def getDouble(label: String): Double                         = unsupported("getDouble(label)")
+    def getFloat(index: Int): Float                              = (row * 100 + index).toFloat
+    def getFloat(label: String): Float                           = unsupported("getFloat(label)")
+    def getBoolean(index: Int): Boolean                          = ((row + index) & 1) == 0
+    def getBoolean(label: String): Boolean                       = unsupported("getBoolean(label)")
+    def getString(index: Int): String                            = s"r${row}c$index"
+    def getString(label: String): String                         = unsupported("getString(label)")
+    def getBigDecimal(index: Int): java.math.BigDecimal          = java.math.BigDecimal.valueOf(row * 100L + index)
+    def getBigDecimal(label: String): java.math.BigDecimal       = unsupported("getBigDecimal(label)")
+    def getBytes(index: Int): Array[Byte]                        = unsupported("getBytes(index)")
+    def getBytes(label: String): Array[Byte]                     = unsupported("getBytes(label)")
+    def getShort(index: Int): Short                              = (row * 100 + index).toShort
+    def getShort(label: String): Short                           = unsupported("getShort(label)")
+    def getByte(index: Int): Byte                                = (row * 100 + index).toByte
+    def getByte(label: String): Byte                             = unsupported("getByte(label)")
+    def getLocalDate(index: Int): java.time.LocalDate            = unsupported("getLocalDate(index)")
+    def getLocalDate(label: String): java.time.LocalDate         = unsupported("getLocalDate(label)")
+    def getLocalDateTime(index: Int): java.time.LocalDateTime    = unsupported("getLocalDateTime(index)")
+    def getLocalDateTime(label: String): java.time.LocalDateTime = unsupported("getLocalDateTime(label)")
+    def getLocalTime(index: Int): java.time.LocalTime            = unsupported("getLocalTime(index)")
+    def getLocalTime(label: String): java.time.LocalTime         = unsupported("getLocalTime(label)")
+    def getInstant(index: Int): java.time.Instant                = unsupported("getInstant(index)")
+    def getInstant(label: String): java.time.Instant             = unsupported("getInstant(label)")
+    def getDuration(index: Int): java.time.Duration              = unsupported("getDuration(index)")
+    def getDuration(label: String): java.time.Duration           = unsupported("getDuration(label)")
+    def getUUID(index: Int): java.util.UUID                      = unsupported("getUUID(index)")
+    def getUUID(label: String): java.util.UUID                   = unsupported("getUUID(label)")
+    def columnLabel(index: Int): String                          = {
+      columnLabelCalls += 1
+      s"c$index"
+    }
+    def hasColumn(label: String): Boolean = true
+    def wasNull: Boolean                  = false
+  }
+
+  /**
+   * Label-driven fake reader backed by a value map plus the result set's column
+   * order. Positional getters resolve through `resultOrder`, label getters
+   * through `byLabel` — a codec taking the wrong path still decodes, but
+   * misalignment assertions (columnLabel/hasColumn) steer record codecs onto
+   * the intended path.
+   */
+  private final class LabelReader(
+    byLabel: Map[String, Any],
+    resultOrder: IndexedSeq[String]
+  ) extends DbResultReader {
+    private def at(index: Int): Any                              = byLabel(resultOrder(index - 1))
+    private def atLabel(label: String): Any                      = byLabel(label)
+    def getInt(index: Int): Int                                  = at(index).asInstanceOf[Int]
+    def getInt(label: String): Int                               = atLabel(label).asInstanceOf[Int]
+    def getLong(index: Int): Long                                = at(index).asInstanceOf[Long]
+    def getLong(label: String): Long                             = atLabel(label).asInstanceOf[Long]
+    def getDouble(index: Int): Double                            = at(index).asInstanceOf[Double]
+    def getDouble(label: String): Double                         = atLabel(label).asInstanceOf[Double]
+    def getFloat(index: Int): Float                              = at(index).asInstanceOf[Float]
+    def getFloat(label: String): Float                           = atLabel(label).asInstanceOf[Float]
+    def getBoolean(index: Int): Boolean                          = at(index).asInstanceOf[Boolean]
+    def getBoolean(label: String): Boolean                       = atLabel(label).asInstanceOf[Boolean]
+    def getString(index: Int): String                            = at(index).asInstanceOf[String]
+    def getString(label: String): String                         = atLabel(label).asInstanceOf[String]
+    def getBigDecimal(index: Int): java.math.BigDecimal          = at(index).asInstanceOf[java.math.BigDecimal]
+    def getBigDecimal(label: String): java.math.BigDecimal       = atLabel(label).asInstanceOf[java.math.BigDecimal]
+    def getBytes(index: Int): Array[Byte]                        = at(index).asInstanceOf[Array[Byte]]
+    def getBytes(label: String): Array[Byte]                     = atLabel(label).asInstanceOf[Array[Byte]]
+    def getShort(index: Int): Short                              = at(index).asInstanceOf[Short]
+    def getShort(label: String): Short                           = atLabel(label).asInstanceOf[Short]
+    def getByte(index: Int): Byte                                = at(index).asInstanceOf[Byte]
+    def getByte(label: String): Byte                             = atLabel(label).asInstanceOf[Byte]
+    def getLocalDate(index: Int): java.time.LocalDate            = at(index).asInstanceOf[java.time.LocalDate]
+    def getLocalDate(label: String): java.time.LocalDate         = atLabel(label).asInstanceOf[java.time.LocalDate]
+    def getLocalDateTime(index: Int): java.time.LocalDateTime    = at(index).asInstanceOf[java.time.LocalDateTime]
+    def getLocalDateTime(label: String): java.time.LocalDateTime =
+      atLabel(label).asInstanceOf[java.time.LocalDateTime]
+    def getLocalTime(index: Int): java.time.LocalTime    = at(index).asInstanceOf[java.time.LocalTime]
+    def getLocalTime(label: String): java.time.LocalTime = atLabel(label).asInstanceOf[java.time.LocalTime]
+    def getInstant(index: Int): java.time.Instant        = at(index).asInstanceOf[java.time.Instant]
+    def getInstant(label: String): java.time.Instant     = atLabel(label).asInstanceOf[java.time.Instant]
+    def getDuration(index: Int): java.time.Duration      = at(index).asInstanceOf[java.time.Duration]
+    def getDuration(label: String): java.time.Duration   = atLabel(label).asInstanceOf[java.time.Duration]
+    def getUUID(index: Int): java.util.UUID              = at(index).asInstanceOf[java.util.UUID]
+    def getUUID(label: String): java.util.UUID           = atLabel(label).asInstanceOf[java.util.UUID]
+    def columnLabel(index: Int): String                  = resultOrder(index - 1)
+    def hasColumn(label: String): Boolean                = byLabel.contains(label)
+    def wasNull: Boolean                                 = false
+  }
+
+  /** Fixed-string reader for char edge cases (null/empty/single-char). */
+  private final class ConstStringReader(value: String) extends DbResultReader {
+    private def unsupported(name: String): Nothing =
+      throw new UnsupportedOperationException(s"char path must not call $name")
+    def getInt(index: Int): Int                                  = unsupported("getInt(index)")
+    def getInt(label: String): Int                               = unsupported("getInt(label)")
+    def getLong(index: Int): Long                                = unsupported("getLong(index)")
+    def getLong(label: String): Long                             = unsupported("getLong(label)")
+    def getDouble(index: Int): Double                            = unsupported("getDouble(index)")
+    def getDouble(label: String): Double                         = unsupported("getDouble(label)")
+    def getFloat(index: Int): Float                              = unsupported("getFloat(index)")
+    def getFloat(label: String): Float                           = unsupported("getFloat(label)")
+    def getBoolean(index: Int): Boolean                          = unsupported("getBoolean(index)")
+    def getBoolean(label: String): Boolean                       = unsupported("getBoolean(label)")
+    def getString(index: Int): String                            = value
+    def getString(label: String): String                         = value
+    def getBigDecimal(index: Int): java.math.BigDecimal          = unsupported("getBigDecimal(index)")
+    def getBigDecimal(label: String): java.math.BigDecimal       = unsupported("getBigDecimal(label)")
+    def getBytes(index: Int): Array[Byte]                        = unsupported("getBytes(index)")
+    def getBytes(label: String): Array[Byte]                     = unsupported("getBytes(label)")
+    def getShort(index: Int): Short                              = unsupported("getShort(index)")
+    def getShort(label: String): Short                           = unsupported("getShort(label)")
+    def getByte(index: Int): Byte                                = unsupported("getByte(index)")
+    def getByte(label: String): Byte                             = unsupported("getByte(label)")
+    def getLocalDate(index: Int): java.time.LocalDate            = unsupported("getLocalDate(index)")
+    def getLocalDate(label: String): java.time.LocalDate         = unsupported("getLocalDate(label)")
+    def getLocalDateTime(index: Int): java.time.LocalDateTime    = unsupported("getLocalDateTime(index)")
+    def getLocalDateTime(label: String): java.time.LocalDateTime = unsupported("getLocalDateTime(label)")
+    def getLocalTime(index: Int): java.time.LocalTime            = unsupported("getLocalTime(index)")
+    def getLocalTime(label: String): java.time.LocalTime         = unsupported("getLocalTime(label)")
+    def getInstant(index: Int): java.time.Instant                = unsupported("getInstant(index)")
+    def getInstant(label: String): java.time.Instant             = unsupported("getInstant(label)")
+    def getDuration(index: Int): java.time.Duration              = unsupported("getDuration(index)")
+    def getDuration(label: String): java.time.Duration           = unsupported("getDuration(label)")
+    def getUUID(index: Int): java.util.UUID                      = unsupported("getUUID(index)")
+    def getUUID(label: String): java.util.UUID                   = unsupported("getUUID(label)")
+    def columnLabel(index: Int): String                          = "c"
+    def hasColumn(label: String): Boolean                        = label == "c"
+    def wasNull: Boolean                                         = false
+  }
+
+  /** Labels wrapper counting `slice` calls to lock the F2b hoist. */
+  private final class CountingLabels(underlying: IndexedSeq[String]) extends IndexedSeq[String] {
+    var sliceCalls: Int                                           = 0
+    def apply(i: Int): String                                     = underlying(i)
+    def length: Int                                               = underlying.length
+    override def iterator: Iterator[String]                       = underlying.iterator
+    override def slice(from: Int, until: Int): IndexedSeq[String] = {
+      sliceCalls += 1
+      underlying.slice(from, until)
+    }
+  }
+
   sealed trait Shape
   object Shape {
     case class Circle(radius: Double)     extends Shape
@@ -994,6 +1155,115 @@ object DbCodecSpec extends ZIOSpecDefault {
         val mcodec = summon[DbCodec[Maybe[String]]]
         val values = mcodec.toDbValues(Maybe.present(null))
         assertTrue(values == IndexedSeq(DbValue.DbNull))
+      }
+    ),
+    suite("positional decode avoids per-row metadata (F2)")(
+      test("all single-column primitives decode 2 rows with zero columnLabel calls") {
+        val reader = new RowReader
+        // Row 1 at indexes 1-9
+        val (i1, l1, s1, b1, d1, f1, sh1, by1, bd1) = (
+          DbCodec.intCodec.readValue(reader, 1),
+          DbCodec.longCodec.readValue(reader, 2),
+          DbCodec.stringCodec.readValue(reader, 3),
+          DbCodec.booleanCodec.readValue(reader, 4),
+          DbCodec.doubleCodec.readValue(reader, 5),
+          DbCodec.floatCodec.readValue(reader, 6),
+          DbCodec.shortCodec.readValue(reader, 7),
+          DbCodec.byteCodec.readValue(reader, 8),
+          DbCodec.bigDecimalCodec.readValue(reader, 9)
+        )
+        reader.row = 2
+        // Row 2 at the same indexes
+        val (i2, l2, s2, b2, d2, f2, sh2, by2, bd2) = (
+          DbCodec.intCodec.readValue(reader, 1),
+          DbCodec.longCodec.readValue(reader, 2),
+          DbCodec.stringCodec.readValue(reader, 3),
+          DbCodec.booleanCodec.readValue(reader, 4),
+          DbCodec.doubleCodec.readValue(reader, 5),
+          DbCodec.floatCodec.readValue(reader, 6),
+          DbCodec.shortCodec.readValue(reader, 7),
+          DbCodec.byteCodec.readValue(reader, 8),
+          DbCodec.bigDecimalCodec.readValue(reader, 9)
+        )
+        assertTrue(
+          (i1, l1, s1, b1, d1, f1, sh1, by1) == (101, 102L, "r1c3", false, 105.0, 106.0f, 107.toShort, 108.toByte),
+          bd1.toString == "109",
+          (i2, l2, s2, b2, d2, f2, sh2, by2) == (201, 202L, "r2c3", true, 205.0, 206.0f, 207.toShort, 208.toByte),
+          bd2.toString == "209",
+          reader.columnLabelCalls == 0
+        )
+      }
+    ),
+    suite("record label-path slice hoist (F2b)")(
+      test("reordered labels slice once per statement, not once per field per row") {
+        val codec  = deriveCodec[SimpleRecord]
+        val labels = new CountingLabels(IndexedSeq("name", "age"))
+        // Result set exposes a different first column, forcing the codec onto
+        // the label fallback path for every row.
+        val reader = new LabelReader(Map[String, Any]("name" -> "Alice", "age" -> 3), IndexedSeq("other", "age"))
+        val first  = codec.readValue(reader, labels)
+        val second = codec.readValue(reader, labels)
+        assertTrue(
+          first == SimpleRecord("Alice", 3),
+          second == SimpleRecord("Alice", 3),
+          labels.sliceCalls == 2
+        )
+      }
+    ),
+    suite("char decoding rejects null and empty (F5)")(
+      test("SQL NULL char fails fast on both overloads") {
+        val codec = deriveCodec[WithChar]
+        // Two labels forces the record codec onto the label fallback path,
+        // exercising the char codec's label overload directly; the single
+        // label takes the aligned positional path.
+        val viaLabels   = scala.util.Try(codec.readValue(new ConstStringReader(null), IndexedSeq("c", "extra")))
+        val viaPosition = scala.util.Try(codec.readValue(new ConstStringReader(null), 1))
+        assertTrue(
+          viaLabels.isFailure,
+          viaLabels.failed.get.isInstanceOf[IllegalStateException],
+          viaLabels.failed.get.getMessage.contains("NULL"),
+          viaPosition.isFailure,
+          viaPosition.failed.get.isInstanceOf[IllegalStateException]
+        )
+      },
+      test("empty string char fails fast on both overloads") {
+        val codec       = deriveCodec[WithChar]
+        val viaLabels   = scala.util.Try(codec.readValue(new ConstStringReader(""), IndexedSeq("c", "extra")))
+        val viaPosition = scala.util.Try(codec.readValue(new ConstStringReader(""), 1))
+        assertTrue(
+          viaLabels.isFailure,
+          viaLabels.failed.get.isInstanceOf[IllegalStateException],
+          viaLabels.failed.get.getMessage.contains("empty"),
+          viaPosition.isFailure,
+          viaPosition.failed.get.isInstanceOf[IllegalStateException]
+        )
+      },
+      test("single-char string still decodes") {
+        val codec  = deriveCodec[WithChar]
+        val reader = new LabelReader(Map[String, Any]("c" -> "Z"), IndexedSeq("c"))
+        assertTrue(codec.readValue(reader, IndexedSeq("c")) == WithChar('Z'))
+      }
+    ),
+    suite("As Either helpers (F10)")(
+      test("decodeViaAs/encodeViaAs preserve success and failure as values") {
+        val conv = new As[String, Int] {
+          def into(s: String): Either[SchemaError, Int] =
+            scala.util.Try(s.toInt).toEither.left.map(_ => SchemaError(s"not an int: $s"))
+          def from(i: Int): Either[SchemaError, String] = Right(i.toString)
+        }
+        assertTrue(
+          DbCodec.decodeViaAs(conv, "42") == Right(42),
+          DbCodec.decodeViaAs(conv, "nope").isLeft,
+          DbCodec.encodeViaAs(conv, 7) == Right("7")
+        )
+      },
+      test("decodeJsonbEither round-trips success and surfaces bad JSON as Left") {
+        implicit val jsonCodec: JsonCodec[JsonPayload] = JsonPayload.jsonCodec
+        assertTrue(
+          DbCodec.decodeJsonbEither[JsonPayload]("{\"message\":\"hello\",\"count\":2}") ==
+            Right(JsonPayload("hello", 2)),
+          DbCodec.decodeJsonbEither[JsonPayload]("not json").isLeft
+        )
       }
     )
   )

--- a/sql/shared/src/test/scala/zio/blocks/sql/DialectSpec.scala
+++ b/sql/shared/src/test/scala/zio/blocks/sql/DialectSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.sql
+
+import zio.test._
+
+object DialectSpec extends ZIOSpecDefault {
+  def spec = suite("DialectSpec")(
+    suite("valid identifiers render unchanged (F9)")(
+      test("Postgres queue DDL golden strings") {
+        assertTrue(
+          Dialect.Postgres.createQueueTableDDL("queue", "id") ==
+            "CREATE TABLE IF NOT EXISTS queue (\n  id TEXT NOT NULL PRIMARY KEY,\n  op TEXT NOT NULL DEFAULT 'I',\n  payload TEXT\n)",
+          Dialect.Postgres.dequeueSQL("queue", "id", 10) ==
+            "SELECT id FROM queue ORDER BY id LIMIT 10 FOR UPDATE SKIP LOCKED",
+          Dialect.Postgres.createShadowTableDDL("shadow_q", "users") ==
+            "CREATE TABLE IF NOT EXISTS shadow_q (LIKE users INCLUDING ALL)"
+        )
+      },
+      test("SQLite queue DDL golden strings") {
+        assertTrue(
+          Dialect.SQLite.createQueueTableDDL("queue", "id") ==
+            "CREATE TABLE IF NOT EXISTS queue (\n  id TEXT NOT NULL PRIMARY KEY,\n  op TEXT NOT NULL DEFAULT 'I',\n  payload TEXT\n)",
+          Dialect.SQLite.dequeueSQL("queue", "id", 10) ==
+            "SELECT id FROM queue ORDER BY id LIMIT 10"
+        )
+      },
+      test("trigger DDL interpolates validated identifiers") {
+        val pg     = Dialect.Postgres.createTriggerDDL("queue", "users", "id", "key")
+        val sqlite = Dialect.SQLite.createTriggerDDL("queue", "users", "id", "key")
+        assertTrue(
+          pg.size == 2,
+          pg.head.contains("INSERT INTO queue (key, op, payload) VALUES (OLD.id, 'D'"),
+          pg(
+            1
+          ) == "CREATE OR REPLACE TRIGGER trg_queue_mod AFTER INSERT OR UPDATE OR DELETE ON users FOR EACH ROW EXECUTE FUNCTION queue_notify();",
+          sqlite.size == 3,
+          sqlite.head ==
+            "CREATE TRIGGER IF NOT EXISTS trg_queue_insert AFTER INSERT ON users BEGIN INSERT OR IGNORE INTO queue (key, op) VALUES (NEW.id, 'I'); END;"
+        )
+      }
+    ),
+    suite("invalid identifiers throw (F9)")(
+      test("Postgres rejects injection in every method") {
+        val results = List(
+          scala.util.Try(Dialect.Postgres.createQueueTableDDL("q; DROP TABLE q", "id")),
+          scala.util.Try(Dialect.Postgres.dequeueSQL("queue", "id desc", 10)),
+          scala.util.Try(Dialect.Postgres.createShadowTableDDL("shadow q", "users")),
+          scala.util.Try(Dialect.Postgres.createTriggerDDL("queue", "users", "id;--", "key"))
+        )
+        assertTrue(
+          results.forall(_.isFailure),
+          results.forall(_.failed.get.isInstanceOf[IllegalArgumentException])
+        )
+      },
+      test("SQLite rejects injection in every method") {
+        val results = List(
+          scala.util.Try(Dialect.SQLite.createQueueTableDDL("queue", "i\"d")),
+          scala.util.Try(Dialect.SQLite.dequeueSQL("que ue", "id", 10)),
+          scala.util.Try(Dialect.SQLite.createTriggerDDL("queue", "users", "id", "ke'y"))
+        )
+        assertTrue(
+          results.forall(_.isFailure),
+          results.forall(_.failed.get.isInstanceOf[IllegalArgumentException])
+        )
+      }
+    )
+  )
+}

--- a/sql/shared/src/test/scala/zio/blocks/sql/ExplainSpec.scala
+++ b/sql/shared/src/test/scala/zio/blocks/sql/ExplainSpec.scala
@@ -17,10 +17,12 @@
 package zio.blocks.sql
 
 import zio.test._
-import zio.blocks.schema.Schema
+import zio.blocks.schema._
 
+// Uses the deprecated stringly SqlQuery for its SqlStatement/explain inspection
+// coverage; silences the F1 deprecation accordingly.
+@scala.annotation.nowarn("cat=deprecation")
 object ExplainSpec extends ZIOSpecDefault {
-
   case class User(id: Int, name: String)
   object User {
     implicit val schema: Schema[User] = Schema.derived
@@ -53,7 +55,7 @@ object ExplainSpec extends ZIOSpecDefault {
       val st      = q.statement(SqlDialect.PostgreSQL)
 
       val expectedSql =
-        "SELECT t0.id, t0.name, t1.id, t1.owner_id, t1.name, t2.user_id, t2.repo_id FROM user t0 INNER JOIN repo t1 ON t0.id = t1.owner_id INNER JOIN star t2 ON t1.id = t2.repo_id WHERE t0.name = ?1 AND t1.name = ?2"
+        """SELECT t0."id", t0."name", t1."id", t1."owner_id", t1."name", t2."user_id", t2."repo_id" FROM "user" t0 INNER JOIN "repo" t1 ON t0."id" = t1."owner_id" INNER JOIN "star" t2 ON t1."id" = t2."repo_id" WHERE t0."name" = ?1 AND t1."name" = ?2"""
 
       assertTrue(
         explain.contains(expectedSql),
@@ -99,8 +101,8 @@ object ExplainSpec extends ZIOSpecDefault {
 
       val explain = q.explain(SqlDialect.PostgreSQL)
       assertTrue(
-        explain.contains("INNER JOIN repo t1 ON t0.id = t1.owner_id"),
-        explain.contains("WHERE t0.id = ?1"),
+        explain.contains("""INNER JOIN "repo" t1 ON t0."id" = t1."owner_id""""),
+        explain.contains("""WHERE t0."id" = ?1"""),
         explain.contains("-- params: 1:Int"),
         !explain.contains("42")
       )
@@ -119,7 +121,7 @@ object ExplainSpec extends ZIOSpecDefault {
       val st      = q.statement(SqlDialect.PostgreSQL)
 
       assertTrue(
-        explain.contains("ORDER BY t0.id ASC, t1.name DESC"),
+        explain.contains("""ORDER BY t0."id" ASC, t1."name" DESC"""),
         explain.contains("LIMIT 10"),
         explain.contains("OFFSET 5"),
         explain.contains("?1"),
@@ -144,8 +146,8 @@ object ExplainSpec extends ZIOSpecDefault {
       val st      = q.statement(SqlDialect.PostgreSQL)
 
       assertTrue(
-        explain.contains("LEFT JOIN repo t1"),
-        explain.contains("GROUP BY t0.id"),
+        explain.contains("""LEFT JOIN "repo" t1"""),
+        explain.contains("""GROUP BY t0."id""""),
         st.joins.head.kind == SqlStatement.JoinKind.Left,
         st.groupBy.contains(SqlStatement.GroupBy(Vector(SqlStatement.ColumnRef("t0", "id"))))
       )
@@ -177,6 +179,18 @@ object ExplainSpec extends ZIOSpecDefault {
       val st   = q.statement(SqlDialect.PostgreSQL)
       val frag = q.toFrag(SqlDialect.PostgreSQL)
       assertTrue(st.frag == frag)
+    },
+    test("reserved and mixed-case columns render double-quoted (F3)") {
+      case class Weird(@Modifier.rename("order") ord: Int, @Modifier.rename("MixedCase") mixed: String)
+      object Weird {
+        implicit val schema: Schema[Weird] = Schema.derived
+      }
+      val table   = Table.derived[Weird]
+      val explain = SqlQuery.from(table).where(table, "order", DbValue.DbInt(1)).explain(SqlDialect.PostgreSQL)
+      assertTrue(
+        explain.contains("""SELECT t0."order", t0."MixedCase" FROM "weird" t0"""),
+        explain.contains("""WHERE t0."order" = ?1""")
+      )
     }
   )
 }

--- a/sql/shared/src/test/scala/zio/blocks/sql/RepoSpec.scala
+++ b/sql/shared/src/test/scala/zio/blocks/sql/RepoSpec.scala
@@ -21,6 +21,74 @@ import zio.blocks.schema._
 
 object RepoSpec extends ZIOSpecDefault {
 
+  /**
+   * Records every `setX` call by 1-based index for batch equivalence checks.
+   */
+  private final class RecordingWriter extends DbParamWriter {
+    private val slots                                                = scala.collection.mutable.Map.empty[Int, DbValue]
+    private def record(index: Int, value: DbValue): Unit             = slots(index) = value
+    def setInt(index: Int, value: Int): Unit                         = record(index, DbValue.DbInt(value))
+    def setLong(index: Int, value: Long): Unit                       = record(index, DbValue.DbLong(value))
+    def setDouble(index: Int, value: Double): Unit                   = record(index, DbValue.DbDouble(value))
+    def setFloat(index: Int, value: Float): Unit                     = record(index, DbValue.DbFloat(value))
+    def setBoolean(index: Int, value: Boolean): Unit                 = record(index, DbValue.DbBoolean(value))
+    def setString(index: Int, value: String): Unit                   = record(index, DbValue.DbString(value))
+    def setBigDecimal(index: Int, value: java.math.BigDecimal): Unit =
+      record(index, DbValue.DbBigDecimal(scala.BigDecimal(value)))
+    def setBytes(index: Int, value: Array[Byte]): Unit                     = record(index, DbValue.DbBytes(value))
+    def setShort(index: Int, value: Short): Unit                           = record(index, DbValue.DbShort(value))
+    def setByte(index: Int, value: Byte): Unit                             = record(index, DbValue.DbByte(value))
+    def setLocalDate(index: Int, value: java.time.LocalDate): Unit         = record(index, DbValue.DbLocalDate(value))
+    def setLocalDateTime(index: Int, value: java.time.LocalDateTime): Unit =
+      record(index, DbValue.DbLocalDateTime(value))
+    def setLocalTime(index: Int, value: java.time.LocalTime): Unit                 = record(index, DbValue.DbLocalTime(value))
+    def setInstant(index: Int, value: java.time.Instant): Unit                     = record(index, DbValue.DbInstant(value))
+    def setDuration(index: Int, value: java.time.Duration): Unit                   = record(index, DbValue.DbDuration(value))
+    def setUUID(index: Int, value: java.util.UUID): Unit                           = record(index, DbValue.DbUUID(value))
+    def setNull(index: Int, sqlType: Int): Unit                                    = record(index, DbValue.DbNull)
+    def setArray(index: Int, elementType: String, elements: IndexedSeq[Any]): Unit =
+      record(index, DbValue.DbArray(elementType, elements))
+    def snapshot: IndexedSeq[DbValue] =
+      slots.toIndexedSeq.sortBy(_._1).map(_._2)
+    def clear(): Unit = slots.clear()
+  }
+
+  /** Captures prepared SQL and per-row param snapshots for batch tests. */
+  private final class RecordingConnection(
+    preparedSql: scala.collection.mutable.ListBuffer[String],
+    rowValues: scala.collection.mutable.ListBuffer[IndexedSeq[DbValue]]
+  ) extends DbConnection {
+    private val writer    = new RecordingWriter
+    private val statement = new DbPreparedStatement {
+      def executeQuery(): DbResultSet               = throw new AssertionError("no queries expected")
+      def executeUpdate(): Int                      = throw new AssertionError("no updates expected")
+      def executeUpdateReturningKeys(): DbResultSet = throw new AssertionError("no keys expected")
+      def close(): Unit                             = ()
+      def paramWriter: DbParamWriter                = writer
+      def addBatch(): Unit                          = {
+        rowValues += writer.snapshot
+        writer.clear()
+      }
+      def executeBatch(): Array[Int] = Array.fill(rowValues.size)(1)
+    }
+    def prepareStatement(sql: String): DbPreparedStatement = {
+      preparedSql += sql
+      writer.clear()
+      statement
+    }
+    def prepareStatementReturningKeys(sql: String): DbPreparedStatement =
+      throw new AssertionError(s"prepareStatementReturningKeys should not be called: $sql")
+    def close(): Unit                            = ()
+    def isClosed: Boolean                        = false
+    def setAutoCommit(autoCommit: Boolean): Unit = ()
+    def getAutoCommit: Boolean                   = true
+    def commit(): Unit                           = ()
+    def rollback(): Unit                         = ()
+    override def savepoint(name: String): Unit   = ()
+    override def release(name: String): Unit     = ()
+    override def rollbackTo(name: String): Unit  = ()
+  }
+
   def spec: Spec[TestEnvironment, Any] = suite("RepoSpec")(
     suite("buildInsertFrag")(
       test("builds correct INSERT Frag for 3 values") {
@@ -250,6 +318,61 @@ object RepoSpec extends ZIOSpecDefault {
         }
 
         assertTrue(repo.update(IdOnly(1)) == 0)
+      }
+    ),
+    suite("insertOrUpdateBatch uses one SQL shape (F4)")(
+      test("batch prepares a single statement and writes insert ++ assignment params per row") {
+        case class User(id: Int, name: String)
+        object User {
+          implicit val schema: Schema[User] = Schema.derived
+        }
+        val repo        = Repo.derived[User, Int]
+        val preparedSql = scala.collection.mutable.ListBuffer.empty[String]
+        val rowValues   = scala.collection.mutable.ListBuffer.empty[IndexedSeq[DbValue]]
+        given DbCon     = new DbCon {
+          val connection: DbConnection = new RecordingConnection(preparedSql, rowValues)
+          val dialect: SqlDialect      = SqlDialect.SQLite
+          val logger: SqlLogger        = SqlLogger.noop
+        }
+        val total = repo.insertOrUpdateBatch(List(User(1, "Alice"), User(2, "Bob")))
+        assertTrue(
+          total == 2,
+          preparedSql.size == 1,
+          preparedSql.head ==
+            """INSERT INTO user (id, name) VALUES (?, ?) ON CONFLICT ("id") DO UPDATE SET "name" = ?""",
+          rowValues.size == 2,
+          rowValues(0) == IndexedSeq(DbValue.DbInt(1), DbValue.DbString("Alice"), DbValue.DbString("Alice")),
+          rowValues(1) == IndexedSeq(DbValue.DbInt(2), DbValue.DbString("Bob"), DbValue.DbString("Bob"))
+        )
+      },
+      test("batch params match Upsert.insertDoUpdate params for the same entity") {
+        case class User(id: Int, name: String)
+        object User {
+          implicit val schema: Schema[User] = Schema.derived
+        }
+        val repo        = Repo.derived[User, Int]
+        val preparedSql = scala.collection.mutable.ListBuffer.empty[String]
+        val rowValues   = scala.collection.mutable.ListBuffer.empty[IndexedSeq[DbValue]]
+        given DbCon     = new DbCon {
+          val connection: DbConnection = new RecordingConnection(preparedSql, rowValues)
+          val dialect: SqlDialect      = SqlDialect.SQLite
+          val logger: SqlLogger        = SqlLogger.noop
+        }
+        repo.insertOrUpdateBatch(List(User(9, "Zed")))
+        val expected = Upsert.insertDoUpdate(repo.table, User(9, "Zed"), "id")
+        assertTrue(
+          preparedSql.head == expected.sql(SqlDialect.SQLite),
+          rowValues.head == expected.queryParams
+        )
+      }
+    ),
+    suite("inListParts (S8)")(
+      test("builds one placeholder group per element") {
+        assertTrue(
+          Repo.inListParts("SELECT a FROM t WHERE (id) IN (", 1) == IndexedSeq("SELECT a FROM t WHERE (id) IN (", ")"),
+          Repo.inListParts("SELECT a FROM t WHERE (id) IN (", 3) ==
+            IndexedSeq("SELECT a FROM t WHERE (id) IN (", ", ", ", ", ")")
+        )
       }
     )
   )

--- a/sql/shared/src/test/scala/zio/blocks/sql/SqlDialectSpec.scala
+++ b/sql/shared/src/test/scala/zio/blocks/sql/SqlDialectSpec.scala
@@ -104,6 +104,11 @@ object SqlDialectSpec extends ZIOSpecDefault {
           ) == "UUID"
         )
       },
+      test("DbArray -> TEXT[] (row-7: array columns no longer throw MatchError)") {
+        assertTrue(
+          SqlDialect.PostgreSQL.typeName(DbValue.DbArray("varchar", IndexedSeq("a"))) == "TEXT[]"
+        )
+      },
       test("paramPlaceholder(1) -> ?") {
         assertTrue(SqlDialect.PostgreSQL.paramPlaceholder(1) == "?")
       },
@@ -186,6 +191,11 @@ object SqlDialectSpec extends ZIOSpecDefault {
       test("DbUUID -> TEXT") {
         assertTrue(
           SqlDialect.SQLite.typeName(DbValue.DbUUID(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"))) == "TEXT"
+        )
+      },
+      test("DbArray -> TEXT (row-7: array columns no longer throw MatchError)") {
+        assertTrue(
+          SqlDialect.SQLite.typeName(DbValue.DbArray("varchar", IndexedSeq("a"))) == "TEXT"
         )
       },
       test("paramPlaceholder(1) -> ?") {

--- a/sql/shared/src/test/scala/zio/blocks/sql/TableSpec.scala
+++ b/sql/shared/src/test/scala/zio/blocks/sql/TableSpec.scala
@@ -172,6 +172,35 @@ object TableSpec extends ZIOSpecDefault {
           case e: IllegalArgumentException => e
         }
         assertTrue(error.getMessage.contains("Invalid SQL column identifier"))
+      },
+      test("manual tables reject duplicate columns when constructed") {
+        val error = try {
+          Table(
+            "users",
+            DbCodec.stringCodec,
+            IndexedSeq(
+              ColumnMeta("id", DbValue.DbInt(0), false),
+              ColumnMeta("id", DbValue.DbInt(0), false)
+            )
+          )
+          throw new AssertionError("Expected IllegalArgumentException")
+        } catch {
+          case e: IllegalArgumentException => e
+        }
+        assertTrue(error.getMessage.contains("uplicate"))
+      },
+      test("array columns render without MatchError (row-7)") {
+        val table = Table(
+          "docs",
+          DbCodec.stringCodec,
+          IndexedSeq(ColumnMeta("tags", DbValue.DbArray("varchar", IndexedSeq.empty), true))
+        )
+        assertTrue(
+          table.createTable(SqlDialect.PostgreSQL).sql(SqlDialect.PostgreSQL) ==
+            "CREATE TABLE IF NOT EXISTS docs (\n  tags TEXT[]\n)",
+          table.createTable(SqlDialect.SQLite).sql(SqlDialect.SQLite) ==
+            "CREATE TABLE IF NOT EXISTS docs (\n  tags TEXT\n)"
+        )
       }
     )
   )

--- a/sql/shared/src/test/scala/zio/blocks/sql/UpsertSpec.scala
+++ b/sql/shared/src/test/scala/zio/blocks/sql/UpsertSpec.scala
@@ -214,6 +214,59 @@ object UpsertSpec extends ZIOSpecDefault {
       test("assignment containing conflict column throws") {
         val result = scala.util.Try(Upsert.insertDoUpdate(userTable, User(1, "A", "a@b"), "id", Seq("id", "email")))
         assertTrue(result.isFailure, result.failed.get.getMessage.contains("conflict"))
+      },
+      test("duplicate assignment columns throw instead of collapsing silently") {
+        val result = scala.util.Try(
+          Upsert.insertDoUpdate(userTable, User(1, "A", "a@b"), "id", Seq("email", "email"))
+        )
+        assertTrue(
+          result.isFailure,
+          result.failed.get.isInstanceOf[IllegalArgumentException],
+          result.failed.get.getMessage.contains("uplicate")
+        )
+      },
+      test("duplicate columns in a hand-built Table fail fast at construction") {
+        val codec  = Table.derived[User].codec
+        val result = scala.util.Try(
+          Table(
+            "user",
+            codec,
+            IndexedSeq(
+              ColumnMeta("id", DbValue.DbInt(0), nullable = false),
+              ColumnMeta("id", DbValue.DbInt(0), nullable = false)
+            )
+          )
+        )
+        assertTrue(
+          result.isFailure,
+          result.failed.get.isInstanceOf[IllegalArgumentException],
+          result.failed.get.getMessage.contains("uplicate")
+        )
+      }
+    ),
+    suite("batch shape stability (F4)")(
+      test("insertDoUpdate renders identical SQL for different entities") {
+        val first  = Upsert.insertDoUpdate(userTable, User(1, "Alice", "alice@example.com"), "id")
+        val second = Upsert.insertDoUpdate(userTable, User(2, "Bob", "bob@test.com"), "id")
+        assertTrue(
+          first.sql(SqlDialect.SQLite) == second.sql(SqlDialect.SQLite),
+          first.sql(SqlDialect.PostgreSQL) ==
+            """INSERT INTO user (id, name, email) VALUES (?, ?, ?) ON CONFLICT ("id") DO UPDATE SET "name" = ?, "email" = ?""",
+          first.queryParams == IndexedSeq(
+            DbValue.DbInt(1),
+            DbValue.DbString("Alice"),
+            DbValue.DbString("alice@example.com"),
+            DbValue.DbString("Alice"),
+            DbValue.DbString("alice@example.com")
+          ),
+          second.queryParams == IndexedSeq(
+            DbValue.DbInt(2),
+            DbValue.DbString("Bob"),
+            DbValue.DbString("bob@test.com"),
+            DbValue.DbString("Bob"),
+            DbValue.DbString("bob@test.com")
+          )
+        )
       }
     )
   )


### PR DESCRIPTION
## Summary
PR2 of the "one PR for each module that needs fixes" series (sql/ only). Fixes from `widen-sql-review.md` Top 10 (F1–F10) + simplification dups + the row-7 `DbArray` hole. Diff is sql/-only (22 files) plus one docs comment sync.

Developed and B1-audited on top of #1653 (PR1 schema); rebased onto latest `main` (which has since reintroduced the query layer — see F1/F3 below, and a new `connect` PRAGMA block the rebase reconciles). Related to #1653 (root dependency); no code dependency remains after the rebase.

- **F1 (arch)**: the typed `query.SqlQuery` IR is now the blessed builder (decision documented atop it: Frag-composed, Rel-validated, quoted identifiers). The legacy stringly `sql.SqlQuery` carries `@deprecated` + a pointer to the IR (no deletion; the `type X = ...` alias awaits the full merge). `@nowarn("cat=deprecation")` at the in-repo use sites (`Dump` legacy macro entry points, `JoinsDumpExample`, `ExplainSpec`, `ExplainDumpGoldenSpec` fixtures). Full merge filed as follow-up (see below).
- **F2 (perf)**: all `DbCodec` companion primitives (`int/long/string/boolean/double/float/short/byte/bigDecimal`) now override positional `readValue` — no more per-row `IndexedSeq.tabulate` + N `columnLabel` (metadata) calls. Tuple macro + deriver already overrode; trait default remains only for exotic multi-column codecs.
- **F2b (perf)**: `deriveRecord.readByLabels` hoists per-field label slices to once-per-statement-per-thread via a `ThreadLocal` cache keyed on labels reference identity (mirrors `regsPool`); static per-field offsets precomputed at construction.
- **F3 (correctness)**: top-level `build` now double-quotes every identifier (`t0."col"`, `FROM "user"`, `JOIN "repo"`, via `ColumnRef.qualified`), like `QueryRenderer`. `LIMIT`/`OFFSET` stay literal-by-design (validated `Int`s, same as the renderer and `Repo.pageAfter`) — documented on the builder.
- **F3b (arch)**: both `dialect` params kept but documented as currently-informational (both dialects render `?`; revisit if a `$N` dialect lands) instead of silently-unused.
- **F4 (perf)**: `Repo.insertOrUpdateBatch` renders once, then per row only `toDbValues` + positional assignment projection — no per-row `Upsert.insertDoUpdate` rebuild.
- **F5 (correctness)**: `charCodec` NULL/empty no longer decode to `'\u0000'` sentinel — both fail fast (`unexpectedNull` / `IllegalStateException`), matching other primitives.
- **F7 (correctness)**: duplicate assignment columns throw; `Table` constructor requires unique columns; `insertDoUpdate` resolves values by position instead of `zip.toMap`.
- **F8**: documented the empty-input policy on `Repo` (builders throw, executors return 0/`List.empty`, `update` ID-only returns 0).
- **F9**: `Dialect` Postgres/SQLite validate every identifier via `SqlIdentifier.validate` at each entry point (plus a `ddl` helper passthrough that landed upstream — untouched).
- **F10**: added `decodeJsonbEither` / `decodeViaAs` / `encodeViaAs` Either-returning variants; throwing overloads kept for compat and rewired through them.
- **B1 audit**: `DbCodec` int/long readers are pure JDBC passthroughs — no widened-bound narrowing exists on the sql side, so no third copy of the PR1 bug. Nothing to fix.
- **Row-7 hole**: `SqlDialect.typeName` gains the missing `DbArray` arm (`TEXT[]` on PG, `TEXT` on SQLite).
- **S-dups**: deriver delegates 10 shared primitive codecs to the companion (single source, ~130 lines saved); `JdbcTransactor` setup/teardown extracted to `openConnection` (reconciled with upstream's new `connect`-time `PRAGMA busy_timeout` block, now via `dbConn.underlying`); `Upsert.doNothingRaw` uses a shared `splitColumnList` helper; `findAll`/`deleteAll` share `Repo.inListParts`.
- **F6**: documented IN-arity stability guidance on `findAll`/`deleteAll` (true fixed-cap chunking needs PG-backed verification — follow-up).

## Follow-ups (not in this PR)
- Full F1/S1 merge: delete the legacy builder + `SqlStatement`, port `explain`'s `?N` footer onto the IR, unify render paths (~180-250 lines).
- F6 fixed-cap (500) OR-chunked IN lists with PG verification.
- S4 `build*` alias deprecation (kept as plain aliases to avoid `-Werror` churn).

## Tests
New/updated regression coverage: `DbCodecSpec` (positional zero-metadata decode over 2 rows, slice-hoist lock via counting labels, char null/empty fail-fast, As Either helpers), `RepoSpec` (batch single-statement equivalence incl. param equality with `Upsert.insertDoUpdate`), `UpsertSpec` (dup columns, shape stability), `TableSpec` (dup columns, array DDL), `SqlDialectSpec` (DbArray), new `DialectSpec` (F9 validation + golden strings), `ExplainSpec` (quoted goldens + reserved/mixed-case quoting test).
- `sqlJVM/test` (3.8.3 + 3.3.7): 606 passed; `JdbcInstantTimezoneSpec` fails locally (needs PostgreSQL testcontainer at localhost:32886 — environmental, expect green in CI).
- `sqlJS/test` (3.8.3): 418 passed, 0 failed.
- `sbt fmt` clean. One `docs/guides/query-dsl-sql.md` comment synced to the quoted `explain` output.