### PR TITLE
fix(http-model): keep unrecognized Accept-Encoding codings as Unparsed

### DIFF
--- a/docs/reference/http-model/headers.md
+++ b/docs/reference/http-model/headers.md
@@ -197,9 +197,7 @@ Header.AcceptEncoding.parse("gzip")
 Header.AcceptEncoding.parse("!!!")
 ```
 
-:::warning[`AcceptEncoding` falls back to `GZip` on unknown values]
-`Header.AcceptEncoding` matches a fixed set of encoding names and returns `GZip` for anything it does not recognize, rather than reporting a parse failure. A request with `accept-encoding: bogus` — or a typo like `identityy` — reads as if the client asked for gzip. `Header.AcceptEncoding.parse` rejects only values with no non-empty comma-separated part, so almost any string succeeds. A server choosing a response encoding from this header should read the raw value instead of trusting the parsed variant. Tracked as [zio/zio-blocks#1618](https://github.com/zio/zio-blocks/issues/1618).
-:::
+`Header.AcceptEncoding` keeps a coding it does not recognize as `Unparsed` rather than rejecting it, so `!!!` parses and renders back unchanged; `Header.AcceptEncoding.parse` fails only when no non-empty comma-separated part remains. A server choosing a response encoding should treat `Unparsed` as unsupported.
 
 ### `Headers#getLast` — last parseable match
 
@@ -503,12 +501,12 @@ Header.CacheControl.parse("max-age=soon")
 | Type                      | Wire name          | Shape                                                            |
 | ------------------------- | ------------------ | ---------------------------------------------------------------- |
 | `Header.Accept`           | `accept`           | `mediaRanges: Chunk[Accept.MediaRange]`                           |
-| `Header.AcceptEncoding`   | `accept-encoding`  | ADT: `GZip`, `Deflate`, `Br`, `Compress`, `Identity`, `Any`, `Multiple` |
+| `Header.AcceptEncoding`   | `accept-encoding`  | ADT: `GZip`, `Deflate`, `Br`, `Compress`, `Identity`, `Any`, `Unparsed`, `Multiple` |
 | `Header.AcceptLanguage`   | `accept-language`  | `languages: Chunk[AcceptLanguage.LanguageRange]`                  |
 | `Header.AcceptRanges`     | `accept-ranges`    | ADT: `Bytes`, `None_`                                             |
 | `Header.AcceptPatch`      | `accept-patch`     | `mediaTypes: Chunk[MediaType]`                                    |
 
-`Accept.MediaRange` and `AcceptLanguage.LanguageRange` are the per-entry types that carry a quality weight, which is what makes these headers a `Chunk` rather than a single value. `None_` on `AcceptRanges` is spelled with a trailing underscore because `None` is taken.
+`Accept.MediaRange` and `AcceptLanguage.LanguageRange` are the per-entry types that carry a quality weight, which is what makes these headers a `Chunk` rather than a single value. `None_` on `AcceptRanges` is spelled with a trailing underscore because `None` is taken. `Unparsed` on `AcceptEncoding` plays the same role as on `Authorization`: a coding the ADT does not name is preserved, weight included, rather than rejected.
 
 ### CORS
 

--- a/docs/undocumented-report.md
+++ b/docs/undocumented-report.md
@@ -149,10 +149,6 @@ Three behaviours the source made non-obvious, now stated with worked output:
 - **The parse cache is keyed by codec identity, compared by reference.** A codec constructed inline per request never reuses its cached values, and `Headers#add` drops the cache entirely.
 - **`Headers#toString` prints credentials verbatim.** There is no redaction, so anything logging a `Request` logs its `authorization` and `cookie` values.
 
-Writing the catalog also surfaced a genuine defect, documented in a warning admonition and worth fixing in the source:
-
-- [ ] `Header.AcceptEncoding.parseSingle` ends with `case _ => GZip(weight)` (`Header.scala:1250`), so any unrecognized encoding name silently parses as `GZip` — `accept-encoding: bogus` reads as a gzip request. `Header.AcceptEncoding.parse` rejects only values with no non-empty comma-separated part, so `""`, `","`, and `"   "` are the only failing inputs. The sibling ADTs handle the same situation correctly: `Authorization` has an `Unparsed` case and `Connection` has `Other`. `AcceptEncoding` should either gain an equivalent case or return `Left`. Tracked as [zio/zio-blocks#1618](https://github.com/zio/zio-blocks/issues/1618).
-
 What remains is the report's own items 4 and 5 rather than anything new:
 
 - [ ] Document `PercentEncoder`, `QueryKey`, `QueryValue`, and `QueryParamsBuilder` in the URL and query sections of `model.md`

--- a/http-model/shared/src/main/scala/zio/http/Header.scala
+++ b/http-model/shared/src/main/scala/zio/http/Header.scala
@@ -1202,12 +1202,13 @@ object Header {
   object AcceptEncoding extends Typed[AcceptEncoding] {
     val name: String = "accept-encoding"
 
-    final case class GZip(weight: Option[Double] = None)     extends AcceptEncoding
-    final case class Deflate(weight: Option[Double] = None)  extends AcceptEncoding
-    final case class Br(weight: Option[Double] = None)       extends AcceptEncoding
-    final case class Compress(weight: Option[Double] = None) extends AcceptEncoding
-    final case class Identity(weight: Option[Double] = None) extends AcceptEncoding
-    final case class Any(weight: Option[Double] = None)      extends AcceptEncoding
+    final case class GZip(weight: Option[Double] = None)                   extends AcceptEncoding
+    final case class Deflate(weight: Option[Double] = None)                extends AcceptEncoding
+    final case class Br(weight: Option[Double] = None)                     extends AcceptEncoding
+    final case class Compress(weight: Option[Double] = None)               extends AcceptEncoding
+    final case class Identity(weight: Option[Double] = None)               extends AcceptEncoding
+    final case class Any(weight: Option[Double] = None)                    extends AcceptEncoding
+    final case class Unparsed(name: String, weight: Option[Double] = None) extends AcceptEncoding
 
     final case class Multiple(values: Chunk[AcceptEncoding]) extends AcceptEncoding
 
@@ -1221,24 +1222,31 @@ object Header {
     }
 
     def render(h: AcceptEncoding): String = h match {
-      case GZip(w)     => renderWithWeight("gzip", w)
-      case Deflate(w)  => renderWithWeight("deflate", w)
-      case Br(w)       => renderWithWeight("br", w)
-      case Compress(w) => renderWithWeight("compress", w)
-      case Identity(w) => renderWithWeight("identity", w)
-      case Any(w)      => renderWithWeight("*", w)
-      case Multiple(v) => v.map(render).mkString(", ")
+      case GZip(w)        => renderWithWeight("gzip", w)
+      case Deflate(w)     => renderWithWeight("deflate", w)
+      case Br(w)          => renderWithWeight("br", w)
+      case Compress(w)    => renderWithWeight("compress", w)
+      case Identity(w)    => renderWithWeight("identity", w)
+      case Any(w)         => renderWithWeight("*", w)
+      case Unparsed(n, w) => renderWithWeight(n, w)
+      case Multiple(v)    => v.map(render).mkString(", ")
     }
 
     private def parseSingle(s: String): AcceptEncoding = {
-      val qIdx          = s.indexOf(";q=")
-      val (raw, weight) =
-        if (qIdx >= 0) {
-          val w =
-            try Some(s.substring(qIdx + 3).trim.toDouble)
+      val semi = s.indexOf(';')
+      val raw  = if (semi < 0) s else s.substring(0, semi).trim
+
+      var weight: Option[Double] = None
+      var from                   = semi
+      while (from >= 0 && weight.isEmpty) {
+        val next  = s.indexOf(';', from + 1)
+        val param = (if (next < 0) s.substring(from + 1) else s.substring(from + 1, next)).trim
+        if (param.length > 2 && param.regionMatches(true, 0, "q=", 0, 2))
+          weight =
+            try Some(param.substring(2).trim.toDouble)
             catch { case _: NumberFormatException => None }
-          (s.substring(0, qIdx).trim, w)
-        } else (s.trim, None)
+        from = next
+      }
 
       raw.toLowerCase match {
         case "gzip"     => GZip(weight)
@@ -1247,7 +1255,7 @@ object Header {
         case "compress" => Compress(weight)
         case "identity" => Identity(weight)
         case "*"        => Any(weight)
-        case _          => GZip(weight)
+        case _          => Unparsed(raw, weight)
       }
     }
 

--- a/http-model/shared/src/test/scala/zio/http/headers/NegotiationHeadersSpec.scala
+++ b/http-model/shared/src/test/scala/zio/http/headers/NegotiationHeadersSpec.scala
@@ -146,6 +146,72 @@ object NegotiationHeadersSpec extends ZIOSpecDefault {
       test("parse empty returns Left") {
         assertTrue(AcceptEncoding.parse("").isLeft)
       },
+      test("unknown encoding is preserved, not coerced to gzip") {
+        assertTrue(
+          AcceptEncoding.parse("bogus") == Right(AcceptEncoding.Unparsed("bogus", None)),
+          AcceptEncoding.parse("!!!") == Right(AcceptEncoding.Unparsed("!!!", None)),
+          AcceptEncoding.parse("identityy") == Right(AcceptEncoding.Unparsed("identityy", None)),
+          AcceptEncoding.parse("identityy") != Right(AcceptEncoding.GZip(None))
+        )
+      },
+      test("unknown encoding keeps its weight") {
+        assertTrue(
+          AcceptEncoding.parse("bogus;q=0.3") ==
+            Right(AcceptEncoding.Unparsed("bogus", Some(0.3)))
+        )
+      },
+      test("unknown encoding round-trips") {
+        val rendered = AcceptEncoding.render(AcceptEncoding.parse("bogus").toOption.get)
+        assertTrue(
+          rendered == "bogus",
+          AcceptEncoding.render(AcceptEncoding.Unparsed("bogus", Some(0.3))) == "bogus;q=0.3"
+        )
+      },
+      test("unknown encoding inside a list is kept in place") {
+        assertTrue(
+          AcceptEncoding.parse("gzip, zstd, br;q=0.5") == Right(
+            AcceptEncoding.Multiple(
+              Chunk(
+                AcceptEncoding.GZip(None),
+                AcceptEncoding.Unparsed("zstd", None),
+                AcceptEncoding.Br(Some(0.5))
+              )
+            )
+          )
+        )
+      },
+      test("weight parameter tolerates optional whitespace and uppercase Q (RFC 9110 §12.4.2)") {
+        assertTrue(
+          AcceptEncoding.parse("identity; q=0.5") ==
+            Right(AcceptEncoding.Identity(Some(0.5))),
+          AcceptEncoding.parse("identity ; q=0.5") ==
+            Right(AcceptEncoding.Identity(Some(0.5))),
+          AcceptEncoding.parse("GZIP;Q=0.5") == Right(AcceptEncoding.GZip(Some(0.5))),
+          AcceptEncoding.parse("gzip; Q=0.5") == Right(AcceptEncoding.GZip(Some(0.5))),
+          AcceptEncoding.parse("gzip;q=1.0, identity; q=0.5, *;q=0") == Right(
+            AcceptEncoding.Multiple(
+              Chunk(
+                AcceptEncoding.GZip(Some(1.0)),
+                AcceptEncoding.Identity(Some(0.5)),
+                AcceptEncoding.Any(Some(0.0))
+              )
+            )
+          )
+        )
+      },
+      test("malformed parameters never throw") {
+        assertTrue(
+          AcceptEncoding.parse(";") == Right(AcceptEncoding.Unparsed("", None)),
+          AcceptEncoding.parse(";q=0.5") == Right(AcceptEncoding.Unparsed("", Some(0.5))),
+          AcceptEncoding.parse("gzip;") == Right(AcceptEncoding.GZip(None)),
+          AcceptEncoding.parse("gzip;;q=0.5") == Right(AcceptEncoding.GZip(Some(0.5))),
+          AcceptEncoding.parse("gzip;level=9;q=0.5") ==
+            Right(AcceptEncoding.GZip(Some(0.5))),
+          AcceptEncoding.parse("gzip;q=abc;q=0.9") == Right(AcceptEncoding.GZip(Some(0.9))),
+          AcceptEncoding.parse("gzip;q=abc") == Right(AcceptEncoding.GZip(None)),
+          AcceptEncoding.parse("gzip;q=") == Right(AcceptEncoding.GZip(None))
+        )
+      },
       test("header name") {
         assertTrue(AcceptEncoding.GZip(None).headerName == "accept-encoding")
       },


### PR DESCRIPTION
Fixes #1618.

## Summary

`Header.AcceptEncoding.parse` mapped any coding name it did not recognize to `GZip`. As reported in #1618, `accept-encoding: bogus`, `!!!`, or a typo such as `identityy` read as a gzip request, and the original text was lost on render: `render(parse("bogus"))` gave `"gzip"`.

This PR takes option 2 from the issue: a new `AcceptEncoding.Unparsed(name, weight)` case preserves the coding verbatim, `parse` stays total, and a server can skip codings it does not support instead of mistaking them for gzip.

## Why weight parsing changes in the same PR

`parseSingle` located the weight by searching for the literal `;q=`. RFC 9110 §12.4.2 allows optional whitespace around `;` and a case-insensitive `q`, and the RFC's own Accept-Encoding example is `gzip;q=1.0, identity; q=0.5, *;q=0`. With the literal search, `identity; q=0.5` does not match, the whole string is taken as the coding name, and it falls into the fallback.

Today that fallback yields `GZip(None)`: wrong, but hidden by the bug this PR fixes. With `Unparsed` alone it would yield `Unparsed("identity; q=0.5", None)`, and a valid `identity` preference would be dropped. Shipping `Unparsed` without fixing the weight parsing would trade one wrong answer for another on RFC-conformant input, so both land together. The parsing now splits on `;`, trims, and matches `q=` case-insensitively; other parameters are skipped.

## Changes

- `AcceptEncoding.Unparsed(name: String, weight: Option[Double])`, returned from the `parseSingle` fallback and rendered back verbatim. The name matches `Authorization.Unparsed`, which plays the same role.
- `parseSingle` weight extraction reworked as described above, without `split` so that malformed parameters cannot index out of bounds.
- Tests in `NegotiationHeadersSpec`: the three inputs from the issue, round trip, weight preserved on `Unparsed`, `Unparsed` kept in place inside a list (`zstd`), the RFC weight forms (`identity; q=0.5`, `GZIP;Q=0.5`, the full RFC example), and malformed parameter inputs (`;`, `;q=0.5`, `gzip;`, `gzip;;q=0.5`, `gzip;level=9;q=0.5`, duplicate `q`) that must never throw.
- Docs: the warning admonition in `docs/reference/http-model/headers.md` is replaced by prose describing the new behaviour, `Unparsed` is added to the ADT table, and the tracking entry in `docs/undocumented-report.md` is removed.

## Behaviour notes

- Only inputs with no non-empty comma-separated part return `Left`, as before.
- This adds a case to a sealed trait, so downstream exhaustive matches on `AcceptEncoding` need an `Unparsed` arm.
- Deliberately not changed, possible follow-ups: `zstd` as a known coding (Chrome sends it by default); `AcceptLanguage` has the same literal `;q=` search; q-values outside 0..1, `NaN`, and `Infinity` are accepted as before; an empty `Accept-Encoding` returns `Left` although RFC 9110 §12.5.3 gives it a meaning.

## Verification

- `http-modelJVM/test` on Scala 3.9.0 and 2.13.18: 1115 passed. `http-modelJS/test`: 1109 passed.
- `http-modelJVM` coverage: 95.74% statements, 94.66% branches (thresholds 95 / 94).
- `scalafmtCheck` clean.
- `docs/mdoc` was not run locally (the `docs` project needs JDK 21+ through `telemetry`). The only affected mdoc block is `Header.AcceptEncoding.parse("!!!")`, which the new tests exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
