### PR TITLE
docs(config): document Secret schema decoding and message redaction

### DIFF
--- a/docs/reference/config/config-source.md
+++ b/docs/reference/config/config-source.md
@@ -343,6 +343,33 @@ Reading the value back requires the explicit `Secret.unwrap`, which makes every 
 Secret.unwrap(token)
 ```
 
+### Schema Decoding
+
+`Secret` carries its own `Schema[Secret]`, derived by transforming `Schema[String]` rather than reflecting over a case class. That means a `Secret` field decodes like any other primitive wherever `Schema.derived` is used — no per-field annotation or special-casing at the call site:
+
+```scala mdoc:silent:reset
+import zio.blocks.config._
+import zio.blocks.schema.Schema
+
+case class Db(host: String, password: Secret)
+
+object Db {
+  implicit val schema: Schema[Db] = Schema.derived[Db]
+}
+```
+
+The raw string is read from the source exactly like any other field, then wrapped:
+
+```scala mdoc
+Config.load[Db](ConfigSource.fromMap(Map("host" -> "localhost", "password" -> "hunter2"), "defaults"))
+```
+
+The decoded `password` is a `Secret`, so the value never appears in a `toString` of the loaded record even though the source held it as a plain string:
+
+```scala mdoc
+Config.load[Db](ConfigSource.fromMap(Map("host" -> "localhost", "password" -> "hunter2"), "defaults")).map(_.password)
+```
+
 ### Displayable
 
 `Displayable[A]` is the type class behind rendered flag values, with instances for `String`, `Int`, `Long`, `Double`, and `Boolean`, plus a low-priority fallback that calls `toString`. The module provides `Displayable[Secret]` as an implicit in the `zio.blocks.config` package object, so a `StaticFlag[Secret]` renders as `<secret>` in `Flag.dump` output without any per-flag configuration.

--- a/docs/reference/config/errors.md
+++ b/docs/reference/config/errors.md
@@ -83,6 +83,29 @@ The `expectedType` string is derived from the schema's primitive type name. When
 
 `InvalidValue` is also what a failing wrapper type produces: if a newtype's constructor throws while wrapping a successfully-decoded inner value, the thrown exception becomes the `cause`.
 
+`InvalidValue#message` redacts the offending value — printing `<secret>` in its place and dropping the `cause` text — when the key's path looks like it names a secret, using the same name-based check [`ProvenanceMap#dump`](./config-source.md) applies. A field named `db.password` that fails to parse reports the type mismatch without ever printing what was typed:
+
+```scala mdoc:silent:reset
+import zio.blocks.config._
+import zio.blocks.schema.Schema
+
+case class Db(password: Int)
+
+object Db {
+  implicit val schema: Schema[Db] = Schema.derived[Db]
+}
+```
+
+```scala mdoc
+Config.load[Db](ConfigSource.fromMap(Map("password" -> "not-a-number"), "defaults")).left.map(_.head.message)
+```
+
+The error's fields still carry the raw value — `.message` is what redacts, not the constructor:
+
+```scala mdoc
+Config.load[Db](ConfigSource.fromMap(Map("password" -> "not-a-number"), "defaults"))
+```
+
 ### ConfigError.ParseError
 
 The raw value could not be decoded at the format level, as distinct from a type mismatch on a well-formed value. Carries the path, source, expected format, and optional cause. The HOCON adapter produces it when the document itself is malformed, and the JVM file loader produces it for a missing file or a rejected include path.

--- a/docs/reference/config/flags.md
+++ b/docs/reference/config/flags.md
@@ -332,6 +332,8 @@ try {
 
 `FlagDuplicateNameException` means two objects derived the same name, which happens when two flags share a fully-qualified name after `$`-to-dot rewriting. Renaming either object resolves it.
 
+`FlagValueParseException#getMessage` redacts the raw value the same way [`ConfigError.InvalidValue`](./errors.md) does — `<secret>` in its place, and the underlying cause dropped — when the flag's name looks like it names a secret. A flag named `Db.password` that fails to parse never leaks the value it was given.
+
 ## Integration Points
 
 Flags depend on `FlagSource` — and therefore accept any `ConfigSource` — on `Flag.Reader` for parsing, on `Displayable` for rendering, and on `ConfigError` for parse failures. `DynamicFlag` additionally depends on `Rollout` for expression evaluation.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,37 @@
+# Documentation Status
+
+## PR Documentation Audit — Batch 1 (2026-09-06)
+
+Scope: PRs #1626–#1665 (20 merged PRs checked).
+
+| Status | Count | PRs |
+|---|---|---|
+| 🔴 Not Documented | 1 | #1649 |
+| 🟡 Partially Documented | 3 | #1631, #1634, #1635 |
+| ✅ Well Documented | 2 | #1632, #1633 |
+| ⚠️ Uncertain (resolved, no action) | 6 | #1628, #1629, #1638, #1640, #1642, #1643 |
+| ⬜ No docs required (deps/fixes) | 8 | #1626, #1630, #1636, #1637, #1645, #1646, #1652, #1665 |
+
+### 🔴 Not Documented
+
+- **#1649** — `fix(config): close config review findings`. Adds new public `Sensitive.scala` (config value redaction type). Zero mentions in `docs/`.
+
+### 🟡 Partially Documented
+
+- **#1634** — `feat(sql): transaction hardening` (isolation, savepoints, Hikari docs). `sql-transactions.md` examples are plain (unverified, not mdoc-compiled); `db-tx.md` is thin; `transactor.md` is solid but has no cross-links to sibling pages.
+- **#1635** — `feat(sql): compile-time checked SQL interpolation`. `sql-checked-interpolation.md` has good mdoc example coverage but zero cross-reference links.
+- **#1631** — `feat(projection): declarative projection engine`. `projection.md` has good depth (654 lines, 16 mdoc blocks) but zero cross-reference links.
+
+### ✅ Well Documented
+
+- **#1632** — `feat(sql): inspectable SQL + opt-in compile-time dumps` — covered in `query-dsl-sql.md`.
+- **#1633** — `feat(sql): upsert and keyset pagination` — covered in `query-dsl-sql.md`.
+
+### Next steps
+
+- `/docs-document-pr 1649` — write docs for `Sensitive`.
+- `/docs-enrich-section docs/guides/sql-transactions.md` — add mdoc-verified examples, cross-links.
+- `/docs-enrich-section docs/guides/sql-checked-interpolation.md` — add cross-links.
+- `/docs-enrich-section docs/reference/projection.md` — add cross-links.
+
+Audit state tracked in `.docs-audit-state.json` (gitignored). ~1600+ older merged PRs remain unchecked.

--- a/docs/status.md
+++ b/docs/status.md
@@ -6,15 +6,15 @@ Scope: PRs #1626–#1665 (20 merged PRs checked).
 
 | Status | Count | PRs |
 |---|---|---|
-| 🔴 Not Documented | 1 | #1649 |
+| ✅ Resolved since audit | 1 | #1649 |
 | 🟡 Partially Documented | 3 | #1631, #1634, #1635 |
 | ✅ Well Documented | 2 | #1632, #1633 |
 | ⚠️ Uncertain (resolved, no action) | 6 | #1628, #1629, #1638, #1640, #1642, #1643 |
 | ⬜ No docs required (deps/fixes) | 8 | #1626, #1630, #1636, #1637, #1645, #1646, #1652, #1665 |
 
-### 🔴 Not Documented
+### ✅ Resolved since audit
 
-- **#1649** — `fix(config): close config review findings`. Adds new public `Sensitive.scala` (config value redaction type). Zero mentions in `docs/`.
+- **#1649** — `fix(config): close config review findings`. Originally flagged as 🔴 Not Documented for adding `Sensitive.scala` — but that type is `private[config]` (an internal marker-matching helper), not public API worth its own page. The real gap was two related, undocumented public behaviors from the same PR: `Secret` gained schema-driven decoding (an implicit `Schema[Secret]`, so a `Secret` field decodes via `Schema.derived` like any primitive), and `ConfigError.InvalidValue#message` / `FlagValueParseException#getMessage` now redact the value to `<secret>` when the key/flag name looks sensitive. Fixed in [zio/zio-blocks#1666](https://github.com/zio/zio-blocks/pull/1666): a new "Schema Decoding" subsection in `config-source.md`, and one-line redaction notes in `errors.md` and `flags.md`, all mdoc-verified.
 
 ### 🟡 Partially Documented
 
@@ -29,7 +29,6 @@ Scope: PRs #1626–#1665 (20 merged PRs checked).
 
 ### Next steps
 
-- `/docs-document-pr 1649` — write docs for `Sensitive`.
 - `/docs-enrich-section docs/guides/sql-transactions.md` — add mdoc-verified examples, cross-links.
 - `/docs-enrich-section docs/guides/sql-checked-interpolation.md` — add cross-links.
 - `/docs-enrich-section docs/reference/projection.md` — add cross-links.


### PR DESCRIPTION
## Summary
- PR #1649 added an implicit `Schema[Secret]` (`Secret.scala`) so a `Secret` field decodes via `Schema.derived` like any other primitive, and made `ConfigError.InvalidValue#message` / `FlagValueParseException#getMessage` redact the value to `<secret>` when the key/flag name looks sensitive. None of this was documented (`Sensitive` itself is `private[config]`, an internal marker-matching helper, not a public type worth its own page).
- `config-source.md`: new "Schema Decoding" subsection under Secrets, with a compile-verified example deriving a `Db` case class with a `Secret` field.
- `errors.md`: notes `InvalidValue#message` redaction, with an example contrasting the redacted message against the still-plain raw error fields.
- `flags.md`: same one-line note for `FlagValueParseException`, cross-linked to `errors.md`.
- Adds `docs/status.md`: a PR-documentation-audit status report (batch 1, PRs #1626-#1665) that surfaced this gap.

## Test plan
- [x] `sbt "docs/mdoc --in docs/reference/config/config-source.md --out website/docs/reference/config/config-source.md"` — 0 errors
- [x] `sbt "docs/mdoc --in docs/reference/config/errors.md --out website/docs/reference/config/errors.md"` — 0 errors
- [x] `sbt "docs/mdoc --in docs/reference/config/flags.md --out website/docs/reference/config/flags.md"` — 0 errors
- [x] Manually inspected rendered output: `Db(host = "localhost", password = <secret>)` and `Left("Invalid value '<secret>' for key 'password' ...")` confirm the redaction claims are accurate