### PR TITLE
fix(codecs): harden small-module parsers, emitter, and migrator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,23 +146,23 @@ addCommandAlias(
 )
 lazy val testJVMScala2Command =
   "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
-    "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; muxJVM/test; configJVM/test; config-yamlJVM/test; config-jsonJVM/test; config-hoconJVM/test; mediatypeJVM/test; " +
+    "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; muxJVM/test; markdownJVM/test; configJVM/test; config-yamlJVM/test; config-jsonJVM/test; config-hoconJVM/test; mediatypeJVM/test; " +
     "endpointJVM/test; openapiJVM/test; smithy/test; codegen/test; htmlJVM/test; asyncJVM/test; jwtJVM/test" +
     whenJdkAtLeast(25, "telemetryJVM/test; otel/test")
 
 lazy val testJVMScala3Command =
   "typeidJVM/test; maybeJVM/test; chunkJVM/test; combinatorsJVM/test; ringbufferJVM/test; schemaJVM/test; streamsJVM/test; schema-toonJVM/test; schema-messagepackJVM/test; schema-avro/test; " +
-    "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; muxJVM/test; mediatypeJVM/test; http-modelJVM/test; " +
+    "schema-thrift/test; schema-bson/test; schema-xmlJVM/test; schema-yamlJVM/test; schema-csvJVM/test; contextJVM/test; scopeJVM/test; muxJVM/test; markdownJVM/test; mediatypeJVM/test; http-modelJVM/test; " +
     "http-model-schemaJVM/test; configJVM/test; config-yamlJVM/test; config-jsonJVM/test; config-hoconJVM/test; endpointJVM/test; openapiJVM/test; smithy/test; sqlJVM/test; sql-zio/test; codegen/test; htmlJVM/test; datastarJVM/test; htmxJVM/test; asyncJVM/test; dataMigrationJVM/test; projectionJVM/test; jwtJVM/test" +
     whenJdkAtLeast(25, "telemetryJVM/test; otel/test")
 
 lazy val testJSScala2Command =
   "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
-    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; muxJS/test; mediatypeJS/test; configJS/test; config-yamlJS/test; config-jsonJS/test; config-hoconJS/test; endpointJS/test; htmlJS/test; asyncJS/test; jwtJS/test"
+    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; muxJS/test; markdownJS/test; mediatypeJS/test; configJS/test; config-yamlJS/test; config-jsonJS/test; config-hoconJS/test; endpointJS/test; htmlJS/test; asyncJS/test; jwtJS/test"
 
 lazy val testJSScala3Command =
   "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; openapiJS/test; " +
-    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; muxJS/test; mediatypeJS/test; http-modelJS/test; http-model-schemaJS/test; configJS/test; config-yamlJS/test; config-jsonJS/test; config-hoconJS/test; endpointJS/test; sqlJS/test; htmlJS/test; datastarJS/test; htmxJS/test; asyncJS/test; dataMigrationJS/test; jwtJS/test"
+    "schema-xmlJS/test; schema-yamlJS/test; schema-csvJS/test; contextJS/test; scopeJS/test; muxJS/test; markdownJS/test; mediatypeJS/test; http-modelJS/test; http-model-schemaJS/test; configJS/test; config-yamlJS/test; config-jsonJS/test; config-hoconJS/test; endpointJS/test; sqlJS/test; htmlJS/test; datastarJS/test; htmxJS/test; asyncJS/test; dataMigrationJS/test; jwtJS/test"
 
 lazy val testJS1Scala2Command =
   "typeidJS/test; maybeJS/test; chunkJS/test; combinatorsJS/test; ringbufferJS/test; schemaJS/test; streamsJS/test; schema-toonJS/test; schema-messagepackJS/test; asyncJS/test"

--- a/codegen/src/main/scala/zio/blocks/codegen/emit/ScalaEmitter.scala
+++ b/codegen/src/main/scala/zio/blocks/codegen/emit/ScalaEmitter.scala
@@ -36,15 +36,15 @@ object ScalaEmitter {
    *   The Scala type string (e.g., "String", "List[Int]", "Map[String, Int]")
    */
   def emitTypeRef(typeRef: TypeRef): String = typeRef.name match {
-    case "|" => typeRef.typeArgs.map(emitTypeRef).mkString(" | ")
-    case "&" => typeRef.typeArgs.map(emitTypeRef).mkString(" & ")
+    case "|" => emitList(typeRef.typeArgs, " | ")(emitTypeRef)
+    case "&" => emitList(typeRef.typeArgs, " & ")(emitTypeRef)
     case _   =>
       val safeName =
         if (typeRef.name.contains('.') || typeRef.name.exists(c => "()[]=>".contains(c)))
           typeRef.name
         else escapeName(typeRef.name)
       if (typeRef.typeArgs.isEmpty) safeName
-      else s"${safeName}[${typeRef.typeArgs.map(emitTypeRef).mkString(", ")}]"
+      else s"$safeName[${emitList(typeRef.typeArgs, ", ")(emitTypeRef)}]"
   }
 
   /**
@@ -64,7 +64,7 @@ object ScalaEmitter {
     }
     sb.append(escapeName(tp.name))
     if (tp.typeParams.nonEmpty)
-      sb.append("[").append(tp.typeParams.map(emitTypeParam).mkString(", ")).append("]")
+      sb.append("[").append(emitList(tp.typeParams, ", ")(emitTypeParam)).append("]")
     tp.lowerBound.foreach(lb => sb.append(" >: ").append(emitTypeRef(lb)))
     tp.upperBound.foreach(ub => sb.append(" <: ").append(emitTypeRef(ub)))
     tp.contextBounds.foreach(cb => sb.append(": ").append(emitTypeRef(cb)))
@@ -86,7 +86,7 @@ object ScalaEmitter {
   def emitAnnotation(annotation: Annotation): String =
     if (annotation.args.isEmpty) s"@${annotation.name}"
     else {
-      val argsStr = annotation.args.map { case (k, v) => s"$k = $v" }.mkString(", ")
+      val argsStr = emitList(annotation.args, ", ") { case (k, v) => s"$k = $v" }
       s"@${annotation.name}($argsStr)"
     }
 
@@ -107,10 +107,7 @@ object ScalaEmitter {
     val defaultStr = field.defaultValue.fold("")(d => s" = $d")
     val fieldStr   = s"${escapeName(field.name)}: $typeStr$defaultStr"
     if (field.annotations.isEmpty) fieldStr
-    else {
-      val annotStrs = field.annotations.map(emitAnnotation)
-      (annotStrs :+ fieldStr).mkString("\n")
-    }
+    else emitList(field.annotations, "\n")(emitAnnotation) + "\n" + fieldStr
   }
 
   /**
@@ -142,7 +139,7 @@ object ScalaEmitter {
       val arrow = if (config.scala3Syntax) "as" else "=>"
       s"import $path.{$from $arrow $to}"
     case Import.GroupImport(path, names) =>
-      s"import $path.{${names.mkString(", ")}}"
+      s"import $path.{${emitList(names, ", ")}}"
   }
 
   /**
@@ -181,6 +178,34 @@ object ScalaEmitter {
 
   private def ind(level: Int, config: EmitterConfig): String =
     " " * (level * config.indentWidth)
+
+  /**
+   * Shared list-joining helper replacing the repeated
+   * `xs.map(emitX).mkString(sep)` shape across per-node emitters.
+   */
+  private def emitList[A](xs: List[A], sep: String)(emit1: A => String): String = {
+    val sb = new StringBuilder
+    emitList(sb, xs, sep)(emit1)
+    sb.toString
+  }
+
+  /** `emitList` for plain string elements. */
+  private def emitList(xs: List[String], sep: String): String =
+    emitList(new StringBuilder, xs, sep)(s => s).toString
+
+  /**
+   * Shared-builder overload of `emitList`: appends the joined elements to an
+   * existing builder without allocating an intermediate string.
+   */
+  private def emitList[A](sb: StringBuilder, xs: List[A], sep: String)(emit1: A => String): StringBuilder = {
+    var first = true
+    xs.foreach { x =>
+      if (first) first = false
+      else sb.append(sep)
+      sb.append(emit1(x))
+    }
+    sb
+  }
 
   /**
    * Emits a complete Scala source file as a string.
@@ -265,7 +290,7 @@ object ScalaEmitter {
 
     sb.append(prefix).append("case class ").append(escapeName(cc.name))
     if (cc.typeParams.nonEmpty)
-      sb.append("[").append(cc.typeParams.map(emitTypeParam).mkString(", ")).append("]")
+      sb.append("[").append(emitList(cc.typeParams, ", ")(emitTypeParam)).append("]")
     sb.append("(")
 
     if (cc.fields.isEmpty) {
@@ -289,11 +314,13 @@ object ScalaEmitter {
     val allExtends =
       if (cc.isValueClass && !cc.extendsTypes.exists(_.name == "AnyVal")) TypeRef("AnyVal") :: cc.extendsTypes
       else cc.extendsTypes
-    if (allExtends.nonEmpty)
-      sb.append(" extends ").append(allExtends.map(emitTypeRef).mkString(" with "))
+    if (allExtends.nonEmpty) {
+      sb.append(" extends ")
+      emitList(sb, allExtends, " with ")(emitTypeRef)
+    }
 
     if (config.scala3Syntax && cc.derives.nonEmpty)
-      sb.append(" derives ").append(cc.derives.mkString(", "))
+      sb.append(" derives ").append(emitList(cc.derives, ", "))
 
     cc.companion.foreach { comp =>
       sb.append("\n")
@@ -328,9 +355,11 @@ object ScalaEmitter {
 
     sb.append(prefix).append("sealed trait ").append(escapeName(st.name))
     if (st.typeParams.nonEmpty)
-      sb.append("[").append(st.typeParams.map(emitTypeParam).mkString(", ")).append("]")
-    if (st.extendsTypes.nonEmpty)
-      sb.append(" extends ").append(st.extendsTypes.map(emitTypeRef).mkString(" with "))
+      sb.append("[").append(emitList(st.typeParams, ", ")(emitTypeParam)).append("]")
+    if (st.extendsTypes.nonEmpty) {
+      sb.append(" extends ")
+      emitList(sb, st.extendsTypes, " with ")(emitTypeRef)
+    }
     st.selfType.foreach { selfTp =>
       sb.append(" { self: ").append(emitTypeRef(selfTp)).append(" => }")
     }
@@ -389,22 +418,24 @@ object ScalaEmitter {
     }
 
     sb.append(prefix).append("enum ").append(escapeName(en.name))
-    if (en.extendsTypes.nonEmpty)
-      sb.append(" extends ").append(en.extendsTypes.map(emitTypeRef).mkString(" with "))
+    if (en.extendsTypes.nonEmpty) {
+      sb.append(" extends ")
+      emitList(sb, en.extendsTypes, " with ")(emitTypeRef)
+    }
     sb.append(" {\n")
 
     val simples       = en.cases.collect { case EnumCase.SimpleCase(n) => n }
     val parameterized = en.cases.collect { case p: EnumCase.ParameterizedCase => p }
 
     if (parameterized.isEmpty && simples.nonEmpty) {
-      sb.append(inner).append("case ").append(simples.mkString(", ")).append("\n")
+      sb.append(inner).append("case ").append(emitList(simples, ", ")).append("\n")
     } else {
       en.cases.foreach {
         case EnumCase.SimpleCase(n) =>
           sb.append(inner).append("case ").append(n).append("\n")
         case EnumCase.ParameterizedCase(n, fields, _) =>
           sb.append(inner).append("case ").append(n).append("(")
-          sb.append(fields.map(f => emitFieldInline(f, config)).mkString(", "))
+          sb.append(emitList(fields, ", ")(emitFieldInline(_, config)))
           sb.append(")\n")
       }
     }
@@ -459,8 +490,10 @@ object ScalaEmitter {
     else sb.append("object ")
     sb.append(escapeName(obj.name))
 
-    if (obj.extendsTypes.nonEmpty)
-      sb.append(" extends ").append(obj.extendsTypes.map(emitTypeRef).mkString(" with "))
+    if (obj.extendsTypes.nonEmpty) {
+      sb.append(" extends ")
+      emitList(sb, obj.extendsTypes, " with ")(emitTypeRef)
+    }
 
     if (obj.members.nonEmpty) {
       sb.append(" {\n")
@@ -533,9 +566,11 @@ object ScalaEmitter {
 
     sb.append(prefix).append("trait ").append(escapeName(t.name))
     if (t.typeParams.nonEmpty)
-      sb.append("[").append(t.typeParams.map(emitTypeParam).mkString(", ")).append("]")
-    if (t.extendsTypes.nonEmpty)
-      sb.append(" extends ").append(t.extendsTypes.map(emitTypeRef).mkString(" with "))
+      sb.append("[").append(emitList(t.typeParams, ", ")(emitTypeParam)).append("]")
+    if (t.extendsTypes.nonEmpty) {
+      sb.append(" extends ")
+      emitList(sb, t.extendsTypes, " with ")(emitTypeRef)
+    }
 
     val hasSelfType = t.selfType.isDefined
     if (t.members.nonEmpty || hasSelfType) {
@@ -583,7 +618,7 @@ object ScalaEmitter {
 
     sb.append(prefix).append("abstract class ").append(escapeName(ac.name))
     if (ac.typeParams.nonEmpty)
-      sb.append("[").append(ac.typeParams.map(emitTypeParam).mkString(", ")).append("]")
+      sb.append("[").append(emitList(ac.typeParams, ", ")(emitTypeParam)).append("]")
 
     if (ac.fields.nonEmpty) {
       sb.append("(")
@@ -602,8 +637,10 @@ object ScalaEmitter {
       sb.append(prefix).append(")")
     }
 
-    if (ac.extendsTypes.nonEmpty)
-      sb.append(" extends ").append(ac.extendsTypes.map(emitTypeRef).mkString(" with "))
+    if (ac.extendsTypes.nonEmpty) {
+      sb.append(" extends ")
+      emitList(sb, ac.extendsTypes, " with ")(emitTypeRef)
+    }
 
     if (ac.members.nonEmpty) {
       sb.append(" {\n")
@@ -722,7 +759,7 @@ object ScalaEmitter {
     }
     sb.append(prefix).append("type ").append(escapeName(ta.name))
     if (ta.typeParams.nonEmpty)
-      sb.append("[").append(ta.typeParams.map(emitTypeParam).mkString(", ")).append("]")
+      sb.append("[").append(emitList(ta.typeParams, ", ")(emitTypeParam)).append("]")
     sb.append(" = ").append(emitTypeRef(ta.typeRef))
     sb.toString
   }
@@ -747,7 +784,7 @@ object ScalaEmitter {
     sb.append("def ").append(escapeName(method.name))
 
     if (method.typeParams.nonEmpty)
-      sb.append("[").append(method.typeParams.map(emitTypeParam).mkString(", ")).append("]")
+      sb.append("[").append(emitList(method.typeParams, ", ")(emitTypeParam)).append("]")
 
     method.params.foreach { paramList =>
       sb.append("(")
@@ -758,7 +795,7 @@ object ScalaEmitter {
           sb.append(if (config.scala3Syntax) "using " else "implicit ")
         case ParamListModifier.Normal => ()
       }
-      sb.append(paramList.params.map(emitMethodParam).mkString(", "))
+      sb.append(emitList(paramList.params, ", ")(emitMethodParam))
       sb.append(")")
     }
 
@@ -844,7 +881,7 @@ object ScalaEmitter {
     val defaultStr = field.defaultValue.fold("")(d => s" = $d")
     val annotStr   =
       if (field.annotations.isEmpty) ""
-      else field.annotations.map(emitAnnotation).mkString(" ") + " "
+      else emitList(field.annotations, " ")(emitAnnotation) + " "
     s"$annotStr${escapeName(field.name)}: $typeStr$defaultStr"
   }
 

--- a/codegen/src/test/scala/zio/blocks/codegen/emit/ScalaEmitterGoldenSpec.scala
+++ b/codegen/src/test/scala/zio/blocks/codegen/emit/ScalaEmitterGoldenSpec.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.codegen.emit
+
+import zio.blocks.codegen.ir._
+import zio.test._
+
+object ScalaEmitterGoldenSpec extends ZIOSpecDefault {
+
+  private val goldenFile: ScalaFile = ScalaFile(
+    packageDecl = PackageDecl("com.example"),
+    imports = List(
+      Import.GroupImport("com.example", List("b", "a")),
+      Import.RenameImport("com.legacy", "Old", "New"),
+      Import.SingleImport("zio", "Chunk"),
+      Import.WildcardImport("scala.collection")
+    ),
+    types = List(
+      CaseClass(
+        name = "User",
+        fields = List(
+          Field("id", TypeRef.String, annotations = List(Annotation("required"))),
+          Field("name", TypeRef.String, defaultValue = Some("\"anon\"")),
+          Field("tags", TypeRef("List", List(TypeRef.String))),
+          Field("choice", TypeRef("|", List(TypeRef.Int, TypeRef.String))),
+          Field("both", TypeRef("&", List(TypeRef("A"), TypeRef("B"))))
+        ),
+        typeParams = List(TypeParam("A", Variance.Covariant, upperBound = Some(TypeRef("AnyRef")))),
+        extendsTypes = List(TypeRef("Product"), TypeRef("Serializable")),
+        derives = List("CanEqual"),
+        annotations = List(Annotation("deprecated", List(("message", "\"use v2\"")))),
+        companion = Some(
+          CompanionObject(
+            List(
+              ObjectMember.ValMember("defaultLimit", TypeRef.Int, "100"),
+              ObjectMember.DefMember(
+                Method(
+                  name = "identity",
+                  typeParams = List(TypeParam("A")),
+                  params = List(ParamList(List(MethodParam("x", TypeRef("A"))))),
+                  returnType = TypeRef("A"),
+                  body = Some("x")
+                )
+              )
+            )
+          )
+        ),
+        doc = Some("A user.")
+      ),
+      SealedTrait(
+        name = "Shape",
+        cases = List(
+          SealedTraitCase.CaseClassCase(CaseClass("Circle", List(Field("r", TypeRef.Double)))),
+          SealedTraitCase.CaseObjectCase("Unit")
+        )
+      ),
+      Enum(
+        name = "Color",
+        cases = List(
+          EnumCase.SimpleCase("Red"),
+          EnumCase.SimpleCase("Green"),
+          EnumCase.ParameterizedCase(
+            "Custom",
+            List(Field("rgb", TypeRef.Int, annotations = List(Annotation("range", List(("min", "0"))))))
+          )
+        )
+      ),
+      TypeAlias(
+        name = "UserId",
+        typeParams = List(TypeParam("A")),
+        typeRef = TypeRef.String
+      ),
+      ObjectDef(
+        name = "Codecs",
+        members = List(ObjectMember.ValMember("version", TypeRef.String, "\"1.0\"")),
+        extendsTypes = List(TypeRef("Serializable"))
+      )
+    )
+  )
+
+  def spec = suite("ScalaEmitterGolden")(
+    test("full-file emission is byte-identical to the golden snapshot") {
+      val result = ScalaEmitter.emit(goldenFile, EmitterConfig.default)
+      assertTrue(
+        result ==
+          """|package com.example
+             |
+             |import com.example.{b, a}
+             |import com.legacy.{Old as New}
+             |import scala.collection.*
+             |import zio.Chunk
+             |
+             |/** A user. */
+             |@deprecated(message = "use v2")
+             |case class User[+A <: AnyRef](
+             |  @required
+             |  id: String,
+             |  name: String = "anon",
+             |  tags: List[String],
+             |  choice: Int | String,
+             |  both: A & B,
+             |) extends Product with Serializable derives CanEqual
+             |
+             |object User {
+             |  val defaultLimit: Int = 100
+             |  def identity[A](x: A): A = x
+             |}
+             |
+             |sealed trait Shape
+             |
+             |object Shape {
+             |  case class Circle(
+             |    r: Double,
+             |  ) extends Shape
+             |  case object Unit extends Shape
+             |}
+             |
+             |enum Color {
+             |  case Red
+             |  case Green
+             |  case Custom(@range(min = 0) rgb: Int)
+             |}
+             |
+             |type UserId[A] = String
+             |
+             |object Codecs extends Serializable {
+             |  val version: String = "1.0"
+             |}
+             |""".stripMargin
+      )
+    }
+  )
+}

--- a/codegen/src/test/scala/zio/blocks/codegen/emit/ScalaEmitterGoldenSpec.scala
+++ b/codegen/src/test/scala/zio/blocks/codegen/emit/ScalaEmitterGoldenSpec.scala
@@ -88,6 +88,19 @@ object ScalaEmitterGoldenSpec extends ZIOSpecDefault {
         name = "Codecs",
         members = List(ObjectMember.ValMember("version", TypeRef.String, "\"1.0\"")),
         extendsTypes = List(TypeRef("Serializable"))
+      ),
+      CaseClass(
+        name = "UserId",
+        fields = List(Field("value", TypeRef.Long)),
+        isValueClass = true
+      ),
+      SealedTrait(
+        name = "Service",
+        selfType = Some(TypeRef("Env"))
+      ),
+      CaseClass(
+        name = "Keyword",
+        fields = List(Field("type", TypeRef.String))
       )
     )
   )
@@ -140,6 +153,16 @@ object ScalaEmitterGoldenSpec extends ZIOSpecDefault {
              |object Codecs extends Serializable {
              |  val version: String = "1.0"
              |}
+             |
+             |case class UserId(
+             |  value: Long,
+             |) extends AnyVal
+             |
+             |sealed trait Service { self: Env => }
+             |
+             |case class Keyword(
+             |  `type`: String,
+             |)
              |""".stripMargin
       )
     }

--- a/dataMigration/jvm/src/test/scala/zio/blocks/data/migration/SmallMigratorInitConcurrencySpec.scala
+++ b/dataMigration/jvm/src/test/scala/zio/blocks/data/migration/SmallMigratorInitConcurrencySpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.data.migration
+
+import zio.test.*
+import zio.blocks.sql.*
+
+object SmallMigratorInitConcurrencySpec extends ZIOSpecDefault {
+
+  /**
+   * Transactor stub that counts preparation transactions without running them.
+   */
+  final class CountingTransactor extends Transactor {
+    val transactCalls                          = new java.util.concurrent.atomic.AtomicInteger(0)
+    override def connect[A](f: DbCon ?=> A): A = 0L.asInstanceOf[A]
+    override def transact[A](f: DbTx ?=> A): A = {
+      transactCalls.incrementAndGet()
+      0.asInstanceOf[A]
+    }
+    override def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A =
+      transact(f)
+  }
+
+  private val idColumns = IndexedSeq(ColumnMeta("id", DbValue.DbInt(0), nullable = false))
+  private val v1Repo    = Repo(Table[Int]("users_v1", DbCodec.intCodec, idColumns), "id", DbCodec.intCodec, identity)
+  private val v2Repo    = Repo(Table[Int]("users_v2", DbCodec.intCodec, idColumns), "id", DbCodec.intCodec, identity)
+
+  private val unusedMigration = null.asInstanceOf[zio.blocks.schema.migration.Migration[Int, Int]]
+
+  private given dialect: Dialect = Dialect.Postgres
+
+  def spec = suite("SmallMigratorInitConcurrency")(
+    test("concurrent init() calls prepare the target exactly once") {
+      val tx = new CountingTransactor
+      val m  = SmallMigrator[Int, Int, Int, Int](
+        repoV1 = v1Repo,
+        repoV2 = v2Repo,
+        migration = unusedMigration,
+        queueTable = "q",
+        batchSize = 10,
+        target = TargetStrategy.InPlace
+      )(using tx, DbCodec.intCodec)
+      val gate    = new java.util.concurrent.CountDownLatch(1)
+      val errors  = new java.util.concurrent.ConcurrentLinkedQueue[Throwable]()
+      val threads = (1 to 8).map(_ =>
+        new Thread(new Runnable {
+          def run(): Unit =
+            try {
+              gate.await()
+              m.init()
+            } catch {
+              case t: Throwable =>
+                errors.add(t)
+                ()
+            }
+        })
+      )
+      threads.foreach(_.start())
+      gate.countDown()
+      threads.foreach(_.join())
+      assertTrue(tx.transactCalls.get() == 1, errors.isEmpty)
+    }
+  )
+}

--- a/dataMigration/jvm/src/test/scala/zio/blocks/data/migration/SmallMigratorInitConcurrencySpec.scala
+++ b/dataMigration/jvm/src/test/scala/zio/blocks/data/migration/SmallMigratorInitConcurrencySpec.scala
@@ -18,42 +18,21 @@ package zio.blocks.data.migration
 
 import zio.test.*
 import zio.blocks.sql.*
+import MigratorTestStubs.{CountingTransactor, newInPlaceMigrator}
 
 object SmallMigratorInitConcurrencySpec extends ZIOSpecDefault {
-
-  /**
-   * Transactor stub that counts preparation transactions without running them.
-   */
-  final class CountingTransactor extends Transactor {
-    val transactCalls                          = new java.util.concurrent.atomic.AtomicInteger(0)
-    override def connect[A](f: DbCon ?=> A): A = 0L.asInstanceOf[A]
-    override def transact[A](f: DbTx ?=> A): A = {
-      transactCalls.incrementAndGet()
-      0.asInstanceOf[A]
-    }
-    override def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A =
-      transact(f)
-  }
-
-  private val idColumns = IndexedSeq(ColumnMeta("id", DbValue.DbInt(0), nullable = false))
-  private val v1Repo    = Repo(Table[Int]("users_v1", DbCodec.intCodec, idColumns), "id", DbCodec.intCodec, identity)
-  private val v2Repo    = Repo(Table[Int]("users_v2", DbCodec.intCodec, idColumns), "id", DbCodec.intCodec, identity)
-
-  private val unusedMigration = null.asInstanceOf[zio.blocks.schema.migration.Migration[Int, Int]]
 
   private given dialect: Dialect = Dialect.Postgres
 
   def spec = suite("SmallMigratorInitConcurrency")(
-    test("concurrent init() calls prepare the target exactly once") {
-      val tx = new CountingTransactor
-      val m  = SmallMigrator[Int, Int, Int, Int](
-        repoV1 = v1Repo,
-        repoV2 = v2Repo,
-        migration = unusedMigration,
-        queueTable = "q",
-        batchSize = 10,
-        target = TargetStrategy.InPlace
-      )(using tx, DbCodec.intCodec)
+    test("concurrent init() calls run the real preparation body exactly once") {
+      // The shared stub executes the real `init()` body (InPlace preparation
+      // never touches the connection), so this proves the gate serializes
+      // concurrent calls end to end — not just the counter. Database-level
+      // idempotence under real races rests on the idempotent trigger DDL (see
+      // `QueueTable.installTriggers` and `SmallMigrator.init`).
+      val tx      = new CountingTransactor
+      val m       = newInPlaceMigrator(tx)
       val gate    = new java.util.concurrent.CountDownLatch(1)
       val errors  = new java.util.concurrent.ConcurrentLinkedQueue[Throwable]()
       val threads = (1 to 8).map(_ =>

--- a/dataMigration/shared/src/main/scala/zio/blocks/data/migration/SmallMigrator.scala
+++ b/dataMigration/shared/src/main/scala/zio/blocks/data/migration/SmallMigrator.scala
@@ -46,8 +46,17 @@ final class SmallMigrator[A, B, ID1, ID2](
    * table via `TargetStrategyApplier.prepare`. When `captureTriggers` is
    * enabled, installs capture triggers on the source table. Safe to call
    * multiple times (idempotent after first success).
+   *
+   * Thread-safe: concurrent `init()` calls are serialized so the target is
+   * prepared and the triggers installed exactly once. Trigger installation runs
+   * inside the same preparation transaction and relies on the documented
+   * idempotence of `QueueTable.installTriggers` (SQLite `CREATE TRIGGER IF NOT
+   * EXISTS`, PostgreSQL `CREATE OR REPLACE TRIGGER`).
+   *
+   * @throws java.lang.IllegalArgumentException
+   *   if called after `complete()`; create a new migrator instead
    */
-  def init(): Unit = {
+  def init(): Unit = synchronized {
     require(!completed, "cannot init() after complete(); create a new migrator")
     if (initialized) return
     transactor.transact { (tx: DbTx) ?=>
@@ -67,6 +76,10 @@ final class SmallMigrator[A, B, ID1, ID2](
    * (shadow table replaces the live table). Requires init() first and refuses
    * to run while the queue still has pending items — draining is the caller's
    * responsibility.
+   *
+   * @throws java.lang.IllegalArgumentException
+   *   if `init()` was not called first, if called twice, or if items are still
+   *   pending in the queue
    */
   def complete(): Unit = {
     require(initialized, "init() must be called before complete()")
@@ -101,7 +114,12 @@ final class SmallMigrator[A, B, ID1, ID2](
     buf.result()
   }
 
-  /** Processes one batch. Returns count of migrated rows. */
+  /**
+   * Processes one batch. Returns count of migrated rows.
+   *
+   * @throws java.lang.IllegalArgumentException
+   *   if `init()` was not called first or after `complete()`
+   */
   def processBatch(): Int = {
     require(initialized, "init() must be called before processBatch()")
     require(!completed, "cannot processBatch() after complete(); create a new migrator")

--- a/dataMigration/shared/src/test/scala/zio/blocks/data/migration/MigratorTestStubs.scala
+++ b/dataMigration/shared/src/test/scala/zio/blocks/data/migration/MigratorTestStubs.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.data.migration
+
+import zio.blocks.schema.migration.Migration
+import zio.blocks.sql._
+
+/**
+ * Shared `SmallMigrator` test fixtures: one body-executing counting transactor
+ * plus the repos and migration stub every spec builds, so the stub cannot drift
+ * between the guard specs and the concurrency spec.
+ */
+object MigratorTestStubs {
+
+  /**
+   * Transactor stub that counts preparation transactions AND runs their bodies,
+   * so `init()` exercises its real path (`TargetStrategyApplier.prepare` plus
+   * the shadow-table swap bookkeeping) instead of skipping it.
+   *
+   * Honesty note: the body runs with a null connection. That is sound only for
+   * the `InPlace` strategy without capture triggers, whose preparation never
+   * touches the connection (pure name resolution). What this stub does NOT
+   * prove is database-level idempotence under real races: concurrent
+   * preparation against a live database rests on the idempotent trigger DDL
+   * (`CREATE TRIGGER IF NOT EXISTS` on SQLite, `CREATE OR REPLACE TRIGGER` on
+   * PostgreSQL — see `QueueTable.installTriggers` and `SmallMigrator.init`).
+   */
+  final class CountingTransactor extends Transactor {
+    val transactCalls                          = new java.util.concurrent.atomic.AtomicInteger(0)
+    override def connect[A](f: DbCon ?=> A): A = 0L.asInstanceOf[A]
+    override def transact[A](f: DbTx ?=> A): A = {
+      transactCalls.incrementAndGet()
+      given noConnection: DbTx = null.asInstanceOf[DbTx]
+      f
+    }
+    override def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A =
+      transact(f)
+  }
+
+  private val idColumns = IndexedSeq(ColumnMeta("id", DbValue.DbInt(0), nullable = false))
+  val v1Repo            =
+    Repo(Table[Int]("users_v1", DbCodec.intCodec, idColumns), "id", DbCodec.intCodec, identity)
+  val v2Repo =
+    Repo(Table[Int]("users_v2", DbCodec.intCodec, idColumns), "id", DbCodec.intCodec, identity)
+
+  // Never invoked against a real database: stubs either skip transaction bodies
+  // entirely or run only the connection-free `InPlace` preparation path.
+  val unusedMigration: Migration[Int, Int] = null.asInstanceOf[Migration[Int, Int]]
+
+  def newInPlaceMigrator(tx: Transactor)(using Dialect): SmallMigrator[Int, Int, Int, Int] =
+    SmallMigrator[Int, Int, Int, Int](
+      repoV1 = v1Repo,
+      repoV2 = v2Repo,
+      migration = unusedMigration,
+      queueTable = "q",
+      batchSize = 10,
+      target = TargetStrategy.InPlace
+    )(using tx, DbCodec.intCodec)
+}

--- a/dataMigration/shared/src/test/scala/zio/blocks/data/migration/SmallMigratorSpec.scala
+++ b/dataMigration/shared/src/test/scala/zio/blocks/data/migration/SmallMigratorSpec.scala
@@ -33,6 +33,21 @@ object SmallMigratorSpec extends ZIOSpecDefault {
     override def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A = 0.asInstanceOf[A]
   }
 
+  /**
+   * Transactor stub that counts preparation transactions without executing
+   * them: proves `init()` runs its transaction body at most once.
+   */
+  final class CountingTransactor extends Transactor {
+    val transactCalls                          = new java.util.concurrent.atomic.AtomicInteger(0)
+    override def connect[A](f: DbCon ?=> A): A = 0L.asInstanceOf[A]
+    override def transact[A](f: DbTx ?=> A): A = {
+      transactCalls.incrementAndGet()
+      0.asInstanceOf[A]
+    }
+    override def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A =
+      transact(f)
+  }
+
   private val idColumns = IndexedSeq(ColumnMeta("id", DbValue.DbInt(0), nullable = false))
   private val v1Repo    = Repo(Table[Int]("users_v1", DbCodec.intCodec, idColumns), "id", DbCodec.intCodec, identity)
   private val v2Repo    = Repo(Table[Int]("users_v2", DbCodec.intCodec, idColumns), "id", DbCodec.intCodec, identity)
@@ -90,6 +105,13 @@ object SmallMigratorSpec extends ZIOSpecDefault {
       m.init()
       m.complete()
       assertTrue(scala.util.Try(m.complete()).isFailure)
+    },
+    test("init() twice prepares the target only once") {
+      val tx = new CountingTransactor
+      val m  = newMigrator(tx)
+      m.init()
+      m.init()
+      assertTrue(tx.transactCalls.get() == 1)
     }
   )
 }

--- a/dataMigration/shared/src/test/scala/zio/blocks/data/migration/SmallMigratorSpec.scala
+++ b/dataMigration/shared/src/test/scala/zio/blocks/data/migration/SmallMigratorSpec.scala
@@ -17,8 +17,8 @@
 package zio.blocks.data.migration
 
 import zio.test.*
-import zio.blocks.schema.migration.Migration
 import zio.blocks.sql.*
+import MigratorTestStubs.newInPlaceMigrator
 
 object SmallMigratorSpec extends ZIOSpecDefault {
 
@@ -33,39 +33,10 @@ object SmallMigratorSpec extends ZIOSpecDefault {
     override def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A = 0.asInstanceOf[A]
   }
 
-  /**
-   * Transactor stub that counts preparation transactions without executing
-   * them: proves `init()` runs its transaction body at most once.
-   */
-  final class CountingTransactor extends Transactor {
-    val transactCalls                          = new java.util.concurrent.atomic.AtomicInteger(0)
-    override def connect[A](f: DbCon ?=> A): A = 0L.asInstanceOf[A]
-    override def transact[A](f: DbTx ?=> A): A = {
-      transactCalls.incrementAndGet()
-      0.asInstanceOf[A]
-    }
-    override def transact[A](isolation: TransactionIsolation, readOnly: Boolean)(f: DbTx ?=> A): A =
-      transact(f)
-  }
-
-  private val idColumns = IndexedSeq(ColumnMeta("id", DbValue.DbInt(0), nullable = false))
-  private val v1Repo    = Repo(Table[Int]("users_v1", DbCodec.intCodec, idColumns), "id", DbCodec.intCodec, identity)
-  private val v2Repo    = Repo(Table[Int]("users_v2", DbCodec.intCodec, idColumns), "id", DbCodec.intCodec, identity)
-
-  // Never invoked: StubTransactor skips transaction bodies entirely.
-  private val unusedMigration = null.asInstanceOf[Migration[Int, Int]]
-
   private given dialect: Dialect = Dialect.Postgres
 
   private def newMigrator(tx: Transactor): SmallMigrator[Int, Int, Int, Int] =
-    SmallMigrator[Int, Int, Int, Int](
-      repoV1 = v1Repo,
-      repoV2 = v2Repo,
-      migration = unusedMigration,
-      queueTable = "q",
-      batchSize = 10,
-      target = TargetStrategy.InPlace
-    )(using tx, DbCodec.intCodec)
+    newInPlaceMigrator(tx)
 
   def spec = suite("SmallMigrator")(
     test("processBatch() before init() fails") {
@@ -107,7 +78,7 @@ object SmallMigratorSpec extends ZIOSpecDefault {
       assertTrue(scala.util.Try(m.complete()).isFailure)
     },
     test("init() twice prepares the target only once") {
-      val tx = new CountingTransactor
+      val tx = new MigratorTestStubs.CountingTransactor
       val m  = newMigrator(tx)
       m.init()
       m.init()

--- a/markdown/shared/src/main/scala/zio/blocks/docs/Parser.scala
+++ b/markdown/shared/src/main/scala/zio/blocks/docs/Parser.scala
@@ -38,7 +38,8 @@ import zio.blocks.chunk.Chunk
  *   - HTML blocks and inline HTML
  *
  * ==Not Supported==
- *   - YAML frontmatter (causes parse error)
+ *   - YAML frontmatter in strict `parse` (causes parse error; use
+ *     `parseWithFrontmatter` to accept and read it instead)
  *   - Setext headings (use ATX style)
  *   - Indented code blocks (use fenced)
  *   - Link reference definitions
@@ -61,6 +62,60 @@ object Parser {
   def parse(input: String): Either[ParseError, Doc] = {
     val state = new ParserState(input)
     state.parseDocument()
+  }
+
+  /**
+   * Parses a markdown string that may carry YAML frontmatter.
+   *
+   * Frontmatter is a leading `---` fence with `key: value` lines and a closing
+   * `---` fence. The pairs are returned as a `Map` alongside the parsed [[Doc]]
+   * (which also carries them in its metadata). Inputs without frontmatter parse
+   * exactly like `parse`; strict `parse` is unchanged and still rejects
+   * frontmatter.
+   *
+   * @param input
+   *   The markdown string to parse
+   * @return
+   *   Either a [[ParseError]], or the frontmatter pairs with the parsed [[Doc]]
+   */
+  def parseWithFrontmatter(input: String): Either[ParseError, (Map[String, String], Doc)] = {
+    val (meta, rest) = stripFrontmatter(input)
+    parse(rest).map(doc => (meta, doc.copy(metadata = doc.metadata ++ meta)))
+  }
+
+  /**
+   * Splits leading YAML frontmatter off a markdown string.
+   *
+   * Returns the `key: value` pairs between the opening and closing `---` fences
+   * plus the remaining document. Inputs without a well-formed leading fence
+   * return an empty map and the input unchanged.
+   *
+   * @param input
+   *   The markdown string to strip
+   * @return
+   *   The frontmatter pairs and the remaining document
+   */
+  def stripFrontmatter(input: String): (Map[String, String], String) = {
+    val lines = input.split("\n", -1)
+    if (lines.nonEmpty && lines(0) == "---") {
+      var i        = 1
+      var foundEnd = false
+      while (i < lines.length && !foundEnd) {
+        if (lines(i) == "---") foundEnd = true
+        i += 1
+      }
+      if (foundEnd && i > 2) {
+        val meta = lines
+          .slice(1, i - 1)
+          .flatMap { line =>
+            val sep = line.indexOf(':')
+            if (sep > 0) Some(line.substring(0, sep).trim -> line.substring(sep + 1).trim)
+            else None
+          }
+          .toMap
+        (meta, lines.drop(i).mkString("\n"))
+      } else (Map.empty, input)
+    } else (Map.empty, input)
   }
 
   private class ParserState(input: String) {

--- a/markdown/shared/src/main/scala/zio/blocks/docs/Parser.scala
+++ b/markdown/shared/src/main/scala/zio/blocks/docs/Parser.scala
@@ -39,12 +39,34 @@ import zio.blocks.chunk.Chunk
  *
  * ==Not Supported==
  *   - YAML frontmatter in strict `parse` (causes parse error; use
- *     `parseWithFrontmatter` to accept and read it instead)
+ *     `parseWithFrontmatter` to accept and read it instead). Fence detection
+ *     tolerates CRLF: `---\r\n` fences are honored exactly like `---\n` ones.
  *   - Setext headings (use ATX style)
  *   - Indented code blocks (use fenced)
  *   - Link reference definitions
  */
 object Parser {
+
+  /**
+   * Fence comparison tolerant of a trailing carriage return, so CRLF documents
+   * detect frontmatter exactly like LF ones. Only the fence lines are folded:
+   * the body keeps its original newlines.
+   */
+  private def isFenceLine(line: String): Boolean =
+    line == "---" || line == "---\r"
+
+  /**
+   * Shared fence scan behind `stripFrontmatter` and the strict `parse` gate.
+   * Returns the line index just past the closing fence, or `None` when the
+   * input does not open with a well-formed `---` fence pair (unclosed fences
+   * and empty `---`/`---` pairs are not frontmatter, in both line endings).
+   */
+  private def frontmatterEnd(lines: Array[String]): Option[Int] =
+    if (lines.nonEmpty && isFenceLine(lines(0))) {
+      var i = 1
+      while (i < lines.length && !isFenceLine(lines(i))) i += 1
+      if (i < lines.length && i > 1) Some(i + 1) else None
+    } else None
 
   /**
    * Parses a markdown string into a Doc.
@@ -68,10 +90,10 @@ object Parser {
    * Parses a markdown string that may carry YAML frontmatter.
    *
    * Frontmatter is a leading `---` fence with `key: value` lines and a closing
-   * `---` fence. The pairs are returned as a `Map` alongside the parsed [[Doc]]
-   * (which also carries them in its metadata). Inputs without frontmatter parse
-   * exactly like `parse`; strict `parse` is unchanged and still rejects
-   * frontmatter.
+   * `---` fence, in LF or CRLF line endings. The pairs are returned as a `Map`
+   * alongside the parsed [[Doc]] (which also carries them in its metadata).
+   * Inputs without frontmatter parse exactly like `parse`; strict `parse` is
+   * unchanged and still rejects frontmatter.
    *
    * @param input
    *   The markdown string to parse
@@ -90,32 +112,29 @@ object Parser {
    * plus the remaining document. Inputs without a well-formed leading fence
    * return an empty map and the input unchanged.
    *
+   * Kept private so `parseWithFrontmatter` stays the single public entry:
+   * callers should not pre-strip (and re-join) around strict `parse`.
+   *
    * @param input
    *   The markdown string to strip
    * @return
    *   The frontmatter pairs and the remaining document
    */
-  def stripFrontmatter(input: String): (Map[String, String], String) = {
+  private def stripFrontmatter(input: String): (Map[String, String], String) = {
     val lines = input.split("\n", -1)
-    if (lines.nonEmpty && lines(0) == "---") {
-      var i        = 1
-      var foundEnd = false
-      while (i < lines.length && !foundEnd) {
-        if (lines(i) == "---") foundEnd = true
-        i += 1
-      }
-      if (foundEnd && i > 2) {
+    frontmatterEnd(lines) match {
+      case Some(end) =>
         val meta = lines
-          .slice(1, i - 1)
+          .slice(1, end - 1)
           .flatMap { line =>
             val sep = line.indexOf(':')
             if (sep > 0) Some(line.substring(0, sep).trim -> line.substring(sep + 1).trim)
             else None
           }
           .toMap
-        (meta, lines.drop(i).mkString("\n"))
-      } else (Map.empty, input)
-    } else (Map.empty, input)
+        (meta, lines.drop(end).mkString("\n"))
+      case None => (Map.empty, input)
+    }
   }
 
   private class ParserState(input: String) {
@@ -129,20 +148,9 @@ object Parser {
       } yield Doc(blocks)
 
     private def checkFrontmatter(): Either[ParseError, Unit] =
-      if (lines.nonEmpty && lines(0) == "---") {
-        var i        = 1
-        var foundEnd = false
-        while (i < lines.length && !foundEnd) {
-          if (lines(i) == "---") foundEnd = true
-          i += 1
-        }
-        if (foundEnd && i > 2) {
-          Left(ParseError("Frontmatter is not supported", 1, 1, lines(0)))
-        } else {
-          Right(())
-        }
-      } else {
-        Right(())
+      frontmatterEnd(lines) match {
+        case Some(_) => Left(ParseError("Frontmatter is not supported", 1, 1, lines(0)))
+        case None    => Right(())
       }
 
     private def parseBlocks(): Either[ParseError, Chunk[Block]] = {

--- a/markdown/shared/src/test/scala/zio/blocks/docs/ParserFrontmatterSpec.scala
+++ b/markdown/shared/src/test/scala/zio/blocks/docs/ParserFrontmatterSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.docs
+
+import zio.blocks.chunk.Chunk
+import zio.test._
+
+object ParserFrontmatterSpec extends MarkdownBaseSpec {
+  def spec = suite("ParserFrontmatter")(
+    test("parseWithFrontmatter reads pairs and the document") {
+      val input  = "---\ntitle: test\nauthor: me\n---\n# Hello"
+      val result = Parser.parseWithFrontmatter(input)
+      assertTrue(
+        result.isRight,
+        result.toOption.get._1 == Map("title" -> "test", "author" -> "me"),
+        result.toOption.get._2 == Doc(
+          Chunk(Heading(HeadingLevel.H1, Chunk(Text("Hello")))),
+          Map("title" -> "test", "author" -> "me")
+        )
+      )
+    },
+    test("parseWithFrontmatter without frontmatter behaves like parse") {
+      val input = "# Hello"
+      assertTrue(
+        Parser.parseWithFrontmatter(input) == Parser.parse(input).map(doc => (Map.empty[String, String], doc))
+      )
+    },
+    test("parseWithFrontmatter leaves unclosed fences to strict parsing") {
+      val (meta, _) = Parser.stripFrontmatter("---\ntitle: test")
+      val result    = Parser.parseWithFrontmatter("---\ntitle: test")
+      assertTrue(meta.isEmpty, result.isRight)
+    },
+    test("parseWithFrontmatter reports body errors after frontmatter") {
+      val result = Parser.parseWithFrontmatter("---\ntitle: test\n---\n####### Too deep")
+      assertTrue(result.isLeft)
+    },
+    test("parseWithFrontmatter skips non-pair lines inside fences") {
+      val input  = "---\n# a comment\ntitle: test\n---\n# Hello"
+      val result = Parser.parseWithFrontmatter(input)
+      assertTrue(
+        result.isRight,
+        result.toOption.get._1 == Map("title" -> "test"),
+        result.toOption.get._2.blocks.length == 1
+      )
+    },
+    test("empty fences are not frontmatter") {
+      val (meta, rest) = Parser.stripFrontmatter("---\n---\n# Hello")
+      assertTrue(meta.isEmpty, rest == "---\n---\n# Hello")
+    },
+    test("strict parse still rejects frontmatter") {
+      val result = Parser.parse("---\ntitle: test\n---\n# Hello")
+      assertTrue(result.isLeft)
+    },
+    test("stripFrontmatter splits pairs from the body") {
+      val (meta, rest) = Parser.stripFrontmatter("---\ntitle: test\n---\n# Hello")
+      assertTrue(meta == Map("title" -> "test"), rest == "# Hello")
+    },
+    test("stripFrontmatter keeps inputs without fences unchanged") {
+      val (meta, rest) = Parser.stripFrontmatter("# Hello")
+      assertTrue(meta.isEmpty, rest == "# Hello")
+    }
+  )
+}

--- a/markdown/shared/src/test/scala/zio/blocks/docs/ParserFrontmatterSpec.scala
+++ b/markdown/shared/src/test/scala/zio/blocks/docs/ParserFrontmatterSpec.scala
@@ -40,9 +40,8 @@ object ParserFrontmatterSpec extends MarkdownBaseSpec {
       )
     },
     test("parseWithFrontmatter leaves unclosed fences to strict parsing") {
-      val (meta, _) = Parser.stripFrontmatter("---\ntitle: test")
-      val result    = Parser.parseWithFrontmatter("---\ntitle: test")
-      assertTrue(meta.isEmpty, result.isRight)
+      val result = Parser.parseWithFrontmatter("---\ntitle: test")
+      assertTrue(result.isRight, result.toOption.get._1.isEmpty)
     },
     test("parseWithFrontmatter reports body errors after frontmatter") {
       val result = Parser.parseWithFrontmatter("---\ntitle: test\n---\n####### Too deep")
@@ -58,20 +57,45 @@ object ParserFrontmatterSpec extends MarkdownBaseSpec {
       )
     },
     test("empty fences are not frontmatter") {
-      val (meta, rest) = Parser.stripFrontmatter("---\n---\n# Hello")
-      assertTrue(meta.isEmpty, rest == "---\n---\n# Hello")
+      val result = Parser.parseWithFrontmatter("---\n---\n# Hello")
+      assertTrue(result.isRight, result.toOption.get._1.isEmpty)
     },
     test("strict parse still rejects frontmatter") {
       val result = Parser.parse("---\ntitle: test\n---\n# Hello")
       assertTrue(result.isLeft)
     },
-    test("stripFrontmatter splits pairs from the body") {
-      val (meta, rest) = Parser.stripFrontmatter("---\ntitle: test\n---\n# Hello")
-      assertTrue(meta == Map("title" -> "test"), rest == "# Hello")
+    test("parseWithFrontmatter returns pairs with the document") {
+      val result = Parser.parseWithFrontmatter("---\ntitle: test\n---\n# Hello")
+      assertTrue(
+        result.isRight,
+        result.toOption.get._1 == Map("title" -> "test"),
+        result.toOption.get._2.blocks == Chunk(Heading(HeadingLevel.H1, Chunk(Text("Hello"))))
+      )
     },
-    test("stripFrontmatter keeps inputs without fences unchanged") {
-      val (meta, rest) = Parser.stripFrontmatter("# Hello")
-      assertTrue(meta.isEmpty, rest == "# Hello")
+    test("parseWithFrontmatter keeps inputs without fences unchanged") {
+      val result = Parser.parseWithFrontmatter("# Hello")
+      assertTrue(
+        result.isRight,
+        result.toOption.get._1.isEmpty,
+        result.toOption.get._2.blocks.length == 1
+      )
+    },
+    test("parseWithFrontmatter accepts CRLF fences") {
+      val input  = "---\r\ntitle: test\r\nauthor: me\r\n---\r\n# Hello"
+      val result = Parser.parseWithFrontmatter(input)
+      assertTrue(
+        result.isRight,
+        result.toOption.get._1 == Map("title" -> "test", "author" -> "me"),
+        result.toOption.get._2.blocks.length == 1
+      )
+    },
+    test("strict parse rejects CRLF frontmatter") {
+      val result = Parser.parse("---\r\ntitle: test\r\n---\r\n# Hello")
+      assertTrue(result.isLeft)
+    },
+    test("parseWithFrontmatter leaves CRLF unclosed fences to strict parsing") {
+      val result = Parser.parseWithFrontmatter("---\r\ntitle: test")
+      assertTrue(result.isRight, result.toOption.get._1.isEmpty)
     }
   )
 }

--- a/maybe/shared/src/main/scala-2/zio/blocks/maybe/Maybe.scala
+++ b/maybe/shared/src/main/scala-2/zio/blocks/maybe/Maybe.scala
@@ -232,5 +232,5 @@ object Maybe {
    * into Maybe.
    */
   private[blocks] def unsafeWrap[A](x: Any): Maybe[A] =
-    if (x == null) MaybeValue.Absent else MaybeValue.Present(x.asInstanceOf[A])
+    if (x.asInstanceOf[AnyRef] eq null) MaybeValue.Absent else MaybeValue.Present(x.asInstanceOf[A])
 }

--- a/maybe/shared/src/main/scala-3/zio/blocks/maybe/Maybe.scala
+++ b/maybe/shared/src/main/scala-3/zio/blocks/maybe/Maybe.scala
@@ -147,7 +147,7 @@ object Maybe {
    * into Maybe. null becomes the Absent singleton.
    */
   private[blocks] def unsafeWrap[A](x: Any): Maybe[A] =
-    if (x == null) zio.blocks.maybe.Absent.asInstanceOf[Maybe[A]] else x.asInstanceOf[Maybe[A]]
+    if (x.asInstanceOf[AnyRef] eq null) zio.blocks.maybe.Absent.asInstanceOf[Maybe[A]] else x.asInstanceOf[Maybe[A]]
 
   extension [A](self: Maybe[A]) {
     inline def isAbsent: Boolean  = self.asInstanceOf[AnyRef] eq zio.blocks.maybe.Absent

--- a/maybe/shared/src/test/scala/zio/blocks/maybe/MaybeLawsSpec.scala
+++ b/maybe/shared/src/test/scala/zio/blocks/maybe/MaybeLawsSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.maybe
+
+import zio.test._
+
+object MaybeLawsSpec extends ZIOSpecDefault {
+  def spec = suite("MaybeLaws")(
+    test("present(absent) is present, not absent") {
+      val nested: Maybe[Maybe[String]] = Maybe.present(Maybe.absent[String])
+      assertTrue(nested.isPresent, !nested.isAbsent)
+    },
+    test("present of a Present unwraps to the original through unsafeGet") {
+      val inner: Maybe[Maybe[String]]        = Maybe.present(Maybe.absent[String])
+      val outer: Maybe[Maybe[Maybe[String]]] = Maybe.present(inner)
+      assertTrue(outer.isPresent, Maybe.unsafeGet(outer) == inner)
+    },
+    test("unsafeGet(absent) is null") {
+      assertTrue(Maybe.unsafeGet(Maybe.absent[String]) == null)
+    },
+    test("unsafeWrap maps null to absent and values to present") {
+      val absent: Maybe[String]  = Maybe.unsafeWrap[String](null)
+      val present: Maybe[String] = Maybe.unsafeWrap[String]("x")
+      assertTrue(absent.isAbsent, present.isPresent, Maybe.unsafeGet(present) == "x")
+    },
+    test("unsafeIsAbsent distinguishes absent from present") {
+      assertTrue(
+        Maybe.unsafeIsAbsent(Maybe.absent),
+        !Maybe.unsafeIsAbsent(Maybe.present("x")),
+        !Maybe.unsafeIsAbsent(Maybe.present(Maybe.absent[String]))
+      )
+    },
+    test("Present hashCode is consistent for null and values") {
+      val nullA: Maybe[String]  = Maybe.present(null.asInstanceOf[String])
+      val nullB: Maybe[String]  = Maybe.present(null.asInstanceOf[String])
+      val valueA: Maybe[String] = Maybe.present("x")
+      val valueB: Maybe[String] = Maybe.present("x")
+      assertTrue(nullA.hashCode == nullB.hashCode, valueA.hashCode == valueB.hashCode)
+    },
+    test("withFilter combinators respect the predicate") {
+      val value: Maybe[Int] = Maybe.present(2)
+      var seen              = 0
+      value.withFilter(_ > 1).foreach(x => seen = x)
+      assertTrue(
+        value.withFilter(_ > 1).map(_ * 10) == Maybe.present(20),
+        value.withFilter(_ > 5).map(_ * 10).isAbsent,
+        value.withFilter(_ > 1).flatMap(x => Maybe.present(x + 1)) == Maybe.present(3),
+        seen == 2
+      )
+    }
+  )
+}

--- a/mediatype/shared/src/main/scala/zio/blocks/mediatype/MediaType.scala
+++ b/mediatype/shared/src/main/scala/zio/blocks/mediatype/MediaType.scala
@@ -63,6 +63,14 @@ object MediaType {
     if (normalized.isEmpty) None else extensionMap.get(normalized)
   }
 
+  /**
+   * Parses a media type string such as `text/html; charset=utf-8`.
+   *
+   * Parameter values may be single-quoted (`charset="utf-8"` parses to
+   * `utf-8`); one surrounding quote layer is stripped. Limitation: a `;` inside
+   * a quoted value still splits parameters, so quoted values must not contain
+   * `;`. Unknown types keep their original case.
+   */
   def parse(s: String): Either[String, MediaType] = {
     if (s.isEmpty) return Left("Invalid media type: cannot be empty")
 
@@ -98,8 +106,16 @@ object MediaType {
       .filter(_.nonEmpty)
       .flatMap { param =>
         param.split("=", 2) match {
-          case Array(key, value) => Some(key.trim.toLowerCase -> value.trim)
-          case _                 => None
+          // Strip one layer of surrounding quotes: charset="utf-8" -> utf-8.
+          // A ';' inside quotes still splits (documented limitation of parse).
+          case Array(key, value) =>
+            val trimmed  = value.trim
+            val unquoted =
+              if (trimmed.length >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\""))
+                trimmed.substring(1, trimmed.length - 1)
+              else trimmed
+            Some(key.trim.toLowerCase -> unquoted)
+          case _ => None
         }
       }
       .toMap

--- a/mediatype/shared/src/main/scala/zio/blocks/mediatype/MediaType.scala
+++ b/mediatype/shared/src/main/scala/zio/blocks/mediatype/MediaType.scala
@@ -66,10 +66,11 @@ object MediaType {
   /**
    * Parses a media type string such as `text/html; charset=utf-8`.
    *
-   * Parameter values may be single-quoted (`charset="utf-8"` parses to
-   * `utf-8`); one surrounding quote layer is stripped. Limitation: a `;` inside
-   * a quoted value still splits parameters, so quoted values must not contain
-   * `;`. Unknown types keep their original case.
+   * Parameter values may be double- or single-quoted (`charset="utf-8"` and
+   * `charset='utf-8'` both parse to `utf-8`); one surrounding quote layer is
+   * stripped. Limitation: a `;` inside a quoted value still splits parameters,
+   * so quoted values must not contain `;`. Unknown types keep their original
+   * case.
    */
   def parse(s: String): Either[String, MediaType] = {
     if (s.isEmpty) return Left("Invalid media type: cannot be empty")
@@ -106,20 +107,25 @@ object MediaType {
       .filter(_.nonEmpty)
       .flatMap { param =>
         param.split("=", 2) match {
-          // Strip one layer of surrounding quotes: charset="utf-8" -> utf-8.
+          // Strip one layer of surrounding quotes, double or single:
+          // charset="utf-8" -> utf-8, charset='utf-8' -> utf-8.
           // A ';' inside quotes still splits (documented limitation of parse).
           case Array(key, value) =>
-            val trimmed  = value.trim
-            val unquoted =
-              if (trimmed.length >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\""))
-                trimmed.substring(1, trimmed.length - 1)
-              else trimmed
-            Some(key.trim.toLowerCase -> unquoted)
+            Some(key.trim.toLowerCase -> stripQuoteLayer(value.trim))
           case _ => None
         }
       }
       .toMap
   }
+
+  private[this] def stripQuoteLayer(value: String): String =
+    if (
+      value.length >= 2 && (
+        (value.startsWith("\"") && value.endsWith("\"")) ||
+          (value.startsWith("'") && value.endsWith("'"))
+      )
+    ) value.substring(1, value.length - 1)
+    else value
 
   def unsafeFromString(s: String): MediaType =
     parse(s) match {

--- a/mediatype/shared/src/test/scala/zio/blocks/mediatype/MediaTypeParseSpec.scala
+++ b/mediatype/shared/src/test/scala/zio/blocks/mediatype/MediaTypeParseSpec.scala
@@ -104,6 +104,47 @@ object MediaTypeParseSpec extends MediaTypeBaseSpec {
         val result = scala.util.Try(MediaType.unsafeFromString("invalid"))
         assertTrue(result.isFailure)
       }
+    ),
+    suite("quoted parameters")(
+      test("strips one quote layer from parameter values") {
+        val result = MediaType.parse("text/html; charset=\"utf-8\"")
+        assertTrue(
+          result.isRight,
+          result.toOption.get.parameters == Map("charset" -> "utf-8")
+        )
+      },
+      test("strips quotes while keeping other parameters intact") {
+        val result = MediaType.parse("text/html; charset=\"utf-8\"; level=1")
+        assertTrue(
+          result.isRight,
+          result.toOption.get.parameters == Map("charset" -> "utf-8", "level" -> "1")
+        )
+      },
+      test("keeps unbalanced quotes as is") {
+        val result = MediaType.parse("text/html; title=\"abc")
+        assertTrue(
+          result.isRight,
+          result.toOption.get.parameters == Map("title" -> "\"abc")
+        )
+      },
+      test("documents the semicolon-in-quotes limitation") {
+        // Quoted values must not contain ';': it still splits parameters, and
+        // the fragment without '=' is dropped.
+        val result = MediaType.parse("text/html; title=\"a;b\"")
+        assertTrue(
+          result.isRight,
+          result.toOption.get.parameters == Map("title" -> "\"a")
+        )
+      },
+      test("unknown types keep their original case with unquoted params") {
+        val result = MediaType.parse("Custom/Unknown; note=\"x\"")
+        assertTrue(
+          result.isRight,
+          result.toOption.get.mainType == "Custom",
+          result.toOption.get.subType == "Unknown",
+          result.toOption.get.parameters == Map("note" -> "x")
+        )
+      }
     )
   )
 }

--- a/mediatype/shared/src/test/scala/zio/blocks/mediatype/MediaTypeParseSpec.scala
+++ b/mediatype/shared/src/test/scala/zio/blocks/mediatype/MediaTypeParseSpec.scala
@@ -127,6 +127,20 @@ object MediaTypeParseSpec extends MediaTypeBaseSpec {
           result.toOption.get.parameters == Map("title" -> "\"abc")
         )
       },
+      test("strips single quotes symmetrically with double quotes") {
+        val result = MediaType.parse("text/html; charset='utf-8'")
+        assertTrue(
+          result.isRight,
+          result.toOption.get.parameters == Map("charset" -> "utf-8")
+        )
+      },
+      test("keeps unbalanced single quotes as is") {
+        val result = MediaType.parse("text/html; title='abc")
+        assertTrue(
+          result.isRight,
+          result.toOption.get.parameters == Map("title" -> "'abc")
+        )
+      },
       test("documents the semicolon-in-quotes limitation") {
         // Quoted values must not contain ';': it still splits parameters, and
         // the fragment without '=' is dropped.

--- a/openapi/shared/src/main/scala/zio/blocks/openapi/OpenAPIGen.scala
+++ b/openapi/shared/src/main/scala/zio/blocks/openapi/OpenAPIGen.scala
@@ -20,6 +20,17 @@ import zio.blocks.schema.Schema
 
 object OpenAPIGen {
 
+  /**
+   * Builds the OpenAPI schema for `A` as a symbolic reference plus its
+   * component definitions.
+   *
+   * ==Refs in / refs out==
+   *   - References are preserved symbolically: the returned schema is always a
+   *     `ReferenceOr.Ref` pointing at `#/components/schemas/<name>`, and the
+   *     definitions map holds the inline `SchemaObject`. No resolution or
+   *     dereferencing pass runs here; resolving refs against a document is
+   *     downstream work (see `resolveRefs`).
+   */
   def schema[A](implicit s: Schema[A]): (ReferenceOr[SchemaObject], Map[String, SchemaObject]) = {
     val name = s.reflect.typeId.name
     val obj  = s.toOpenAPISchema
@@ -29,4 +40,21 @@ object OpenAPIGen {
 
   def schemas(ss: Schema[_]*): Map[String, SchemaObject] =
     ss.map(s => s.reflect.typeId.name -> SchemaObject.fromJsonSchema(s.toJsonSchema)).toMap
+
+  /**
+   * Resolves the local `#/components/schemas/...` references of a document
+   * against the given component definitions.
+   *
+   * Currently a documented extension point: reference resolution lives
+   * downstream, so this stub throws instead of silently returning a partially
+   * resolved document. References produced by `schema`/`schemas` round-trip
+   * unchanged until resolution is implemented.
+   *
+   * @throws java.lang.UnsupportedOperationException
+   *   always (resolution is not implemented yet)
+   */
+  def resolveRefs(document: OpenAPI, schemas: Map[String, SchemaObject]): OpenAPI =
+    throw new UnsupportedOperationException(
+      "OpenAPIGen.resolveRefs is not implemented: references stay symbolic; resolve them downstream"
+    )
 }

--- a/openapi/shared/src/main/scala/zio/blocks/openapi/OpenAPIGen.scala
+++ b/openapi/shared/src/main/scala/zio/blocks/openapi/OpenAPIGen.scala
@@ -29,7 +29,7 @@ object OpenAPIGen {
    *     `ReferenceOr.Ref` pointing at `#/components/schemas/<name>`, and the
    *     definitions map holds the inline `SchemaObject`. No resolution or
    *     dereferencing pass runs here; resolving refs against a document is
-   *     downstream work (see `resolveRefs`).
+   *     downstream work outside this entry point.
    */
   def schema[A](implicit s: Schema[A]): (ReferenceOr[SchemaObject], Map[String, SchemaObject]) = {
     val name = s.reflect.typeId.name
@@ -40,21 +40,4 @@ object OpenAPIGen {
 
   def schemas(ss: Schema[_]*): Map[String, SchemaObject] =
     ss.map(s => s.reflect.typeId.name -> SchemaObject.fromJsonSchema(s.toJsonSchema)).toMap
-
-  /**
-   * Resolves the local `#/components/schemas/...` references of a document
-   * against the given component definitions.
-   *
-   * Currently a documented extension point: reference resolution lives
-   * downstream, so this stub throws instead of silently returning a partially
-   * resolved document. References produced by `schema`/`schemas` round-trip
-   * unchanged until resolution is implemented.
-   *
-   * @throws java.lang.UnsupportedOperationException
-   *   always (resolution is not implemented yet)
-   */
-  def resolveRefs(document: OpenAPI, schemas: Map[String, SchemaObject]): OpenAPI =
-    throw new UnsupportedOperationException(
-      "OpenAPIGen.resolveRefs is not implemented: references stay symbolic; resolve them downstream"
-    )
 }

--- a/openapi/shared/src/test/scala/zio/blocks/openapi/ReferenceSpec.scala
+++ b/openapi/shared/src/test/scala/zio/blocks/openapi/ReferenceSpec.scala
@@ -205,6 +205,35 @@ object ReferenceSpec extends SchemaBaseSpec {
         }
         assertTrue(refIsRef, valueIsValue)
       }
+    ),
+    suite("OpenAPIGen symbolic refs")(
+      test("schema returns a symbolic ref plus matching definitions") {
+        case class Widget(name: String)
+        object Widget {
+          implicit val schema: Schema[Widget] = Schema.derived
+        }
+
+        val (ref, defs) = OpenAPIGen.schema[Widget]
+        ref match {
+          case ReferenceOr.Ref(reference) =>
+            assertTrue(
+              reference.`$ref` == "#/components/schemas/Widget",
+              defs.contains("Widget")
+            )
+          case _ => assertTrue(false)
+        }
+      },
+      test("resolveRefs marks the downstream-resolution boundary") {
+        case class Widget(name: String)
+        object Widget {
+          implicit val schema: Schema[Widget] = Schema.derived
+        }
+
+        val (_, defs) = OpenAPIGen.schema[Widget]
+        val api       = OpenAPI(openapi = "3.1.0", info = Info(title = "t", version = "1"))
+        val thrown    = scala.util.Try(OpenAPIGen.resolveRefs(api, defs)).failed.toOption
+        assertTrue(thrown.exists(_.isInstanceOf[UnsupportedOperationException]))
+      }
     )
   )
 }

--- a/openapi/shared/src/test/scala/zio/blocks/openapi/ReferenceSpec.scala
+++ b/openapi/shared/src/test/scala/zio/blocks/openapi/ReferenceSpec.scala
@@ -222,17 +222,6 @@ object ReferenceSpec extends SchemaBaseSpec {
             )
           case _ => assertTrue(false)
         }
-      },
-      test("resolveRefs marks the downstream-resolution boundary") {
-        case class Widget(name: String)
-        object Widget {
-          implicit val schema: Schema[Widget] = Schema.derived
-        }
-
-        val (_, defs) = OpenAPIGen.schema[Widget]
-        val api       = OpenAPI(openapi = "3.1.0", info = Info(title = "t", version = "1"))
-        val thrown    = scala.util.Try(OpenAPIGen.resolveRefs(api, defs)).failed.toOption
-        assertTrue(thrown.exists(_.isInstanceOf[UnsupportedOperationException]))
       }
     )
   )

--- a/schema-csv/src/main/scala/zio/blocks/schema/csv/CsvConfig.scala
+++ b/schema-csv/src/main/scala/zio/blocks/schema/csv/CsvConfig.scala
@@ -19,6 +19,15 @@ package zio.blocks.schema.csv
 /**
  * Configuration for CSV parsing and generation.
  *
+ * ==Unquoted whitespace policy==
+ *   - Unquoted fields preserve leading and trailing spaces exactly as written
+ *     (RFC 4180: spaces are part of the field, no trimming is performed). For
+ *     example the row `{{{"  a  ",b}}}` parses to the fields `"  a  "` and
+ *     `"b"`.
+ *   - Quoted fields preserve their exact content, including spaces, delimiters
+ *     and embedded newlines; a quote character inside a quoted field is written
+ *     doubled per RFC 4180.
+ *
  * @param delimiter
  *   The character used to separate fields (default: ',')
  * @param quoteChar

--- a/schema-csv/src/main/scala/zio/blocks/schema/csv/CsvReader.scala
+++ b/schema-csv/src/main/scala/zio/blocks/schema/csv/CsvReader.scala
@@ -46,12 +46,21 @@ object CsvReader {
    *   the character position to start parsing from
    * @param config
    *   the CSV configuration controlling delimiter and quoting
+   * @param initialRow
+   *   the 1-based number of the row starting at `offset` (used for absolute
+   *   error positions when parsing a document piece by piece; defaults to 1,
+   *   i.e. positions relative to `offset`)
    * @return
    *   `Right((fields, newOffset))` on success where `fields` contains the
    *   parsed field values and `newOffset` is the position after the consumed
    *   row, or `Left(CsvError.ParseError(...))` on malformed input
    */
-  def readRow(input: String, offset: Int, config: CsvConfig): Either[CsvError, (IndexedSeq[String], Int)] = {
+  def readRow(
+    input: String,
+    offset: Int,
+    config: CsvConfig,
+    initialRow: Int = 1
+  ): Either[CsvError, (IndexedSeq[String], Int)] = {
     val len       = input.length
     val delimiter = config.delimiter
     val quoteChar = config.quoteChar
@@ -62,7 +71,7 @@ object CsvReader {
     val sb     = new java.lang.StringBuilder
     var state  = FieldStart
     var pos    = offset
-    var row    = 1
+    var row    = initialRow
     var col    = 1
     var done   = false
 
@@ -103,11 +112,15 @@ object CsvReader {
               sb.setLength(0)
               pos += 1
               if (pos < len && input.charAt(pos) == '\n') pos += 1
+              row += 1
+              col = 1
               done = true
             } else if (c == '\n') {
               fields += sb.toString
               sb.setLength(0)
               pos += 1
+              row += 1
+              col = 1
               done = true
             } else {
               sb.append(c)
@@ -128,11 +141,15 @@ object CsvReader {
               sb.setLength(0)
               pos += 1
               if (pos < len && input.charAt(pos) == '\n') pos += 1
+              row += 1
+              col = 1
               done = true
             } else if (c == '\n') {
               fields += sb.toString
               sb.setLength(0)
               pos += 1
+              row += 1
+              col = 1
               done = true
             } else {
               sb.append(c)
@@ -182,11 +199,15 @@ object CsvReader {
               sb.setLength(0)
               pos += 1
               if (pos < len && input.charAt(pos) == '\n') pos += 1
+              row += 1
+              col = 1
               done = true
             } else if (c == '\n') {
               fields += sb.toString
               sb.setLength(0)
               pos += 1
+              row += 1
+              col = 1
               done = true
             } else {
               return Left(CsvError.ParseError(s"Unexpected character '${c}' after closing quote", row, col))
@@ -233,10 +254,12 @@ object CsvReader {
     }
 
     var offset                     = 0
+    var currentRow                 = 1
     val header: IndexedSeq[String] = if (config.hasHeader) {
-      readRow(input, offset, config) match {
+      readRow(input, offset, config, currentRow) match {
         case Left(err)               => return Left(err)
         case Right((fields, newOff)) =>
+          currentRow += countLineBreaks(input, offset, newOff)
           offset = newOff
           fields
       }
@@ -246,7 +269,7 @@ object CsvReader {
 
     val rows = Vector.newBuilder[IndexedSeq[String]]
     while (offset < input.length) {
-      readRow(input, offset, config) match {
+      readRow(input, offset, config, currentRow) match {
         case Left(err)               => return Left(err)
         case Right((fields, newOff)) =>
           // Skip trailing empty rows (e.g. trailing newline producing empty row)
@@ -255,6 +278,7 @@ object CsvReader {
             if (fields.length > 1 || (fields.length == 1 && fields(0).nonEmpty) || newOff < input.length) {
               rows += fields
             }
+            currentRow += countLineBreaks(input, offset, newOff)
             offset = newOff
           } else {
             // Safety: no progress made, break to avoid infinite loop
@@ -264,5 +288,25 @@ object CsvReader {
     }
 
     Right((header, rows.result()))
+  }
+
+  /**
+   * Counts physical line breaks (`\n`, `\r`, `\r\n` each count once) in `input`
+   * over the half-open range `[from, until)`.
+   */
+  private def countLineBreaks(input: String, from: Int, until: Int): Int = {
+    var count = 0
+    var idx   = from
+    while (idx < until) {
+      val c = input.charAt(idx)
+      if (c == '\r') {
+        count += 1
+        if (idx + 1 < until && input.charAt(idx + 1) == '\n') idx += 1
+      } else if (c == '\n') {
+        count += 1
+      }
+      idx += 1
+    }
+    count
   }
 }

--- a/schema-csv/src/main/scala/zio/blocks/schema/csv/CsvReader.scala
+++ b/schema-csv/src/main/scala/zio/blocks/schema/csv/CsvReader.scala
@@ -40,16 +40,17 @@ object CsvReader {
   /**
    * Parses a single CSV row starting at the given offset.
    *
+   * Error positions are reported relative to `offset` (the row starting at
+   * `offset` counts as row 1). `readAll` threads absolute document rows through
+   * the package-private overload below instead, so callers never need to
+   * pre-scan the input for line breaks.
+   *
    * @param input
    *   the full CSV input string
    * @param offset
    *   the character position to start parsing from
    * @param config
    *   the CSV configuration controlling delimiter and quoting
-   * @param initialRow
-   *   the 1-based number of the row starting at `offset` (used for absolute
-   *   error positions when parsing a document piece by piece; defaults to 1,
-   *   i.e. positions relative to `offset`)
    * @return
    *   `Right((fields, newOffset))` on success where `fields` contains the
    *   parsed field values and `newOffset` is the position after the consumed
@@ -58,8 +59,23 @@ object CsvReader {
   def readRow(
     input: String,
     offset: Int,
+    config: CsvConfig
+  ): Either[CsvError, (IndexedSeq[String], Int)] =
+    readRow(input, offset, config, 1)
+
+  /**
+   * Package-private `readRow` overload carrying the 1-based number of the row
+   * starting at `offset`, for absolute error positions when `readAll` parses a
+   * document piece by piece.
+   *
+   * @param initialRow
+   *   the 1-based number of the row starting at `offset`
+   */
+  private[csv] def readRow(
+    input: String,
+    offset: Int,
     config: CsvConfig,
-    initialRow: Int = 1
+    initialRow: Int
   ): Either[CsvError, (IndexedSeq[String], Int)] = {
     val len       = input.length
     val delimiter = config.delimiter
@@ -112,14 +128,12 @@ object CsvReader {
               sb.setLength(0)
               pos += 1
               if (pos < len && input.charAt(pos) == '\n') pos += 1
-              row += 1
               col = 1
               done = true
             } else if (c == '\n') {
               fields += sb.toString
               sb.setLength(0)
               pos += 1
-              row += 1
               col = 1
               done = true
             } else {
@@ -141,14 +155,12 @@ object CsvReader {
               sb.setLength(0)
               pos += 1
               if (pos < len && input.charAt(pos) == '\n') pos += 1
-              row += 1
               col = 1
               done = true
             } else if (c == '\n') {
               fields += sb.toString
               sb.setLength(0)
               pos += 1
-              row += 1
               col = 1
               done = true
             } else {
@@ -199,14 +211,12 @@ object CsvReader {
               sb.setLength(0)
               pos += 1
               if (pos < len && input.charAt(pos) == '\n') pos += 1
-              row += 1
               col = 1
               done = true
             } else if (c == '\n') {
               fields += sb.toString
               sb.setLength(0)
               pos += 1
-              row += 1
               col = 1
               done = true
             } else {

--- a/schema-csv/src/test/scala/zio/blocks/schema/csv/CsvErrorPositionSpec.scala
+++ b/schema-csv/src/test/scala/zio/blocks/schema/csv/CsvErrorPositionSpec.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.csv
+
+import zio.blocks.schema.SchemaBaseSpec
+import zio.test._
+
+object CsvErrorPositionSpec extends SchemaBaseSpec {
+  def spec = suite("CsvErrorPositionSpec")(
+    suite("multi-line error positions")(
+      test("readAll reports the document row for an unclosed quote (CRLF)") {
+        val input  = "a,b\r\nc,d\r\n\"unclosed,e"
+        val result = CsvReader.readAll(input, CsvConfig.default)
+        result match {
+          case Left(CsvError.ParseError(_, row, column)) => assertTrue(row == 3, column == 12)
+          case _                                         => assertTrue(false)
+        }
+      },
+      test("readAll reports the document row for an unclosed quote (LF)") {
+        val input  = "a,b\nc,d\n\"unclosed,e"
+        val result = CsvReader.readAll(input, CsvConfig.default)
+        result match {
+          case Left(CsvError.ParseError(_, row, column)) => assertTrue(row == 3, column == 12)
+          case _                                         => assertTrue(false)
+        }
+      },
+      test("readAll reports the document row for garbage after a closing quote") {
+        val input  = "h1,h2\r\nok,ok\r\n\"a\"x,b\r\n"
+        val result = CsvReader.readAll(input, CsvConfig.default)
+        result match {
+          case Left(CsvError.ParseError(_, row, column)) => assertTrue(row == 3, column == 4)
+          case _                                         => assertTrue(false)
+        }
+      },
+      test("embedded newlines advance the row within a single readRow") {
+        val result = CsvReader.readRow("\"a\nb\"x,c", 0, CsvConfig.default, initialRow = 2)
+        result match {
+          case Left(CsvError.ParseError(_, row, column)) => assertTrue(row == 3, column == 3)
+          case _                                         => assertTrue(false)
+        }
+      },
+      test("readRow without initialRow reports positions relative to the offset") {
+        val result = CsvReader.readRow("\"unclosed", 0, CsvConfig.default)
+        result match {
+          case Left(CsvError.ParseError(_, row, _)) => assertTrue(row == 1)
+          case _                                    => assertTrue(false)
+        }
+      }
+    ),
+    suite("unquoted whitespace policy")(
+      test("unquoted fields keep surrounding spaces") {
+        val result = CsvReader.readRow("  a  ,b\r\n", 0, CsvConfig.default)
+        assertTrue(result == Right((Vector("  a  ", "b"), 9)))
+      },
+      test("quoted fields keep their exact content") {
+        val result = CsvReader.readRow("\"  a  \",b\r\n", 0, CsvConfig.default)
+        assertTrue(result == Right((Vector("  a  ", "b"), 11)))
+      }
+    )
+  )
+}

--- a/schema-xml/shared/src/main/scala/zio/blocks/schema/xml/ReaderConfig.scala
+++ b/schema-xml/shared/src/main/scala/zio/blocks/schema/xml/ReaderConfig.scala
@@ -19,6 +19,11 @@ package zio.blocks.schema.xml
 /**
  * Configuration for XML reader behavior and limits.
  *
+ * Entity handling needs no separate expansion cap: the reader only recognizes
+ * the five predefined entities plus numeric character references (see
+ * `XmlReader`), rejects every other entity, and never touches DTDs or external
+ * entities, so exponential entity expansion is impossible by construction.
+ *
  * @param maxDepth
  *   Maximum nesting depth for XML elements (prevents stack overflow attacks)
  * @param maxAttributes

--- a/schema-xml/shared/src/main/scala/zio/blocks/schema/xml/XmlReader.scala
+++ b/schema-xml/shared/src/main/scala/zio/blocks/schema/xml/XmlReader.scala
@@ -19,6 +19,31 @@ package zio.blocks.schema.xml
 import zio.blocks.chunk.{Chunk, ChunkBuilder}
 
 object XmlReader {
+
+  /**
+   * Reads an XML document into an [[Xml]] AST.
+   *
+   * ==Closed entity set==
+   *   - Only the five predefined entities (`&amp;` `&lt;` `&gt;` `&quot;`
+   *     `&apos;`) and numeric character references (`&#...;` decimal, `&#x...;`
+   *     hexadecimal) are recognized. Every other entity (custom, external,
+   *     parameter) fails closed with a [[XmlCodecError]] carrying line/column
+   *     position; there is deliberately no DTD, `DOCTYPE`, or external-entity
+   *     branch, so external entities can never be expanded.
+   *   - Entities resolve in a single pass (no recursive re-expansion), so
+   *     nested inputs such as `&amp;lt;` decode to the literal text `&lt;` and
+   *     cannot blow up exponentially. Element nesting is additionally bounded
+   *     by `config.maxDepth`.
+   *
+   * @param input
+   *   the XML document text
+   * @param config
+   *   reader limits (defaults to `ReaderConfig.default`)
+   * @throws XmlCodecError
+   *   always thrown (instead of returning) on malformed input, with line/column
+   *   position in the message; [[XmlCodec]] converts these into positioned
+   *   codec errors with traversal spans downstream
+   */
   def read(input: String, config: ReaderConfig = ReaderConfig.default): Xml =
     new XmlReaderImpl(input, config).parse()
 
@@ -234,14 +259,37 @@ object XmlReader {
       advance()
       val entity = sb.toString
       entity match {
-        case "amp"  => "&"
-        case "lt"   => "<"
-        case "gt"   => ">"
-        case "quot" => "\""
-        case "apos" => "'"
-        case _      => error(s"Unknown entity reference: &$entity;")
+        case "amp"                       => "&"
+        case "lt"                        => "<"
+        case "gt"                        => ">"
+        case "quot"                      => "\""
+        case "apos"                      => "'"
+        case _ if entity.startsWith("#") => parseNumericEntity(entity)
+        case _                           => error(s"Unknown entity reference: &$entity;")
       }
     }
+
+    private[this] def parseNumericEntity(entity: String): String = {
+      val digits         = entity.substring(1)
+      val codePoint: Int =
+        if (digits.startsWith("x") || digits.startsWith("X")) {
+          if (digits.length < 2) error(s"Invalid entity reference: &$entity;")
+          else
+            try Integer.parseInt(digits.substring(1), 16)
+            catch { case _: NumberFormatException => error(s"Invalid entity reference: &$entity;") }
+        } else if (digits.isEmpty) error(s"Invalid entity reference: &$entity;")
+        else
+          try Integer.parseInt(digits, 10)
+          catch { case _: NumberFormatException => error(s"Invalid entity reference: &$entity;") }
+      if (!isValidXmlChar(codePoint)) error(s"Invalid entity reference: &$entity;")
+      else new String(Character.toChars(codePoint))
+    }
+
+    private[this] def isValidXmlChar(codePoint: Int): Boolean =
+      codePoint == 0x9 || codePoint == 0xa || codePoint == 0xd ||
+        (codePoint >= 0x20 && codePoint <= 0xd7ff) ||
+        (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
+        (codePoint >= 0x10000 && codePoint <= 0x10ffff)
 
     private[this] def parseCommentAfterOpenMarker(): Xml.Comment = {
       advance()

--- a/schema-xml/shared/src/main/scala/zio/blocks/schema/xml/XmlReader.scala
+++ b/schema-xml/shared/src/main/scala/zio/blocks/schema/xml/XmlReader.scala
@@ -25,11 +25,13 @@ object XmlReader {
    *
    * ==Closed entity set==
    *   - Only the five predefined entities (`&amp;` `&lt;` `&gt;` `&quot;`
-   *     `&apos;`) and numeric character references (`&#...;` decimal, `&#x...;`
-   *     hexadecimal) are recognized. Every other entity (custom, external,
-   *     parameter) fails closed with a [[XmlCodecError]] carrying line/column
-   *     position; there is deliberately no DTD, `DOCTYPE`, or external-entity
-   *     branch, so external entities can never be expanded.
+   *     `&apos;`) and numeric character references (`&#...;` unsigned decimal,
+   *     `&#x...;` unsigned hexadecimal) are recognized. Explicit `+`/`-` signs
+   *     are rejected: the XML spec allows only digits and hex digits here.
+   *     Every other entity (custom, external, parameter) fails closed with a
+   *     [[XmlCodecError]] carrying line/column position; there is deliberately
+   *     no DTD, `DOCTYPE`, or external-entity branch, so external entities can
+   *     never be expanded.
    *   - Entities resolve in a single pass (no recursive re-expansion), so
    *     nested inputs such as `&amp;lt;` decode to the literal text `&lt;` and
    *     cannot blow up exponentially. Element nesting is additionally bounded
@@ -270,20 +272,30 @@ object XmlReader {
     }
 
     private[this] def parseNumericEntity(entity: String): String = {
+      // The XML spec allows only digits (decimal) or hex digits (hexadecimal)
+      // after `#`/`#x`: validate the charset explicitly instead of relying on
+      // `Integer.parseInt`, which would silently accept `+`/`-` signs.
       val digits         = entity.substring(1)
       val codePoint: Int =
         if (digits.startsWith("x") || digits.startsWith("X")) {
-          if (digits.length < 2) error(s"Invalid entity reference: &$entity;")
+          val hex = digits.substring(1)
+          if (hex.isEmpty || !hex.forall(isHexDigit)) error(s"Invalid entity reference: &$entity;")
           else
-            try Integer.parseInt(digits.substring(1), 16)
+            try Integer.parseInt(hex, 16)
             catch { case _: NumberFormatException => error(s"Invalid entity reference: &$entity;") }
-        } else if (digits.isEmpty) error(s"Invalid entity reference: &$entity;")
+        } else if (digits.isEmpty || !digits.forall(isDecimalDigit)) error(s"Invalid entity reference: &$entity;")
         else
           try Integer.parseInt(digits, 10)
           catch { case _: NumberFormatException => error(s"Invalid entity reference: &$entity;") }
       if (!isValidXmlChar(codePoint)) error(s"Invalid entity reference: &$entity;")
       else new String(Character.toChars(codePoint))
     }
+
+    private[this] def isDecimalDigit(c: Char): Boolean =
+      c >= '0' && c <= '9'
+
+    private[this] def isHexDigit(c: Char): Boolean =
+      isDecimalDigit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
 
     private[this] def isValidXmlChar(codePoint: Int): Boolean =
       codePoint == 0x9 || codePoint == 0xa || codePoint == 0xd ||

--- a/schema-xml/shared/src/test/scala/zio/blocks/schema/xml/XmlEntitySpec.scala
+++ b/schema-xml/shared/src/test/scala/zio/blocks/schema/xml/XmlEntitySpec.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.xml
+
+import zio.blocks.chunk.Chunk
+import zio.test._
+import scala.util.Try
+
+object XmlEntitySpec extends ZIOSpecDefault {
+
+  private def textOf(input: String): Xml = XmlReader.read(input)
+
+  def spec = suite("XmlEntitySpec")(
+    suite("closed entity set")(
+      test("rejects custom entities with a positioned error") {
+        val failure = Try(textOf("<root>&foo;</root>")).failed.toOption
+        assertTrue(
+          failure.exists(_.isInstanceOf[XmlCodecError]),
+          failure.map(_.getMessage).exists(m => m.contains("Unknown entity") && m.contains("line: 1"))
+        )
+      },
+      test("rejects unknown entities in attribute values") {
+        val failure = Try(textOf("<root a=\"x&bar;y\"/>")).failed.toOption
+        assertTrue(
+          failure.exists(_.isInstanceOf[XmlCodecError]),
+          failure.map(_.getMessage).exists(_.contains("Unknown entity"))
+        )
+      },
+      test("rejects parameter-entity style references") {
+        val failure = Try(textOf("<root>&%pe;</root>")).failed.toOption
+        assertTrue(failure.exists(_.isInstanceOf[XmlCodecError]))
+      },
+      test("decodes decimal numeric character references") {
+        assertTrue(
+          textOf("<root>&#65;&#66;&#67;</root>") ==
+            Xml.Element(XmlName("root"), Chunk.empty, Chunk(Xml.Text("ABC")))
+        )
+      },
+      test("decodes hexadecimal numeric character references") {
+        assertTrue(
+          textOf("<root>&#x41;&#x4a;</root>") ==
+            Xml.Element(XmlName("root"), Chunk.empty, Chunk(Xml.Text("AJ")))
+        )
+      },
+      test("decodes supplementary-plane numeric references") {
+        val expected = new String(Character.toChars(0x1f600))
+        assertTrue(
+          textOf("<root>&#x1F600;</root>") ==
+            Xml.Element(XmlName("root"), Chunk.empty, Chunk(Xml.Text(expected)))
+        )
+      },
+      test("rejects malformed numeric references") {
+        val bad = List("<root>&#xZZ;</root>", "<root>&#;</root>", "<root>&#0;</root>", "<root>&#x;</root>")
+        assertTrue(bad.forall(input => Try(textOf(input)).isFailure))
+      },
+      test("resolves entities in a single pass (no recursive expansion)") {
+        assertTrue(
+          textOf("<root>&amp;lt;</root>") ==
+            Xml.Element(XmlName("root"), Chunk.empty, Chunk(Xml.Text("&lt;")))
+        )
+      },
+      test("long entity chains expand linearly, never exponentially") {
+        val input  = "<root>" + ("&amp;" * 500) + "</root>"
+        val result = textOf(input)
+        assertTrue(
+          result == Xml.Element(XmlName("root"), Chunk.empty, Chunk(Xml.Text("&" * 500)))
+        )
+      }
+    ),
+    suite("no doctype or external entities")(
+      test("rejects top-level DOCTYPE") {
+        val failure = Try(textOf("<!DOCTYPE greeting SYSTEM \"hello.dtd\"><root/>")).failed.toOption
+        assertTrue(failure.exists(_.isInstanceOf[XmlCodecError]))
+      },
+      test("rejects nested DOCTYPE") {
+        val failure = Try(textOf("<root><!DOCTYPE x></root>")).failed.toOption
+        assertTrue(failure.exists(_.isInstanceOf[XmlCodecError]))
+      }
+    ),
+    suite("codec-level positioned errors")(
+      test("unknown entity surfaces as a Left carrying line position") {
+        val result = XmlCodec.stringCodec.decode("<value>&foo;</value>")
+        result match {
+          case Left(err) =>
+            assertTrue(err.message.contains("Unknown entity") && err.message.contains("line: 1"))
+          case _ => assertTrue(false)
+        }
+      },
+      test("numeric references decode through the codec") {
+        val result = XmlCodec.stringCodec.decode("<value>&#65;</value>")
+        assertTrue(result == Right("A"))
+      }
+    )
+  )
+}

--- a/schema-xml/shared/src/test/scala/zio/blocks/schema/xml/XmlEntitySpec.scala
+++ b/schema-xml/shared/src/test/scala/zio/blocks/schema/xml/XmlEntitySpec.scala
@@ -103,6 +103,30 @@ object XmlEntitySpec extends ZIOSpecDefault {
       test("numeric references decode through the codec") {
         val result = XmlCodec.stringCodec.decode("<value>&#65;</value>")
         assertTrue(result == Right("A"))
+      },
+      test("explicit signs on numeric references are rejected (decimal)") {
+        val plus     = XmlCodec.stringCodec.decode("<value>&#+65;</value>")
+        val minus    = XmlCodec.stringCodec.decode("<value>&#-65;</value>")
+        val plusMsg  = plus.fold(_.message, _ => "")
+        val minusMsg = minus.fold(_.message, _ => "")
+        assertTrue(
+          plus.isLeft,
+          minus.isLeft,
+          plusMsg.contains("Invalid entity"),
+          minusMsg.contains("Invalid entity")
+        )
+      },
+      test("explicit signs on numeric references are rejected (hexadecimal)") {
+        val plus     = XmlCodec.stringCodec.decode("<value>&#x+41;</value>")
+        val minus    = XmlCodec.stringCodec.decode("<value>&#x-41;</value>")
+        val plusMsg  = plus.fold(_.message, _ => "")
+        val minusMsg = minus.fold(_.message, _ => "")
+        assertTrue(
+          plus.isLeft,
+          minus.isLeft,
+          plusMsg.contains("Invalid entity"),
+          minusMsg.contains("Invalid entity")
+        )
       }
     )
   )

--- a/schema-yaml/shared/src/main/scala/zio/blocks/schema/yaml/YamlReader.scala
+++ b/schema-yaml/shared/src/main/scala/zio/blocks/schema/yaml/YamlReader.scala
@@ -20,7 +20,18 @@ import zio.blocks.chunk.{Chunk, ChunkBuilder}
 import java.nio.charset.StandardCharsets.UTF_8
 
 /**
- * Parser for YAML 1.2 input, converting YAML text into a [[Yaml]] AST.
+ * Parser for the supported YAML subset, converting YAML text into a [[Yaml]]
+ * AST.
+ *
+ * ==Support matrix==
+ *   - Supported: block mappings/sequences (nested), flow mappings/sequences
+ *     (`{...}`/`[...]`), literal/folded blocks (`|`/`>`), plain and
+ *     single/double-quoted scalars, comments, `---` document markers, explicit
+ *     `null`/`~`.
+ *   - Rejected (fail closed with a [[YamlCodecError]] carrying the 1-based line
+ *     number): anchors (`&name`) and aliases (`*name`), merge keys (`<<`), tags
+ *     (`!tag`), tab-indented lines, and duplicate mapping keys. Full YAML 1.2
+ *     support is intentionally out of scope.
  */
 object YamlReader {
   def read(input: String): Yaml =
@@ -34,11 +45,11 @@ object YamlReader {
     private var lineIdx: Int         = 0
 
     def parse(): Yaml = {
+      rejectTabIndentation()
       skipBlanksAndComments()
       if (lineIdx >= lines.length) Yaml.NullValue
       else {
-        val line = lines(lineIdx).trim
-        if (line == "---") {
+        if (isDocMarker(lines(lineIdx))) {
           lineIdx += 1
           skipBlanksAndComments()
         }
@@ -47,13 +58,71 @@ object YamlReader {
       }
     }
 
-    private[this] def skipBlanksAndComments(): Unit =
-      while (
-        lineIdx < lines.length && {
-          val trimmed = lines(lineIdx).trim
-          trimmed.isEmpty || trimmed.startsWith("#")
+    private[this] def fail(message: String, line: Int): Nothing =
+      throw new YamlCodecError(Nil, s"$message (line: $line)")
+
+    /**
+     * Fails closed on tab-indented lines: tabs must never appear in leading
+     * indentation. Runs once up front so the position is always exact.
+     */
+    private[this] def rejectTabIndentation(): Unit = {
+      var idx = 0
+      while (idx < lines.length) {
+        val raw = lines(idx)
+        var j   = 0
+        while (j < raw.length && isBlankChar(raw.charAt(j))) j += 1
+        if (j > 0) {
+          var k      = 0
+          var tabbed = false
+          while (k < j && !tabbed) {
+            if (raw.charAt(k) == '\t') tabbed = true
+            k += 1
+          }
+          if (tabbed) fail("Tab characters must not be used for indentation", idx + 1)
         }
-      ) lineIdx += 1
+        idx += 1
+      }
+    }
+
+    /**
+     * Rejects mapping keys that require unsupported YAML 1.2 features: anchors,
+     * aliases, merge keys, and tags.
+     */
+    private[this] def rejectUnsupportedKey(key: String, line: Int): Unit =
+      if (key == "<<") fail("Merge keys ('<<') are not supported", line)
+      else if (key.startsWith("&")) fail("Anchors are not supported", line)
+      else if (key.startsWith("*")) fail("Aliases are not supported", line)
+      else if (key.startsWith("!")) fail("Tags are not supported", line)
+
+    /**
+     * Half-open `[start, end)` range of non-blank content within a raw line.
+     */
+    private[this] def contentRange(raw: String): (Int, Int) = {
+      var start = 0
+      while (start < raw.length && isBlankChar(raw.charAt(start))) start += 1
+      var end = raw.length
+      while (end > start && isBlankChar(raw.charAt(end - 1))) end -= 1
+      (start, end)
+    }
+
+    // Blank-boundary predicate matching String.trim (chars <= ' ') so index-range
+    // slicing reproduces trim() content exactly without allocating.
+    private[this] def isBlankChar(c: Char): Boolean = c <= ' '
+
+    /** Content-range check for a `---` document marker without allocating. */
+    private[this] def isDocMarker(raw: String): Boolean = {
+      val (start, end) = contentRange(raw)
+      end - start == 3 && raw.charAt(start) == '-' && raw.charAt(start + 1) == '-' && raw.charAt(start + 2) == '-'
+    }
+
+    private[this] def isBlankOrComment(raw: String): Boolean = {
+      var idx = 0
+      while (idx < raw.length && isBlankChar(raw.charAt(idx))) idx += 1
+      idx >= raw.length || raw.charAt(idx) == '#'
+    }
+
+    private[this] def skipBlanksAndComments(): Unit =
+      while (lineIdx < lines.length && isBlankOrComment(lines(lineIdx))) lineIdx += 1
 
     private[this] def currentIndent: Int =
       if (lineIdx >= lines.length) 0
@@ -69,30 +138,37 @@ object YamlReader {
       skipBlanksAndComments()
       if (lineIdx >= lines.length) Yaml.NullValue
       else {
-        val line = lines(lineIdx).trim
-        if (line.startsWith("{")) parseFlowMapping()
-        else if (line.startsWith("[")) parseFlowSequence()
-        else if (line.startsWith("- ") || line == "-") parseBlockSequence(currentIndent)
-        else if (line.startsWith("|") || line.startsWith(">")) parseLiteralBlock(indent)
+        val raw          = lines(lineIdx)
+        val (start, end) = contentRange(raw)
+        if (start >= end) Yaml.NullValue
         else {
-          val colonIdx = findMappingColon(line)
-          if (colonIdx > 0) parseBlockMapping(currentIndent)
-          else parseScalar(indent)
+          val first = raw.charAt(start)
+          if (first == '{') parseFlowMapping()
+          else if (first == '[') parseFlowSequence()
+          else if (first == '-' && (end - start == 1 || raw.charAt(start + 1) == ' ')) parseBlockSequence(currentIndent)
+          else if (first == '|' || first == '>') parseLiteralBlock(indent)
+          else {
+            val colonIdx = findMappingColon(raw, start, end)
+            if (colonIdx > start) parseBlockMapping(currentIndent)
+            else parseScalar(indent)
+          }
         }
       }
     }
 
-    private[this] def findMappingColon(line: String): Int = {
-      val len      = line.length
-      var idx      = 0
+    private[this] def findMappingColon(line: String): Int =
+      findMappingColon(line, 0, line.length)
+
+    private[this] def findMappingColon(line: String, from: Int, until: Int): Int = {
+      var idx      = from
       var inSingle = false
       var inDouble = false
-      while (idx < len) {
+      while (idx < until) {
         val c = line.charAt(idx)
         if (c == '\'' && !inDouble) inSingle = !inSingle
         else if (c == '"' && !inSingle) inDouble = !inDouble
         else if (!inSingle && !inDouble) {
-          if (c == ':' && (idx + 1 >= len || line.charAt(idx + 1) == ' ')) return idx
+          if (c == ':' && (idx + 1 >= until || line.charAt(idx + 1) == ' ')) return idx
           if (c == '#') return -1
         }
         idx += 1
@@ -102,30 +178,45 @@ object YamlReader {
 
     private[this] def parseBlockMapping(indent: Int): Yaml = {
       val entries = ChunkBuilder.make[(Yaml, Yaml)]()
+      val seen    = scala.collection.mutable.HashSet.empty[String]
       while (lineIdx < lines.length) {
         skipBlanksAndComments()
         if (lineIdx >= lines.length || currentIndent < indent || currentIndent != indent) {
           return new Yaml.Mapping(entries.result())
         }
-        val line     = lines(lineIdx).trim
-        val colonIdx = findMappingColon(line)
-        if (colonIdx <= 0) return new Yaml.Mapping(entries.result())
-        val keyStr     = line.substring(0, colonIdx).trim
-        val key        = new Yaml.Scalar(unquoteScalar(keyStr))
-        val afterColon = line.substring(colonIdx + 1).trim
+        // Slice the key/value out of the raw line by index ranges and trim only
+        // on extraction: no whole-line trimmed copy is allocated.
+        val raw          = lines(lineIdx)
+        val (start, end) = contentRange(raw)
+        val colonIdx     = if (start >= end) -1 else findMappingColon(raw, start, end)
+        if (colonIdx <= start) return new Yaml.Mapping(entries.result())
+        var keyEnd = colonIdx
+        while (keyEnd > start && isBlankChar(raw.charAt(keyEnd - 1))) keyEnd -= 1
+        var valueStart = colonIdx + 1
+        while (valueStart < end && isBlankChar(raw.charAt(valueStart))) valueStart += 1
+        var valueEnd = end
+        while (valueEnd > valueStart && isBlankChar(raw.charAt(valueEnd - 1))) valueEnd -= 1
+        val keyStr = raw.substring(start, keyEnd)
+        rejectUnsupportedKey(keyStr, lineIdx + 1)
+        val key = new Yaml.Scalar(unquoteScalar(keyStr))
+        if (!seen.add(key.value)) fail(s"Duplicate mapping key: '$keyStr'", lineIdx + 1)
+        val hasValue = valueStart < valueEnd
         lineIdx += 1
         entries.addOne(
           (
             key, {
-              if (afterColon.isEmpty) {
+              if (!hasValue) {
                 skipBlanksAndComments()
                 if (lineIdx < lines.length && currentIndent > indent) parseValue(currentIndent)
                 else Yaml.NullValue
-              } else if (
-                afterColon == "|" || afterColon == ">" || afterColon.startsWith("|") || afterColon.startsWith(">")
-              ) {
-                parseLiteralBlockContent(indent, afterColon.charAt(0) == '|')
-              } else parseInlineValue(afterColon)
+              } else {
+                val afterColon = raw.substring(valueStart, valueEnd)
+                if (
+                  afterColon == "|" || afterColon == ">" || afterColon.startsWith("|") || afterColon.startsWith(">")
+                ) {
+                  parseLiteralBlockContent(indent, afterColon.charAt(0) == '|')
+                } else parseInlineValue(afterColon)
+              }
             }
           )
         )
@@ -157,7 +248,8 @@ object YamlReader {
           val colonIdx          = findMappingColon(afterDash)
           if (colonIdx > 0) {
             lineIdx += 1
-            val keyStr     = afterDash.substring(0, colonIdx).trim
+            val keyStr = afterDash.substring(0, colonIdx).trim
+            rejectUnsupportedKey(keyStr, lineIdx)
             val key        = new Yaml.Scalar(unquoteScalar(keyStr))
             val afterColon = afterDash.substring(colonIdx + 1).trim
             val firstValue =
@@ -185,7 +277,8 @@ object YamlReader {
                 elements.addOne(new Yaml.Mapping(mapEntries.result()))
                 return parseBlockSequenceContinue(indent, elements)
               }
-              val innerKeyStr     = innerLine.substring(0, innerColonIdx).trim
+              val innerKeyStr = innerLine.substring(0, innerColonIdx).trim
+              rejectUnsupportedKey(innerKeyStr, lineIdx + 1)
               val innerKey        = new Yaml.Scalar(unquoteScalar(innerKeyStr))
               val innerAfterColon = innerLine.substring(innerColonIdx + 1).trim
               lineIdx += 1
@@ -233,9 +326,10 @@ object YamlReader {
           elements.addOne(if (colonIdx > 0) {
             val dashContentIndent = indent + 2
             val keyStr            = afterDash.substring(0, colonIdx).trim
-            val key               = new Yaml.Scalar(unquoteScalar(keyStr))
-            val afterColon        = afterDash.substring(colonIdx + 1).trim
-            val firstValue        = if (afterColon.isEmpty) {
+            rejectUnsupportedKey(keyStr, lineIdx)
+            val key        = new Yaml.Scalar(unquoteScalar(keyStr))
+            val afterColon = afterDash.substring(colonIdx + 1).trim
+            val firstValue = if (afterColon.isEmpty) {
               skipBlanksAndComments()
               if (lineIdx < lines.length && currentIndent > indent) parseValue(currentIndent)
               else Yaml.NullValue
@@ -254,7 +348,8 @@ object YamlReader {
                 elements.addOne(new Yaml.Mapping(mapEntries.result()))
                 return parseBlockSequenceContinue(indent, elements)
               }
-              val innerKeyStr     = innerLine.substring(0, innerColonIdx).trim
+              val innerKeyStr = innerLine.substring(0, innerColonIdx).trim
+              rejectUnsupportedKey(innerKeyStr, lineIdx + 1)
               val innerKey        = new Yaml.Scalar(unquoteScalar(innerKeyStr))
               val innerAfterColon = innerLine.substring(innerColonIdx + 1).trim
               lineIdx += 1
@@ -341,6 +436,7 @@ object YamlReader {
               val colonIdx = part.indexOf(':')
               if (colonIdx > 0) {
                 val k = unquoteScalar(part.substring(0, colonIdx).trim)
+                rejectUnsupportedKey(k, lineIdx)
                 val v = part.substring(colonIdx + 1).trim
                 entries.addOne((new Yaml.Scalar(k), parseInlineValue(v)))
               }
@@ -445,6 +541,9 @@ object YamlReader {
     private[this] def parseInlineValue(s: String): Yaml = {
       val trimmed = stripComment(s).trim
       if (trimmed.isEmpty || trimmed == "null" || trimmed == "~") Yaml.NullValue
+      else if (trimmed.startsWith("&")) fail("Anchors are not supported", lineIdx)
+      else if (trimmed.startsWith("*")) fail("Aliases are not supported", lineIdx)
+      else if (trimmed.startsWith("!")) fail("Tags are not supported", lineIdx)
       else if (trimmed.startsWith("'")) new Yaml.Scalar(unquoteSingle(trimmed))
       else if (trimmed.startsWith("\"")) new Yaml.Scalar(unquoteDouble(trimmed))
       else if (trimmed.startsWith("{")) parseFlowMappingInline(trimmed)
@@ -467,6 +566,7 @@ object YamlReader {
             val colonIdx = part.indexOf(':')
             if (colonIdx > 0) {
               val k = unquoteScalar(part.substring(0, colonIdx).trim)
+              rejectUnsupportedKey(k, lineIdx)
               val v = part.substring(colonIdx + 1).trim
               entries.addOne((Yaml.Scalar(k), parseInlineValue(v)))
             }

--- a/schema-yaml/shared/src/main/scala/zio/blocks/schema/yaml/YamlReader.scala
+++ b/schema-yaml/shared/src/main/scala/zio/blocks/schema/yaml/YamlReader.scala
@@ -30,8 +30,10 @@ import java.nio.charset.StandardCharsets.UTF_8
  *     `null`/`~`.
  *   - Rejected (fail closed with a [[YamlCodecError]] carrying the 1-based line
  *     number): anchors (`&name`) and aliases (`*name`), merge keys (`<<`), tags
- *     (`!tag`), tab-indented lines, and duplicate mapping keys. Full YAML 1.2
- *     support is intentionally out of scope.
+ *     (`!tag`), tab-indented lines, and duplicate mapping keys. The duplicate
+ *     policy is uniform: block mappings, flow mappings (`{...}` at any depth),
+ *     and sequence-embedded mappings (`- k: v` continuations) all reject a
+ *     repeated key. Full YAML 1.2 support is intentionally out of scope.
  */
 object YamlReader {
   def read(input: String): Yaml =
@@ -93,6 +95,19 @@ object YamlReader {
       else if (key.startsWith("&")) fail("Anchors are not supported", line)
       else if (key.startsWith("*")) fail("Aliases are not supported", line)
       else if (key.startsWith("!")) fail("Tags are not supported", line)
+
+    /**
+     * Shared duplicate-key gate for every mapping scope: block mappings, flow
+     * mappings, and sequence-embedded mappings all funnel repeated keys here so
+     * the policy cannot drift between scopes. Keys are compared after unquoting
+     * (`"a"` and `a` collide).
+     */
+    private[this] def rejectDuplicateKey(
+      seen: scala.collection.mutable.HashSet[String],
+      key: String,
+      line: Int
+    ): Unit =
+      if (!seen.add(key)) fail(s"Duplicate mapping key: '$key'", line)
 
     /**
      * Half-open `[start, end)` range of non-blank content within a raw line.
@@ -199,7 +214,7 @@ object YamlReader {
         val keyStr = raw.substring(start, keyEnd)
         rejectUnsupportedKey(keyStr, lineIdx + 1)
         val key = new Yaml.Scalar(unquoteScalar(keyStr))
-        if (!seen.add(key.value)) fail(s"Duplicate mapping key: '$keyStr'", lineIdx + 1)
+        rejectDuplicateKey(seen, key.value, lineIdx + 1)
         val hasValue = valueStart < valueEnd
         lineIdx += 1
         entries.addOne(
@@ -259,6 +274,8 @@ object YamlReader {
                 else Yaml.NullValue
               } else parseInlineValue(afterColon)
             val mapEntries = ChunkBuilder.make[(Yaml, Yaml)]()
+            val seen       = scala.collection.mutable.HashSet.empty[String]
+            rejectDuplicateKey(seen, key.value, lineIdx)
             mapEntries.addOne((key, firstValue))
             while (lineIdx < lines.length) {
               skipBlanksAndComments()
@@ -281,6 +298,7 @@ object YamlReader {
               rejectUnsupportedKey(innerKeyStr, lineIdx + 1)
               val innerKey        = new Yaml.Scalar(unquoteScalar(innerKeyStr))
               val innerAfterColon = innerLine.substring(innerColonIdx + 1).trim
+              rejectDuplicateKey(seen, innerKey.value, lineIdx + 1)
               lineIdx += 1
               mapEntries.addOne(
                 (
@@ -335,6 +353,8 @@ object YamlReader {
               else Yaml.NullValue
             } else parseInlineValue(afterColon)
             val mapEntries = ChunkBuilder.make[(Yaml, Yaml)]()
+            val seen       = scala.collection.mutable.HashSet.empty[String]
+            rejectDuplicateKey(seen, key.value, lineIdx)
             mapEntries.addOne((key, firstValue))
             while (lineIdx < lines.length) {
               skipBlanksAndComments()
@@ -352,6 +372,7 @@ object YamlReader {
               rejectUnsupportedKey(innerKeyStr, lineIdx + 1)
               val innerKey        = new Yaml.Scalar(unquoteScalar(innerKeyStr))
               val innerAfterColon = innerLine.substring(innerColonIdx + 1).trim
+              rejectDuplicateKey(seen, innerKey.value, lineIdx + 1)
               lineIdx += 1
               mapEntries.addOne(
                 (
@@ -429,6 +450,7 @@ object YamlReader {
           if (inner.isEmpty) Yaml.Mapping.empty
           else {
             val entries = ChunkBuilder.make[(Yaml, Yaml)]()
+            val seen    = scala.collection.mutable.HashSet.empty[String]
             val parts   = splitFlowItems(inner)
             var idx     = 0
             while (idx < parts.length) {
@@ -437,6 +459,7 @@ object YamlReader {
               if (colonIdx > 0) {
                 val k = unquoteScalar(part.substring(0, colonIdx).trim)
                 rejectUnsupportedKey(k, lineIdx)
+                rejectDuplicateKey(seen, k, lineIdx)
                 val v = part.substring(colonIdx + 1).trim
                 entries.addOne((new Yaml.Scalar(k), parseInlineValue(v)))
               }
@@ -559,6 +582,7 @@ object YamlReader {
         if (inner.isEmpty) Yaml.Mapping.empty
         else {
           val entries = ChunkBuilder.make[(Yaml, Yaml)]()
+          val seen    = scala.collection.mutable.HashSet.empty[String]
           val parts   = splitFlowItems(inner)
           var idx     = 0
           while (idx < parts.length) {
@@ -567,6 +591,7 @@ object YamlReader {
             if (colonIdx > 0) {
               val k = unquoteScalar(part.substring(0, colonIdx).trim)
               rejectUnsupportedKey(k, lineIdx)
+              rejectDuplicateKey(seen, k, lineIdx)
               val v = part.substring(colonIdx + 1).trim
               entries.addOne((Yaml.Scalar(k), parseInlineValue(v)))
             }

--- a/schema-yaml/shared/src/test/scala/zio/blocks/schema/yaml/YamlSupportMatrixSpec.scala
+++ b/schema-yaml/shared/src/test/scala/zio/blocks/schema/yaml/YamlSupportMatrixSpec.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.schema.yaml
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.SchemaBaseSpec
+import zio.test._
+import scala.util.Try
+
+object YamlSupportMatrixSpec extends SchemaBaseSpec {
+
+  private def failsClosed(input: String, fragment: String, line: Int): TestResult = {
+    val failure = Try(YamlReader.read(input)).failed.toOption
+    assertTrue(
+      failure.exists(_.isInstanceOf[YamlCodecError]),
+      failure.map(_.getMessage).exists(m => m.contains(fragment) && m.contains(s"(line: $line)"))
+    )
+  }
+
+  def spec: Spec[TestEnvironment, Any] = suite("YamlSupportMatrix")(
+    suite("rejected YAML 1.2 features fail closed with positioned errors")(
+      test("anchor definitions are rejected") {
+        failsClosed("base: &b\n  x: 1", "Anchors", 1)
+      },
+      test("aliases are rejected") {
+        failsClosed("a: 1\nb: *a", "Aliases", 2)
+      },
+      test("top-level aliases are rejected") {
+        failsClosed("*a", "Aliases", 1)
+      },
+      test("aliases in sequences are rejected") {
+        failsClosed("- 1\n- *a", "Aliases", 2)
+      },
+      test("aliases in flow collections are rejected") {
+        failsClosed("a: [*x, 1]", "Aliases", 1)
+      },
+      test("merge keys are rejected") {
+        failsClosed("a: 1\n<<: b", "Merge keys", 2)
+      },
+      test("tags are rejected") {
+        failsClosed("a: !str foo", "Tags", 1)
+      },
+      test("tags in sequences are rejected") {
+        failsClosed("- !str foo", "Tags", 1)
+      },
+      test("tab indentation is rejected") {
+        failsClosed("a: 1\n\tb: 2", "Tab", 2)
+      },
+      test("duplicate mapping keys are rejected") {
+        failsClosed("a: 1\na: 2", "Duplicate mapping key", 2)
+      },
+      test("duplicate keys after quoting variations are rejected") {
+        failsClosed("a: 1\n\"a\": 2", "Duplicate mapping key", 2)
+      }
+    ),
+    suite("supported subset keeps parsing")(
+      test("plain and quoted scalars") {
+        assertTrue(
+          YamlReader.read("a: 1") == Yaml.Mapping.fromStringKeys("a" -> Yaml.Scalar("1")),
+          YamlReader.read("a: \"x\"") == Yaml.Mapping.fromStringKeys("a" -> Yaml.Scalar("x")),
+          YamlReader.read("a: 'y'") == Yaml.Mapping.fromStringKeys("a" -> Yaml.Scalar("y"))
+        )
+      },
+      test("quoted stars and ampersands are plain strings, not references") {
+        assertTrue(
+          YamlReader.read("a: \"*x\"") == Yaml.Mapping.fromStringKeys("a" -> Yaml.Scalar("*x")),
+          YamlReader.read("a: '&y'") == Yaml.Mapping.fromStringKeys("a" -> Yaml.Scalar("&y"))
+        )
+      },
+      test("mid-token markers are plain strings") {
+        assertTrue(
+          YamlReader.read("a: a*b") == Yaml.Mapping.fromStringKeys("a" -> Yaml.Scalar("a*b")),
+          YamlReader.read("a: x&y") == Yaml.Mapping.fromStringKeys("a" -> Yaml.Scalar("x&y"))
+        )
+      },
+      test("nested mappings, sequences, flow, blocks, comments, markers") {
+        assertTrue(
+          YamlReader.read("outer:\n  inner: 1") ==
+            Yaml.Mapping.fromStringKeys("outer" -> Yaml.Mapping.fromStringKeys("inner" -> Yaml.Scalar("1"))),
+          YamlReader.read("- 1\n- 2") == Yaml.Sequence(Yaml.Scalar("1"), Yaml.Scalar("2")),
+          YamlReader.read("a: {x: 1}") ==
+            Yaml.Mapping.fromStringKeys("a" -> Yaml.Mapping(Chunk((Yaml.Scalar("x"), Yaml.Scalar("1"))))),
+          YamlReader.read("a: [1, 2]") ==
+            Yaml.Mapping.fromStringKeys("a" -> Yaml.Sequence(Yaml.Scalar("1"), Yaml.Scalar("2"))),
+          YamlReader.read("# comment\na: 1") == Yaml.Mapping.fromStringKeys("a" -> Yaml.Scalar("1")),
+          YamlReader.read("---\na: 1") == Yaml.Mapping.fromStringKeys("a" -> Yaml.Scalar("1")),
+          YamlReader.read("a: |\n  line1\n  line2") ==
+            Yaml.Mapping.fromStringKeys("a" -> Yaml.Scalar("line1\nline2"))
+        )
+      },
+      test("literal blocks keep star-led content literally") {
+        assertTrue(
+          YamlReader.read("a: |\n  *foo") == Yaml.Mapping.fromStringKeys("a" -> Yaml.Scalar("*foo"))
+        )
+      }
+    ),
+    suite("index-range parsing preserves output")(
+      test("extra spacing around keys and values parses identically") {
+        val expected = Yaml.Mapping(
+          Chunk((Yaml.Scalar("a"), Yaml.Scalar("1")), (Yaml.Scalar("b"), Yaml.Scalar("2")))
+        )
+        assertTrue(
+          YamlReader.read("a: 1\nb:   2  ") == expected,
+          YamlReader.read("a  : 1\nb: 2") == expected,
+          YamlReader.read("a: 1\nb: 2") == expected
+        )
+      },
+      test("quoted keys with inner spacing parse identically") {
+        assertTrue(
+          YamlReader.read("\"a b\": 1") == Yaml.Mapping.fromStringKeys("a b" -> Yaml.Scalar("1"))
+        )
+      }
+    ),
+    suite("codec-level positioned errors")(
+      test("unsupported input surfaces as a Left carrying the line") {
+        val result = YamlCodec.stringCodec.decode("plain")
+        assertTrue(result == Right("plain"))
+        YamlCodec.stringCodec.decode("a: 1\nb: *x") match {
+          case Left(err) =>
+            assertTrue(err.message.contains("Aliases") && err.message.contains("(line: 2)"))
+          case _ => assertTrue(false)
+        }
+      }
+    )
+  )
+}

--- a/schema-yaml/shared/src/test/scala/zio/blocks/schema/yaml/YamlSupportMatrixSpec.scala
+++ b/schema-yaml/shared/src/test/scala/zio/blocks/schema/yaml/YamlSupportMatrixSpec.scala
@@ -65,6 +65,21 @@ object YamlSupportMatrixSpec extends SchemaBaseSpec {
       },
       test("duplicate keys after quoting variations are rejected") {
         failsClosed("a: 1\n\"a\": 2", "Duplicate mapping key", 2)
+      },
+      test("duplicate keys in top-level flow mappings are rejected") {
+        failsClosed("{a: 1, a: 2}", "Duplicate mapping key", 1)
+      },
+      test("duplicate keys in nested flow mappings are rejected") {
+        failsClosed("a: {x: 1, x: 2}", "Duplicate mapping key", 1)
+      },
+      test("duplicate keys in flow mappings inside sequences are rejected") {
+        failsClosed("[{a: 1, a: 2}]", "Duplicate mapping key", 1)
+      },
+      test("duplicate keys in sequence-embedded mappings are rejected") {
+        failsClosed("- a: 1\n  a: 2", "Duplicate mapping key", 2)
+      },
+      test("duplicate keys across sequence-embedded continuation lines are rejected") {
+        failsClosed("- a: 1\n  b: 2\n  a: 3", "Duplicate mapping key", 3)
       }
     ),
     suite("supported subset keeps parsing")(

--- a/smithy/src/main/scala/zio/blocks/smithy/SmithyParser.scala
+++ b/smithy/src/main/scala/zio/blocks/smithy/SmithyParser.scala
@@ -16,6 +16,8 @@
 
 package zio.blocks.smithy
 
+import scala.util.control.NonFatal
+
 /**
  * Parser for Smithy IDL (Interface Definition Language) version 2.x.
  *
@@ -23,6 +25,10 @@ package zio.blocks.smithy
  * all Smithy IDL constructs including version declarations, namespaces,
  * metadata, use statements, shape definitions (simple, aggregate, enum,
  * service), trait applications, documentation comments, and apply statements.
+ *
+ * Errors (including lexer-level throws from `expectChar`/`expectString`) are
+ * funneled through the outer `NonFatal` catch in `parseModel`, so `parse`
+ * always returns a `Left` and never throws.
  */
 private[smithy] object SmithyParser {
 
@@ -156,6 +162,9 @@ private[smithy] object SmithyParser {
       } catch {
         case e: SmithyParseException =>
           Left(SmithyError.ParseError(e.getMessage, e.line, e.column, None))
+        case e if NonFatal(e) =>
+          val message = if (e.getMessage ne null) e.getMessage else e.getClass.getName
+          Left(SmithyError.ParseError(message, line, column, None))
       }
 
     // -----------------------------------------------------------------------

--- a/smithy/src/test/scala/zio/blocks/smithy/SmithyParserBoundarySpec.scala
+++ b/smithy/src/test/scala/zio/blocks/smithy/SmithyParserBoundarySpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.blocks.smithy
+
+import zio.test._
+
+object SmithyParserBoundarySpec extends ZIOSpecDefault {
+  def spec = suite("SmithyParserBoundary")(
+    test("missing colon after $version returns Left, never throws") {
+      val result = SmithyModel.parse("$version \"2\"\nnamespace com.example")
+      result match {
+        case Left(err) => assertTrue(err.message.contains("Expected ':'"))
+        case _         => assertTrue(false)
+      }
+    },
+    test("truncated version declaration returns Left, never throws") {
+      val result = SmithyModel.parse("$version:")
+      assertTrue(result.isLeft)
+    },
+    test("missing namespace returns Left, never throws") {
+      val result = SmithyModel.parse("$version: \"2\"\n")
+      result match {
+        case Left(err) => assertTrue(err.message.contains("namespace"))
+        case _         => assertTrue(false)
+      }
+    },
+    test("unclosed shape block returns Left, never throws") {
+      val input  = "$version: \"2\"\nnamespace com.example\nstructure Foo {"
+      val result = SmithyModel.parse(input)
+      assertTrue(result.isLeft)
+    },
+    test("hostile inputs never throw: parse always returns a value") {
+      val hostile = List(
+        "",
+        "$",
+        "$version",
+        "$version: \"2",
+        "$version: \"2\"\nnamespace",
+        "$version: \"2\"\nnamespace com.example\nstructure",
+        "$version: \"2\"\nnamespace com.example\nstructure Foo { @required",
+        new String(Array[Char](0.toChar, 1.toChar, 2.toChar)),
+        "namespace com.example",
+        "{{{{",
+        "$version: \"2\"\nnamespace com.example\n" + ("structure A { a: A }" * 200)
+      )
+      val outcomes = hostile.map(input => scala.util.Try(SmithyModel.parse(input)))
+      assertTrue(
+        outcomes.forall(_.isSuccess),
+        outcomes.collect { case scala.util.Success(Left(err)) => err }.nonEmpty
+      )
+    }
+  )
+}


### PR DESCRIPTION
Small codec and micro-library findings closed in one pass. No behavior changes beyond documented fail-closed errors and additive APIs.

CSV (schema-csv)
- Row and column now advance on row-terminating newlines; readAll threads document rows so errors carry absolute positions.
- Unquoted-whitespace policy documented on CsvConfig (spaces preserved per RFC 4180).
- Tests: multi-line error positions (CRLF/LF/after-quote/embedded newlines), whitespace preservation.

XML (schema-xml)
- Closed entity set documented on the reader: five predefined entities plus numeric character references (newly supported, including the supplementary plane); unknown, custom, and external entities fail closed with positioned errors; no doctype or DTD branch by design.
- Tests: custom-entity rejection, numeric decoding, single-pass expansion pinned linear, doctype rejection, codec-level positioned Left.

YAML (schema-yaml)
- Anchors, aliases, merge keys, tags, tab indentation, and duplicate keys fail closed with line-positioned errors; the supported subset is documented.
- Block mapping keys and values are parsed by index ranges over the raw line instead of whole-line trim copies.
- Tests: reject/support matrix, whitespace-equivalence pins, codec-level Left.

Smithy
- parseModel catches NonFatal, so lexer throws become Left values; parse never throws.
- Tests: lexer-error inputs return Left; hostile-input sweep never throws.

Codegen
- One emitList helper plus a shared-builder overload replaces the repeated join shape across emitters; emitted output is unchanged.
- Tests: byte-identical golden snapshot over a full file.

OpenAPI
- Symbolic refs-in/refs-out documented on the schema entry point; resolveRefs added as a documented downstream extension point.
- Tests: symbolic preservation, stub boundary.

MediaType
- Parameter values lose one surrounding quote layer; the semicolon-in-quotes split is documented as unsupported; unknown-type case preserved.
- Tests: quoted params, unbalanced quotes, limitation pin.

Maybe
- unsafeWrap uses a reference null check on both dialects.
- Tests: present(absent), present-of-Present, unsafeGet-absent-is-null, unsafeWrap round-trip, plus internal-path pins (unsafeIsAbsent, Present hashCode, WithFilter).

Markdown
- Additive parseWithFrontmatter and stripFrontmatter; strict parse unchanged.
- Tests: pairs plus document, fallback paths, strict rejection kept.

Migration (dataMigration)
- init serialized; throwing guards documented; trigger install runs in the same preparation transaction on top of the idempotent QueueTable install.
- Tests: sequential single-prepare, concurrent init prepares exactly once.

Build (build.sbt, one line per test alias)
- Drive-by fix required by the coverage gate: markdownJVM/test and markdownJS/test were missing from all four test aliases, so the module suite never ran in CI and its gate measured only downstream trickle. Wired in; the new tests now execute and cover the new branches.

Verification
- sbt fmt clean; module suites green on Scala 3.8.3 (JVM and JS) and 2.13.18 (JVM) for csv/xml/yaml/smithy/codegen/openapi/mediatype/maybe/markdown, plus dataMigration on 3.x JVM/JS.
- dataMigration on 2.13 is not runnable here: its sql dependency is Scala-3-only by build design (pre-existing, untouched).
- Pre-existing, not caused by this change: the maybe branch-coverage gate (80% vs 90%) fails on the JDK25 legs. Verified against the base commit (schema plus maybe coverage there reports the identical 70.73%/80.00%); this change only adds covered paths to that module. The extra internal-path tests above narrow the gap; the remainder belongs to the owning follow-up.