### PR TITLE
fix(telemetry,config): close widened review findings across telemetry, otel, config, scope and projection

### DIFF
--- a/config/shared/src/main/scala/zio/blocks/config/Config.scala
+++ b/config/shared/src/main/scala/zio/blocks/config/Config.scala
@@ -21,6 +21,24 @@ import zio.blocks.scope.Wire
 
 /**
  * Entry point for loading typed configuration from a `ConfigSource`.
+ *
+ * ==Two configuration systems==
+ *
+ * This module offers two parallel systems — pick one per use case:
+ *
+ * {{{
+ *                        Schema-derived (`Config.load`)   Flag objects (`DynamicFlag`/`StaticFlag`)
+ *                        ------------------------------   ------------------------------------------
+ * Shape                  Whole typed document `A`         One named value (boolean, int, string, ...)
+ * Typing                 `Schema[A]`-derived decoder      `Flag.Reader[A]` instance
+ * Source                 Any `ConfigSource`               `FlagSource` → system property → env → default
+ * Reloads                Re-`load` on demand              `DynamicFlag` re-reads rollout expressions live
+ * Provenance             `loadWithProvenance`             Flag dump/registry APIs
+ * Use when               Startup/service config           Feature flags, rollouts, kill switches
+ * }}}
+ *
+ * Neither replaces the other: service config belongs in `Config.load`,
+ * per-request switches belong in flags.
  */
 object Config {
 

--- a/config/shared/src/main/scala/zio/blocks/config/Sensitive.scala
+++ b/config/shared/src/main/scala/zio/blocks/config/Sensitive.scala
@@ -16,12 +16,33 @@
 
 package zio.blocks.config
 
+/**
+ * Decides whether a config/flag key path names a secret, so error messages,
+ * provenance dumps, and exporter headers can redact the value.
+ *
+ * Matching is case-insensitive substring matching over the path with `-`
+ * normalized to `_` (so `apiKey` lowercases to `apikey` and matches). The
+ * marker list below errs toward redaction:
+ *
+ *   - Covered: secret, password, passwd, pwd, passphrase, auth, token,
+ *     apikey/api_key, accesskey/access_key, privatekey/private_key,
+ *     credential(s).
+ *   - Known false positives: ordinary words containing a marker (e.g.
+ *     `tokenizer` contains `token`) redact too. That is the safe direction — an
+ *     error string shows `<secret>` instead of a value that might be sensitive.
+ *
+ * `Secret` itself always redacts; this list only guards paths that carry raw
+ * strings (parse errors, dumps, headers).
+ */
 private[config] object Sensitive {
 
   private val markers = List(
     "secret",
     "password",
     "passwd",
+    "pwd",
+    "passphrase",
+    "auth",
     "token",
     "apikey",
     "api_key",

--- a/config/shared/src/test/scala/zio/blocks/config/SensitiveSpec.scala
+++ b/config/shared/src/test/scala/zio/blocks/config/SensitiveSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.config
+
+import zio.test._
+
+object SensitiveSpec extends ZIOSpecDefault {
+
+  def spec = suite("Sensitive")(
+    test("flags every documented marker") {
+      val sensitive = List(
+        "db.secret",
+        "db.password",
+        "svc.passwd",
+        "db.pwd",
+        "user.passphrase",
+        "service.auth",
+        "auth.token",
+        "api.token",
+        "x.apiKey",
+        "x.api_key",
+        "svc.accessKey",
+        "svc.access_key",
+        "m.privateKey",
+        "m.private_key",
+        "svc.credential",
+        "svc.credentials"
+      )
+      assertTrue(sensitive.forall(Sensitive.isSensitive))
+    },
+    test("leaves plain keys visible") {
+      val plain = List("app.port", "host", "service.timeout", "db.name")
+      assertTrue(plain.forall(p => !Sensitive.isSensitive(p)))
+    },
+    test("dash-separated keys match after normalization") {
+      assertTrue(Sensitive.isSensitive("db-access-key"))
+    },
+    test("documents the substring trade-off: tokenizer redacts") {
+      // Substring matching errs toward redaction: an ordinary word containing
+      // a marker redacts too. Pinned here so the trade-off stays deliberate.
+      assertTrue(Sensitive.isSensitive("tokenizer"))
+    },
+    test("new markers redact through ConfigError messages") {
+      val error = ConfigError.InvalidValue("service.auth", "hunter2", "Int", "env")
+      assertTrue(
+        error.message.contains("<secret>"),
+        !error.message.contains("hunter2")
+      )
+    }
+  )
+}

--- a/otel/src/main/scala/zio/blocks/telemetry/otel/B3Propagator.scala
+++ b/otel/src/main/scala/zio/blocks/telemetry/otel/B3Propagator.scala
@@ -32,6 +32,10 @@ object B3Propagator {
    * Returns a B3 single-header propagator.
    *
    * Single-header format: `{traceId}-{spanId}-{sampling}-{parentSpanId}`
+   *
+   * Note: the debug (`"d"`) sampling marker sets the sampled flag, but
+   * debug-ness itself is not propagated — [[zio.blocks.telemetry.SpanContext]]
+   * has no debug field, so debug degrades to sampled.
    */
   val single: Propagator = B3SinglePropagator
 
@@ -42,6 +46,20 @@ object B3Propagator {
    * and `X-B3-Flags` headers.
    */
   val multi: Propagator = B3MultiPropagator
+
+  /**
+   * Sampling marker for the B3 single-header third segment: `"1"` (accept) and
+   * `"d"` (debug, degrades to sampled — see [[single]]) enable sampling;
+   * anything else, including absence, means unsampled.
+   */
+  private def samplingFlags(sampling: String): TraceFlags =
+    sampling match {
+      case "1" | "d" => TraceFlags.sampled
+      case _         => TraceFlags.none
+    }
+
+  private def isTruthySampled(value: String): Boolean =
+    value == "1" || value.equalsIgnoreCase("true")
 
   /**
    * Normalizes a trace ID hex string. Accepts 16 or 32 hex characters. 16-char
@@ -72,23 +90,26 @@ object B3Propagator {
             case "1" | "d" =>
               Some(SpanContext.create(0L, 0L, SpanId.invalid, TraceFlags.sampled, traceState = "", isRemote = true))
             case _ =>
-              val parts = value.split('-')
-              if (parts.length < 2) None
+              // Hand-split on dash indices (no per-extract regex). Accepts
+              // {traceId}-{spanId} with optional -{sampling} and
+              // -{parentSpanId}; extra segments are ignored.
+              val firstDash = value.indexOf('-')
+              if (firstDash < 0) None
               else {
+                val secondDash   = value.indexOf('-', firstDash + 1)
+                val spanEnd      = if (secondDash < 0) value.length else secondDash
+                val samplingDash = if (secondDash < 0) -1 else value.indexOf('-', secondDash + 1)
+                val samplingEnd  = if (samplingDash < 0) value.length else samplingDash
+                val sampling     =
+                  if (secondDash < 0) ""
+                  else value.substring(secondDash + 1, samplingEnd)
                 for {
-                  (tidHi, tidLo) <- normalizeTraceId(parts(0))
+                  (tidHi, tidLo) <- normalizeTraceId(value.substring(0, firstDash))
                   if TraceId.isValid(tidHi, tidLo)
-                  spanId <- SpanId.fromHex(parts(1).toLowerCase(java.util.Locale.ROOT))
+                  spanId <- SpanId.fromHex(value.substring(firstDash + 1, spanEnd).toLowerCase(java.util.Locale.ROOT))
                   if spanId.isValid
                 } yield {
-                  val flags = if (parts.length >= 3) {
-                    parts(2) match {
-                      case "1" | "d" => TraceFlags.sampled
-                      case "0"       => TraceFlags.none
-                      case _         => TraceFlags.none
-                    }
-                  } else TraceFlags.none
-                  SpanContext.create(tidHi, tidLo, spanId, flags, traceState = "", isRemote = true)
+                  SpanContext.create(tidHi, tidLo, spanId, samplingFlags(sampling), traceState = "", isRemote = true)
                 }
               }
           }
@@ -121,9 +142,13 @@ object B3Propagator {
         spanId         <- SpanId.fromHex(spanIdRaw.trim.toLowerCase(java.util.Locale.ROOT))
         _              <- if (spanId.isValid) Some(()) else None
       } yield {
+        // X-B3-Flags "1" means debug, which implies sampled (debug-ness
+        // itself is not propagated — see [[single]]). X-B3-Sampled accepts
+        // both "1" and the spec's "true" form (case-insensitive).
         val debug   = getter(carrier, FlagsHeader).exists(_.trim == "1")
-        val sampled = debug || getter(carrier, SampledHeader).exists(_.trim == "1")
-        val flags   = if (sampled) TraceFlags.sampled else TraceFlags.none
+        val sampled =
+          debug || getter(carrier, SampledHeader).exists(v => isTruthySampled(v.trim))
+        val flags = if (sampled) TraceFlags.sampled else TraceFlags.none
         SpanContext.create(tidHi, tidLo, spanId, flags, traceState = "", isRemote = true)
       }
 

--- a/otel/src/main/scala/zio/blocks/telemetry/otel/BatchProcessor.scala
+++ b/otel/src/main/scala/zio/blocks/telemetry/otel/BatchProcessor.scala
@@ -36,6 +36,12 @@ private[otel] final class BatchProcessor[A](
   private val queueSize: AtomicInteger        = new AtomicInteger(0)
   private val isShutdown: AtomicBoolean       = new AtomicBoolean(false)
 
+  // Monitor for the retry backoff wait. shutdown() notifies it so a flush
+  // parked in backoff wakes immediately instead of sleeping out the delay —
+  // the scheduler thread is never blocked longer than necessary and shutdown
+  // still flushes promptly.
+  private val retryMonitor = new Object
+
   private val flushTask: Runnable = new Runnable {
     def run(): Unit = doFlush()
   }
@@ -63,6 +69,11 @@ private[otel] final class BatchProcessor[A](
   def shutdown(): Unit =
     if (isShutdown.compareAndSet(false, true)) {
       scheduledFuture.cancel(false)
+      // Wake any flush parked in retry backoff so it stops retrying now;
+      // the doFlush below then drains whatever is left in the queue.
+      retryMonitor.synchronized {
+        retryMonitor.notifyAll()
+      }
       doFlush()
     }
 
@@ -116,15 +127,26 @@ private[otel] final class BatchProcessor[A](
         } else {
           val shift   = math.min(attempt, 30)
           val delayMs = math.min(retryBaseMillis * (1L << shift), 30000L)
-          if (isShutdown.get()) {
+          if (awaitBackoff(delayMs)) exportWithRetry(batch, attempt + 1)
+          else {
             System.err.println(
               "[zio-blocks-telemetry] BatchProcessor shutting down, not retrying. Dropping " + batch.size + " items."
             )
-          } else {
-            try Thread.sleep(delayMs)
-            catch { case _: InterruptedException => Thread.currentThread().interrupt() }
-            exportWithRetry(batch, attempt + 1)
           }
         }
+    }
+
+  /**
+   * Waits out the retry backoff, returning `false` early (without sleeping the
+   * full delay) once shutdown has started.
+   */
+  private def awaitBackoff(delayMs: Long): Boolean =
+    retryMonitor.synchronized {
+      if (isShutdown.get()) false
+      else {
+        try retryMonitor.wait(delayMs)
+        catch { case _: InterruptedException => Thread.currentThread().interrupt() }
+        !isShutdown.get()
+      }
     }
 }

--- a/otel/src/main/scala/zio/blocks/telemetry/otel/OtlpJsonEncoder.scala
+++ b/otel/src/main/scala/zio/blocks/telemetry/otel/OtlpJsonEncoder.scala
@@ -113,7 +113,7 @@ object OtlpJsonEncoder {
         case _    =>
           if (c < 0x20 || (c >= 0xd800 && c <= 0xdfff)) {
             sb.append("\\u")
-            sb.append(String.format("%04x", c.toInt))
+            Hex.appendChar4(sb, c.toInt)
           } else {
             sb.append(c)
           }
@@ -124,9 +124,12 @@ object OtlpJsonEncoder {
   }
 
   private def writeKey(sb: StringBuilder, key: String): Unit = {
-    sb.append('"')
-    sb.append(key) // keys are always safe ASCII
-    sb.append("\":")
+    // Route even fixed protocol keys through the escaper: all current call
+    // sites pass literals, but the cost is one scan and this removes the only
+    // raw-append key path (user-controlled keys already escape via
+    // writeAttributes).
+    writeJsonString(sb, key)
+    sb.append(':')
   }
 
   private def writeKeyString(sb: StringBuilder, key: String, value: String): Unit = {
@@ -518,7 +521,14 @@ object OtlpJsonEncoder {
     // trace correlation
     writeKeyString(sb, "traceId", if (log.hasTraceId) TraceId.toHex(log.traceIdHi, log.traceIdLo) else "")
     sb.append(',')
-    writeKeyString(sb, "spanId", if (log.hasSpanId) String.format("%016x", log.spanId) else "")
+    writeKey(sb, "spanId")
+    if (log.hasSpanId) {
+      sb.append('"')
+      Hex.appendLong16(sb, log.spanId)
+      sb.append('"')
+    } else {
+      sb.append("\"\"")
+    }
     sb.append(',')
     writeKeyInt(sb, "flags", log.traceFlags.toInt & 0xff)
 

--- a/otel/src/main/scala/zio/blocks/telemetry/otel/OtlpJsonExporter.scala
+++ b/otel/src/main/scala/zio/blocks/telemetry/otel/OtlpJsonExporter.scala
@@ -16,6 +16,15 @@
 
 package zio.blocks.telemetry.otel
 
+/**
+ * Shared helpers for the OTLP JSON exporters (trace, log, metric).
+ *
+ * Exporters batch through [[BatchProcessor]] and POST OTLP JSON via
+ * [[HttpSender]]. Note the flush asymmetry: the trace and log exporters buffer
+ * through a batch processor (so `forceFlush` pushes queued items), while the
+ * metric exporter is pull-based (`exportMetrics` collects on demand) and its
+ * `forceFlush` is a no-op by design.
+ */
 private[otel] object OtlpJsonExporter {
 
   private[otel] def mergeHeaders(config: ExporterConfig): Map[String, String] = {

--- a/otel/src/main/scala/zio/blocks/telemetry/otel/W3CTraceContextPropagator.scala
+++ b/otel/src/main/scala/zio/blocks/telemetry/otel/W3CTraceContextPropagator.scala
@@ -22,8 +22,16 @@ import zio.blocks.telemetry._
  * W3C TraceContext propagator implementing the traceparent/tracestate headers.
  *
  * traceparent format:
- * {version:2hex}-{trace-id:32hex}-{span-id:16hex}-{flags:2hex} Only version
- * "00" is supported.
+ * {version:2hex}-{trace-id:32hex}-{span-id:16hex}-{flags:2hex}
+ *
+ * Version handling follows the forward-compatibility rule: version `"00"` must
+ * be exactly 55 characters; future versions (any 2-hex version other than
+ * `"ff"`) are accepted when they carry at least the 55-character version-00
+ * prefix, and trailing fields are ignored. `"ff"` is always rejected.
+ *
+ * tracestate is validated and bounded per the spec (at most 512 characters of
+ * comma-separated `key=value` members). An absent, overlong, or malformed
+ * tracestate is dropped to `""` — the traceparent context still extracts.
  *
  * @see
  *   https://www.w3.org/TR/trace-context/
@@ -35,6 +43,9 @@ object W3CTraceContextPropagator extends Propagator {
   private val Version           = "00"
   private val TraceparentLength = 55 // 2 + 1 + 32 + 1 + 16 + 1 + 2
 
+  /** Maximum tracestate length in characters (W3C trace-context bound). */
+  private[otel] final val MaxTracestateLength = 512
+
   override val fields: Seq[String] = Seq(TraceparentHeader, TracestateHeader)
 
   override def extract[C](carrier: C, getter: (C, String) => Option[String]): Option[SpanContext] =
@@ -45,7 +56,7 @@ object W3CTraceContextPropagator extends Propagator {
       _          <- if (traceparent.charAt(2) == '-' && traceparent.charAt(35) == '-' && traceparent.charAt(52) == '-') Some(())
            else None
       version         = traceparent.substring(0, 2)
-      _              <- if (version == Version) Some(()) else None
+      _              <- if (isSupportedVersion(version, traceparent.length)) Some(()) else None
       traceIdHex      = traceparent.substring(3, 35).toLowerCase
       (tidHi, tidLo) <- TraceId.fromHex(traceIdHex)
       _              <- if (TraceId.isValid(tidHi, tidLo)) Some(()) else None
@@ -55,9 +66,60 @@ object W3CTraceContextPropagator extends Propagator {
       flagsHex        = traceparent.substring(53, 55).toLowerCase
       flags          <- TraceFlags.fromHex(flagsHex)
     } yield {
-      val traceState = getter(carrier, TracestateHeader).map(_.trim).getOrElse("")
+      val traceState =
+        normalizeTraceState(getter(carrier, TracestateHeader).map(_.trim).getOrElse(""))
       SpanContext.create(tidHi, tidLo, spanId, flags, traceState, isRemote = true)
     }
+
+  /**
+   * Accepts version `"00"` at exactly 55 characters, and any other 2-hex
+   * version (except `"ff"`) at 55+ characters so future versions with the same
+   * shape keep extracting.
+   */
+  private def isSupportedVersion(version: String, length: Int): Boolean =
+    if (version.length != 2 || !isHexByte(version) || version == "ff") false
+    else if (version == Version) length == TraceparentLength
+    else length >= TraceparentLength
+
+  private def isHexByte(s: String): Boolean =
+    isHexChar(s.charAt(0)) && isHexChar(s.charAt(1))
+
+  private def isHexChar(c: Char): Boolean =
+    (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+
+  /**
+   * Bounds tracestate to 512 characters and checks the `key=value` member
+   * shape. Returns `""` for absent, overlong, or malformed values.
+   */
+  private[otel] def normalizeTraceState(state: String): String =
+    if (state.isEmpty || state.length > MaxTracestateLength) ""
+    else if (isValidTraceState(state)) state
+    else ""
+
+  private def isValidTraceState(state: String): Boolean = {
+    var i        = 0
+    val len      = state.length
+    var valid    = true
+    var keyEmpty = true
+    var hasEq    = false
+    while (i < len && valid) {
+      val c = state.charAt(i)
+      if (c == ',') {
+        // End of member: must have had key=value with a non-empty key.
+        if (!hasEq || keyEmpty) valid = false
+        else {
+          keyEmpty = true
+          hasEq = false
+        }
+      } else if (c == '=' && !hasEq) {
+        hasEq = true
+      } else if (!hasEq && !c.isWhitespace) {
+        keyEmpty = false
+      }
+      i += 1
+    }
+    valid && hasEq && !keyEmpty
+  }
 
   override def inject[C](spanContext: SpanContext, carrier: C, setter: (C, String, String) => C): C =
     if (!spanContext.isValid) carrier

--- a/otel/src/main/scala/zio/blocks/telemetry/otel/W3CTraceContextPropagator.scala
+++ b/otel/src/main/scala/zio/blocks/telemetry/otel/W3CTraceContextPropagator.scala
@@ -27,7 +27,9 @@ import zio.blocks.telemetry._
  * Version handling follows the forward-compatibility rule: version `"00"` must
  * be exactly 55 characters; future versions (any 2-hex version other than
  * `"ff"`) are accepted when they carry at least the 55-character version-00
- * prefix, and trailing fields are ignored. `"ff"` is always rejected.
+ * prefix, and trailing fields are ignored. Longer inputs are only accepted when
+ * the trailing fields start with a `-` delimiter at index 55. `"ff"` is always
+ * rejected, in any letter case.
  *
  * tracestate is validated and bounded per the spec (at most 512 characters of
  * comma-separated `key=value` members). An absent, overlong, or malformed
@@ -56,7 +58,7 @@ object W3CTraceContextPropagator extends Propagator {
       _          <- if (traceparent.charAt(2) == '-' && traceparent.charAt(35) == '-' && traceparent.charAt(52) == '-') Some(())
            else None
       version         = traceparent.substring(0, 2)
-      _              <- if (isSupportedVersion(version, traceparent.length)) Some(()) else None
+      _              <- if (isSupportedVersion(version, traceparent)) Some(()) else None
       traceIdHex      = traceparent.substring(3, 35).toLowerCase
       (tidHi, tidLo) <- TraceId.fromHex(traceIdHex)
       _              <- if (TraceId.isValid(tidHi, tidLo)) Some(()) else None
@@ -73,13 +75,21 @@ object W3CTraceContextPropagator extends Propagator {
 
   /**
    * Accepts version `"00"` at exactly 55 characters, and any other 2-hex
-   * version (except `"ff"`) at 55+ characters so future versions with the same
-   * shape keep extracting.
+   * version (except `"ff"` in any letter case) at exactly 55 characters or
+   * longer when the extra fields start with a `-` delimiter at index 55, so
+   * future versions with the same shape keep extracting.
    */
-  private def isSupportedVersion(version: String, length: Int): Boolean =
-    if (version.length != 2 || !isHexByte(version) || version == "ff") false
-    else if (version == Version) length == TraceparentLength
-    else length >= TraceparentLength
+  private def isSupportedVersion(version: String, traceparent: String): Boolean =
+    if (version.length != 2 || !isHexByte(version)) false
+    else {
+      // Hex acceptance is case-insensitive, so the `ff` ban must be too.
+      val lower = version.toLowerCase
+      if (lower == "ff") false
+      else if (lower == Version) traceparent.length == TraceparentLength
+      else
+        traceparent.length == TraceparentLength ||
+        (traceparent.length > TraceparentLength && traceparent.charAt(TraceparentLength) == '-')
+    }
 
   private def isHexByte(s: String): Boolean =
     isHexChar(s.charAt(0)) && isHexChar(s.charAt(1))

--- a/otel/src/test/scala/zio/blocks/telemetry/otel/B3PropagatorSpec.scala
+++ b/otel/src/test/scala/zio/blocks/telemetry/otel/B3PropagatorSpec.scala
@@ -170,6 +170,22 @@ object B3PropagatorSpec extends ZIOSpecDefault {
       val headers = Map("b3" -> "   ")
       val result  = B3Propagator.single.extract(headers, getter)
       assertTrue(result.isEmpty)
+    },
+    test("parses unknown sampling marker as unsampled") {
+      val headers = Map("b3" -> s"$traceIdHex-$spanIdHex-2")
+      val result  = B3Propagator.single.extract(headers, getter)
+      assertTrue(
+        result.isDefined &&
+          !result.get.traceFlags.isSampled
+      )
+    },
+    test("ignores a trailing empty segment") {
+      val headers = Map("b3" -> s"$traceIdHex-$spanIdHex-1-")
+      val result  = B3Propagator.single.extract(headers, getter)
+      assertTrue(
+        result.isDefined &&
+          result.get.traceFlags.isSampled
+      )
     }
   )
 
@@ -400,6 +416,42 @@ object B3PropagatorSpec extends ZIOSpecDefault {
       )
       val result = B3Propagator.multi.extract(headers, getter)
       assertTrue(result.isEmpty)
+    },
+    test("accepts the true form of X-B3-Sampled") {
+      val headers = Map(
+        "X-B3-TraceId" -> traceIdHex,
+        "X-B3-SpanId"  -> spanIdHex,
+        "X-B3-Sampled" -> "true"
+      )
+      val result = B3Propagator.multi.extract(headers, getter)
+      assertTrue(
+        result.isDefined &&
+          result.get.traceFlags.isSampled
+      )
+    },
+    test("accepts case-insensitive True for X-B3-Sampled") {
+      val headers = Map(
+        "X-B3-TraceId" -> traceIdHex,
+        "X-B3-SpanId"  -> spanIdHex,
+        "X-B3-Sampled" -> "True"
+      )
+      val result = B3Propagator.multi.extract(headers, getter)
+      assertTrue(
+        result.isDefined &&
+          result.get.traceFlags.isSampled
+      )
+    },
+    test("debug X-B3-Flags implies sampled") {
+      val headers = Map(
+        "X-B3-TraceId" -> traceIdHex,
+        "X-B3-SpanId"  -> spanIdHex,
+        "X-B3-Flags"   -> "1"
+      )
+      val result = B3Propagator.multi.extract(headers, getter)
+      assertTrue(
+        result.isDefined &&
+          result.get.traceFlags.isSampled
+      )
     }
   )
 

--- a/otel/src/test/scala/zio/blocks/telemetry/otel/BatchProcessorSpec.scala
+++ b/otel/src/test/scala/zio/blocks/telemetry/otel/BatchProcessorSpec.scala
@@ -273,6 +273,36 @@ object BatchProcessorSpec extends ZIOSpecDefault {
       pe.shutdown()
       val totalAttempts = attempts.get()
       assertTrue(totalAttempts >= 1 && totalAttempts < 100)
+    },
+    test("shutdown during backoff returns without sleeping out the delay") {
+      val pe                                    = PlatformExecutor.create()
+      val attempts                              = new AtomicInteger(0)
+      val exportFn: Seq[String] => ExportResult = { _ =>
+        attempts.incrementAndGet()
+        ExportResult.Failure(retryable = true, message = "always fails")
+      }
+      val processor =
+        new BatchProcessor[String](
+          exportFn,
+          executor = pe.executor,
+          maxRetries = 100,
+          flushIntervalMillis = 600000L,
+          retryBaseMillis = 60000L
+        )
+      processor.enqueue("x")
+      val flushThread = new Thread {
+        override def run(): Unit = processor.forceFlush()
+      }
+      flushThread.start()
+      Thread.sleep(500)
+      val startNanos = System.nanoTime()
+      processor.shutdown()
+      flushThread.join(10000)
+      pe.shutdown()
+      val elapsedMillis = (System.nanoTime() - startNanos) / 1000000L
+      // A 60s backoff (capped at 30s) must not be slept out: shutdown wakes
+      // the waiter and returns promptly with only a couple of attempts made.
+      assertTrue(!flushThread.isAlive, elapsedMillis < 5000L, attempts.get() < 5)
     }
   ) @@ TestAspect.sequential
 }

--- a/otel/src/test/scala/zio/blocks/telemetry/otel/OtlpJsonEncoderSpec.scala
+++ b/otel/src/test/scala/zio/blocks/telemetry/otel/OtlpJsonEncoderSpec.scala
@@ -504,11 +504,22 @@ object OtlpJsonEncoderSpec extends ZIOSpecDefault {
         )
       },
       test("escapes control characters") {
-        val attrs = Attributes.builder.put("k", "null\u0000char").build
+        val attrs = Attributes.builder.put("k", "null char").build
         val span  = makeSimpleSpan(attributes = attrs)
         val json  = jsonString(OtlpJsonEncoder.encodeTraces(Seq(span), testResource, testScope))
 
         assertTrue(json.contains("\\u0000"))
+      },
+      test("escapes user-controlled attribute keys") {
+        val trickyKey = "ke\"y\\with\ncontrols\u0001end"
+        val attrs     = Attributes.builder.put(trickyKey, "v").build
+        val span      = makeSimpleSpan(attributes = attrs)
+        val json      = jsonString(OtlpJsonEncoder.encodeTraces(Seq(span), testResource, testScope))
+
+        assertTrue(
+          json.contains("{\"key\":\"ke\\\"y\\\\with\\ncontrols\\u0001end\",\"value\":{\"stringValue\":\"v\"}}"),
+          !json.contains(trickyKey)
+        )
       }
     ),
     suite("empty collections")(

--- a/otel/src/test/scala/zio/blocks/telemetry/otel/W3CTraceContextSpec.scala
+++ b/otel/src/test/scala/zio/blocks/telemetry/otel/W3CTraceContextSpec.scala
@@ -85,9 +85,45 @@ object W3CTraceContextSpec extends ZIOSpecDefault {
         val result  = propagator.extract(headers, getter)
         assertTrue(result.isEmpty)
       },
-      test("rejects unknown version") {
+      test("accepts a future version with the same shape") {
         val headers = Map(
           "traceparent" -> "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        )
+        val result = propagator.extract(headers, getter)
+        assertTrue(
+          result.isDefined &&
+            result.get.traceIdHex == "4bf92f3577b34da6a3ce929d0e0e4736" &&
+            result.get.spanId.toHex == "00f067aa0ba902b7" &&
+            result.get.traceFlags.isSampled
+        )
+      },
+      test("accepts a future version with trailing fields") {
+        val headers = Map(
+          "traceparent" -> "02-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-deadbeef"
+        )
+        val result = propagator.extract(headers, getter)
+        assertTrue(
+          result.isDefined &&
+            result.get.traceIdHex == "4bf92f3577b34da6a3ce929d0e0e4736"
+        )
+      },
+      test("rejects version ff") {
+        val headers = Map(
+          "traceparent" -> "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        )
+        val result = propagator.extract(headers, getter)
+        assertTrue(result.isEmpty)
+      },
+      test("rejects a non-hex version") {
+        val headers = Map(
+          "traceparent" -> "zz-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        )
+        val result = propagator.extract(headers, getter)
+        assertTrue(result.isEmpty)
+      },
+      test("rejects version 00 with trailing data") {
+        val headers = Map(
+          "traceparent" -> "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra"
         )
         val result = propagator.extract(headers, getter)
         assertTrue(result.isEmpty)
@@ -292,6 +328,28 @@ object W3CTraceContextSpec extends ZIOSpecDefault {
         assertTrue(
           result.isDefined &&
             result.get.traceState == "congo=t61rcWkgMzE"
+        )
+      },
+      test("overlong tracestate is dropped but context still extracts") {
+        val headers = Map(
+          "traceparent" -> "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+          "tracestate"  -> ("k=" + ("v" * 600))
+        )
+        val result = propagator.extract(headers, getter)
+        assertTrue(
+          result.isDefined &&
+            result.get.traceState == ""
+        )
+      },
+      test("malformed tracestate is dropped but context still extracts") {
+        val headers = Map(
+          "traceparent" -> "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+          "tracestate"  -> "not-a-list-member"
+        )
+        val result = propagator.extract(headers, getter)
+        assertTrue(
+          result.isDefined &&
+            result.get.traceState == ""
         )
       },
       test("inject preserves existing carrier entries") {

--- a/otel/src/test/scala/zio/blocks/telemetry/otel/W3CTraceContextSpec.scala
+++ b/otel/src/test/scala/zio/blocks/telemetry/otel/W3CTraceContextSpec.scala
@@ -114,6 +114,27 @@ object W3CTraceContextSpec extends ZIOSpecDefault {
         val result = propagator.extract(headers, getter)
         assertTrue(result.isEmpty)
       },
+      test("rejects version FF in upper case") {
+        val headers = Map(
+          "traceparent" -> "FF-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        )
+        val result = propagator.extract(headers, getter)
+        assertTrue(result.isEmpty)
+      },
+      test("rejects version Ff in mixed case") {
+        val headers = Map(
+          "traceparent" -> "Ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        )
+        val result = propagator.extract(headers, getter)
+        assertTrue(result.isEmpty)
+      },
+      test("rejects a future version with trailing data but no delimiter") {
+        val headers = Map(
+          "traceparent" -> "02-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01Xdeadbeef"
+        )
+        val result = propagator.extract(headers, getter)
+        assertTrue(result.isEmpty)
+      },
       test("rejects a non-hex version") {
         val headers = Map(
           "traceparent" -> "zz-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"

--- a/projection/jvm/src/test/scala/zio/blocks/projection/ProjectionStoreParitySpec.scala
+++ b/projection/jvm/src/test/scala/zio/blocks/projection/ProjectionStoreParitySpec.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.projection
+
+import zio.*
+import zio.test.*
+import zio.blocks.chunk.Chunk
+import zio.blocks.projection.testing.InMemoryProjectionStore
+import zio.blocks.schema.{Modifier, Schema}
+
+/**
+ * Cross-store parity: the dual `ProjectionStore` implementations
+ * (`InMemoryProjectionStore` for tests, `SQLiteProjectionStore` on the JVM)
+ * must agree on observable semantics. Runs one op script against both stores
+ * and asserts identical outcomes, so a change to either store's semantics
+ * breaks this spec instead of silently drifting.
+ */
+object ProjectionStoreParitySpec extends ZIOSpecDefault {
+
+  case class User(
+    @Modifier.id id: String,
+    name: String,
+    email: String,
+    age: Long,
+    score: Long,
+    active: Boolean
+  )
+  object User {
+    implicit val schema: Schema[User]         = Schema.derived[User]
+    implicit val entityPath: EntityPath[User] = EntityPath.derived[User]
+  }
+
+  private def tempPath(): Task[(String, java.nio.file.Path)] =
+    ZIO.attempt {
+      val p = java.nio.file.Files.createTempFile("parity", ".db")
+      (p.toAbsolutePath.toString, p)
+    }
+
+  private def cleanup(path: String, tmp: java.nio.file.Path): UIO[Unit] =
+    ZIO.succeed {
+      try java.nio.file.Files.deleteIfExists(tmp)
+      catch { case _: Throwable => () }
+      try java.nio.file.Files.deleteIfExists(java.nio.file.Paths.get(path + "-wal"))
+      catch { case _: Throwable => () }
+      try java.nio.file.Files.deleteIfExists(java.nio.file.Paths.get(path + "-shm"))
+      catch { case _: Throwable => () }
+      try java.nio.file.Files.deleteIfExists(java.nio.file.Paths.get(path + "-journal"))
+      catch { case _: Throwable => () }
+    }
+
+  /**
+   * The shared op script. Returns the observable outcome of each step so both
+   * stores can be compared for equality.
+   */
+  private def script(store: ProjectionStore[User]): Task[List[String]] = {
+    val u1 = User("u1", "Alice", "a@b.com", 30L, 100L, active = true)
+    for {
+      freshSeq  <- store.getLastProcessedSeq
+      freshHash <- store.getSchemaHash
+      freshMiss <- store.findById("missing")
+      _         <- store.insert(u1)
+      found     <- store.findById("u1")
+      dupFailed <- store.insert(u1).either.map(_.isLeft)
+      _         <- store.upsert(u1.copy(name = "Alicia"))
+      updated   <- store.findById("u1")
+      _         <- store.updateFields("u1", Chunk(FieldUpdate("name", "Ally")))
+      patched   <- store.findById("u1")
+      _         <- store.updateLastProcessedSeq(7L)
+      seq       <- store.getLastProcessedSeq
+      _         <- store.updateSchemaHash("hash-1")
+      hash      <- store.getSchemaHash
+      _         <- store.delete("u1")
+      deleted   <- store.findById("u1")
+      _         <- store.delete("u1")
+      _         <- store.insert(u1)
+      _         <- store.truncate
+      truncated <- store.findById("u1")
+    } yield List(
+      s"freshSeq=$freshSeq",
+      s"freshHash=$freshHash",
+      s"freshMiss=$freshMiss",
+      s"found=$found",
+      s"dupFailed=$dupFailed",
+      s"updated=${updated.map(_.name)}",
+      s"patched=${patched.map(_.name)}",
+      s"seq=$seq",
+      s"hash=$hash",
+      s"deleted=$deleted",
+      s"truncated=$truncated"
+    )
+  }
+
+  def spec: Spec[TestEnvironment, Any] = suite("ProjectionStoreParity")(
+    test("in-memory and SQLite stores agree on the shared op script") {
+      ZIO.scoped {
+        for {
+          tmp            <- tempPath()
+          (path, tmpPath) = tmp
+          cache          <- TransactorCache.make()
+          sqlite         <- SQLiteProjectionStore.make[User](path, cache)
+          mem            <- InMemoryProjectionStore.make[User]
+          memOut         <- script(mem)
+          sqliteOut      <- script(sqlite).ensuring(cleanup(path, tmpPath))
+        } yield assertTrue(sqliteOut == memOut) &&
+          assertTrue(
+            memOut.contains("freshSeq=0"),
+            memOut.contains("freshHash=None"),
+            memOut.contains("freshMiss=None"),
+            memOut.exists(_.startsWith("found=Some(User(u1,Alice")),
+            memOut.contains("dupFailed=true"),
+            memOut.contains("updated=Some(Alicia)"),
+            memOut.contains("patched=Some(Ally)"),
+            memOut.contains("seq=7"),
+            memOut.contains("hash=Some(hash-1)"),
+            memOut.contains("deleted=None"),
+            memOut.contains("truncated=None")
+          )
+      }
+    }
+  )
+}

--- a/projection/shared/src/main/scala/zio/blocks/projection/ProjectionEngine.scala
+++ b/projection/shared/src/main/scala/zio/blocks/projection/ProjectionEngine.scala
@@ -19,9 +19,6 @@ package zio.blocks.projection
 import zio.*
 import zio.blocks.projection.testing.InMemoryProjectionStore
 import zio.blocks.schema.Schema
-import zio.stream.ZStream
-
-import scala.util.Try
 
 // ---------------------------------------------------------------------------
 // Config
@@ -64,6 +61,24 @@ object ProjectionEngineConfig {
  * "sqlite-jdbc" % "3.53.4.0"` for SQLite persistence, or it falls back to
  * `InMemory` (see `docs/reference/projection.md`).
  *
+ * ==Why ZIO lives here==
+ *
+ * Projection is the one module in this family that is ZIO-coupled by design:
+ * keeping read models current requires background fibers (catch-up plus live
+ * subscription per binding), Hub/Queue event streams, scoped transactor
+ * lifetimes, and semaphore-guarded rebuilds. The rule is that ZIO effects are
+ * allowed exactly when fibers, streams, or lifetime management are required —
+ * the engine qualifies, while telemetry, config, context, and scope stay
+ * ZIO-free (and the OTLP exporters remain plain JVM callbacks for the same
+ * reason).
+ *
+ * ==Where the logic lives==
+ *
+ * The engine class below is a thin facade; the logic is split by concern:
+ * [[EngineLifecycle]] (startup, fibers, consumption pipeline),
+ * [[EngineRebuild]] (migration registry, schema-drift rebuilds), and
+ * [[EngineQuery]] (reads over primary and sharded stores).
+ *
  * @param specs
  *   list of projections this engine manages
  * @param primaryStores
@@ -84,15 +99,15 @@ object ProjectionEngineConfig {
  *   semaphore guarding rebuilds
  */
 final class ProjectionEngine private[projection] (
-  private val specs: List[Projection[_]],
-  private val primaryStores: Map[String, ProjectionStore[_]],
-  private val eventStores: Map[String, EventStore[_]],
-  private val cache: TransactorCache,
+  private[projection] val specs: List[Projection[_]],
+  private[projection] val primaryStores: Map[String, ProjectionStore[_]],
+  private[projection] val eventStores: Map[String, EventStore[_]],
+  private[projection] val cache: TransactorCache,
   val config: ProjectionEngineConfig,
-  private val shardsRef: Ref[Map[String, Map[String, ProjectionStore[_]]]],
-  private val pendingRebuildRef: Ref[Map[String, Boolean]],
-  private val migrationRegistry: Ref[Map[String, zio.blocks.schema.migration.Migration[?, ?]]],
-  private val evolutionSem: Semaphore
+  private[projection] val shardsRef: Ref[Map[String, Map[String, ProjectionStore[_]]]],
+  private[projection] val pendingRebuildRef: Ref[Map[String, Boolean]],
+  private[projection] val migrationRegistry: Ref[Map[String, zio.blocks.schema.migration.Migration[?, ?]]],
+  private[projection] val evolutionSem: Semaphore
 ) {
 
   /**
@@ -124,217 +139,7 @@ final class ProjectionEngine private[projection] (
     spec: Projection[New],
     migration: zio.blocks.schema.migration.Migration[Old, New]
   ): Task[Unit] =
-    migrationRegistry.update(_ + (spec.name -> migration.asInstanceOf[zio.blocks.schema.migration.Migration[?, ?]]))
-
-  private def eventStoreForSpec(spec: Projection[_]): Option[EventStore[Any]] = {
-    val bindingSource = spec.bindings.headOption.map(_.sourceName)
-    bindingSource
-      .flatMap(eventStores.get)
-      .map(_.asInstanceOf[EventStore[Any]])
-      .orElse(eventStores.get("_default").map(_.asInstanceOf[EventStore[Any]]))
-      .orElse(eventStores.values.headOption.map(_.asInstanceOf[EventStore[Any]]))
-  }
-
-  private def currentHashFor(spec: Projection[_]): String =
-    SchemaHash.compute(using spec.schema.asInstanceOf[zio.blocks.schema.Schema[Any]])
-
-  private def checkSchemaAndRebuild(specAny: Projection[_]): Task[Unit] = {
-    val spec  = specAny.asInstanceOf[Projection[Any]]
-    val store = primaryStores(spec.name).asInstanceOf[ProjectionStore[Any]]
-    val cur   = currentHashFor(specAny)
-    store.getSchemaHash.catchAll(_ => ZIO.succeed(None)).flatMap {
-      case None =>
-        store.updateSchemaHash(cur).catchAll(_ => ZIO.unit)
-      case Some(stored) if stored == cur =>
-        ZIO.unit
-      case Some(_) =>
-        if (config.lazyRebuild) {
-          pendingRebuildRef.update(_ + (spec.name -> true))
-        } else {
-          val esOpt = eventStoreForSpec(specAny)
-          esOpt match {
-            case None     => ZIO.unit
-            case Some(es) =>
-              migrationRegistry.get.flatMap { regs =>
-                val migOpt = regs.get(spec.name)
-                SchemaEvolution.tryMigrationShortcutForSpec(specAny, store, migOpt, cur).flatMap {
-                  case true  => ZIO.unit
-                  case false => SchemaEvolution.rebuild(store, es, spec, cur)
-                }
-              }.catchAll(e =>
-                ZIO.logError(s"SchemaEvolution rebuild failed for ${spec.name}: ${e.getMessage}") *> ZIO.unit
-              )
-          }
-        }
-    }
-  }
-
-  private def ensureRebuiltIfPending[A](spec: Projection[A]): Task[Unit] =
-    pendingRebuildRef.get.map(_.getOrElse(spec.name, false)).flatMap {
-      case false => ZIO.unit
-      case true  =>
-        evolutionSem.withPermit {
-          pendingRebuildRef.get.map(_.getOrElse(spec.name, false)).flatMap {
-            case false => ZIO.unit
-            case true  =>
-              val store = primaryStores(spec.name).asInstanceOf[ProjectionStore[Any]]
-              val esOpt = eventStoreForSpec(spec)
-              esOpt match {
-                case None     => pendingRebuildRef.update(_ - spec.name)
-                case Some(es) =>
-                  val cur = currentHashFor(spec)
-                  migrationRegistry.get.flatMap { regs =>
-                    val migOpt = regs.get(spec.name)
-                    SchemaEvolution.tryMigrationShortcutForSpec(spec, store, migOpt, cur).flatMap {
-                      case true  => pendingRebuildRef.update(_ - spec.name)
-                      case false =>
-                        SchemaEvolution.rebuild(store, es, spec.asInstanceOf[Projection[Any]], cur) *>
-                          pendingRebuildRef.update(_ - spec.name)
-                    }
-                  }
-              }
-          }
-        }
-    }
-
-  private def primaryStoreFor[A](spec: Projection[A]): ProjectionStore[A] =
-    primaryStores(spec.name).asInstanceOf[ProjectionStore[A]]
-
-  // Factory for shards: uses same store type as primary (SQLite on JVM, else InMemory)
-  private def getOrCreateShard[A](spec: Projection[A], routingKey: String): Task[ProjectionStore[A]] = {
-    val specName = spec.name
-    shardsRef.get.flatMap { outer =>
-      outer.get(specName).flatMap(_.get(routingKey)) match {
-        case Some(cached) => ZIO.succeed(cached.asInstanceOf[ProjectionStore[A]])
-        case None         =>
-          val create: Task[ProjectionStore[A]] = {
-            implicit val schema: Schema[A] = spec.schema
-            implicit val ep: EntityPath[A] =
-              spec.entityPath.getOrElse(EntityPath[A](specName, "id"))
-            // If primary is SQLite, create SQLite shard with sanitized path
-            val primary = primaryStores.get(specName)
-            if (primary.exists(_.isInstanceOf[SQLiteProjectionStore[_]])) {
-              val base      = spec.entityPath.map(_.basePath).getOrElse("projections")
-              val sanitized = routingKey.replaceAll("[^a-zA-Z0-9_-]", "_").take(64)
-              val shardPath = s"$base/${specName}_shard_$sanitized.db"
-              SQLiteProjectionStore.make[A](shardPath, cache)
-            } else InMemoryProjectionStore.make[A]
-          }
-          create.flatMap { newStore =>
-            shardsRef.update { outer2 =>
-              val inner = outer2.getOrElse(specName, Map.empty)
-              outer2.updated(specName, inner.updated(routingKey, newStore.asInstanceOf[ProjectionStore[_]]))
-            }.as(newStore)
-          }
-      }
-    }
-  }
-
-  // Simplified shard fallback: if cross-entity, still use primary but trace routing
-  private def resolveTargetStore[A](
-    spec: Projection[A],
-    event: Any,
-    ctx: ProjectionContext,
-    sourceName: String
-  ): Task[ProjectionStore[A]] = {
-    // Use ctx fallback to ensure parameter is not unused
-    val fallbackEntityId = ctx.entityId
-    spec.scope match {
-      case ProjectionScope.Global =>
-        ZIO.succeed(primaryStoreFor(spec))
-      case ProjectionScope.CrossEntity(extractor) =>
-        val routingKeyAttempt: Option[String] = {
-          val fromBinding = spec.bindings.find(_.sourceName == sourceName).flatMap { b =>
-            b.routing match {
-              case rm: RoutingMode.RoutedBy[?] =>
-                Try(rm.asInstanceOf[RoutingMode.RoutedBy[Any]].extractAny(event)).toOption
-              case _ => None
-            }
-          }
-          fromBinding.orElse(Try(extractor(event)).toOption).orElse(Some(fallbackEntityId))
-        }
-        routingKeyAttempt match {
-          case Some(key) =>
-            getOrCreateShard(spec, key).catchAll { _ =>
-              ZIO.succeed(primaryStoreFor(spec))
-            }
-          case None =>
-            ZIO.succeed(primaryStoreFor(spec))
-        }
-      case _ =>
-        // PerEntity or default: use primary
-        ZIO.succeed(primaryStoreFor(spec))
-    }
-  }
-
-  private def applyAction[A](
-    store: ProjectionStore[A],
-    action: ProjectionAction[A],
-    ctx: ProjectionContext
-  ): Task[Unit] =
-    action match {
-      case ProjectionAction.Insert(v)    => store.insert(v)
-      case ProjectionAction.Upsert(v)    => store.upsert(v)
-      case ProjectionAction.Update(mods) => store.updateFields(ctx.entityId, mods)
-      case ProjectionAction.Delete       => store.delete(ctx.entityId)
-      case ProjectionAction.Truncate     => store.truncate
-      case ProjectionAction.Noop         => ZIO.unit
-    }
-
-  private def processBatch[A](
-    spec: Projection[A],
-    binding: SourceBinding[?, A],
-    batch: zio.Chunk[EventEnvelope[Any]]
-  ): Task[Unit] = {
-    val primary = primaryStoreFor(spec)
-    // C1+C2: per-event processing with lastSuccess tracking; each success atomically
-    // applies the action and persists seq in same logical transaction (SQLite: single JDBC tx)
-    ZIO
-      .foldLeft(batch)(Option.empty[Long]) { (acc, env) =>
-        val ctx                                            = ProjectionContext(env.entityId, env.timestamp, env.seq, Some(env.entityId))
-        val handlerTask: Task[Option[ProjectionAction[A]]] =
-          ZIO
-            .attempt(spec.handle(env.event, ctx))
-            .catchAll { e =>
-              ZIO.logError(s"ProjectionEngine[${spec.name}] handler failed at seq ${env.seq}: ${e.getMessage}") *>
-                ZIO.succeed(None)
-            }
-        handlerTask.flatMap {
-          case None =>
-            // No handler or handler error: do NOT advance watermark, keep acc
-            ZIO
-              .logDebug(
-                s"ProjectionEngine[${spec.name}] no handler for event ${env.event.getClass.getSimpleName} at seq ${env.seq}"
-              )
-              .as(acc)
-          case Some(action) =>
-            val processOne: Task[Option[Long]] =
-              resolveTargetStore(spec, env.event, ctx, binding.sourceName).flatMap { targetStore =>
-                // Transactional: applyAction + seq persist share same DB transaction where possible
-                // For SQLite primary, the same connection backs both; for InMemory, sequential but watermark
-                // only moves on success, so crash between apply and seq causes replay not double-count (dedup)
-                val transactional: Task[Unit] =
-                  applyAction(targetStore.asInstanceOf[ProjectionStore[A]], action, ctx).flatMap { _ =>
-                    primary.updateLastProcessedSeq(env.seq)
-                  }
-                transactional.as(Some(env.seq)).catchAll { e =>
-                  ZIO.logError(
-                    s"ProjectionEngine[${spec.name}] apply failed at seq ${env.seq}: ${e.getMessage}"
-                  ) *> ZIO.succeed(acc)
-                }
-              }.catchAll { e =>
-                ZIO.logError(
-                  s"ProjectionEngine[${spec.name}] routing failed at seq ${env.seq}: ${e.getMessage}"
-                ) *> ZIO.succeed(acc)
-              }
-            processOne
-        }
-      }
-      .flatMap {
-        case Some(_) => ZIO.unit // watermark already at lastSuccess via per-event updates
-        case None    => ZIO.unit // no successful event, watermark stays as before
-      }
-  }
+    EngineRebuild.registerMigration(this, spec, migration)
 
   /**
    * Starts the engine: validates schemas, rebuilds stale stores, then launches
@@ -347,127 +152,8 @@ final class ProjectionEngine private[projection] (
    *   a scoped task that completes when fibers are launched (not when they
    *   finish)
    */
-  def start: ZIO[Scope, Nothing, Unit] = {
-    val schemaChecks: ZIO[Any, Nothing, Unit] =
-      ZIO.foreachDiscard(specs)(specAny => checkSchemaAndRebuild(specAny).orDie)
-
-    val launchBindings: ZIO[Scope, Nothing, Unit] =
-      ZIO.foreachDiscard(specs) { specAny =>
-        val spec                                  = specAny.asInstanceOf[Projection[Any]]
-        val bindings: List[SourceBinding[?, Any]] =
-          if (spec.bindings.isEmpty) {
-            List(
-              SourceBinding[Any, Any](
-                "_default",
-                RoutingMode.RouteToSelf,
-                spec.allHandlers.asInstanceOf[List[Handler[?, Any]]]
-              )
-            )
-          } else {
-            spec.bindings.asInstanceOf[List[SourceBinding[?, Any]]]
-          }
-        ZIO.foreachDiscard(bindings) { binding =>
-          val esOpt: Option[EventStore[Any]] =
-            eventStores
-              .get(binding.sourceName)
-              .map(_.asInstanceOf[EventStore[Any]])
-              .orElse(eventStores.get("_default").map(_.asInstanceOf[EventStore[Any]]))
-              .orElse(eventStores.values.headOption.map(_.asInstanceOf[EventStore[Any]]))
-
-          esOpt match {
-            case None =>
-              ZIO
-                .logWarning(
-                  s"ProjectionEngine[${spec.name}] no EventStore for source '${binding.sourceName}' - skipping"
-                )
-                .unit
-            case Some(es) =>
-              val primary =
-                primaryStoreFor(specAny.asInstanceOf[Projection[Any]]).asInstanceOf[ProjectionStore[Any]]
-              // C3: catch-up first, then subscribe for live; avoids race where subscribed queue
-              // sees events that catch-up also replays. Subscribe after catch-up, filter seq > lastSeq.
-              val bindTask: ZIO[Scope, Throwable, Unit] =
-                for {
-                  initialLast <- primary.getLastProcessedSeq
-                  _           <- es
-                         .readFrom(initialLast)
-                         .groupedWithin(config.batchSize, config.batchTimeout)
-                         .mapZIO { chunk =>
-                           if (chunk.isEmpty) ZIO.unit
-                           else
-                             processBatch(
-                               spec.asInstanceOf[Projection[Any]],
-                               binding.asInstanceOf[SourceBinding[?, Any]],
-                               chunk.asInstanceOf[zio.Chunk[EventEnvelope[Any]]]
-                             )
-                         }
-                         .runDrain
-                  queue <- es.subscribe.subscribe
-                  _     <- ZStream
-                         .fromQueue(queue)
-                         .mapZIO { env =>
-                           processBatch(
-                             spec.asInstanceOf[Projection[Any]],
-                             binding.asInstanceOf[SourceBinding[?, Any]],
-                             zio.Chunk.single(env)
-                           )
-                         }
-                         .runDrain
-                         .forkScoped
-                } yield ()
-              bindTask.catchAll { e =>
-                ZIO.logError(s"ProjectionEngine[${spec.name}] bind failed: ${e.getMessage}") *> ZIO.unit
-              }
-          }
-        }
-      }
-
-    val backgroundPrewarm: ZIO[Scope, Nothing, Unit] =
-      if (!config.lazyRebuild) ZIO.unit
-      else {
-        ZIO
-          .foreachDiscard(specs.grouped(config.rebuildParallelism).toList) { batch =>
-            ZIO.foreachDiscard(batch) { specAny =>
-              val spec  = specAny.asInstanceOf[Projection[Any]]
-              val store = primaryStores(spec.name).asInstanceOf[ProjectionStore[Any]]
-              val esOpt = eventStoreForSpec(specAny)
-              esOpt match {
-                case None     => ZIO.unit
-                case Some(es) =>
-                  pendingRebuildRef.get.flatMap(_.get(spec.name) match {
-                    case Some(true) =>
-                      evolutionSem.withPermit {
-                        pendingRebuildRef.get.flatMap(_.get(spec.name) match {
-                          case Some(true) =>
-                            val cur = currentHashFor(specAny)
-                            migrationRegistry.get.flatMap { regs =>
-                              val migOpt = regs.get(spec.name)
-                              SchemaEvolution.tryMigrationShortcutForSpec(specAny, store, migOpt, cur).flatMap {
-                                case true  => pendingRebuildRef.update(_ - spec.name)
-                                case false =>
-                                  SchemaEvolution.rebuild(store, es, spec, cur) *> pendingRebuildRef.update(
-                                    _ - spec.name
-                                  )
-                              }
-                            }.catchAll(_ => ZIO.unit)
-                          case _ => ZIO.unit
-                        })
-                      }
-                    case _ => ZIO.unit
-                  })
-              }
-            }
-          }
-          .forkScoped
-          .unit
-      }
-
-    schemaChecks *> launchBindings *> backgroundPrewarm
-  }
-
-  // ---------------------------------------------------------------------------
-  // Query
-  // ---------------------------------------------------------------------------
+  def start: ZIO[Scope, Nothing, Unit] =
+    EngineLifecycle.start(this)
 
   /**
    * Queries the projection for the entity with the given id.
@@ -486,36 +172,14 @@ final class ProjectionEngine private[projection] (
    *   the entity if found
    */
   def query[A](spec: Projection[A], entityId: String): Task[Option[A]] =
-    ensureRebuiltIfPending(spec) *>
-      primaryStoreFor(spec).findById(entityId).flatMap {
-        case some @ Some(_) => ZIO.succeed(some)
-        case None           =>
-          spec.scope match {
-            case ProjectionScope.CrossEntity(_) =>
-              shardsRef.get.flatMap { outer =>
-                outer.get(spec.name) match {
-                  case None        => ZIO.succeed(None)
-                  case Some(inner) =>
-                    ZIO
-                      .foreach(inner.values.toList)(
-                        _.asInstanceOf[ProjectionStore[A]].findById(entityId).catchAll(_ => ZIO.succeed(None))
-                      )
-                      .map(_.collectFirst { case Some(v) => v })
-                }
-              }
-            case _ => ZIO.succeed(None)
-          }
-      }
+    EngineQuery.query(this, spec, entityId)
 
   /** Query by spec name + id (untyped helper) */
   def queryByName[A](specName: String, entityId: String): Task[Option[A]] =
-    primaryStores.get(specName) match {
-      case Some(store) => store.asInstanceOf[ProjectionStore[A]].findById(entityId)
-      case None        => ZIO.succeed(None)
-    }
+    EngineQuery.queryByName(this, specName, entityId)
 
   def getLastProcessedSeq[A](spec: Projection[A]): Task[Long] =
-    primaryStoreFor(spec).getLastProcessedSeq
+    EngineQuery.getLastProcessedSeq(this, spec)
 
   def storesMap: Map[String, ProjectionStore[_]] = primaryStores
 

--- a/projection/shared/src/main/scala/zio/blocks/projection/ProjectionEngineLifecycle.scala
+++ b/projection/shared/src/main/scala/zio/blocks/projection/ProjectionEngineLifecycle.scala
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.projection
+
+import zio.*
+import zio.blocks.projection.testing.InMemoryProjectionStore
+import zio.blocks.schema.Schema
+import zio.stream.ZStream
+
+import scala.util.Try
+
+/**
+ * Lifecycle concern of [[ProjectionEngine]]: startup validation, per-binding
+ * catch-up and live subscription fibers, background lazy-rebuild prewarm, and
+ * the event-consumption pipeline (routing + action application + watermark).
+ *
+ * Split out of the engine god-file so lifecycle (fibers), rebuild (schema
+ * drift), and query (reads) can be reasoned about independently. No behavior
+ * change — [[ProjectionEngine]] delegates to these helpers.
+ */
+private[projection] object EngineLifecycle {
+
+  def start(engine: ProjectionEngine): ZIO[Scope, Nothing, Unit] = {
+    val schemaChecks: ZIO[Any, Nothing, Unit] =
+      ZIO.foreachDiscard(engine.specs)(specAny => EngineRebuild.checkSchemaAndRebuild(engine, specAny).orDie)
+
+    val launchBindings: ZIO[Scope, Nothing, Unit] =
+      ZIO.foreachDiscard(engine.specs) { specAny =>
+        val spec                                  = specAny.asInstanceOf[Projection[Any]]
+        val bindings: List[SourceBinding[?, Any]] =
+          if (spec.bindings.isEmpty) {
+            List(
+              SourceBinding[Any, Any](
+                "_default",
+                RoutingMode.RouteToSelf,
+                spec.allHandlers.asInstanceOf[List[Handler[?, Any]]]
+              )
+            )
+          } else {
+            spec.bindings.asInstanceOf[List[SourceBinding[?, Any]]]
+          }
+        ZIO.foreachDiscard(bindings) { binding =>
+          val esOpt: Option[EventStore[Any]] =
+            engine.eventStores
+              .get(binding.sourceName)
+              .map(_.asInstanceOf[EventStore[Any]])
+              .orElse(engine.eventStores.get("_default").map(_.asInstanceOf[EventStore[Any]]))
+              .orElse(engine.eventStores.values.headOption.map(_.asInstanceOf[EventStore[Any]]))
+
+          esOpt match {
+            case None =>
+              ZIO
+                .logWarning(
+                  s"ProjectionEngine[${spec.name}] no EventStore for source '${binding.sourceName}' - skipping"
+                )
+                .unit
+            case Some(es) =>
+              val primary =
+                EngineQuery
+                  .primaryStoreFor(engine, specAny.asInstanceOf[Projection[Any]])
+                  .asInstanceOf[ProjectionStore[Any]]
+              // C3: catch-up first, then subscribe for live; avoids race where subscribed queue
+              // sees events that catch-up also replays. Subscribe after catch-up, filter seq > lastSeq.
+              val bindTask: ZIO[Scope, Throwable, Unit] =
+                for {
+                  initialLast <- primary.getLastProcessedSeq
+                  _           <- es
+                         .readFrom(initialLast)
+                         .groupedWithin(engine.config.batchSize, engine.config.batchTimeout)
+                         .mapZIO { chunk =>
+                           if (chunk.isEmpty) ZIO.unit
+                           else
+                             processBatch(
+                               engine,
+                               spec.asInstanceOf[Projection[Any]],
+                               binding.asInstanceOf[SourceBinding[?, Any]],
+                               chunk.asInstanceOf[zio.Chunk[EventEnvelope[Any]]]
+                             )
+                         }
+                         .runDrain
+                  queue <- es.subscribe.subscribe
+                  _     <- ZStream
+                         .fromQueue(queue)
+                         .mapZIO { env =>
+                           processBatch(
+                             engine,
+                             spec.asInstanceOf[Projection[Any]],
+                             binding.asInstanceOf[SourceBinding[?, Any]],
+                             zio.Chunk.single(env)
+                           )
+                         }
+                         .runDrain
+                         .forkScoped
+                } yield ()
+              bindTask.catchAll { e =>
+                ZIO.logError(s"ProjectionEngine[${spec.name}] bind failed: ${e.getMessage}") *> ZIO.unit
+              }
+          }
+        }
+      }
+
+    val backgroundPrewarm: ZIO[Scope, Nothing, Unit] =
+      if (!engine.config.lazyRebuild) ZIO.unit
+      else {
+        ZIO
+          .foreachDiscard(engine.specs.grouped(engine.config.rebuildParallelism).toList) { batch =>
+            ZIO.foreachDiscard(batch) { specAny =>
+              val spec  = specAny.asInstanceOf[Projection[Any]]
+              val store = engine.primaryStores(spec.name).asInstanceOf[ProjectionStore[Any]]
+              val esOpt = EngineRebuild.eventStoreForSpec(engine, specAny)
+              esOpt match {
+                case None     => ZIO.unit
+                case Some(es) =>
+                  engine.pendingRebuildRef.get.flatMap(_.get(spec.name) match {
+                    case Some(true) =>
+                      engine.evolutionSem.withPermit {
+                        engine.pendingRebuildRef.get.flatMap(_.get(spec.name) match {
+                          case Some(true) =>
+                            val cur = EngineRebuild.currentHashFor(specAny)
+                            engine.migrationRegistry.get.flatMap { regs =>
+                              val migOpt = regs.get(spec.name)
+                              SchemaEvolution.tryMigrationShortcutForSpec(specAny, store, migOpt, cur).flatMap {
+                                case true  => engine.pendingRebuildRef.update(_ - spec.name)
+                                case false =>
+                                  SchemaEvolution.rebuild(store, es, spec, cur) *> engine.pendingRebuildRef.update(
+                                    _ - spec.name
+                                  )
+                              }
+                            }.catchAll(_ => ZIO.unit)
+                          case _ => ZIO.unit
+                        })
+                      }
+                    case _ => ZIO.unit
+                  })
+              }
+            }
+          }
+          .forkScoped
+          .unit
+      }
+
+    schemaChecks *> launchBindings *> backgroundPrewarm
+  }
+
+  // Factory for shards: uses same store type as primary (SQLite on JVM, else InMemory)
+  private def getOrCreateShard[A](
+    engine: ProjectionEngine,
+    spec: Projection[A],
+    routingKey: String
+  ): Task[ProjectionStore[A]] = {
+    val specName = spec.name
+    engine.shardsRef.get.flatMap { outer =>
+      outer.get(specName).flatMap(_.get(routingKey)) match {
+        case Some(cached) => ZIO.succeed(cached.asInstanceOf[ProjectionStore[A]])
+        case None         =>
+          val create: Task[ProjectionStore[A]] = {
+            implicit val schema: Schema[A] = spec.schema
+            implicit val ep: EntityPath[A] =
+              spec.entityPath.getOrElse(EntityPath[A](specName, "id"))
+            // If primary is SQLite, create SQLite shard with sanitized path
+            val primary = engine.primaryStores.get(specName)
+            if (primary.exists(_.isInstanceOf[SQLiteProjectionStore[_]])) {
+              val base      = spec.entityPath.map(_.basePath).getOrElse("projections")
+              val sanitized = routingKey.replaceAll("[^a-zA-Z0-9_-]", "_").take(64)
+              val shardPath = s"$base/${specName}_shard_$sanitized.db"
+              SQLiteProjectionStore.make[A](shardPath, engine.cache)
+            } else InMemoryProjectionStore.make[A]
+          }
+          create.flatMap { newStore =>
+            engine.shardsRef.update { outer2 =>
+              val inner = outer2.getOrElse(specName, Map.empty)
+              outer2.updated(specName, inner.updated(routingKey, newStore.asInstanceOf[ProjectionStore[_]]))
+            }.as(newStore)
+          }
+      }
+    }
+  }
+
+  // Simplified shard fallback: if cross-entity, still use primary but trace routing
+  private def resolveTargetStore[A](
+    engine: ProjectionEngine,
+    spec: Projection[A],
+    event: Any,
+    ctx: ProjectionContext,
+    sourceName: String
+  ): Task[ProjectionStore[A]] = {
+    // Use ctx fallback to ensure parameter is not unused
+    val fallbackEntityId = ctx.entityId
+    spec.scope match {
+      case ProjectionScope.Global =>
+        ZIO.succeed(EngineQuery.primaryStoreFor(engine, spec))
+      case ProjectionScope.CrossEntity(extractor) =>
+        val routingKeyAttempt: Option[String] = {
+          val fromBinding = spec.bindings.find(_.sourceName == sourceName).flatMap { b =>
+            b.routing match {
+              case rm: RoutingMode.RoutedBy[?] =>
+                Try(rm.asInstanceOf[RoutingMode.RoutedBy[Any]].extractAny(event)).toOption
+              case _ => None
+            }
+          }
+          fromBinding.orElse(Try(extractor(event)).toOption).orElse(Some(fallbackEntityId))
+        }
+        routingKeyAttempt match {
+          case Some(key) =>
+            getOrCreateShard(engine, spec, key).catchAll { _ =>
+              ZIO.succeed(EngineQuery.primaryStoreFor(engine, spec))
+            }
+          case None =>
+            ZIO.succeed(EngineQuery.primaryStoreFor(engine, spec))
+        }
+      case _ =>
+        // PerEntity or default: use primary
+        ZIO.succeed(EngineQuery.primaryStoreFor(engine, spec))
+    }
+  }
+
+  private def applyAction[A](
+    store: ProjectionStore[A],
+    action: ProjectionAction[A],
+    ctx: ProjectionContext
+  ): Task[Unit] =
+    action match {
+      case ProjectionAction.Insert(v)    => store.insert(v)
+      case ProjectionAction.Upsert(v)    => store.upsert(v)
+      case ProjectionAction.Update(mods) => store.updateFields(ctx.entityId, mods)
+      case ProjectionAction.Delete       => store.delete(ctx.entityId)
+      case ProjectionAction.Truncate     => store.truncate
+      case ProjectionAction.Noop         => ZIO.unit
+    }
+
+  private def processBatch[A](
+    engine: ProjectionEngine,
+    spec: Projection[A],
+    binding: SourceBinding[?, A],
+    batch: zio.Chunk[EventEnvelope[Any]]
+  ): Task[Unit] = {
+    val primary = EngineQuery.primaryStoreFor(engine, spec)
+    // C1+C2: per-event processing with lastSuccess tracking; each success atomically
+    // applies the action and persists seq in same logical transaction (SQLite: single JDBC tx)
+    ZIO
+      .foldLeft(batch)(Option.empty[Long]) { (acc, env) =>
+        val ctx                                            = ProjectionContext(env.entityId, env.timestamp, env.seq, Some(env.entityId))
+        val handlerTask: Task[Option[ProjectionAction[A]]] =
+          ZIO
+            .attempt(spec.handle(env.event, ctx))
+            .catchAll { e =>
+              ZIO.logError(s"ProjectionEngine[${spec.name}] handler failed at seq ${env.seq}: ${e.getMessage}") *>
+                ZIO.succeed(None)
+            }
+        handlerTask.flatMap {
+          case None =>
+            // No handler or handler error: do NOT advance watermark, keep acc
+            ZIO
+              .logDebug(
+                s"ProjectionEngine[${spec.name}] no handler for event ${env.event.getClass.getSimpleName} at seq ${env.seq}"
+              )
+              .as(acc)
+          case Some(action) =>
+            val processOne: Task[Option[Long]] =
+              resolveTargetStore(engine, spec, env.event, ctx, binding.sourceName).flatMap { targetStore =>
+                // Transactional: applyAction + seq persist share same DB transaction where possible
+                // For SQLite primary, the same connection backs both; for InMemory, sequential but watermark
+                // only moves on success, so crash between apply and seq causes replay not double-count (dedup)
+                val transactional: Task[Unit] =
+                  applyAction(targetStore.asInstanceOf[ProjectionStore[A]], action, ctx).flatMap { _ =>
+                    primary.updateLastProcessedSeq(env.seq)
+                  }
+                transactional.as(Some(env.seq)).catchAll { e =>
+                  ZIO.logError(
+                    s"ProjectionEngine[${spec.name}] apply failed at seq ${env.seq}: ${e.getMessage}"
+                  ) *> ZIO.succeed(acc)
+                }
+              }.catchAll { e =>
+                ZIO.logError(
+                  s"ProjectionEngine[${spec.name}] routing failed at seq ${env.seq}: ${e.getMessage}"
+                ) *> ZIO.succeed(acc)
+              }
+            processOne
+        }
+      }
+      .flatMap {
+        case Some(_) => ZIO.unit // watermark already at lastSuccess via per-event updates
+        case None    => ZIO.unit // no successful event, watermark stays as before
+      }
+  }
+}

--- a/projection/shared/src/main/scala/zio/blocks/projection/ProjectionEngineQuery.scala
+++ b/projection/shared/src/main/scala/zio/blocks/projection/ProjectionEngineQuery.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.projection
+
+import zio.*
+
+/**
+ * Query concern of [[ProjectionEngine]]: point reads over primary and sharded
+ * stores.
+ *
+ * Split out of the engine god-file so lifecycle (fibers), rebuild (schema
+ * drift), and query (reads) can be reasoned about independently. No behavior
+ * change — [[ProjectionEngine]] delegates to these helpers.
+ */
+private[projection] object EngineQuery {
+
+  def primaryStoreFor[A](engine: ProjectionEngine, spec: Projection[A]): ProjectionStore[A] =
+    engine.primaryStores(spec.name).asInstanceOf[ProjectionStore[A]]
+
+  def query[A](engine: ProjectionEngine, spec: Projection[A], entityId: String): Task[Option[A]] =
+    EngineRebuild.ensureRebuiltIfPending(engine, spec) *>
+      primaryStoreFor(engine, spec).findById(entityId).flatMap {
+        case some @ Some(_) => ZIO.succeed(some)
+        case None           =>
+          spec.scope match {
+            case ProjectionScope.CrossEntity(_) =>
+              engine.shardsRef.get.flatMap { outer =>
+                outer.get(spec.name) match {
+                  case None        => ZIO.succeed(None)
+                  case Some(inner) =>
+                    ZIO
+                      .foreach(inner.values.toList)(
+                        _.asInstanceOf[ProjectionStore[A]].findById(entityId).catchAll(_ => ZIO.succeed(None))
+                      )
+                      .map(_.collectFirst { case Some(v) => v })
+                }
+              }
+            case _ => ZIO.succeed(None)
+          }
+      }
+
+  /** Query by spec name + id (untyped helper) */
+  def queryByName[A](engine: ProjectionEngine, specName: String, entityId: String): Task[Option[A]] =
+    engine.primaryStores.get(specName) match {
+      case Some(store) => store.asInstanceOf[ProjectionStore[A]].findById(entityId)
+      case None        => ZIO.succeed(None)
+    }
+
+  def getLastProcessedSeq[A](engine: ProjectionEngine, spec: Projection[A]): Task[Long] =
+    primaryStoreFor(engine, spec).getLastProcessedSeq
+}

--- a/projection/shared/src/main/scala/zio/blocks/projection/ProjectionEngineRebuild.scala
+++ b/projection/shared/src/main/scala/zio/blocks/projection/ProjectionEngineRebuild.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.projection
+
+import zio.*
+
+/**
+ * Schema-evolution concern of [[ProjectionEngine]]: migration registration,
+ * stale-store detection, and (lazy or eager) rebuilds.
+ *
+ * Split out of the engine god-file so lifecycle (fibers), rebuild (schema
+ * drift), and query (reads) can be reasoned about independently. No behavior
+ * change — [[ProjectionEngine]] delegates to these helpers.
+ */
+private[projection] object EngineRebuild {
+
+  def registerMigration[Old, New](
+    engine: ProjectionEngine,
+    spec: Projection[New],
+    migration: zio.blocks.schema.migration.Migration[Old, New]
+  ): Task[Unit] =
+    engine.migrationRegistry.update(
+      _ + (spec.name -> migration.asInstanceOf[zio.blocks.schema.migration.Migration[?, ?]])
+    )
+
+  def eventStoreForSpec(engine: ProjectionEngine, spec: Projection[_]): Option[EventStore[Any]] = {
+    val bindingSource = spec.bindings.headOption.map(_.sourceName)
+    bindingSource
+      .flatMap(engine.eventStores.get)
+      .map(_.asInstanceOf[EventStore[Any]])
+      .orElse(engine.eventStores.get("_default").map(_.asInstanceOf[EventStore[Any]]))
+      .orElse(engine.eventStores.values.headOption.map(_.asInstanceOf[EventStore[Any]]))
+  }
+
+  def currentHashFor(spec: Projection[_]): String =
+    SchemaHash.compute(using spec.schema.asInstanceOf[zio.blocks.schema.Schema[Any]])
+
+  def checkSchemaAndRebuild(engine: ProjectionEngine, specAny: Projection[_]): Task[Unit] = {
+    val spec  = specAny.asInstanceOf[Projection[Any]]
+    val store = engine.primaryStores(spec.name).asInstanceOf[ProjectionStore[Any]]
+    val cur   = currentHashFor(specAny)
+    store.getSchemaHash.catchAll(_ => ZIO.succeed(None)).flatMap {
+      case None =>
+        store.updateSchemaHash(cur).catchAll(_ => ZIO.unit)
+      case Some(stored) if stored == cur =>
+        ZIO.unit
+      case Some(_) =>
+        if (engine.config.lazyRebuild) {
+          engine.pendingRebuildRef.update(_ + (spec.name -> true))
+        } else {
+          val esOpt = eventStoreForSpec(engine, specAny)
+          esOpt match {
+            case None     => ZIO.unit
+            case Some(es) =>
+              engine.migrationRegistry.get.flatMap { regs =>
+                val migOpt = regs.get(spec.name)
+                SchemaEvolution.tryMigrationShortcutForSpec(specAny, store, migOpt, cur).flatMap {
+                  case true  => ZIO.unit
+                  case false => SchemaEvolution.rebuild(store, es, spec, cur)
+                }
+              }.catchAll(e =>
+                ZIO.logError(s"SchemaEvolution rebuild failed for ${spec.name}: ${e.getMessage}") *> ZIO.unit
+              )
+          }
+        }
+    }
+  }
+
+  def ensureRebuiltIfPending[A](engine: ProjectionEngine, spec: Projection[A]): Task[Unit] =
+    engine.pendingRebuildRef.get.map(_.getOrElse(spec.name, false)).flatMap {
+      case false => ZIO.unit
+      case true  =>
+        engine.evolutionSem.withPermit {
+          engine.pendingRebuildRef.get.map(_.getOrElse(spec.name, false)).flatMap {
+            case false => ZIO.unit
+            case true  =>
+              val store = engine.primaryStores(spec.name).asInstanceOf[ProjectionStore[Any]]
+              val esOpt = eventStoreForSpec(engine, spec)
+              esOpt match {
+                case None     => engine.pendingRebuildRef.update(_ - spec.name)
+                case Some(es) =>
+                  val cur = currentHashFor(spec)
+                  engine.migrationRegistry.get.flatMap { regs =>
+                    val migOpt = regs.get(spec.name)
+                    SchemaEvolution.tryMigrationShortcutForSpec(spec, store, migOpt, cur).flatMap {
+                      case true  => engine.pendingRebuildRef.update(_ - spec.name)
+                      case false =>
+                        SchemaEvolution.rebuild(store, es, spec.asInstanceOf[Projection[Any]], cur) *>
+                          engine.pendingRebuildRef.update(_ - spec.name)
+                    }
+                  }
+              }
+          }
+        }
+    }
+}

--- a/scope/shared/src/main/scala/zio/blocks/scope/Resource.scala
+++ b/scope/shared/src/main/scala/zio/blocks/scope/Resource.scala
@@ -29,6 +29,12 @@ import java.util.concurrent.atomic.AtomicReference
  * Resources are lazy—they describe ''what'' to do, not ''when''. Creation only
  * happens when passed to a scope via `scope.allocate(resource)`.
  *
+ * Note: this is the lifecycle resource (''how a value is acquired and released
+ * in a scope''). It is not the same as `zio.blocks.telemetry.Resource` (the
+ * OpenTelemetry resource: data identity, ''what produced this telemetry''). The
+ * names collide across modules (which cannot link to each other here); they
+ * share nothing else.
+ *
  * ==Creating Resources==
  *
  *   - `Resource(=> a)`: By-name value; auto-registers `close()` if

--- a/scope/shared/src/main/scala/zio/blocks/scope/Scope.scala
+++ b/scope/shared/src/main/scala/zio/blocks/scope/Scope.scala
@@ -21,16 +21,27 @@ import zio.blocks.scope.internal.{ErrorMessages, Finalizers}
 /**
  * A scope that manages resource lifecycle with compile-time verified safety.
  *
- * ==Closed-scope safety==
+ * ==Closed-scope behavior==
  *
- * The operations `allocate`, `open`, and `$` throw
- * [[java.lang.IllegalStateException]] if called on a scope that has already
- * closed. The exception message explains what went wrong and how to fix it.
- * This prevents silent use-after-free bugs where a scope reference escapes its
- * `scoped { }` block and a resource is accessed after its finalizers have run.
+ * Once a scope has closed, its finalizers have already run. Every operation
+ * below keeps that invariant — but they signal it differently:
  *
- * `defer` on a closed scope is silently ignored (no-op), and `scoped` on a
- * closed scope creates a born-closed child.
+ * {{{
+ * Operation              On a closed scope
+ * ---------------------  ------------------------------------------------
+ * `allocate`             Throws [[java.lang.IllegalStateException]]
+ * `open`                 Throws [[java.lang.IllegalStateException]]
+ * `$` (apply)            Throws [[java.lang.IllegalStateException]]
+ * `defer`                Silently ignored: returns `DeferHandle.Noop`
+ * `scoped`               Creates a born-closed child
+ * }}}
+ *
+ * In particular, `defer` on a closed scope drops the finalizer without running
+ * it. If the cleanup must happen, check [[isClosed]] first or keep the
+ * registration inside the scope's lifetime — a typo'd `defer` after close loses
+ * cleanup silently. `allocate`, `open`, and `$` throw instead so
+ * use-after-close of values fails loudly. The exception messages explain what
+ * went wrong and how to fix it.
  */
 sealed abstract class Scope extends Finalizer with ScopeVersionSpecific { self =>
 

--- a/scope/shared/src/test/scala/zio/blocks/scope/ScopeSpec.scala
+++ b/scope/shared/src/test/scala/zio/blocks/scope/ScopeSpec.scala
@@ -873,6 +873,35 @@ object ScopeSpec extends ZIOSpecDefault {
         child.defer { finalizerRan = true }
         assertTrue(child.isClosed, !finalizerRan)
       },
+      test("closed-scope trio behaves as documented in one scope") {
+        val child = new Scope.Child[Scope.global.type](
+          Scope.global,
+          new zio.blocks.scope.internal.Finalizers,
+          PlatformScope.captureOwner()
+        )
+        child.close()
+        var finalizerRan   = false
+        val handle         = child.defer { finalizerRan = true }
+        val allocateThrows = try {
+          child.allocate(Resource(new Database))
+          false
+        } catch {
+          case _: IllegalStateException => true
+        }
+        val openThrows = try {
+          child.open()
+          false
+        } catch {
+          case _: IllegalStateException => true
+        }
+        assertTrue(
+          child.isClosed,
+          handle == DeferHandle.Noop,
+          !finalizerRan,
+          allocateThrows,
+          openThrows
+        )
+      },
       test("global scope isClosed is always false") {
         assertTrue(!Scope.global.isClosed)
       }

--- a/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LogFormatterSpec.scala
+++ b/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LogFormatterSpec.scala
@@ -524,6 +524,69 @@ object LogFormatterSpec extends ZIOSpecDefault {
         )
       }
     ),
+    suite("direct builder without code attributes")(
+      test("text format prints every user attribute") {
+        val timestamp = 1719792611123000000L
+        val builder   = Attributes.builder
+          .put("user", "nabil")
+          .put("tries", 3L)
+          .put("ratio", 1.5)
+          .put("active", true)
+
+        val rendered = renderText(timestamp, Severity.Info, "INFO", "hello", builder)
+
+        assertTrue(
+          rendered.contains("[] hello {"),
+          rendered.contains("user=\"nabil\""),
+          rendered.contains("tries=3"),
+          rendered.contains("ratio=1.5"),
+          rendered.contains("active=true")
+        )
+      }
+    ),
+    suite("shared render core parity")(
+      test("text format and formatRecord are byte-identical") {
+        val timestamp = 1719792612123000000L
+        val builder   = Attributes.builder
+          .put("code.filepath", "Service.scala")
+          .put("code.namespace", "com.example.Service")
+          .put("code.function", "run")
+          .put("code.lineno", 42L)
+          .put("user.string", "value")
+          .put("user.long", 7L)
+          .put("user.double", 3.5)
+          .put("user.bool", true)
+          .put(AttributeKey.stringSeq("tags"), Seq("a", "b"))
+          .put(AttributeKey.longSeq("nums"), Seq(1L, 2L))
+
+        val viaBuilder = renderText(timestamp, Severity.Info, "INFO", "hello", builder)
+        val viaRecord  =
+          renderTextRecord(logRecord(timestamp, Severity.Info, "INFO", "hello", builder.build))
+
+        assertTrue(viaBuilder == viaRecord)
+      },
+      test("json format and formatRecord are byte-identical") {
+        val timestamp = 1719792613123000000L
+        val traceIdHi = 0x1111222233334444L
+        val traceIdLo = 0x5555666677778888L
+        val spanId    = 0x9999aaaabbbbccccL
+        val builder   = Attributes.builder
+          .put("code.namespace", "com.example.Service")
+          .put("user.string", "value")
+          .put("user.long", 11L)
+          .put("user.double", 4.25)
+          .put("user.bool", true)
+
+        val viaBuilder =
+          renderJson(timestamp, Severity.Warn, "WARN", "json message", builder, traceIdHi, traceIdLo, spanId)
+        val viaRecord =
+          renderJsonRecord(
+            logRecord(timestamp, Severity.Warn, "WARN", "json message", builder.build, traceIdHi, traceIdLo, spanId)
+          )
+
+        assertTrue(viaBuilder == viaRecord)
+      }
+    ),
     suite("JsonLogFormatter.writeJsonStringContent")(
       test("escapes quotes, slashes, control chars, surrogates, and preserves normal text") {
         val input = "\"\\\n\r\t\b\f" + 1.toChar + 31.toChar + "\ud83d\ude00plain"

--- a/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LogFormatterSpec.scala
+++ b/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LogFormatterSpec.scala
@@ -552,6 +552,7 @@ object LogFormatterSpec extends ZIOSpecDefault {
           .put("code.namespace", "com.example.Service")
           .put("code.function", "run")
           .put("code.lineno", 42L)
+          .put("code.reviewer", "ada")
           .put("user.string", "value")
           .put("user.long", 7L)
           .put("user.double", 3.5)
@@ -563,7 +564,11 @@ object LogFormatterSpec extends ZIOSpecDefault {
         val viaRecord  =
           renderTextRecord(logRecord(timestamp, Severity.Info, "INFO", "hello", builder.build))
 
-        assertTrue(viaBuilder == viaRecord)
+        assertTrue(
+          viaBuilder == viaRecord,
+          viaBuilder.contains("code.reviewer=\"ada\""),
+          viaRecord.contains("code.reviewer=\"ada\"")
+        )
       },
       test("json format and formatRecord are byte-identical") {
         val timestamp = 1719792613123000000L
@@ -572,6 +577,7 @@ object LogFormatterSpec extends ZIOSpecDefault {
         val spanId    = 0x9999aaaabbbbccccL
         val builder   = Attributes.builder
           .put("code.namespace", "com.example.Service")
+          .put("code.reviewer", "ada")
           .put("user.string", "value")
           .put("user.long", 11L)
           .put("user.double", 4.25)
@@ -584,7 +590,11 @@ object LogFormatterSpec extends ZIOSpecDefault {
             logRecord(timestamp, Severity.Warn, "WARN", "json message", builder.build, traceIdHi, traceIdLo, spanId)
           )
 
-        assertTrue(viaBuilder == viaRecord)
+        assertTrue(
+          viaBuilder == viaRecord,
+          viaBuilder.contains("\"key\":\"code.reviewer\""),
+          viaRecord.contains("\"key\":\"code.reviewer\"")
+        )
       }
     ),
     suite("JsonLogFormatter.writeJsonStringContent")(

--- a/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LogFormatterSpec.scala
+++ b/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LogFormatterSpec.scala
@@ -249,6 +249,23 @@ object LogFormatterSpec extends ZIOSpecDefault {
           rendered.contains("flags=[true, false]"),
           rendered.contains("empty=[]")
         )
+      },
+      test("escapes quotes, backslashes, and line breaks in text string values") {
+        val timestamp = 1719792602723000000L
+        val builder   = Attributes.builder
+          .put("code.filepath", "Escape.scala")
+          .put("code.namespace", "Escape")
+          .put("code.function", "go")
+          .put("code.lineno", 1L)
+          .put("quote", "say \"hi\"\nbye\\done")
+          .put(AttributeKey.stringSeq("tags"), Seq("a\"b", "c\nd"))
+
+        val rendered = renderText(timestamp, Severity.Info, "INFO", "escaped", builder)
+
+        assertTrue(
+          rendered.contains("quote=\"say \\\"hi\\\"\\nbye\\\\done\""),
+          rendered.contains("tags=[\"a\\\"b\", \"c\\nd\"]")
+        )
       }
     ),
     suite("TextLogFormatter.formatRecord")(
@@ -309,6 +326,19 @@ object LogFormatterSpec extends ZIOSpecDefault {
         val rendered = renderTextRecord(logRecord(timestamp, Severity.Warn, "WARN", "no line", attrs))
 
         assertTrue(rendered.startsWith(s"${expectedTimestamp(timestamp)} WARN  [Standalone.act] no line"))
+      },
+      test("escapes quotes and line breaks in record string values") {
+        val timestamp = 1719792604523000000L
+        val attrs     = Attributes.builder
+          .put("code.namespace", "Escape")
+          .put("code.function", "go")
+          .put("code.lineno", 1L)
+          .put("quote", "say \"hi\"\nbye")
+          .build
+
+        val rendered = renderTextRecord(logRecord(timestamp, Severity.Info, "INFO", "escaped", attrs))
+
+        assertTrue(rendered.contains("quote=\"say \\\"hi\\\"\\nbye\""))
       }
     ),
     suite("JsonLogFormatter.format")(

--- a/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LoggerDirectSpec.scala
+++ b/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LoggerDirectSpec.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.telemetry
+
+import zio.test._
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+
+import scala.collection.mutable.ArrayBuffer
+
+object LoggerDirectSpec extends ZIOSpecDefault {
+
+  private final class RecordingProcessor(level: Int) extends LogRecordProcessor {
+    val seen: ArrayBuffer[LogRecord] = ArrayBuffer.empty
+
+    override def minimumLevel: Int = level
+
+    override def onEmit(logRecord: LogRecord): Unit =
+      seen += logRecord
+
+    override def shutdown(): Unit   = ()
+    override def forceFlush(): Unit = ()
+  }
+
+  private def captureStdout[A](body: => A): (A, String) = {
+    val original = System.out
+    val bytes    = new ByteArrayOutputStream()
+    val stream   = new PrintStream(bytes, true, StandardCharsets.UTF_8.name)
+
+    System.setOut(stream)
+    try {
+      val result = Console.withOut(stream)(body)
+      stream.flush()
+      (result, bytes.toString(StandardCharsets.UTF_8.name))
+    } finally {
+      System.setOut(original)
+      stream.close()
+    }
+  }
+
+  private def consoleLogger(): Logger =
+    LoggerProvider.builder
+      .addLogRecordProcessor(new ConsoleLogRecordProcessor)
+      .build()
+      .get("direct")
+
+  def spec = suite("LoggerDirect")(
+    test("formatted emit without code attributes still prints every attribute") {
+      // emitRaw with a builder that carries no code.* slots exercises the
+      // builder-array formatter path directly (the macro path always writes
+      // code.* first, so only this path could drop user attributes).
+      val logger  = consoleLogger()
+      val builder = Attributes.builder
+        .put("user", "nabil")
+        .put("tries", 3L)
+        .put("ratio", 1.5)
+        .put("active", true)
+      val (_, out) = captureStdout {
+        logger.emitRaw(
+          EpochClock.epochNanos(),
+          Severity.Info,
+          "INFO",
+          "hello",
+          builder,
+          0L,
+          0L,
+          0L,
+          0.toByte,
+          Resource.empty,
+          InstrumentationScope("direct"),
+          None
+        )
+      }
+      assertTrue(
+        out.contains("hello"),
+        out.contains("user=\"nabil\""),
+        out.contains("tries=3"),
+        out.contains("ratio=1.5"),
+        out.contains("active=true")
+      )
+    },
+    test("direct info with attributes prints every attribute") {
+      val logger   = consoleLogger()
+      val (_, out) = captureStdout {
+        logger.info(
+          "hello",
+          "user"   -> AttributeValue.StringValue("nabil"),
+          "tries"  -> AttributeValue.LongValue(3L),
+          "ratio"  -> AttributeValue.DoubleValue(1.5),
+          "active" -> AttributeValue.BooleanValue(true)
+        )
+      }
+      assertTrue(
+        out.contains("hello"),
+        out.contains("user=\"nabil\""),
+        out.contains("tries=3"),
+        out.contains("ratio=1.5"),
+        out.contains("active=true")
+      )
+    },
+    test("direct call below the processor minimum level emits nothing") {
+      val processor = new RecordingProcessor(Severity.Error.number)
+      val logger    =
+        LoggerProvider.builder
+          .addLogRecordProcessor(processor)
+          .build()
+          .get("direct")
+      logger.info("dropped", "k" -> AttributeValue.StringValue("v"))
+      logger.debug("dropped")
+      val dropped = processor.seen.isEmpty
+      logger.error("kept", "k" -> AttributeValue.StringValue("v"))
+      assertTrue(
+        dropped,
+        processor.seen.size == 1,
+        processor.seen.head.body.value == "kept",
+        processor.seen.head.attributes.get(AttributeKey.string("k")).contains("v")
+      )
+    },
+    test("direct call at exactly the minimum level emits") {
+      val processor = new RecordingProcessor(Severity.Warn.number)
+      val logger    =
+        LoggerProvider.builder
+          .addLogRecordProcessor(processor)
+          .build()
+          .get("direct")
+      logger.warn("boundary")
+      assertTrue(
+        processor.seen.size == 1,
+        processor.seen.head.severity == Severity.Warn
+      )
+    }
+  ) @@ TestAspect.sequential
+}

--- a/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LoggerDirectSpec.scala
+++ b/telemetry/jvm/src/test/scala/zio/blocks/telemetry/LoggerDirectSpec.scala
@@ -144,6 +144,40 @@ object LoggerDirectSpec extends ZIOSpecDefault {
         processor.seen.size == 1,
         processor.seen.head.severity == Severity.Warn
       )
+    },
+    test("direct calls ignore per-namespace level overrides") {
+      // Direct calls carry no SourceLocation, so the macro path's
+      // per-namespace effectiveLevel cannot apply: only this Logger's own
+      // processor levels gate them.
+      val processor = new RecordingProcessor(Severity.Info.number)
+      val logger    =
+        LoggerProvider.builder
+          .addLogRecordProcessor(processor)
+          .build()
+          .get("direct")
+      log.setMinSeverity("com.example.noisy", Severity.Error)
+      try {
+        logger.info("kept")
+        assertTrue(
+          processor.seen.size == 1,
+          processor.seen.head.body.value == "kept"
+        )
+      } finally log.clearMinSeverity("com.example.noisy")
+    },
+    test("direct calls ignore the live global severity floor") {
+      val processor = new RecordingProcessor(Severity.Info.number)
+      val logger    =
+        LoggerProvider.builder
+          .addLogRecordProcessor(processor)
+          .build()
+          .get("direct")
+      log.withMinSeverity(Severity.Fatal) {
+        logger.info("kept")
+      }
+      assertTrue(
+        processor.seen.size == 1,
+        processor.seen.head.body.value == "kept"
+      )
     }
   ) @@ TestAspect.sequential
 }

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/Attributes.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/Attributes.scala
@@ -38,7 +38,15 @@ final class Attributes private (
   private[telemetry] val len: Int
 ) {
 
-  private val cachedHash: Int = {
+  // Hash is computed lazily: Attributes instances are short-lived (one per
+  // log record) and usually never hashed, so paying string hashes up front on
+  // the standard log path is pure overhead. Benign race is safe — computeHash
+  // is a pure function of the final arrays, and the volatile flag publishes
+  // the cached value.
+  @volatile private var hashComputed: Boolean = false
+  private var cachedHashValue: Int            = 0
+
+  private def computeHash(): Int = {
     var h = 0
     var i = 0
     while (i < len) {
@@ -190,7 +198,13 @@ final class Attributes private (
     map
   }
 
-  override def hashCode(): Int = cachedHash
+  override def hashCode(): Int = {
+    if (!hashComputed) {
+      cachedHashValue = computeHash()
+      hashComputed = true
+    }
+    cachedHashValue
+  }
 
   override def equals(obj: Any): Boolean =
     (this eq obj.asInstanceOf[AnyRef]) || (obj match {

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/LogEmitter.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/LogEmitter.scala
@@ -75,7 +75,9 @@ private[telemetry] final class StandardLogEmitter(
         severity = severity,
         severityText = severityText,
         body = LogMessage(body),
-        attributes = builder.build,
+        // Zero-copy handoff: the builder is pooled and would be cleared right
+        // after anyway, so hand its arrays to the record instead of copying.
+        attributes = builder.buildAndReset(),
         traceIdHi = traceIdHi,
         traceIdLo = traceIdLo,
         spanId = spanId,
@@ -84,7 +86,6 @@ private[telemetry] final class StandardLogEmitter(
         instrumentationScope = instrumentationScope,
         throwable = throwable
       )
-      builder.clear()
       var i = 0
       while (i < processors.length) {
         try {

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/LogFormatter.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/LogFormatter.scala
@@ -62,26 +62,11 @@ object TextLogFormatter extends LogFormatter {
     traceFlags: Byte,
     throwable: Option[Throwable]
   ): Unit = {
-    // Timestamp — manual UTC formatting, cached per second
-    val epochMillis = timestampNanos / 1000000L
-    val epochSecond = epochMillis / 1000L
-    val millis      = (epochMillis % 1000L).toInt
+    renderHead(sb, timestampNanos, severityText)
 
-    if (epochSecond != cachedSecond) {
-      cachedSecond = epochSecond
-      cachedPrefix = formatDateTimePrefix(epochSecond)
-    }
-    sb.append(cachedPrefix)
-    appendPadded(sb, millis, 3)
-    sb.append("Z ")
-
-    // Severity — pad to 5
-    sb.append(severityText)
-    var pad = 5 - severityText.length
-    while (pad > 0) { sb.append(' '); pad -= 1 }
-
-    // Source location from builder arrays
-    sb.append(" [")
+    // Source location — matched by key over all slots. The macro path always
+    // writes the four code.* attributes first, but direct Logger calls never
+    // write them, so position-based matching would misread user attributes.
     val keys    = builder.builderKeys
     val longs   = builder.builderLongs
     val strings = builder.builderStrings
@@ -91,7 +76,7 @@ object TextLogFormatter extends LogFormatter {
     var method    = ""
     var lineNo    = 0L
     var i         = 0
-    while (i < len && i < 4) {
+    while (i < len) {
       keys(i) match {
         case "code.namespace" => if (strings(i) != null) namespace = strings(i)
         case "code.function"  => if (strings(i) != null) method = strings(i)
@@ -100,73 +85,36 @@ object TextLogFormatter extends LogFormatter {
       }
       i += 1
     }
-
-    if (namespace.nonEmpty) {
-      val lastDot = namespace.lastIndexOf('.')
-      if (lastDot >= 0) sb.append(namespace, lastDot + 1, namespace.length)
-      else sb.append(namespace)
-    }
-    if (method.nonEmpty) { sb.append('.'); sb.append(method) }
-    if (lineNo > 0) { sb.append(':'); sb.append(lineNo) }
-    sb.append("] ")
+    renderLocation(sb, namespace, method, lineNo)
 
     // Body
     sb.append(body)
 
-    // User attributes (after source location, index 4+)
+    // User attributes — everything that is not a code.* attribute, in slot
+    // order (same rule as formatRecord).
     val types        = builder.builderTypes
     val seqs         = builder.builderSeqs
     var hasUserAttrs = false
-    i = 4
+    i = 0
     while (i < len) {
-      if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
-      else sb.append(", ")
-      sb.append(keys(i)); sb.append('=')
-      (types(i): @scala.annotation.switch) match {
-        case 0 /* STRING */      => sb.append('"'); sb.append(strings(i)); sb.append('"')
-        case 1 /* LONG */        => sb.append(longs(i))
-        case 2 /* DOUBLE */      => sb.append(java.lang.Double.longBitsToDouble(longs(i)))
-        case 3 /* BOOLEAN */     => sb.append(if (longs(i) != 0L) "true" else "false")
-        case 4 /* STRING_SEQ */  => appendStringSeq(sb, seqValueAt(seqs, i))
-        case 5 /* LONG_SEQ */    => appendScalarSeq(sb, seqValueAt(seqs, i))
-        case 6 /* DOUBLE_SEQ */  => appendScalarSeq(sb, seqValueAt(seqs, i))
-        case 7 /* BOOLEAN_SEQ */ => appendScalarSeq(sb, seqValueAt(seqs, i))
-        case _                   => sb.append("?")
+      if (!keys(i).startsWith("code.")) {
+        if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
+        else sb.append(", ")
+        sb.append(keys(i)); sb.append('=')
+        val tpe = types(i)
+        renderTextAttrValue(sb, tpe, longs(i), strings(i), if (tpe >= 4) seqValueAt(seqs, i) else null)
       }
       i += 1
     }
     if (hasUserAttrs) sb.append('}')
 
-    // Throwable
-    throwable.foreach { t =>
-      sb.append('\n')
-      val sw = new java.io.StringWriter()
-      t.printStackTrace(new java.io.PrintWriter(sw))
-      sb.append(sw.toString)
-    }
+    renderThrowable(sb, throwable)
   }
 
   override def formatRecord(sb: StringBuilder, record: LogRecord): Unit = {
-    // Timestamp — manual UTC formatting, cached per second
-    val epochMillis = record.timestampNanos / 1000000L
-    val epochSecond = epochMillis / 1000L
-    val millis      = (epochMillis % 1000L).toInt
-
-    if (epochSecond != cachedSecond) {
-      cachedSecond = epochSecond
-      cachedPrefix = formatDateTimePrefix(epochSecond)
-    }
-    sb.append(cachedPrefix)
-    appendPadded(sb, millis, 3)
-    sb.append("Z ")
-
-    // Severity — pad to 5
-    sb.append(record.severityText)
-    var pad = 5 - record.severityText.length
-    while (pad > 0) { sb.append(' '); pad -= 1 }
+    renderHead(sb, record.timestampNanos, record.severityText)
 
     // Source location from record attributes
-    sb.append(" [")
     var namespace = ""
     var method    = ""
     var lineNo    = 0L
@@ -188,7 +136,97 @@ object TextLogFormatter extends LogFormatter {
       override def visitDoubleSeq(key: String, value: Seq[Double]): Unit   = ()
       override def visitBooleanSeq(key: String, value: Seq[Boolean]): Unit = ()
     })
+    renderLocation(sb, namespace, method, lineNo)
 
+    // Body
+    sb.append(record.body.value)
+
+    // User attributes (skip code.* attributes)
+    var hasUserAttrs = false
+    record.attributes.accept(new AttributeVisitor {
+      private def nextAttr(key: String): Unit = {
+        if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
+        else sb.append(", ")
+        sb.append(key).append('=')
+      }
+
+      override def visitString(key: String, value: String): Unit =
+        if (!key.startsWith("code.")) {
+          nextAttr(key)
+          renderTextAttrValue(sb, 0, 0L, value, null)
+        }
+
+      override def visitLong(key: String, value: Long): Unit =
+        if (!key.startsWith("code.")) {
+          nextAttr(key)
+          renderTextAttrValue(sb, 1, value, null, null)
+        }
+
+      override def visitDouble(key: String, value: Double): Unit =
+        if (!key.startsWith("code.")) {
+          nextAttr(key)
+          renderTextAttrValue(sb, 2, java.lang.Double.doubleToRawLongBits(value), null, null)
+        }
+
+      override def visitBoolean(key: String, value: Boolean): Unit =
+        if (!key.startsWith("code.")) {
+          nextAttr(key)
+          renderTextAttrValue(sb, 3, if (value) 1L else 0L, null, null)
+        }
+
+      override def visitStringSeq(key: String, value: Seq[String]): Unit =
+        if (!key.startsWith("code.")) {
+          nextAttr(key)
+          renderTextAttrValue(sb, 4, 0L, null, value)
+        }
+
+      override def visitLongSeq(key: String, value: Seq[Long]): Unit =
+        if (!key.startsWith("code.")) {
+          nextAttr(key)
+          renderTextAttrValue(sb, 5, 0L, null, value)
+        }
+
+      override def visitDoubleSeq(key: String, value: Seq[Double]): Unit =
+        if (!key.startsWith("code.")) {
+          nextAttr(key)
+          renderTextAttrValue(sb, 6, 0L, null, value)
+        }
+
+      override def visitBooleanSeq(key: String, value: Seq[Boolean]): Unit =
+        if (!key.startsWith("code.")) {
+          nextAttr(key)
+          renderTextAttrValue(sb, 7, 0L, null, value)
+        }
+    })
+    if (hasUserAttrs) sb.append('}')
+
+    renderThrowable(sb, record.throwable)
+  }
+
+  /** Shared head: timestamp plus severity, used by both entry points. */
+  private def renderHead(sb: StringBuilder, timestampNanos: Long, severityText: String): Unit = {
+    // Timestamp — manual UTC formatting, cached per second
+    val epochMillis = timestampNanos / 1000000L
+    val epochSecond = epochMillis / 1000L
+    val millis      = (epochMillis % 1000L).toInt
+
+    if (epochSecond != cachedSecond) {
+      cachedSecond = epochSecond
+      cachedPrefix = formatDateTimePrefix(epochSecond)
+    }
+    sb.append(cachedPrefix)
+    appendPadded(sb, millis, 3)
+    sb.append("Z ")
+
+    // Severity — pad to 5
+    sb.append(severityText)
+    var pad = 5 - severityText.length
+    while (pad > 0) { sb.append(' '); pad -= 1 }
+  }
+
+  /** Shared source-location rendering, used by both entry points. */
+  private def renderLocation(sb: StringBuilder, namespace: String, method: String, lineNo: Long): Unit = {
+    sb.append(" [")
     if (namespace.nonEmpty) {
       val lastDot = namespace.lastIndexOf('.')
       if (lastDot >= 0) sb.append(namespace, lastDot + 1, namespace.length)
@@ -197,83 +235,34 @@ object TextLogFormatter extends LogFormatter {
     if (method.nonEmpty) { sb.append('.'); sb.append(method) }
     if (lineNo > 0) { sb.append(':'); sb.append(lineNo) }
     sb.append("] ")
+  }
 
-    // Body
-    sb.append(record.body.value)
+  /**
+   * Shared attribute-value rendering, used by both entry points. Scalar slots
+   * arrive unboxed (`long`/`str`); `seq` is only consulted for seq-typed
+   * attributes and may be `null` otherwise.
+   */
+  private def renderTextAttrValue(sb: StringBuilder, tpe: Byte, long: Long, str: String, seq: Seq[Any]): Unit =
+    (tpe: @scala.annotation.switch) match {
+      case 0 /* STRING */      => sb.append('"'); sb.append(str); sb.append('"')
+      case 1 /* LONG */        => sb.append(long)
+      case 2 /* DOUBLE */      => sb.append(java.lang.Double.longBitsToDouble(long))
+      case 3 /* BOOLEAN */     => sb.append(if (long != 0L) "true" else "false")
+      case 4 /* STRING_SEQ */  => appendStringSeq(sb, if (seq == null) Seq.empty else seq)
+      case 5 /* LONG_SEQ */    => appendScalarSeq(sb, if (seq == null) Seq.empty else seq)
+      case 6 /* DOUBLE_SEQ */  => appendScalarSeq(sb, if (seq == null) Seq.empty else seq)
+      case 7 /* BOOLEAN_SEQ */ => appendScalarSeq(sb, if (seq == null) Seq.empty else seq)
+      case _                   => sb.append("?")
+    }
 
-    // User attributes (skip code.* attributes)
-    var hasUserAttrs = false
-    record.attributes.accept(new AttributeVisitor {
-      override def visitString(key: String, value: String): Unit =
-        if (!key.startsWith("code.")) {
-          if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
-          else sb.append(", ")
-          sb.append(key).append("=\"").append(value).append('"')
-        }
-
-      override def visitLong(key: String, value: Long): Unit =
-        if (!key.startsWith("code.")) {
-          if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
-          else sb.append(", ")
-          sb.append(key).append('=').append(value)
-        }
-
-      override def visitDouble(key: String, value: Double): Unit =
-        if (!key.startsWith("code.")) {
-          if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
-          else sb.append(", ")
-          sb.append(key).append('=').append(value)
-        }
-
-      override def visitBoolean(key: String, value: Boolean): Unit =
-        if (!key.startsWith("code.")) {
-          if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
-          else sb.append(", ")
-          sb.append(key).append('=').append(value)
-        }
-
-      override def visitStringSeq(key: String, value: Seq[String]): Unit =
-        if (!key.startsWith("code.")) {
-          if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
-          else sb.append(", ")
-          sb.append(key).append('=')
-          appendStringSeq(sb, value)
-        }
-
-      override def visitLongSeq(key: String, value: Seq[Long]): Unit =
-        if (!key.startsWith("code.")) {
-          if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
-          else sb.append(", ")
-          sb.append(key).append('=')
-          appendScalarSeq(sb, value)
-        }
-
-      override def visitDoubleSeq(key: String, value: Seq[Double]): Unit =
-        if (!key.startsWith("code.")) {
-          if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
-          else sb.append(", ")
-          sb.append(key).append('=')
-          appendScalarSeq(sb, value)
-        }
-
-      override def visitBooleanSeq(key: String, value: Seq[Boolean]): Unit =
-        if (!key.startsWith("code.")) {
-          if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
-          else sb.append(", ")
-          sb.append(key).append('=')
-          appendScalarSeq(sb, value)
-        }
-    })
-    if (hasUserAttrs) sb.append('}')
-
-    // Throwable
-    record.throwable.foreach { t =>
+  /** Shared throwable rendering, used by both entry points. */
+  private def renderThrowable(sb: StringBuilder, throwable: Option[Throwable]): Unit =
+    throwable.foreach { t =>
       sb.append('\n')
       val sw = new java.io.StringWriter()
       t.printStackTrace(new java.io.PrintWriter(sw))
       sb.append(sw.toString)
     }
-  }
 
   private def formatDateTimePrefix(epochSecond: Long): String = {
     // Civil date calculation from epoch seconds (Rata Die / Howard Hinnant algorithm)
@@ -369,19 +358,7 @@ object JsonLogFormatter extends LogFormatter {
     traceFlags: Byte,
     throwable: Option[Throwable]
   ): Unit = {
-    sb.append('{')
-
-    // Timestamp
-    sb.append("\"timeUnixNano\":\""); sb.append(timestampNanos); sb.append('"')
-
-    // Severity
-    sb.append(",\"severityNumber\":"); sb.append(severity.number)
-    sb.append(",\"severityText\":\""); sb.append(severityText); sb.append('"')
-
-    // Body
-    sb.append(",\"body\":{\"stringValue\":\"")
-    writeJsonStringContent(sb, body)
-    sb.append("\"}")
+    renderJsonHead(sb, timestampNanos, severity.number, severityText, body)
 
     var hasAttrs = false
 
@@ -416,49 +393,18 @@ object JsonLogFormatter extends LogFormatter {
     }
 
     // Trace context
-    if (traceIdHi != 0L || traceIdLo != 0L) {
-      sb.append(",\"traceId\":\"")
-      sb.append(TraceId.toHex(traceIdHi, traceIdLo))
-      sb.append('"')
-    }
-    if (spanId != 0L) {
-      sb.append(",\"spanId\":\"")
-      sb.append(String.format("%016x", spanId: java.lang.Long))
-      sb.append('"')
-    }
+    renderJsonTrace(sb, traceIdHi, traceIdLo, spanId)
 
     // Throwable as exception.stacktrace attribute
     throwable.foreach { t =>
-      val sw = new java.io.StringWriter()
-      t.printStackTrace(new java.io.PrintWriter(sw))
-      if (!hasAttrs) {
-        sb.append(",\"attributes\":[")
-        hasAttrs = true
-      } else {
-        sb.setLength(sb.length - 1)
-        sb.append(',')
-      }
-      appendJsonAttribute(sb, "exception.stacktrace", JsonAttrValue.StringValue(sw.toString))
-      sb.append(']')
+      hasAttrs = renderJsonThrowableAttr(sb, t, hasAttrs)
     }
 
     sb.append('}')
   }
 
   override def formatRecord(sb: StringBuilder, record: LogRecord): Unit = {
-    sb.append('{')
-
-    // Timestamp
-    sb.append("\"timeUnixNano\":\""); sb.append(record.timestampNanos); sb.append('"')
-
-    // Severity
-    sb.append(",\"severityNumber\":"); sb.append(record.severity.number)
-    sb.append(",\"severityText\":\""); sb.append(record.severityText); sb.append('"')
-
-    // Body
-    sb.append(",\"body\":{\"stringValue\":\"")
-    writeJsonStringContent(sb, record.body.value)
-    sb.append("\"}")
+    renderJsonHead(sb, record.timestampNanos, record.severity.number, record.severityText, record.body.value)
 
     // Attributes from record
     var hasAttrs = record.attributes.size > 0
@@ -518,33 +464,74 @@ object JsonLogFormatter extends LogFormatter {
     }
 
     // Trace context
-    if (record.traceIdHi != 0L || record.traceIdLo != 0L) {
-      sb.append(",\"traceId\":\"")
-      sb.append(TraceId.toHex(record.traceIdHi, record.traceIdLo))
-      sb.append('"')
-    }
-    if (record.spanId != 0L) {
-      sb.append(",\"spanId\":\"")
-      sb.append(String.format("%016x", record.spanId: java.lang.Long))
-      sb.append('"')
-    }
+    renderJsonTrace(sb, record.traceIdHi, record.traceIdLo, record.spanId)
 
     // Throwable as exception.stacktrace attribute
     record.throwable.foreach { t =>
-      val sw = new java.io.StringWriter()
-      t.printStackTrace(new java.io.PrintWriter(sw))
-      if (!hasAttrs) {
-        sb.append(",\"attributes\":[")
-        hasAttrs = true
-      } else {
-        sb.setLength(sb.length - 1)
-        sb.append(',')
-      }
-      appendJsonAttribute(sb, "exception.stacktrace", JsonAttrValue.StringValue(sw.toString))
-      sb.append(']')
+      hasAttrs = renderJsonThrowableAttr(sb, t, hasAttrs)
     }
 
     sb.append('}')
+  }
+
+  /** Shared JSON head: envelope, timestamp, severity, and body. */
+  private def renderJsonHead(
+    sb: StringBuilder,
+    timestampNanos: Long,
+    severityNumber: Int,
+    severityText: String,
+    body: String
+  ): Unit = {
+    sb.append('{')
+
+    // Timestamp
+    sb.append("\"timeUnixNano\":\""); sb.append(timestampNanos); sb.append('"')
+
+    // Severity
+    sb.append(",\"severityNumber\":"); sb.append(severityNumber)
+    sb.append(",\"severityText\":\""); sb.append(severityText); sb.append('"')
+
+    // Body
+    sb.append(",\"body\":{\"stringValue\":\"")
+    writeJsonStringContent(sb, body)
+    sb.append("\"}")
+  }
+
+  /**
+   * Shared JSON trace-correlation block (hand-rolled hex, no String.format).
+   */
+  private def renderJsonTrace(sb: StringBuilder, traceIdHi: Long, traceIdLo: Long, spanId: Long): Unit = {
+    if (traceIdHi != 0L || traceIdLo != 0L) {
+      sb.append(",\"traceId\":\"")
+      sb.append(TraceId.toHex(traceIdHi, traceIdLo))
+      sb.append('"')
+    }
+    if (spanId != 0L) {
+      sb.append(",\"spanId\":\"")
+      Hex.appendLong16(sb, spanId)
+      sb.append('"')
+    }
+  }
+
+  /**
+   * Shared JSON throwable rendering as an `exception.stacktrace` attribute.
+   * Returns the updated `hasAttrs` flag.
+   */
+  private def renderJsonThrowableAttr(sb: StringBuilder, t: Throwable, hasAttrs: Boolean): Boolean = {
+    val sw = new java.io.StringWriter()
+    t.printStackTrace(new java.io.PrintWriter(sw))
+    val updated =
+      if (!hasAttrs) {
+        sb.append(",\"attributes\":[")
+        true
+      } else {
+        sb.setLength(sb.length - 1)
+        sb.append(',')
+        hasAttrs
+      }
+    appendJsonAttribute(sb, "exception.stacktrace", JsonAttrValue.StringValue(sw.toString))
+    sb.append(']')
+    updated
   }
 
   private def appendJsonAttribute(sb: StringBuilder, key: String, value: JsonAttrValue): Unit = {
@@ -631,7 +618,7 @@ object JsonLogFormatter extends LogFormatter {
         case _    =>
           if (c < 0x20 || (c >= 0xd800 && c <= 0xdfff)) {
             sb.append("\\u")
-            sb.append(String.format("%04x", c.toInt))
+            Hex.appendChar4(sb, c.toInt)
           } else {
             sb.append(c)
           }

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/LogFormatter.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/LogFormatter.scala
@@ -43,6 +43,11 @@ trait LogFormatter {
 /**
  * Human-readable text format: "2026-03-31T17:30:00.123Z INFO
  * [MyClass.method:42] message {key=val}"
+ *
+ * String attribute values render double-quoted. A value containing `"`, `\`, or
+ * a line break would otherwise blur where the value ends, so those characters
+ * are backslash-escaped (`\"`, `\\`, `\n`, `\r`, `\t`) — in both scalar strings
+ * and string-seq elements, on both entry points.
  */
 object TextLogFormatter extends LogFormatter {
 
@@ -254,7 +259,7 @@ object TextLogFormatter extends LogFormatter {
    */
   private def renderTextAttrValue(sb: StringBuilder, tpe: Byte, long: Long, str: String, seq: Seq[Any]): Unit =
     (tpe: @scala.annotation.switch) match {
-      case 0 /* STRING */      => sb.append('"'); sb.append(str); sb.append('"')
+      case 0 /* STRING */      => sb.append('"'); appendTextEscaped(sb, str); sb.append('"')
       case 1 /* LONG */        => sb.append(long)
       case 2 /* DOUBLE */      => sb.append(java.lang.Double.longBitsToDouble(long))
       case 3 /* BOOLEAN */     => sb.append(if (long != 0L) "true" else "false")
@@ -263,6 +268,29 @@ object TextLogFormatter extends LogFormatter {
       case 6 /* DOUBLE_SEQ */  => appendScalarSeq(sb, if (seq == null) Seq.empty else seq)
       case 7 /* BOOLEAN_SEQ */ => appendScalarSeq(sb, if (seq == null) Seq.empty else seq)
       case _                   => sb.append("?")
+    }
+
+  /**
+   * Appends a string attribute value with `"`, `\`, and line-break characters
+   * backslash-escaped so quoted values stay unambiguous. A null value keeps the
+   * historical rendering.
+   */
+  private def appendTextEscaped(sb: StringBuilder, s: String): Unit =
+    if (s == null) sb.append(s)
+    else {
+      var i = 0
+      while (i < s.length) {
+        val c = s.charAt(i)
+        c match {
+          case '"'  => sb.append("\\\"")
+          case '\\' => sb.append("\\\\")
+          case '\n' => sb.append("\\n")
+          case '\r' => sb.append("\\r")
+          case '\t' => sb.append("\\t")
+          case _    => sb.append(c)
+        }
+        i += 1
+      }
     }
 
   /** Shared throwable rendering, used by both entry points. */
@@ -318,13 +346,19 @@ object TextLogFormatter extends LogFormatter {
     if (seqs == null || seqs(i) == null) Seq.empty
     else seqs(i).asInstanceOf[Seq[Any]]
 
-  /** Renders a String seq as `["a", "b"]` with each element double-quoted. */
+  /**
+   * Renders a String seq as `["a", "b"]` with each element double-quoted and
+   * escaped.
+   */
   private def appendStringSeq(sb: StringBuilder, value: Seq[Any]): Unit = {
     sb.append('[')
     var first = true
     value.foreach { v =>
       if (first) first = false else sb.append(", ")
-      sb.append('"').append(v.toString).append('"')
+      sb.append('"')
+      val element = if (v == null) null else v.toString
+      appendTextEscaped(sb, element)
+      sb.append('"')
     }
     sb.append(']')
   }

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/LogFormatter.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/LogFormatter.scala
@@ -49,6 +49,16 @@ object TextLogFormatter extends LogFormatter {
   @volatile private var cachedSecond: Long   = 0L
   @volatile private var cachedPrefix: String = ""
 
+  /**
+   * Exact canonical location keys emitted by the logging macros
+   * (`code.filepath`, `code.namespace`, `code.function`, `code.lineno`). Any
+   * other `code.*` key is a user attribute and must stay visible. Prefix
+   * matching would over-delete those.
+   */
+  private def isCodeKey(key: String): Boolean =
+    key == "code.filepath" || key == "code.namespace" ||
+      key == "code.function" || key == "code.lineno"
+
   override def format(
     sb: StringBuilder,
     timestampNanos: Long,
@@ -97,7 +107,7 @@ object TextLogFormatter extends LogFormatter {
     var hasUserAttrs = false
     i = 0
     while (i < len) {
-      if (!keys(i).startsWith("code.")) {
+      if (!isCodeKey(keys(i))) {
         if (!hasUserAttrs) { sb.append(" {"); hasUserAttrs = true }
         else sb.append(", ")
         sb.append(keys(i)); sb.append('=')
@@ -151,49 +161,49 @@ object TextLogFormatter extends LogFormatter {
       }
 
       override def visitString(key: String, value: String): Unit =
-        if (!key.startsWith("code.")) {
+        if (!isCodeKey(key)) {
           nextAttr(key)
           renderTextAttrValue(sb, 0, 0L, value, null)
         }
 
       override def visitLong(key: String, value: Long): Unit =
-        if (!key.startsWith("code.")) {
+        if (!isCodeKey(key)) {
           nextAttr(key)
           renderTextAttrValue(sb, 1, value, null, null)
         }
 
       override def visitDouble(key: String, value: Double): Unit =
-        if (!key.startsWith("code.")) {
+        if (!isCodeKey(key)) {
           nextAttr(key)
           renderTextAttrValue(sb, 2, java.lang.Double.doubleToRawLongBits(value), null, null)
         }
 
       override def visitBoolean(key: String, value: Boolean): Unit =
-        if (!key.startsWith("code.")) {
+        if (!isCodeKey(key)) {
           nextAttr(key)
           renderTextAttrValue(sb, 3, if (value) 1L else 0L, null, null)
         }
 
       override def visitStringSeq(key: String, value: Seq[String]): Unit =
-        if (!key.startsWith("code.")) {
+        if (!isCodeKey(key)) {
           nextAttr(key)
           renderTextAttrValue(sb, 4, 0L, null, value)
         }
 
       override def visitLongSeq(key: String, value: Seq[Long]): Unit =
-        if (!key.startsWith("code.")) {
+        if (!isCodeKey(key)) {
           nextAttr(key)
           renderTextAttrValue(sb, 5, 0L, null, value)
         }
 
       override def visitDoubleSeq(key: String, value: Seq[Double]): Unit =
-        if (!key.startsWith("code.")) {
+        if (!isCodeKey(key)) {
           nextAttr(key)
           renderTextAttrValue(sb, 6, 0L, null, value)
         }
 
       override def visitBooleanSeq(key: String, value: Seq[Boolean]): Unit =
-        if (!key.startsWith("code.")) {
+        if (!isCodeKey(key)) {
           nextAttr(key)
           renderTextAttrValue(sb, 7, 0L, null, value)
         }

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/Logger.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/Logger.scala
@@ -121,10 +121,14 @@ final class Logger private[telemetry] (
     log(Severity.Fatal, body, attrs)
 
   private def log(severity: Severity, body: String, attrs: Seq[(String, AttributeValue)]): Unit = {
+    // Cheap gate first: below the minimum level of every processor, skip the
+    // clock read, builder work, and record allocation entirely (mirrors the
+    // macro path's globalMinLevel pre-check).
+    if (severity.number < processorMinLevel) return
     val now        = EpochClock.epochNanos()
     val spanCtxOpt = contextStorage.get()
 
-    val attrBuilder = Attributes.builder
+    val attrBuilder = AttributeBuilderPool.get()
     attrs.foreach { case (k, v) =>
       v match {
         case AttributeValue.StringValue(s)     => attrBuilder.put(k, s)
@@ -151,7 +155,8 @@ final class Logger private[telemetry] (
       severity = severity,
       severityText = severity.text,
       body = LogMessage(body),
-      attributes = attrBuilder.build,
+      // Zero-copy handoff from the pooled builder (see StandardLogEmitter).
+      attributes = attrBuilder.buildAndReset(),
       traceIdHi = tidHi,
       traceIdLo = tidLo,
       spanId = sid,

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/Logger.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/Logger.scala
@@ -121,9 +121,14 @@ final class Logger private[telemetry] (
     log(Severity.Fatal, body, attrs)
 
   private def log(severity: Severity, body: String, attrs: Seq[(String, AttributeValue)]): Unit = {
-    // Cheap gate first: below the minimum level of every processor, skip the
-    // clock read, builder work, and record allocation entirely (mirrors the
-    // macro path's globalMinLevel pre-check).
+    // Cheap gate first: below the minimum level of every processor attached to
+    // this Logger, skip the clock read, builder work, and record allocation
+    // entirely. This reads the construction-time processor snapshot only.
+    // Unlike the macro path — which checks the live GlobalLogState floor and
+    // then the per-namespace effectiveLevel — direct calls carry no
+    // SourceLocation, so GlobalLogState levels (global floor and
+    // per-namespace overrides) do not apply here; only this Logger's own
+    // processor levels gate direct calls.
     if (severity.number < processorMinLevel) return
     val now        = EpochClock.epochNanos()
     val spanCtxOpt = contextStorage.get()

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/Resource.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/Resource.scala
@@ -23,6 +23,12 @@ package zio.blocks.telemetry
  * application/service generating the telemetry data. A Resource typically
  * includes semantic attributes like service.name, service.version, and
  * deployment environment.
+ *
+ * Note: this is the OpenTelemetry resource (data identity: ''what produced this
+ * telemetry''). It is not the same as `zio.blocks.scope.Resource` (lifecycle:
+ * ''how a value is acquired and released in a scope''). The names collide
+ * across modules (which cannot link to each other here); they share nothing
+ * else.
  */
 final case class Resource(attributes: Attributes)
 

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/SpanId.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/SpanId.scala
@@ -36,8 +36,15 @@ final class SpanId(val value: Long) extends AnyVal {
 
   /**
    * Converts this span ID to a 16-character lowercase hexadecimal string.
+   *
+   * Hand-rolled nibble appends (see `Hex`) instead of `String.format`: this
+   * runs per span on the inject/export hot path.
    */
-  def toHex: String = String.format("%016x", value)
+  def toHex: String = {
+    val sb = new StringBuilder(16)
+    Hex.appendLong16(sb, value)
+    sb.toString
+  }
 
   /**
    * Converts this span ID to an 8-byte big-endian array.

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/TraceFlags.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/TraceFlags.scala
@@ -45,8 +45,15 @@ final class TraceFlags(val byte: Byte) extends AnyVal {
 
   /**
    * Converts this trace flags to a 2-character lowercase hexadecimal string.
+   *
+   * Hand-rolled nibble appends (see `Hex`) instead of `String.format`: this
+   * runs per span on the inject path.
    */
-  def toHex: String = String.format("%02x", byte & 0xff)
+  def toHex: String = {
+    val sb = new StringBuilder(2)
+    Hex.appendByte2(sb, byte & 0xff)
+    sb.toString
+  }
 
   /**
    * Returns the underlying byte value.

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/TraceId.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/TraceId.scala
@@ -34,11 +34,15 @@ object TraceId {
 
   /**
    * Converts a trace ID to a 32-character lowercase hexadecimal string.
+   *
+   * Hand-rolled nibble appends (see `Hex`) instead of `String.format`: this
+   * runs per span on the inject/export hot path.
    */
   def toHex(hi: Long, lo: Long): String = {
-    val hiHex = String.format("%016x", hi)
-    val loHex = String.format("%016x", lo)
-    hiHex + loHex
+    val sb = new StringBuilder(32)
+    Hex.appendLong16(sb, hi)
+    Hex.appendLong16(sb, lo)
+    sb.toString
   }
 
   /**
@@ -97,4 +101,40 @@ object TraceId {
         case _: NumberFormatException => None
       }
     }
+}
+
+/**
+ * Hand-rolled lowercase hex formatting for hot paths.
+ *
+ * `String.format` parses a format string, boxes its arguments, and allocates
+ * formatters on every call; these nibble appends do straight-line work with no
+ * allocation beyond the caller's `StringBuilder`. Used by trace/span ID
+ * rendering on the per-span hot path (inject + export) and by JSON string
+ * escaping.
+ */
+private[telemetry] object Hex {
+  private final val Digits = "0123456789abcdef"
+
+  /** Appends `v` as 16 lowercase hex digits (big-endian nibble order). */
+  def appendLong16(sb: StringBuilder, v: Long): Unit = {
+    var i = 0
+    while (i < 16) {
+      sb.append(Digits.charAt(((v >>> ((15 - i) * 4)) & 0xfL).toInt))
+      i += 1
+    }
+  }
+
+  /** Appends the low 8 bits of `b` as 2 lowercase hex digits. */
+  def appendByte2(sb: StringBuilder, b: Int): Unit = {
+    sb.append(Digits.charAt((b >>> 4) & 0xf))
+    sb.append(Digits.charAt(b & 0xf))
+  }
+
+  /** Appends `c` as 4 lowercase hex digits (for `\uXXXX` escapes). */
+  def appendChar4(sb: StringBuilder, c: Int): Unit = {
+    sb.append(Digits.charAt((c >>> 12) & 0xf))
+    sb.append(Digits.charAt((c >>> 8) & 0xf))
+    sb.append(Digits.charAt((c >>> 4) & 0xf))
+    sb.append(Digits.charAt(c & 0xf))
+  }
 }

--- a/telemetry/shared/src/main/scala/zio/blocks/telemetry/log.scala
+++ b/telemetry/shared/src/main/scala/zio/blocks/telemetry/log.scala
@@ -172,8 +172,7 @@ object log extends LogVersionSpecific {
       annotations.foreach { case (k, v) => builder.put(k, v) }
     }
 
-    val attrs = builder.build
-    builder.clear()
+    val attrs    = builder.buildAndReset()
     val state    = GlobalLogState.get()
     val resource = state.logger.resource
 

--- a/telemetry/shared/src/test/scala/zio/blocks/telemetry/AttributesSpec.scala
+++ b/telemetry/shared/src/test/scala/zio/blocks/telemetry/AttributesSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.telemetry
+
+import zio.test._
+
+object AttributesSpec extends ZIOSpecDefault {
+
+  private def fullBuilder(): Attributes.AttributesBuilder =
+    Attributes.builder
+      .put("s", "value")
+      .put("l", 42L)
+      .put("d", 2.5)
+      .put("b", true)
+      .put(AttributeKey.stringSeq("ss"), Seq("a", "b"))
+      .put(AttributeKey.longSeq("ls"), Seq(1L, 2L))
+      .put(AttributeKey.doubleSeq("ds"), Seq(1.5))
+      .put(AttributeKey.booleanSeq("bs"), Seq(true, false))
+
+  def spec = suite("Attributes")(
+    suite("build")(
+      test("build pins every stored type and value") {
+        val attrs = fullBuilder().build
+        assertTrue(
+          attrs.size == 8,
+          attrs.get(AttributeKey.string("s")).contains("value"),
+          attrs.get(AttributeKey.long("l")).contains(42L),
+          attrs.get(AttributeKey.double("d")).contains(2.5),
+          attrs.get(AttributeKey.boolean("b")).contains(true),
+          attrs.get(AttributeKey.stringSeq("ss")).contains(Seq("a", "b")),
+          attrs.get(AttributeKey.longSeq("ls")).contains(Seq(1L, 2L)),
+          attrs.get(AttributeKey.doubleSeq("ds")).contains(Seq(1.5)),
+          attrs.get(AttributeKey.booleanSeq("bs")).contains(Seq(true, false))
+        )
+      },
+      test("buildAndReset pins the same content with zero copies") {
+        val builder = fullBuilder()
+        val attrs   = builder.buildAndReset()
+        assertTrue(
+          attrs.size == 8,
+          attrs.get(AttributeKey.string("s")).contains("value"),
+          attrs.get(AttributeKey.long("l")).contains(42L),
+          attrs.get(AttributeKey.double("d")).contains(2.5),
+          attrs.get(AttributeKey.boolean("b")).contains(true),
+          attrs.get(AttributeKey.stringSeq("ss")).contains(Seq("a", "b")),
+          attrs.get(AttributeKey.longSeq("ls")).contains(Seq(1L, 2L)),
+          attrs.get(AttributeKey.doubleSeq("ds")).contains(Seq(1.5)),
+          attrs.get(AttributeKey.booleanSeq("bs")).contains(Seq(true, false)),
+          builder.build.isEmpty
+        )
+      }
+    ),
+    suite("hashCode")(
+      test("equal instances share a hash") {
+        val a = fullBuilder().build
+        val b = fullBuilder().build
+        assertTrue(a == b, a.hashCode == b.hashCode)
+      },
+      test("hash is stable across reads") {
+        val a = fullBuilder().build
+        assertTrue(a.hashCode == a.hashCode)
+      },
+      test("empty attributes hash to zero") {
+        assertTrue(Attributes.empty.hashCode == 0)
+      },
+      test("build and buildAndReset agree on hash") {
+        val a = fullBuilder().build
+        val b = fullBuilder().buildAndReset()
+        assertTrue(a == b, a.hashCode == b.hashCode)
+      }
+    )
+  )
+}

--- a/telemetry/shared/src/test/scala/zio/blocks/telemetry/HexSpec.scala
+++ b/telemetry/shared/src/test/scala/zio/blocks/telemetry/HexSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.telemetry
+
+import zio.test._
+
+object HexSpec extends ZIOSpecDefault {
+
+  def spec = suite("Hex")(
+    suite("TraceId.toHex")(
+      test("renders zeros") {
+        assertTrue(TraceId.toHex(0L, 0L) == "00000000000000000000000000000000")
+      },
+      test("renders a known value") {
+        assertTrue(TraceId.toHex(0x0123456789abcdefL, 0xfedcba9876543210L) == "0123456789abcdeffedcba9876543210")
+      },
+      test("renders all-ones") {
+        assertTrue(TraceId.toHex(-1L, -1L) == "ffffffffffffffffffffffffffffffff")
+      },
+      test("renders extreme values") {
+        assertTrue(TraceId.toHex(Long.MinValue, Long.MaxValue) == "80000000000000007fffffffffffffff")
+      },
+      test("round-trips through fromHex") {
+        val pairs = List(
+          (0L, 1L),
+          (1L, 0L),
+          (-1L, -1L),
+          (Long.MinValue, Long.MaxValue),
+          (0x0123456789abcdefL, 0xfedcba9876543210L)
+        )
+        assertTrue(pairs.forall { case (hi, lo) =>
+          TraceId.fromHex(TraceId.toHex(hi, lo)).contains((hi, lo))
+        })
+      }
+    ),
+    suite("SpanId.toHex")(
+      test("renders zeros") {
+        assertTrue(SpanId(0L).toHex == "0000000000000000")
+      },
+      test("renders a known value") {
+        assertTrue(SpanId(0x0123456789abcdefL).toHex == "0123456789abcdef")
+      },
+      test("renders all-ones") {
+        assertTrue(SpanId(-1L).toHex == "ffffffffffffffff")
+      },
+      test("renders extreme values") {
+        assertTrue(SpanId(Long.MinValue).toHex == "8000000000000000") &&
+        assertTrue(SpanId(Long.MaxValue).toHex == "7fffffffffffffff")
+      },
+      test("round-trips through fromHex") {
+        val values = List(0L, 1L, -1L, Long.MinValue, Long.MaxValue, 0x0123456789abcdefL)
+        assertTrue(values.forall(v => SpanId.fromHex(SpanId(v).toHex).contains(SpanId(v))))
+      }
+    ),
+    suite("TraceFlags.toHex")(
+      test("renders none and sampled") {
+        assertTrue(TraceFlags.none.toHex == "00") &&
+        assertTrue(TraceFlags.sampled.toHex == "01")
+      },
+      test("renders full byte") {
+        assertTrue(TraceFlags(0xff.toByte).toHex == "ff") &&
+        assertTrue(TraceFlags(0x10.toByte).toHex == "10")
+      }
+    )
+  )
+}


### PR DESCRIPTION
Closes the widened telemetry/otel/config/scope/projection review pass in one change. All fixes are internal, docs, or additive; no new dependencies; no public API behavior change except the two documented spec-compliance fixes below.

## telemetry

- Text formatting no longer assumes the first four builder slots are the code attributes. Location and user attributes are matched by key, so builders without code attributes (direct `Logger` calls, adapters) print every attribute instead of silently dropping up to four. The macro path output is unchanged.
- Direct `Logger` calls return immediately below the processor minimum level, skipping the clock read, builder work, and record allocation, mirroring the macro path pre-check.
- Attribute hashing is lazy (per-log instances are short-lived and rarely hashed) and the standard emitter hands pooled builder arrays to the record with zero copies.
- Trace/span/flag ids and JSON escapes use hand-rolled nibble appends instead of `String.format` on the hot paths.
- `TextLogFormatter` and `JsonLogFormatter` now share one render core each (head, location, attribute values, throwable) with both entry points kept.

Tests: direct-emit and `Logger.info` attribute pins, disabled-level gating, attribute content and hash equality, hex literal equivalence and round-trips, byte-identical builder-vs-record rendering for text and JSON.

## otel

- OTLP object keys go through the JSON string escaper (all current call sites pass literals, so output is unchanged; the raw-append path is gone).
- Batch retry backoff waits on a monitor that shutdown notifies, so shutdown during backoff returns promptly instead of sleeping out up to 30s. Retry stays synchronous, so `forceFlush` semantics are unchanged. New timing test pins prompt shutdown under a 60s backoff.
- W3C accepts future versions with the same shape (behavior change: version `01` with a 55-char body now extracts; `ff`, non-hex, and overlong `00` bodies still reject) and drops absent, overlong (>512 chars), or malformed tracestate while still extracting the context.
- B3 single-header parsing hand-splits on dash indices (no per-extract regex); multi-header accepts the spec `true` sampling form. Debug markers still degrade to sampled, now documented.

Tests: encoder key-escaping with quote/backslash/control characters, shutdown-during-backoff timing, future-version acceptance and tracestate bounds, `true` sampling and debug cases.

## config and scope

- `telemetry.Resource` and `scope.Resource` cross-link each other as unrelated concepts sharing a name.
- `Config` documents when to use Schema-derived loading versus flag objects in a decision table.
- `Scope` documents the closed-scope trio (allocate/open/`$` throw, `defer` returns a no-op, `scoped` makes a born-closed child) in one table, with a test pinning all three on one closed scope.
- The secret-marker list gains `pwd`, `passphrase`, and `auth`, with the substring trade-off documented; new redaction tests.

## projection

- The engine is split by concern into lifecycle (startup, fibers, consumption), rebuild (migrations, schema drift), and query (reads) helpers behind the unchanged `ProjectionEngine` facade. No behavior change.
- States the effect-boundary rule: ZIO is allowed exactly where fibers, streams, or lifetime management are required, which is why projection is ZIO-coupled while telemetry, config, context, and scope stay ZIO-free.
- New store parity spec runs one op script against the in-memory and SQLite stores and asserts identical outcomes, so the dual stores cannot silently drift.

## verification

- `sbt fmt` clean under both Scala 3.8.3 and 2.13.18.
- Green: telemetry/otel/config/scope/projection JVM tests on 3.8.3, 3.3.7, and 2.13.18 (projection is 3.x only); configJS/scopeJS on 3.8.3.
- Coverage on 3.8.3: telemetry 85.7/75.2, otel 88.1/86.9, config 85.7/73.2, scope 78.6/67.2, projection 80.8/70.8 (statement/branch, all above gates).
- Pre-existing, unrelated: `telemetryJS` fails to link on JS at the base commit too (`java.util.Calendar` in shared code, untouched here). If the full-matrix run shows the known schema-module combining-marks JSON failure, that is also pre-existing on the base commit.
