### PR TITLE
fix(http-model): add strict header accessors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -324,6 +324,7 @@ lazy val root = project
     scalaNextTests.js,
     benchmarks,
     `scope-benchmarks`,
+    `http-model-benchmarks`,
     `sql-benchmarks`,
     `streams-benchmark`,
     docs,
@@ -1066,6 +1067,18 @@ lazy val `http-model-examples` = project
     coverageMinimumBranchTotal := 0
   )
   .dependsOn(`http-model`.jvm)
+
+lazy val `http-model-benchmarks` = project
+  .in(file("http-model-benchmarks"))
+  .settings(stdSettings("zio-blocks-http-model-benchmarks", Seq("3.9.0")))
+  .dependsOn(`http-model`.jvm)
+  .enablePlugins(JmhPlugin)
+  .settings(
+    publish / skip             := true,
+    mimaPreviousArtifacts      := Set(),
+    coverageMinimumStmtTotal   := 0,
+    coverageMinimumBranchTotal := 0
+  )
 
 lazy val `zio-blocks-htmx-examples` = project
   .in(file("zio-blocks-htmx-examples"))

--- a/docs/reference/http-model/headers.md
+++ b/docs/reference/http-model/headers.md
@@ -29,7 +29,7 @@ object Header {
 
 An HTTP message is a bag of strings, and treating it that way pushes the same three mistakes into every handler. `headers.rawGet("content-length").map(_.toInt)` throws on a malformed value. `headers.rawGet("Content-Length")` works only because someone remembered the casing rules. `cache-control: max-age=600, no-store` has to be split, trimmed, and matched by hand at each call site.
 
-A typed header replaces all three with one lookup. `Header.ContentLength` knows its wire name is `content-length`, that the value is a `Long`, and that a non-numeric value is a parse failure rather than an exception. Reading it is `headers.get(Header.ContentLength)`, and the result is an `Option[ContentLength]` with a `length: Long` inside.
+A typed header replaces all three with one lookup. `Header.ContentLength` knows its wire name is `content-length`, that the value is a `Long`, and that a non-numeric value is a parse failure rather than an exception. Reading it is `headers.get(Header.ContentLength)`, and the result is a `Maybe[ContentLength]` with a `length: Long` inside — `Maybe` is the zero-allocation sibling of `Option` used across ZIO Blocks, so a middleware checking a header on every request pays no wrapper allocation for the hit.
 
 Parsing stays lazy because most handlers read two or three headers out of fifteen. `Headers` keeps the raw strings and only parses an entry when a typed read asks for it, caching the parsed value per entry so a header read twice is parsed once.
 
@@ -108,7 +108,7 @@ Header.CacheControl.MaxAge(600).renderedValue
 
 ## Reading Headers
 
-Six methods read from a `Headers` collection: three typed, three raw. Which you want depends on whether you need the domain value or the exact bytes.
+Eight methods read from a `Headers` collection: five typed, three raw. Which you want depends on whether you need the domain value or the exact bytes — and, for the typed ones, whether a malformed value should read as absent or surface its parse error.
 
 ### `Headers#get` — first parseable match
 
@@ -116,11 +116,11 @@ Six methods read from a `Headers` collection: three typed, three raw. Which you 
 
 ```scala
 final class Headers {
-  def get[A](headerCodec: Header.Codec[A]): Option[A]
+  def get[A](headerCodec: Header.Codec[A]): Maybe[A]
 }
 ```
 
-A present, well-formed header parses; an absent one is `None`:
+A present, well-formed header parses; an absent one is `Maybe.absent`:
 
 ```scala mdoc:silent:reset
 import zio.http.{Header, Headers}
@@ -136,7 +136,7 @@ headers.get(Header.ETag)
 ```
 
 :::warning[Unparseable headers are skipped, not reported]
-`Headers#get` treats a parse failure exactly like a name mismatch: it discards the error and keeps scanning. A malformed header therefore reads as `None` — or as the *next* entry with the same name that does parse. There is no method that surfaces the parse error from a collection read.
+`Headers#get` treats a parse failure exactly like a name mismatch: it discards the error and keeps scanning. A malformed header therefore reads as `Maybe.absent` — or as the *next* entry with the same name that does parse. To surface the parse error instead, use the strict variants below.
 :::
 
 That behaviour is worth seeing, because it is the one place a typed read can mislead you:
@@ -203,11 +203,11 @@ Header.AcceptEncoding.parse("!!!")
 
 ### `Headers#getLast` — last parseable match
 
-`Headers#getLast` is `Headers#getAll` keeping only the final element, which is what you want when a later header is meant to override an earlier one:
+`Headers#getLast` scans backwards for the last entry that parses, which is what you want when a later header is meant to override an earlier one. Scanning from the end means entries after the last parseable one are the only ones ever parsed — unlike `getAll` followed by taking the final element, it never parses the whole list to return a single value:
 
 ```scala
 final class Headers {
-  def getLast[H <: Header](headerType: Header.Typed[H]): Option[H]
+  def getLast[H <: Header](headerType: Header.Typed[H]): Maybe[H]
 }
 ```
 
@@ -226,14 +226,50 @@ overridden.get(Header.ContentLength)
 overridden.getLast(Header.ContentLength)
 ```
 
+### Strict reads — telling "missing" from "malformed"
+
+The lenient reads above conflate absence with corruption: both surface as `Maybe.absent` (or a skipped entry). `Headers#getStrict` and `Headers#getAllStrict` keep the same scanning and caching but report parse failures as `Left` instead of skipping them:
+
+```scala
+final class Headers {
+  def getStrict[A](headerCodec: Header.Codec[A]): Either[String, Maybe[A]]
+  def getAllStrict[A](headerCodec: Header.Codec[A]): Either[String, Chunk[A]]
+}
+```
+
+```scala mdoc:silent:reset
+import zio.http.{Header, Headers}
+
+val bad      = Headers("content-length" -> "huge")
+val mixed    = Headers("content-length" -> "huge", "content-length" -> "512")
+val twoGoods = Headers("content-length" -> "100", "content-length" -> "200")
+```
+
+`Headers#getStrict` keeps scanning past bad entries while a later entry may still parse, and reports the first error only when nothing parseable is found. `Right(Maybe.absent)` means no entry matched at all:
+
+```scala mdoc
+bad.getStrict(Header.ContentLength)
+mixed.getStrict(Header.ContentLength)
+Headers.empty.getStrict(Header.ContentLength)
+```
+
+`Headers#getAllStrict` is the fail-fast counterpart: it collects every match in header order and returns the first parse error immediately instead of skipping it:
+
+```scala mdoc
+twoGoods.getAllStrict(Header.ContentLength)
+bad.getAllStrict(Header.ContentLength)
+```
+
+Reach for the strict variants when a malformed header should be a 400 rather than silent fallback — request validation, strict proxies, and debugging corrupt clients. Stay on the lenient reads for the per-request hot path: the `Either` wrapper allocates on every call, while `Maybe` on the lenient path does not.
+
 ### Raw Access
 
 Three methods bypass parsing entirely and hand back the stored string. Use them for headers with no typed model, for pass-through proxying, and for telling a malformed value from an absent one:
 
 | Method                    | Returns             | Picks                        |
 | ------------------------- | ------------------- | ---------------------------- |
-| `Headers#rawGet`          | `Option[String]`    | First entry with that name    |
-| `Headers#rawGetLast`      | `Option[String]`    | Last entry with that name     |
+| `Headers#rawGet`          | `Maybe[String]`     | First entry with that name    |
+| `Headers#rawGetLast`      | `Maybe[String]`     | Last entry with that name     |
 | `Headers#rawGetAll`       | `Chunk[String]`     | Every entry, in header order  |
 
 All three validate the name before scanning and are case-insensitive:
@@ -261,7 +297,7 @@ headers.contains("x-missing")
 
 ## The Parse Cache
 
-`Headers` stores three parallel arrays: lowercased names, raw values, and a lazily-filled slot for the parsed value of each entry. A typed read fills that slot; a second read of the same header reuses it.
+`Headers` stores four parallel arrays: lowercased names, raw values, the codec instance that parsed each entry, and the parsed value itself. A typed read fills the codec/value slots; a second read of the same header with the same codec instance reuses them with a single reference comparison — no wrapper object is allocated for the cache entry itself.
 
 The cache is keyed by *codec identity*, compared by reference. Two codecs sharing a wire name therefore never read each other's cached values, which is what keeps a custom `Header.Codec[MyType]` named `content-length` from colliding with `Header.ContentLength`.
 
@@ -638,7 +674,7 @@ val headers = Headers("x-tenant-id" -> "acme-42")
 headers.get(tenantIdCodec)
 ```
 
-A rejected value is skipped like any other parse failure, so the collection read is `None` rather than the error message:
+A rejected value is skipped like any other parse failure, so the collection read is `Maybe.absent` rather than the error message (use `getStrict` to surface it):
 
 ```scala mdoc
 Headers("x-tenant-id" -> "").get(tenantIdCodec)

--- a/docs/reference/http-model/model.md
+++ b/docs/reference/http-model/model.md
@@ -640,8 +640,8 @@ val allIds = params.get("id")         // Some(Chunk("1", "2", "3"))
 ```scala
 final class Headers private[http] (...) {
   def size: Int
-  def get[A](headerCodec: Header.Codec[A]): Option[A]
-  def rawGet(name: String): Option[String]
+  def get[A](headerCodec: Header.Codec[A]): Maybe[A]
+  def rawGet(name: String): Maybe[String]
   def add(header: Header): Headers
   def set(header: Header): Headers
   def remove(name: String): Headers

--- a/http-model-benchmarks/src/main/scala/zio/http/HeadersBenchmark.scala
+++ b/http-model-benchmarks/src/main/scala/zio/http/HeadersBenchmark.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+
+import java.util.concurrent.TimeUnit
+
+import zio.blocks.chunk.Chunk
+import zio.blocks.maybe.Maybe
+
+/**
+ * Throughput benchmarks for the `Headers` hot path: the per-request lookups a
+ * middleware performs on every call (`rawGet`, `get`, `has`) plus the
+ * multi-value and strict variants.
+ *
+ * The target entry sits at the END of the collection (worst-case scan) with
+ * `size` filler entries before it. Results are returned (not sunk into a
+ * `Blackhole`) to defeat dead-code elimination.
+ *
+ * Run with:
+ * {{{
+ * sbt --client "++3.9.0; http-model-benchmarks/Jmh/run HeadersBenchmark"
+ * }}}
+ */
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+  value = 1,
+  jvmArgs = Array(
+    "-server",
+    "-Xnoclassgc",
+    "-Xms3g",
+    "-Xmx3g",
+    "-Xss4m",
+    "-XX:NewSize=2g",
+    "-XX:MaxNewSize=2g",
+    "-XX:InitialCodeCacheSize=512m",
+    "-XX:ReservedCodeCacheSize=512m",
+    "-XX:TLABSize=16m",
+    "-XX:-ResizeTLAB",
+    "-XX:+UseParallelGC",
+    "-XX:-UseAdaptiveSizePolicy",
+    "-XX:MaxInlineLevel=20",
+    "-XX:InlineSmallCode=2500",
+    "-XX:+AlwaysPreTouch",
+    "-XX:+PerfDisableSharedMem",
+    "-XX:-UsePerfData",
+    "-XX:+UnlockExperimentalVMOptions",
+    "-XX:+TrustFinalNonStaticFields"
+  )
+)
+class HeadersBenchmark {
+
+  @Param(Array("5", "20"))
+  var size: Int = 5
+
+  var headers: Headers = Headers.empty
+  var multi: Headers   = Headers.empty
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    var h = Headers.empty
+    var i = 0
+    while (i < size) {
+      h = h.add("x-filler-" + i, "v-" + i)
+      i += 1
+    }
+    headers = h.add("content-length", "1024")
+    var m = Headers.empty
+    var j = 0
+    while (j < size) {
+      m = m.add("set-cookie", "a=" + j)
+      j += 1
+    }
+    multi = m
+  }
+
+  @Benchmark
+  def rawGetHit: Maybe[String] = headers.rawGet("content-length")
+
+  @Benchmark
+  def rawGetMiss: Maybe[String] = headers.rawGet("x-missing")
+
+  @Benchmark
+  def getHit: Maybe[Header.ContentLength] = headers.get(Header.ContentLength)
+
+  @Benchmark
+  def getMiss: Maybe[Header.ContentLength] = Headers.empty.get(Header.ContentLength)
+
+  @Benchmark
+  def getStrictHit: Either[String, Maybe[Header.ContentLength]] = headers.getStrict(Header.ContentLength)
+
+  @Benchmark
+  def hasHit: Boolean = headers.has("content-length")
+
+  @Benchmark
+  def getLastHit: Maybe[Header.SetCookieHeader] = multi.getLast(Header.SetCookieHeader)
+
+  @Benchmark
+  def getAllHit: Chunk[Header.SetCookieHeader] = multi.getAll(Header.SetCookieHeader)
+}

--- a/http-model-schema/shared/src/main/scala/zio/http/schema/HeadersSchemaOps.scala
+++ b/http-model-schema/shared/src/main/scala/zio/http/schema/HeadersSchemaOps.scala
@@ -23,9 +23,8 @@ import zio.http.{Header, Headers}
 final class HeadersSchemaOps(private val headers: Headers) extends AnyVal {
 
   def header[T](name: String)(implicit schema: Schema[T]): Either[HeaderError, T] =
-    headers.rawGet(name) match {
-      case None      => Left(HeaderError.Missing(name))
-      case Some(raw) => StringDecoder.decode(raw, schema).left.map(e => HeaderError.Malformed(name, raw, e))
+    headers.rawGet(name).fold(Left(HeaderError.Missing(name)): Either[HeaderError, T]) { raw =>
+      StringDecoder.decode(raw, schema).left.map(e => HeaderError.Malformed(name, raw, e))
     }
 
   /**
@@ -35,9 +34,8 @@ final class HeadersSchemaOps(private val headers: Headers) extends AnyVal {
    * [[HeaderError.Malformed]] when parsing fails.
    */
   def header[A](headerCodec: Header.Codec[A]): Either[HeaderError, A] =
-    headers.rawGet(headerCodec.name) match {
-      case None      => Left(HeaderError.Missing(headerCodec.name))
-      case Some(raw) => headerCodec.parse(raw).left.map(e => HeaderError.Malformed(headerCodec.name, raw, e))
+    headers.rawGet(headerCodec.name).fold(Left(HeaderError.Missing(headerCodec.name)): Either[HeaderError, A]) { raw =>
+      headerCodec.parse(raw).left.map(e => HeaderError.Malformed(headerCodec.name, raw, e))
     }
 
   def headerAll[T](name: String)(implicit schema: Schema[T]): Either[HeaderError, Chunk[T]] = {

--- a/http-model-schema/shared/src/test/scala/zio/http/schema/HeaderCodecSpec.scala
+++ b/http-model-schema/shared/src/test/scala/zio/http/schema/HeaderCodecSpec.scala
@@ -110,15 +110,13 @@ object HeaderCodecSpec extends ZIOSpecDefault {
         def encode(value: Int, output: HeadersBuilder): Unit =
           output.add("Value", s"custom-$value")
 
-        def decode(input: Headers): Either[SchemaError, Int] = {
-          val raw = input.rawGet("Value")
-          raw match {
-            case Some(s) if s.startsWith("custom-") =>
-              Right(s.stripPrefix("custom-").toInt)
-            case other =>
-              Left(SchemaError(s"Expected custom- prefix, got: $other"))
-          }
-        }
+        def decode(input: Headers): Either[SchemaError, Int] =
+          input
+            .rawGet("Value")
+            .fold(Left(SchemaError("Expected custom- prefix, got: absent")): Either[SchemaError, Int]) { s =>
+              if (s.startsWith("custom-")) Right(s.stripPrefix("custom-").toInt)
+              else Left(SchemaError(s"Expected custom- prefix, got: $s"))
+            }
       }
       val codec = Schema[Int].deriving(HeaderCodecDeriver).instance(TypeId.int, customIntCodec).derive
 

--- a/http-model/shared/src/main/scala/zio/http/Headers.scala
+++ b/http-model/shared/src/main/scala/zio/http/Headers.scala
@@ -19,31 +19,67 @@ package zio.http
 import java.util.Locale
 
 import zio.blocks.chunk.Chunk
+import zio.blocks.maybe.Maybe
 
 /**
  * Immutable collection of HTTP headers, backed by parallel arrays.
  *
  * Header names are stored pre-lowercased for case-insensitive matching.
- * Multiple headers with the same name are allowed (multi-value). The `parsed`
- * array is populated lazily on typed `get` calls. The cache is an optimization
- * only: duplicate benign parses are possible if the same `Headers` is read
- * concurrently.
+ * Multiple headers with the same name are allowed (multi-value).
+ * `parsedCodecs`/`parsedValues` are populated lazily on typed `get` calls: a
+ * non-null codec marks its entry as parsed by that exact codec instance. The
+ * cache is an optimization only: duplicate benign parses are possible if the
+ * same `Headers` is read concurrently.
  *
  * Typed reads come in two flavors. The lenient [[get]] / [[getAll]] skip
  * entries that fail to parse and continue scanning, so a wrong-typed header
- * reads as absent (`None` / empty). Use the strict [[getStrict]] /
+ * reads as absent ([[Maybe.absent]] / empty). Use the strict [[getStrict]] /
  * [[getAllStrict]] when you need to distinguish "header absent" from "header
  * present but unparseable": they report the parse error as `Left`.
  */
 final class Headers private[http] (
   private val names: Array[String],
   private val rawValues: Array[String],
-  private val parsed: Array[AnyRef],
+  private val parsedCodecs: Array[Header.Codec[_]],
+  private val parsedValues: Array[AnyRef],
   val size: Int
 ) {
 
   private def sameCodec(left: Header.Codec[_], right: Header.Codec[_]): Boolean =
     left.asInstanceOf[AnyRef] eq right.asInstanceOf[AnyRef]
+
+  /**
+   * Value cached for entry `i` when it was parsed by this exact codec instance,
+   * or `null` on a cache miss. A `null` value is treated as a miss (matching
+   * the previous behaviour where a `null` parse result never hit).
+   */
+  private def cachedValue[A](i: Int, headerCodec: Header.Codec[A]): AnyRef =
+    if (sameCodec(parsedCodecs(i), headerCodec)) parsedValues(i) else null
+
+  private def storeParsed[A](i: Int, headerCodec: Header.Codec[A], value: A): Unit = {
+    parsedCodecs(i) = headerCodec
+    parsedValues(i) = value.asInstanceOf[AnyRef]
+  }
+
+  /** Index of the first entry named `target` in `[0, size)`, or `-1`. */
+  private def indexOf(target: String): Int = {
+    var i = 0
+    while (i < size) {
+      if (names(i) == target) return i
+      i += 1
+    }
+    -1
+  }
+
+  /** Index of the last entry named `target` in `[0, size)`, or `-1`. */
+  private def lastIndexOf(target: String): Int = {
+    var i = size - 1
+    while (i >= 0) {
+      if (names(i) == target) return i
+      i -= 1
+    }
+    -1
+  }
 
   def isEmpty: Boolean  = size == 0
   def nonEmpty: Boolean = size > 0
@@ -57,89 +93,75 @@ final class Headers private[http] (
    *
    * This is the lenient read: entries that fail to parse are skipped and
    * scanning continues, so a present-but-wrong-typed header reads as absent
-   * (`None`). See [[getStrict]] for the error-reporting variant.
+   * ([[Maybe.absent]]). See [[getStrict]] for the error-reporting variant.
+   *
+   * The result is a [[Maybe]] rather than an `Option` so the hot path (e.g. a
+   * middleware checking a header on every request) pays no `Some` allocation on
+   * Scala 3: a present value is returned raw, absence is the `Absent`
+   * singleton.
    */
-  def get[A](headerCodec: Header.Codec[A]): Option[A] = {
-    val target = headerCodec.name.toLowerCase(Locale.ROOT)
+  def get[A](headerCodec: Header.Codec[A]): Maybe[A] = {
+    val target = Headers.lowerName(headerCodec.name)
     var i      = 0
     while (i < size) {
       if (names(i) == target) {
-        parsed(i) match {
-          case cached: Headers.ParsedValue if sameCodec(cached.codec, headerCodec) =>
-            return Some(cached.value.asInstanceOf[A])
-          case _ =>
-        }
+        val cached = cachedValue(i, headerCodec)
+        if (cached != null) return Maybe.present(cached.asInstanceOf[A])
         headerCodec.parse(rawValues(i)) match {
           case Right(value) =>
-            parsed(i) = new Headers.ParsedValue(headerCodec, value.asInstanceOf[AnyRef])
-            return Some(value)
+            storeParsed(i, headerCodec, value)
+            return Maybe.present(value)
           case Left(_) => // skip unparseable, continue scanning
         }
       }
       i += 1
     }
-    None
+    Maybe.absent
   }
 
   /**
    * Strict variant of [[get]]: distinguishes "header absent" from "header
    * present but unparseable".
    *
-   * Returns `Right(Some(value))` for the first entry that parses, `Right(None)`
+   * Returns `Right` of the first entry that parses, `Right` of [[Maybe.absent]]
    * when no entry matches the codec name, and `Left(error)` carrying the first
    * parse error when entries match but none parses. Like [[get]], scanning
    * continues past unparseable entries while a later entry may still parse; the
    * error is reported only when nothing parseable is found.
    */
-  def getStrict[A](headerCodec: Header.Codec[A]): Either[String, Option[A]] = {
-    val target             = headerCodec.name.toLowerCase(Locale.ROOT)
+  def getStrict[A](headerCodec: Header.Codec[A]): Either[String, Maybe[A]] = {
+    val target             = Headers.lowerName(headerCodec.name)
     var i                  = 0
     var firstError: String = null
     while (i < size) {
       if (names(i) == target) {
-        parsed(i) match {
-          case cached: Headers.ParsedValue if sameCodec(cached.codec, headerCodec) =>
-            return Right(Some(cached.value.asInstanceOf[A]))
-          case _ =>
-        }
+        val cached = cachedValue(i, headerCodec)
+        if (cached != null) return Right(Maybe.present(cached.asInstanceOf[A]))
         headerCodec.parse(rawValues(i)) match {
           case Right(value) =>
-            parsed(i) = new Headers.ParsedValue(headerCodec, value.asInstanceOf[AnyRef])
-            return Right(Some(value))
+            storeParsed(i, headerCodec, value)
+            return Right(Maybe.present(value))
           case Left(err) =>
             if (firstError == null) firstError = err
         }
       }
       i += 1
     }
-    if (firstError == null) Right(None) else Left(firstError)
+    if (firstError == null) Right(Maybe.absent) else Left(firstError)
   }
 
-  def rawGet(name: String): Option[String] = {
-    Headers.validateNameOrThrow(name)
-    val target = name.toLowerCase(Locale.ROOT)
-    var i      = 0
-    while (i < size) {
-      if (names(i) == target) return Some(rawValues(i))
-      i += 1
-    }
-    None
+  def rawGet(name: String): Maybe[String] = {
+    val idx = indexOf(Headers.validatedLowerName(name))
+    if (idx < 0) Maybe.absent else Maybe.present(rawValues(idx))
   }
 
-  def rawGetLast(name: String): Option[String] = {
-    Headers.validateNameOrThrow(name)
-    val target = name.toLowerCase(Locale.ROOT)
-    var i      = size - 1
-    while (i >= 0) {
-      if (names(i) == target) return Some(rawValues(i))
-      i -= 1
-    }
-    None
+  def rawGetLast(name: String): Maybe[String] = {
+    val idx = lastIndexOf(Headers.validatedLowerName(name))
+    if (idx < 0) Maybe.absent else Maybe.present(rawValues(idx))
   }
 
   def rawGetAll(name: String): Chunk[String] = {
-    Headers.validateNameOrThrow(name)
-    val target  = name.toLowerCase(Locale.ROOT)
+    val target  = Headers.validatedLowerName(name)
     val builder = Chunk.newBuilder[String]
     var i       = 0
     while (i < size) {
@@ -158,22 +180,20 @@ final class Headers private[http] (
    * fail-fast variant.
    */
   def getAll[A](headerCodec: Header.Codec[A]): Chunk[A] = {
-    val target  = headerCodec.name.toLowerCase(Locale.ROOT)
+    val target  = Headers.lowerName(headerCodec.name)
     val builder = Chunk.newBuilder[A]
     var i       = 0
     while (i < size) {
       if (names(i) == target) {
-        parsed(i) match {
-          case cached: Headers.ParsedValue if sameCodec(cached.codec, headerCodec) =>
-            builder += cached.value.asInstanceOf[A]
-          case _ =>
-            headerCodec.parse(rawValues(i)) match {
-              case Right(value) =>
-                parsed(i) = new Headers.ParsedValue(headerCodec, value.asInstanceOf[AnyRef])
-                builder += value
-              case Left(_) => // skip unparseable entries
-            }
-        }
+        val cached = cachedValue(i, headerCodec)
+        if (cached != null) builder += cached.asInstanceOf[A]
+        else
+          headerCodec.parse(rawValues(i)) match {
+            case Right(value) =>
+              storeParsed(i, headerCodec, value)
+              builder += value
+            case Left(_) => // skip unparseable entries
+          }
       }
       i += 1
     }
@@ -185,87 +205,98 @@ final class Headers private[http] (
    * of skipping unparseable entries.
    */
   def getAllStrict[A](headerCodec: Header.Codec[A]): Either[String, Chunk[A]] = {
-    val target  = headerCodec.name.toLowerCase(Locale.ROOT)
+    val target  = Headers.lowerName(headerCodec.name)
     val builder = Chunk.newBuilder[A]
     var i       = 0
     while (i < size) {
       if (names(i) == target) {
-        parsed(i) match {
-          case cached: Headers.ParsedValue if sameCodec(cached.codec, headerCodec) =>
-            builder += cached.value.asInstanceOf[A]
-          case _ =>
-            headerCodec.parse(rawValues(i)) match {
-              case Right(value) =>
-                parsed(i) = new Headers.ParsedValue(headerCodec, value.asInstanceOf[AnyRef])
-                builder += value
-              case Left(err) => return Left(err)
-            }
-        }
+        val cached = cachedValue(i, headerCodec)
+        if (cached != null) builder += cached.asInstanceOf[A]
+        else
+          headerCodec.parse(rawValues(i)) match {
+            case Right(value) =>
+              storeParsed(i, headerCodec, value)
+              builder += value
+            case Left(err) => return Left(err)
+          }
       }
       i += 1
     }
     Right(builder.result())
   }
 
-  def getLast[H <: Header](headerType: Header.Typed[H]): Option[H] = {
-    val all = getAll(headerType)
-    if (all.isEmpty) None else Some(all(all.length - 1))
+  /**
+   * Decodes the last header matching the supplied codec.
+   *
+   * Scans backwards so only entries down to the last parseable one are parsed;
+   * unlike `getAll(...).lastOption` this never parses the whole header list to
+   * return a single value. Unparseable entries are skipped like in [[get]].
+   */
+  def getLast[H <: Header](headerType: Header.Typed[H]): Maybe[H] = {
+    val target = Headers.lowerName(headerType.name)
+    var i      = size - 1
+    while (i >= 0) {
+      if (names(i) == target) {
+        val cached = cachedValue(i, headerType)
+        if (cached != null) return Maybe.present(cached.asInstanceOf[H])
+        headerType.parse(rawValues(i)) match {
+          case Right(value) =>
+            storeParsed(i, headerType, value)
+            return Maybe.present(value)
+          case Left(_) => // skip unparseable, keep scanning backwards
+        }
+      }
+      i -= 1
+    }
+    Maybe.absent
   }
 
   def add(header: Header): Headers = add(header.headerName, header.renderedValue)
 
   def add(name: String, value: String): Headers = {
-    Headers.validateNameOrThrow(name)
     Headers.validateValueOrThrow(value)
-    val newSize      = size + 1
-    val newNames     = new Array[String](newSize)
-    val newRawValues = new Array[String](newSize)
-    val newParsed    = new Array[AnyRef](newSize)
+    val newSize         = size + 1
+    val newNames        = new Array[String](newSize)
+    val newRawValues    = new Array[String](newSize)
+    val newParsedCodecs = new Array[Header.Codec[_]](newSize)
+    val newParsedValues = new Array[AnyRef](newSize)
     System.arraycopy(names, 0, newNames, 0, size)
     System.arraycopy(rawValues, 0, newRawValues, 0, size)
-    newNames(size) = name.toLowerCase(Locale.ROOT)
+    newNames(size) = Headers.validatedLowerName(name)
     newRawValues(size) = value
-    new Headers(newNames, newRawValues, newParsed, newSize)
+    new Headers(newNames, newRawValues, newParsedCodecs, newParsedValues, newSize)
   }
 
   def set(name: String, value: String): Headers = {
-    Headers.validateNameOrThrow(name)
-    Headers.validateValueOrThrow(value)
-    val lowerName = name.toLowerCase(Locale.ROOT)
-    val builder   = HeadersBuilder.make(size)
-    var i         = 0
+    val builder = HeadersBuilder.make(size)
+    var i       = 0
+    // Carried entries are already validated and lowercased: copy unchecked.
+    // The new pair goes through the validating `add`, which also enforces the
+    // name/value invariants for this call.
+    val target = Headers.lowerName(name)
     while (i < size) {
-      if (names(i) != lowerName) builder.add(names(i), rawValues(i))
+      if (names(i) != target) builder.addUnchecked(names(i), rawValues(i))
       i += 1
     }
-    builder.add(lowerName, value)
+    builder.add(name, value)
     builder.build()
   }
 
   def set(header: Header): Headers = set(header.headerName, header.renderedValue)
 
   def remove(name: String): Headers = {
-    Headers.validateNameOrThrow(name)
-    val lowerName = name.toLowerCase(Locale.ROOT)
+    val lowerName = Headers.validatedLowerName(name)
     val builder   = HeadersBuilder.make(size)
     var i         = 0
     while (i < size) {
-      if (names(i) != lowerName) builder.add(names(i), rawValues(i))
+      if (names(i) != lowerName) builder.addUnchecked(names(i), rawValues(i))
       i += 1
     }
     builder.build()
   }
 
-  def has(name: String): Boolean = {
-    Headers.validateNameOrThrow(name)
-    val target = name.toLowerCase(Locale.ROOT)
-    var i      = 0
-    while (i < size) {
-      if (names(i) == target) return true
-      i += 1
-    }
-    false
-  }
+  def has(name: String): Boolean =
+    indexOf(Headers.validatedLowerName(name)) >= 0
 
   def toList: List[(String, String)] = {
     val builder = List.newBuilder[(String, String)]
@@ -278,22 +309,40 @@ final class Headers private[http] (
   }
 
   override def equals(that: Any): Boolean = that match {
-    case h: Headers => toList == h.toList
-    case _          => false
+    case h: Headers =>
+      if (size != h.size) false
+      else {
+        var i = 0
+        while (i < size) {
+          if (names(i) != h.names(i) || rawValues(i) != h.rawValues(i)) return false
+          i += 1
+        }
+        true
+      }
+    case _ => false
   }
 
-  override def hashCode: Int = toList.hashCode
+  override def hashCode: Int = {
+    var h = 1
+    var i = 0
+    while (i < size) {
+      h = 31 * h + names(i).hashCode
+      h = 31 * h + rawValues(i).hashCode
+      i += 1
+    }
+    h
+  }
 
   def ++(other: Headers): Headers = {
     val builder = HeadersBuilder.make(size + other.size)
     var i       = 0
     while (i < size) {
-      builder.add(names(i), rawValues(i))
+      builder.addUnchecked(names(i), rawValues(i))
       i += 1
     }
     i = 0
     while (i < other.size) {
-      builder.add(other.names(i), other.rawValues(i))
+      builder.addUnchecked(other.names(i), other.rawValues(i))
       i += 1
     }
     builder.build()
@@ -327,9 +376,44 @@ final class Headers private[http] (
 }
 
 object Headers {
-  private final class ParsedValue(val codec: Header.Codec[_], val value: AnyRef)
+  val empty: Headers =
+    new Headers(Array.empty, Array.empty, Array.empty, Array.empty, 0)
 
-  val empty: Headers = new Headers(Array.empty, Array.empty, Array.empty, 0)
+  /**
+   * Lowercases a header name without validating it, allocating only when the
+   * name actually contains an uppercase ASCII character (or a non-ASCII
+   * character, which falls back to the JDK converter). Used for codec names,
+   * which were never validated on the read path.
+   */
+  private[http] def lowerName(name: String): String = {
+    var i = 0
+    while (i < name.length) {
+      val c = name.charAt(i)
+      if ((c >= 'A' && c <= 'Z') || c > 127) return name.toLowerCase(Locale.ROOT)
+      i += 1
+    }
+    name
+  }
+
+  /**
+   * Validates a header field name and returns its lowercase form in a single
+   * scan, allocating only when the name actually contains an uppercase ASCII
+   * character. Already-lowercase names — the common case — cost one cheap pass;
+   * this fuses the validation and case-normalization scans that raw reads would
+   * otherwise pay separately.
+   */
+  private[http] def validatedLowerName(name: String): String = {
+    if (name.isEmpty) throw new IllegalArgumentException("Header name cannot be empty")
+    var i          = 0
+    var needsLower = false
+    while (i < name.length) {
+      val c = name.charAt(i)
+      if (!isTokenChar(c)) throw new IllegalArgumentException(s"Invalid header name: $name")
+      if (c >= 'A' && c <= 'Z') needsLower = true
+      i += 1
+    }
+    if (needsLower) name.toLowerCase(Locale.ROOT) else name
+  }
 
   /**
    * Validates a header field name.
@@ -366,17 +450,32 @@ object Headers {
     Right(())
   }
 
-  private[http] def validateNameOrThrow(name: String): Unit =
-    validateName(name) match {
-      case Right(()) => ()
-      case Left(err) => throw new IllegalArgumentException(err)
+  /**
+   * Validates a header field name, throwing on failure. This is the hot-path
+   * entry point used by every read and write: unlike [[validateName]] it never
+   * allocates an `Either`, so a valid name costs a single scan.
+   */
+  private[http] def validateNameOrThrow(name: String): Unit = {
+    if (name.isEmpty) throw new IllegalArgumentException("Header name cannot be empty")
+    var i = 0
+    while (i < name.length) {
+      if (!isTokenChar(name.charAt(i))) throw new IllegalArgumentException(s"Invalid header name: $name")
+      i += 1
     }
+  }
 
-  private[http] def validateValueOrThrow(value: String): Unit =
-    validateValue(value) match {
-      case Right(()) => ()
-      case Left(err) => throw new IllegalArgumentException(err)
+  /**
+   * Validates a raw header field value, throwing on failure. Allocation-free on
+   * success, like [[validateNameOrThrow]].
+   */
+  private[http] def validateValueOrThrow(value: String): Unit = {
+    var i = 0
+    while (i < value.length) {
+      val c = value.charAt(i)
+      if (c == '\r' || c == '\n') throw new IllegalArgumentException("Header value cannot contain CR or LF")
+      i += 1
     }
+  }
 
   private def isTokenChar(c: Char): Boolean =
     (c >= 'A' && c <= 'Z') ||
@@ -400,10 +499,21 @@ final class HeadersBuilder private (
 ) {
 
   def add(name: String, value: String): Unit = {
-    Headers.validateNameOrThrow(name)
     Headers.validateValueOrThrow(value)
     ensureCapacity()
-    names(len) = name.toLowerCase(Locale.ROOT)
+    names(len) = Headers.validatedLowerName(name)
+    rawValues(len) = value
+    len += 1
+  }
+
+  /**
+   * Adds an entry whose name is already validated and lowercased, skipping both
+   * checks. Used when copying entries between collections, where every stored
+   * name already satisfies the invariants.
+   */
+  private[http] def addUnchecked(lowercasedName: String, value: String): Unit = {
+    ensureCapacity()
+    names(len) = lowercasedName
     rawValues(len) = value
     len += 1
   }
@@ -426,12 +536,13 @@ final class HeadersBuilder private (
     }
 
   def build(): Headers = {
-    val n = new Array[String](len)
-    val v = new Array[String](len)
-    val p = new Array[AnyRef](len)
+    val n  = new Array[String](len)
+    val v  = new Array[String](len)
+    val pc = new Array[Header.Codec[_]](len)
+    val pv = new Array[AnyRef](len)
     System.arraycopy(names, 0, n, 0, len)
     System.arraycopy(rawValues, 0, v, 0, len)
-    new Headers(n, v, p, len)
+    new Headers(n, v, pc, pv, len)
   }
 }
 

--- a/http-model/shared/src/main/scala/zio/http/Headers.scala
+++ b/http-model/shared/src/main/scala/zio/http/Headers.scala
@@ -28,6 +28,12 @@ import zio.blocks.chunk.Chunk
  * array is populated lazily on typed `get` calls. The cache is an optimization
  * only: duplicate benign parses are possible if the same `Headers` is read
  * concurrently.
+ *
+ * Typed reads come in two flavors. The lenient [[get]] / [[getAll]] skip
+ * entries that fail to parse and continue scanning, so a wrong-typed header
+ * reads as absent (`None` / empty). Use the strict [[getStrict]] /
+ * [[getAllStrict]] when you need to distinguish "header absent" from "header
+ * present but unparseable": they report the parse error as `Left`.
  */
 final class Headers private[http] (
   private val names: Array[String],
@@ -48,6 +54,10 @@ final class Headers private[http] (
    * Matching is case-insensitive by header name. Parsed values are cached per
    * header entry and codec instance so different codecs with the same name do
    * not reuse each other's cached values.
+   *
+   * This is the lenient read: entries that fail to parse are skipped and
+   * scanning continues, so a present-but-wrong-typed header reads as absent
+   * (`None`). See [[getStrict]] for the error-reporting variant.
    */
   def get[A](headerCodec: Header.Codec[A]): Option[A] = {
     val target = headerCodec.name.toLowerCase(Locale.ROOT)
@@ -69,6 +79,40 @@ final class Headers private[http] (
       i += 1
     }
     None
+  }
+
+  /**
+   * Strict variant of [[get]]: distinguishes "header absent" from "header
+   * present but unparseable".
+   *
+   * Returns `Right(Some(value))` for the first entry that parses, `Right(None)`
+   * when no entry matches the codec name, and `Left(error)` carrying the first
+   * parse error when entries match but none parses. Like [[get]], scanning
+   * continues past unparseable entries while a later entry may still parse; the
+   * error is reported only when nothing parseable is found.
+   */
+  def getStrict[A](headerCodec: Header.Codec[A]): Either[String, Option[A]] = {
+    val target             = headerCodec.name.toLowerCase(Locale.ROOT)
+    var i                  = 0
+    var firstError: String = null
+    while (i < size) {
+      if (names(i) == target) {
+        parsed(i) match {
+          case cached: Headers.ParsedValue if sameCodec(cached.codec, headerCodec) =>
+            return Right(Some(cached.value.asInstanceOf[A]))
+          case _ =>
+        }
+        headerCodec.parse(rawValues(i)) match {
+          case Right(value) =>
+            parsed(i) = new Headers.ParsedValue(headerCodec, value.asInstanceOf[AnyRef])
+            return Right(Some(value))
+          case Left(err) =>
+            if (firstError == null) firstError = err
+        }
+      }
+      i += 1
+    }
+    if (firstError == null) Right(None) else Left(firstError)
   }
 
   def rawGet(name: String): Option[String] = {
@@ -110,7 +154,8 @@ final class Headers private[http] (
    *
    * Values are returned in header order. Entries that fail to parse for the
    * requested codec are skipped, and cached values are reused only when they
-   * were produced by the same codec instance.
+   * were produced by the same codec instance. See [[getAllStrict]] for the
+   * fail-fast variant.
    */
   def getAll[A](headerCodec: Header.Codec[A]): Chunk[A] = {
     val target  = headerCodec.name.toLowerCase(Locale.ROOT)
@@ -133,6 +178,33 @@ final class Headers private[http] (
       i += 1
     }
     builder.result()
+  }
+
+  /**
+   * Strict variant of [[getAll]]: fails fast with the first parse error instead
+   * of skipping unparseable entries.
+   */
+  def getAllStrict[A](headerCodec: Header.Codec[A]): Either[String, Chunk[A]] = {
+    val target  = headerCodec.name.toLowerCase(Locale.ROOT)
+    val builder = Chunk.newBuilder[A]
+    var i       = 0
+    while (i < size) {
+      if (names(i) == target) {
+        parsed(i) match {
+          case cached: Headers.ParsedValue if sameCodec(cached.codec, headerCodec) =>
+            builder += cached.value.asInstanceOf[A]
+          case _ =>
+            headerCodec.parse(rawValues(i)) match {
+              case Right(value) =>
+                parsed(i) = new Headers.ParsedValue(headerCodec, value.asInstanceOf[AnyRef])
+                builder += value
+              case Left(err) => return Left(err)
+            }
+        }
+      }
+      i += 1
+    }
+    Right(builder.result())
   }
 
   def getLast[H <: Header](headerType: Header.Typed[H]): Option[H] = {

--- a/http-model/shared/src/main/scala/zio/http/Headers.scala
+++ b/http-model/shared/src/main/scala/zio/http/Headers.scala
@@ -451,22 +451,8 @@ object Headers {
   }
 
   /**
-   * Validates a header field name, throwing on failure. This is the hot-path
-   * entry point used by every read and write: unlike [[validateName]] it never
-   * allocates an `Either`, so a valid name costs a single scan.
-   */
-  private[http] def validateNameOrThrow(name: String): Unit = {
-    if (name.isEmpty) throw new IllegalArgumentException("Header name cannot be empty")
-    var i = 0
-    while (i < name.length) {
-      if (!isTokenChar(name.charAt(i))) throw new IllegalArgumentException(s"Invalid header name: $name")
-      i += 1
-    }
-  }
-
-  /**
    * Validates a raw header field value, throwing on failure. Allocation-free on
-   * success, like [[validateNameOrThrow]].
+   * success.
    */
   private[http] def validateValueOrThrow(value: String): Unit = {
     var i = 0

--- a/http-model/shared/src/main/scala/zio/http/Request.scala
+++ b/http-model/shared/src/main/scala/zio/http/Request.scala
@@ -16,6 +16,8 @@
 
 package zio.http
 
+import zio.blocks.maybe.Maybe
+
 /**
  * Immutable HTTP request consisting of method, URL, headers, body, and protocol
  * version.
@@ -33,17 +35,18 @@ final case class Request(
   /**
    * Decodes the first request header matching the supplied codec.
    */
-  def header[A](headerCodec: Header.Codec[A]): Option[A] = headers.get(headerCodec)
+  def header[A](headerCodec: Header.Codec[A]): Maybe[A] = headers.get(headerCodec)
 
   /**
    * Returns this request's content type.
    *
    * The typed `Content-Type` header is preferred when present and parseable. If
    * the header is absent or cannot be parsed as a typed `Content-Type` header,
-   * this method falls back to the body's content type.
+   * this method falls back to the body's content type, so the result is always
+   * defined and needs no `Option`/`Maybe` wrapper.
    */
-  def contentType: Option[ContentType] =
-    header(Header.ContentType).map(_.value).orElse(Some(body.contentType))
+  def contentType: ContentType =
+    header(Header.ContentType).map(_.value).getOrElse(body.contentType)
 
   def path: Path = url.path
 

--- a/http-model/shared/src/main/scala/zio/http/Response.scala
+++ b/http-model/shared/src/main/scala/zio/http/Response.scala
@@ -16,6 +16,8 @@
 
 package zio.http
 
+import zio.blocks.maybe.Maybe
+
 /**
  * Immutable HTTP response consisting of status, headers, body, and protocol
  * version.
@@ -30,17 +32,18 @@ final case class Response(
   /**
    * Decodes the first response header matching the supplied codec.
    */
-  def header[A](headerCodec: Header.Codec[A]): Option[A] = headers.get(headerCodec)
+  def header[A](headerCodec: Header.Codec[A]): Maybe[A] = headers.get(headerCodec)
 
   /**
    * Returns this response's content type.
    *
    * The typed `Content-Type` header is preferred when present and parseable. If
    * the header is absent or cannot be parsed as a typed `Content-Type` header,
-   * this method falls back to the body's content type.
+   * this method falls back to the body's content type, so the result is always
+   * defined and needs no `Option`/`Maybe` wrapper.
    */
-  def contentType: Option[ContentType] =
-    header(Header.ContentType).map(_.value).orElse(Some(body.contentType))
+  def contentType: ContentType =
+    header(Header.ContentType).map(_.value).getOrElse(body.contentType)
 
   def cookies: zio.blocks.chunk.Chunk[ResponseCookie] = {
     val raw     = headers.getAll(Header.SetCookieHeader)

--- a/http-model/shared/src/test/scala/zio/http/HeaderSpec.scala
+++ b/http-model/shared/src/test/scala/zio/http/HeaderSpec.scala
@@ -17,6 +17,7 @@
 package zio.http
 
 import zio.test._
+import zio.blocks.maybe.Maybe
 
 object HeaderSpec extends HttpModelBaseSpec {
   private object RequestIdHeader extends Header.Codec[String] {
@@ -31,9 +32,9 @@ object HeaderSpec extends HttpModelBaseSpec {
       test("custom headers via rawGet") {
         val headers = Headers("x-request-id" -> "abc-123", "x-trace-id" -> "trace-456")
         assertTrue(
-          headers.rawGet("x-request-id") == Some("abc-123"),
-          headers.rawGet("x-trace-id") == Some("trace-456"),
-          headers.rawGet("x-missing") == None
+          headers.rawGet("x-request-id") == Maybe.present("abc-123"),
+          headers.rawGet("x-trace-id") == Maybe.present("trace-456"),
+          headers.rawGet("x-missing") == Maybe.absent
         )
       },
       test("custom header codec can be defined without extending Header") {

--- a/http-model/shared/src/test/scala/zio/http/HeadersSpec.scala
+++ b/http-model/shared/src/test/scala/zio/http/HeadersSpec.scala
@@ -18,6 +18,7 @@ package zio.http
 
 import _root_.zio.test._
 import zio.blocks.chunk.Chunk
+import zio.blocks.maybe.Maybe
 
 object HeadersSpec extends HttpModelBaseSpec {
   private object TraceIdHeader extends Header.Codec[String] {
@@ -66,7 +67,7 @@ object HeadersSpec extends HttpModelBaseSpec {
       },
       test("stores names lowercased") {
         val h = Headers("Content-Type" -> "text/html")
-        assertTrue(h.rawGet("content-type") == Some("text/html"))
+        assertTrue(h.rawGet("content-type") == Maybe.present("text/html"))
       },
       test("multiple entries with same name") {
         val h = Headers("Set-Cookie" -> "a=1", "Set-Cookie" -> "b=2")
@@ -76,19 +77,19 @@ object HeadersSpec extends HttpModelBaseSpec {
     suite("rawGet")(
       test("returns Some for existing header") {
         val h = Headers("content-type" -> "text/html")
-        assertTrue(h.rawGet("content-type") == Some("text/html"))
+        assertTrue(h.rawGet("content-type") == Maybe.present("text/html"))
       },
       test("returns None for missing header") {
         val h = Headers("content-type" -> "text/html")
-        assertTrue(h.rawGet("accept") == None)
+        assertTrue(h.rawGet("accept") == Maybe.absent)
       },
       test("returns first matching value") {
         val h = Headers("set-cookie" -> "a=1", "set-cookie" -> "b=2")
-        assertTrue(h.rawGet("set-cookie") == Some("a=1"))
+        assertTrue(h.rawGet("set-cookie") == Maybe.present("a=1"))
       },
       test("case-insensitive matching via lowercased storage") {
         val h = Headers("Content-Type" -> "text/html")
-        assertTrue(h.rawGet("content-type") == Some("text/html"))
+        assertTrue(h.rawGet("content-type") == Maybe.present("text/html"))
       }
     ),
     suite("rawGetAll")(
@@ -131,34 +132,34 @@ object HeadersSpec extends HttpModelBaseSpec {
       test("parses ContentLength header") {
         val h      = Headers("Content-Length" -> "42")
         val result = h.get(Header.ContentLength)
-        assertTrue(result == Some(Header.ContentLength(42L)))
+        assertTrue(result == Maybe.present(Header.ContentLength(42L)))
       },
       test("parses Host header") {
         val h      = Headers("Host" -> "example.com:8080")
         val result = h.get(Header.Host)
-        assertTrue(result == Some(Header.Host("example.com", Some(8080))))
+        assertTrue(result == Maybe.present(Header.Host("example.com", Some(8080))))
       },
       test("returns None for missing header type") {
         val h = Headers("accept" -> "text/html")
-        assertTrue(h.get(Header.ContentLength) == None)
+        assertTrue(h.get(Header.ContentLength) == Maybe.absent)
       },
       test("returns None when parse fails") {
         val h = Headers("content-length" -> "not-a-number")
-        assertTrue(h.get(Header.ContentLength) == None)
+        assertTrue(h.get(Header.ContentLength) == Maybe.absent)
       },
       test("caches parsed result on second call") {
         val h      = Headers("Content-Length" -> "42")
         val first  = h.get(Header.ContentLength)
         val second = h.get(Header.ContentLength)
         assertTrue(
-          first == Some(Header.ContentLength(42L)),
-          second == Some(Header.ContentLength(42L))
+          first == Maybe.present(Header.ContentLength(42L)),
+          second == Maybe.present(Header.ContentLength(42L))
         )
       },
       test("parses custom header codec without Header subtype") {
         val h      = Headers("X-Trace-Id" -> "trace-123")
         val result = h.get(TraceIdHeader)
-        assertTrue(result == Some("trace-123"))
+        assertTrue(result == Maybe.present("trace-123"))
       },
       test("keeps built-in convenience header values working through Header.Codec") {
         val h = Headers(
@@ -166,8 +167,8 @@ object HeadersSpec extends HttpModelBaseSpec {
           "Access-Control-Allow-Credentials" -> "true"
         )
         assertTrue(
-          h.get(Header.AccessControlAllowHeaders) == Some(Header.AccessControlAllowHeaders.All),
-          h.get(Header.AccessControlAllowCredentials) == Some(Header.AccessControlAllowCredentials.Allow)
+          h.get(Header.AccessControlAllowHeaders) == Maybe.present(Header.AccessControlAllowHeaders.All),
+          h.get(Header.AccessControlAllowCredentials) == Maybe.present(Header.AccessControlAllowCredentials.Allow)
         )
       },
       test("does not reuse cached value across codecs with the same header name") {
@@ -176,9 +177,9 @@ object HeadersSpec extends HttpModelBaseSpec {
         val second = h.get(TraceIdLengthHeader)
         val third  = h.get(TraceIdHeader)
         assertTrue(
-          first == Some("trace-123"),
-          second == Some(9),
-          third == Some("trace-123")
+          first == Maybe.present("trace-123"),
+          second == Maybe.present(9),
+          third == Maybe.present("trace-123")
         )
       }
     ),
@@ -224,20 +225,20 @@ object HeadersSpec extends HttpModelBaseSpec {
     ),
     suite("getStrict")(
       test("reports an absent header as Right(None)") {
-        assertTrue(Headers.empty.getStrict(IntHeader) == Right(None))
+        assertTrue(Headers.empty.getStrict(IntHeader) == Right(Maybe.absent))
       },
       test("reports a present-but-unparseable header as Left where get reads None") {
         val h = Headers("x-n" -> "abc")
         assertTrue(
-          h.get(IntHeader) == None,
+          h.get(IntHeader) == Maybe.absent,
           h.getStrict(IntHeader) == Left("not an int: abc")
         )
       },
       test("keeps scanning past bad entries for a later good one") {
         val h = Headers("x-n" -> "abc", "x-n" -> "42")
         assertTrue(
-          h.get(IntHeader) == Some(42),
-          h.getStrict(IntHeader) == Right(Some(42))
+          h.get(IntHeader) == Maybe.present(42),
+          h.getStrict(IntHeader) == Right(Maybe.present(42))
         )
       },
       test("reports the first error when no entry parses") {
@@ -248,8 +249,8 @@ object HeadersSpec extends HttpModelBaseSpec {
         val h     = Headers("x-n" -> "7")
         val first = h.get(IntHeader)
         assertTrue(
-          first == Some(7),
-          h.getStrict(IntHeader) == Right(Some(7))
+          first == Maybe.present(7),
+          h.getStrict(IntHeader) == Right(Maybe.present(7))
         )
       }
     ),
@@ -273,7 +274,7 @@ object HeadersSpec extends HttpModelBaseSpec {
       test("returns the last matching typed header") {
         val h      = Headers("Set-Cookie" -> "a=1", "Set-Cookie" -> "b=2")
         val cookie = h.getLast(Header.SetCookieHeader)
-        assertTrue(cookie == Some(Header.SetCookieHeader("b=2")))
+        assertTrue(cookie == Maybe.present(Header.SetCookieHeader("b=2")))
       },
       test("returns None when no matching typed header exists") {
         val h = Headers("content-type" -> "text/html")
@@ -283,7 +284,7 @@ object HeadersSpec extends HttpModelBaseSpec {
     suite("rawGetLast")(
       test("returns the last raw header value") {
         val h = Headers("Set-Cookie" -> "a=1", "Set-Cookie" -> "b=2")
-        assertTrue(h.rawGetLast("set-cookie") == Some("b=2"))
+        assertTrue(h.rawGetLast("set-cookie") == Maybe.present("b=2"))
       },
       test("returns None when header is missing") {
         val h = Headers("content-type" -> "text/html")
@@ -295,19 +296,19 @@ object HeadersSpec extends HttpModelBaseSpec {
         val h = Headers("content-type" -> "text/html").add("accept", "application/json")
         assertTrue(
           h.size == 2,
-          h.rawGet("accept") == Some("application/json")
+          h.rawGet("accept") == Maybe.present("application/json")
         )
       },
       test("appends duplicate name") {
         val h = Headers("set-cookie" -> "a=1").add("set-cookie", "b=2")
         assertTrue(
           h.size == 2,
-          h.rawGet("set-cookie") == Some("a=1")
+          h.rawGet("set-cookie") == Maybe.present("a=1")
         )
       },
       test("stores name lowercased") {
         val h = Headers.empty.add("Content-Type", "text/html")
-        assertTrue(h.rawGet("content-type") == Some("text/html"))
+        assertTrue(h.rawGet("content-type") == Maybe.present("text/html"))
       },
       test("does not carry parsed cache") {
         val h  = Headers("Content-Length" -> "42")
@@ -315,18 +316,18 @@ object HeadersSpec extends HttpModelBaseSpec {
         val h2 = h.add("accept", "text/html")
         // h2 is a fresh Headers, its parsed cache is all-null
         // but get should still work after re-parsing
-        assertTrue(h2.get(Header.ContentLength) == Some(Header.ContentLength(42L)))
+        assertTrue(h2.get(Header.ContentLength) == Maybe.present(Header.ContentLength(42L)))
       }
     ),
     suite("typed add/set")(
       test("add accepts a typed header") {
         val h = Headers.empty.add(Header.Host("example.com", Some(8080)))
-        assertTrue(h.get(Header.Host) == Some(Header.Host("example.com", Some(8080))))
+        assertTrue(h.get(Header.Host) == Maybe.present(Header.Host("example.com", Some(8080))))
       },
       test("set accepts a typed header") {
         val h = Headers("host" -> "old.example.com").set(Header.Host("example.com", Some(8080)))
         assertTrue(
-          h.get(Header.Host) == Some(Header.Host("example.com", Some(8080))),
+          h.get(Header.Host) == Maybe.present(Header.Host("example.com", Some(8080))),
           h.size == 1
         )
       }
@@ -336,15 +337,15 @@ object HeadersSpec extends HttpModelBaseSpec {
         val h = Headers("set-cookie" -> "a=1", "host" -> "example.com", "set-cookie" -> "b=2")
           .set("set-cookie", "c=3")
         assertTrue(
-          h.rawGet("set-cookie") == Some("c=3"),
-          h.rawGet("host") == Some("example.com")
+          h.rawGet("set-cookie") == Maybe.present("c=3"),
+          h.rawGet("host") == Maybe.present("example.com")
         )
       },
       test("adds entry if name not present") {
         val h = Headers("content-type" -> "text/html").set("accept", "application/json")
         assertTrue(
           h.size == 2,
-          h.rawGet("accept") == Some("application/json")
+          h.rawGet("accept") == Maybe.present("application/json")
         )
       },
       test("resulting Headers has exactly one entry for the set name") {
@@ -355,7 +356,7 @@ object HeadersSpec extends HttpModelBaseSpec {
       test("case-insensitive replacement") {
         val h = Headers("Content-Type" -> "text/html").set("CONTENT-TYPE", "application/json")
         assertTrue(
-          h.rawGet("content-type") == Some("application/json"),
+          h.rawGet("content-type") == Maybe.present("application/json"),
           h.size == 1
         )
       }
@@ -461,8 +462,8 @@ object HeadersSpec extends HttpModelBaseSpec {
         val h = builder.build()
         assertTrue(
           h.size == 2,
-          h.rawGet("content-type") == Some("text/html"),
-          h.rawGet("accept") == Some("application/json")
+          h.rawGet("content-type") == Maybe.present("text/html"),
+          h.rawGet("accept") == Maybe.present("application/json")
         )
       },
       test("allows duplicate names") {
@@ -488,7 +489,7 @@ object HeadersSpec extends HttpModelBaseSpec {
         val builder = HeadersBuilder.make()
         builder.add("Content-Type", "text/html")
         val h = builder.build()
-        assertTrue(h.rawGet("content-type") == Some("text/html"))
+        assertTrue(h.rawGet("content-type") == Maybe.present("text/html"))
       },
       test("rejects invalid header names") {
         assertTrue(
@@ -526,8 +527,8 @@ object HeadersSpec extends HttpModelBaseSpec {
         val h = builder.build()
         assertTrue(
           h.size == 9,
-          h.rawGet("a") == Some("1"),
-          h.rawGet("i") == Some("9")
+          h.rawGet("a") == Maybe.present("1"),
+          h.rawGet("i") == Maybe.present("9")
         )
       },
       test("builds empty headers from builder") {
@@ -562,14 +563,14 @@ object HeadersSpec extends HttpModelBaseSpec {
         val combined = h1 ++ h2
         assertTrue(
           combined.size == 2,
-          combined.rawGet("a") == Some("1"),
-          combined.rawGet("b") == Some("2")
+          combined.rawGet("a") == Maybe.present("1"),
+          combined.rawGet("b") == Maybe.present("2")
         )
       },
       test("combining with empty returns same entries") {
         val h        = Headers("a" -> "1")
         val combined = h ++ Headers.empty
-        assertTrue(combined.size == 1, combined.rawGet("a") == Some("1"))
+        assertTrue(combined.size == 1, combined.rawGet("a") == Maybe.present("1"))
       },
       test("preserves order") {
         val h1       = Headers("a" -> "1")

--- a/http-model/shared/src/test/scala/zio/http/HeadersSpec.scala
+++ b/http-model/shared/src/test/scala/zio/http/HeadersSpec.scala
@@ -34,6 +34,13 @@ object HeadersSpec extends HttpModelBaseSpec {
     def render(value: Int): String = "trace-" + value.toString
   }
 
+  private object IntHeader extends Header.Codec[Int] {
+    def name: String                              = "x-n"
+    def parse(value: String): Either[String, Int] =
+      value.toIntOption.toRight(s"not an int: $value")
+    def render(value: Int): String = value.toString
+  }
+
   def spec: Spec[TestEnvironment, Any] = suite("Headers")(
     suite("empty")(
       test("is empty") {
@@ -212,6 +219,53 @@ object HeadersSpec extends HttpModelBaseSpec {
           strings == Chunk("trace-1", "trace-22"),
           lengths == Chunk(7, 8),
           again == Chunk("trace-1", "trace-22")
+        )
+      }
+    ),
+    suite("getStrict")(
+      test("reports an absent header as Right(None)") {
+        assertTrue(Headers.empty.getStrict(IntHeader) == Right(None))
+      },
+      test("reports a present-but-unparseable header as Left where get reads None") {
+        val h = Headers("x-n" -> "abc")
+        assertTrue(
+          h.get(IntHeader) == None,
+          h.getStrict(IntHeader) == Left("not an int: abc")
+        )
+      },
+      test("keeps scanning past bad entries for a later good one") {
+        val h = Headers("x-n" -> "abc", "x-n" -> "42")
+        assertTrue(
+          h.get(IntHeader) == Some(42),
+          h.getStrict(IntHeader) == Right(Some(42))
+        )
+      },
+      test("reports the first error when no entry parses") {
+        val h = Headers("x-n" -> "abc", "x-n" -> "def")
+        assertTrue(h.getStrict(IntHeader) == Left("not an int: abc"))
+      },
+      test("reuses values cached by the same codec") {
+        val h     = Headers("x-n" -> "7")
+        val first = h.get(IntHeader)
+        assertTrue(
+          first == Some(7),
+          h.getStrict(IntHeader) == Right(Some(7))
+        )
+      }
+    ),
+    suite("getAllStrict")(
+      test("collects every matching entry") {
+        val h = Headers("x-n" -> "1", "x-n" -> "2")
+        assertTrue(h.getAllStrict(IntHeader) == Right(Chunk(1, 2)))
+      },
+      test("returns Right(empty) when no header matches") {
+        assertTrue(Headers.empty.getAllStrict(IntHeader) == Right(Chunk.empty))
+      },
+      test("fails fast on the first bad entry where getAll skips it") {
+        val h = Headers("x-n" -> "1", "x-n" -> "abc", "x-n" -> "3")
+        assertTrue(
+          h.getAll(IntHeader) == Chunk(1, 3),
+          h.getAllStrict(IntHeader) == Left("not an int: abc")
         )
       }
     ),

--- a/http-model/shared/src/test/scala/zio/http/HeadersSpec.scala
+++ b/http-model/shared/src/test/scala/zio/http/HeadersSpec.scala
@@ -221,11 +221,24 @@ object HeadersSpec extends HttpModelBaseSpec {
           lengths == Chunk(7, 8),
           again == Chunk("trace-1", "trace-22")
         )
+      },
+      test("reuses cached values on a repeated read with the same codec") {
+        val h      = Headers("X-Trace-Id" -> "trace-1", "X-Trace-Id" -> "trace-2")
+        val first  = h.getAll(TraceIdHeader)
+        val second = h.getAll(TraceIdHeader)
+        assertTrue(
+          first == Chunk("trace-1", "trace-2"),
+          second == Chunk("trace-1", "trace-2")
+        )
       }
     ),
     suite("getStrict")(
-      test("reports an absent header as Right(None)") {
+      test("reports an absent header as Right(absent)") {
         assertTrue(Headers.empty.getStrict(IntHeader) == Right(Maybe.absent))
+      },
+      test("parses on a cold cache without a prior lenient read") {
+        val h = Headers("x-n" -> "7")
+        assertTrue(h.getStrict(IntHeader) == Right(Maybe.present(7)))
       },
       test("reports a present-but-unparseable header as Left where get reads None") {
         val h = Headers("x-n" -> "abc")
@@ -268,6 +281,10 @@ object HeadersSpec extends HttpModelBaseSpec {
           h.getAll(IntHeader) == Chunk(1, 3),
           h.getAllStrict(IntHeader) == Left("not an int: abc")
         )
+      },
+      test("ignores entries with other names") {
+        val h = Headers("x-n" -> "1", "other" -> "z", "x-n" -> "2")
+        assertTrue(h.getAllStrict(IntHeader) == Right(Chunk(1, 2)))
       }
     ),
     suite("getLast")(
@@ -276,9 +293,22 @@ object HeadersSpec extends HttpModelBaseSpec {
         val cookie = h.getLast(Header.SetCookieHeader)
         assertTrue(cookie == Maybe.present(Header.SetCookieHeader("b=2")))
       },
-      test("returns None when no matching typed header exists") {
+      test("returns absent when no matching typed header exists") {
         val h = Headers("content-type" -> "text/html")
-        assertTrue(h.getLast(Header.SetCookieHeader).isEmpty)
+        assertTrue(h.getLast(Header.SetCookieHeader).isAbsent)
+      },
+      test("skips unparseable entries scanning backwards") {
+        val h = Headers("content-length" -> "42", "content-length" -> "abc")
+        assertTrue(h.getLast(Header.ContentLength) == Maybe.present(Header.ContentLength(42L)))
+      },
+      test("reuses the cached value on a repeated read") {
+        val h      = Headers("content-length" -> "7")
+        val first  = h.getLast(Header.ContentLength)
+        val second = h.getLast(Header.ContentLength)
+        assertTrue(
+          first == Maybe.present(Header.ContentLength(7L)),
+          second == Maybe.present(Header.ContentLength(7L))
+        )
       }
     ),
     suite("rawGetLast")(
@@ -432,6 +462,11 @@ object HeadersSpec extends HttpModelBaseSpec {
         val h2 = Headers("a" -> "2")
         assertTrue(h1 != h2)
       },
+      test("headers of different sizes are not equal") {
+        val h1 = Headers("a" -> "1")
+        val h2 = Headers("a" -> "1", "b" -> "2")
+        assertTrue(h1 != h2)
+      },
       test("order matters") {
         val h1 = Headers("a" -> "1", "b" -> "2")
         val h2 = Headers("b" -> "2", "a" -> "1")
@@ -451,6 +486,29 @@ object HeadersSpec extends HttpModelBaseSpec {
           s.contains("Headers"),
           s.contains("content-type"),
           s.contains("text/html")
+        )
+      }
+    ),
+    suite("validateName / validateValue")(
+      test("accepts valid names and values") {
+        assertTrue(
+          Headers.validateName("content-type") == Right(()),
+          Headers.validateName("X-TRACE-ID") == Right(()),
+          Headers.validateValue("text/html") == Right(()),
+          Headers.validateValue("") == Right(())
+        )
+      },
+      test("rejects empty and non-token names") {
+        assertTrue(
+          Headers.validateName("") == Left("Header name cannot be empty"),
+          Headers.validateName("bad name").isLeft,
+          Headers.validateName("bad@name").isLeft
+        )
+      },
+      test("rejects values containing CR or LF") {
+        assertTrue(
+          Headers.validateValue("a\rb").isLeft,
+          Headers.validateValue("a\nb").isLeft
         )
       }
     ),

--- a/http-model/shared/src/test/scala/zio/http/RequestSpec.scala
+++ b/http-model/shared/src/test/scala/zio/http/RequestSpec.scala
@@ -18,6 +18,7 @@ package zio.http
 
 import _root_.zio.test._
 import zio.blocks.chunk.Chunk
+import zio.blocks.maybe.Maybe
 
 object RequestSpec extends HttpModelBaseSpec {
   private object TraceIdHeader extends Header.Codec[String] {
@@ -102,22 +103,18 @@ object RequestSpec extends HttpModelBaseSpec {
           Body.empty,
           Version.`HTTP/1.1`
         )
-        assertTrue(request.header(TraceIdHeader) == Some("trace-123"))
+        assertTrue(request.header(TraceIdHeader) == Maybe.present("trace-123"))
       }
     ),
     suite("contentType")(
       test("returns ContentType from headers") {
         val headers = Headers("content-type" -> "application/json")
         val request = Request(Method.POST, URL.fromPath(Path.root), headers, Body.empty, Version.`HTTP/1.1`)
-        val ct      = request.contentType
-        assertTrue(
-          ct.isDefined,
-          ct.get == ContentType.`application/json`
-        )
+        assertTrue(request.contentType == ContentType.`application/json`)
       },
       test("falls back to body content type when no content-type header is present") {
         val request = Request.get(URL.fromPath(Path.root))
-        assertTrue(request.contentType == Some(ContentType.`application/octet-stream`))
+        assertTrue(request.contentType == ContentType.`application/octet-stream`)
       }
     ),
     suite("path")(
@@ -195,11 +192,11 @@ object RequestSpec extends HttpModelBaseSpec {
     suite("addHeader")(
       test("adds a header to request") {
         val request = Request.get(URL.fromPath(Path.root)).addHeader("Accept", "text/html")
-        assertTrue(request.headers.rawGet("accept") == Some("text/html"))
+        assertTrue(request.headers.rawGet("accept") == Maybe.present("text/html"))
       },
       test("adds a typed header to request") {
         val request = Request.get(URL.fromPath(Path.root)).addHeader(Header.Host("example.com", Some(8080)))
-        assertTrue(request.header(Header.Host) == Some(Header.Host("example.com", Some(8080))))
+        assertTrue(request.header(Header.Host) == Maybe.present(Header.Host("example.com", Some(8080))))
       }
     ),
     suite("addHeaders")(
@@ -207,8 +204,8 @@ object RequestSpec extends HttpModelBaseSpec {
         val extra   = Headers("Accept" -> "text/html", "X-Custom" -> "value")
         val request = Request.get(URL.fromPath(Path.root)).addHeaders(extra)
         assertTrue(
-          request.headers.rawGet("accept") == Some("text/html"),
-          request.headers.rawGet("x-custom") == Some("value")
+          request.headers.rawGet("accept") == Maybe.present("text/html"),
+          request.headers.rawGet("x-custom") == Maybe.present("value")
         )
       }
     ),
@@ -227,13 +224,13 @@ object RequestSpec extends HttpModelBaseSpec {
           .get(URL.fromPath(Path.root))
           .addHeader("Accept", "text/html")
           .setHeader("Accept", "application/json")
-        assertTrue(request.headers.rawGet("accept") == Some("application/json"))
+        assertTrue(request.headers.rawGet("accept") == Maybe.present("application/json"))
       },
       test("sets a typed header on request") {
         val request = Request
           .get(URL.fromPath(Path.root))
           .setHeader(Header.Host("example.com", Some(8080)))
-        assertTrue(request.header(Header.Host) == Some(Header.Host("example.com", Some(8080))))
+        assertTrue(request.header(Header.Host) == Maybe.present(Header.Host("example.com", Some(8080))))
       }
     ),
     suite("cookies")(
@@ -252,7 +249,7 @@ object RequestSpec extends HttpModelBaseSpec {
           .addCookie(RequestCookie("session", "abc123"))
           .addCookie(RequestCookie("theme", "dark"))
         assertTrue(
-          request.headers.rawGet("cookie") == Some("session=abc123; theme=dark"),
+          request.headers.rawGet("cookie") == Maybe.present("session=abc123; theme=dark"),
           request.cookies == Chunk(RequestCookie("session", "abc123"), RequestCookie("theme", "dark"))
         )
       }
@@ -261,7 +258,10 @@ object RequestSpec extends HttpModelBaseSpec {
       test("replaces body") {
         val newBody = Body.fromString("new body")
         val request = Request.get(URL.fromPath(Path.root)).body(newBody)
-        assertTrue(request.body == newBody, request.headers.rawGet("content-type") == Some(newBody.contentType.render))
+        assertTrue(
+          request.body == newBody,
+          request.headers.rawGet("content-type") == Maybe.present(newBody.contentType.render)
+        )
       }
     ),
     suite("url (setter)")(
@@ -315,8 +315,8 @@ object RequestSpec extends HttpModelBaseSpec {
           .addHeader("Accept", "text/html")
           .updateHeaders(_.add("X-Custom", "value"))
         assertTrue(
-          request.headers.rawGet("accept") == Some("text/html"),
-          request.headers.rawGet("x-custom") == Some("value")
+          request.headers.rawGet("accept") == Maybe.present("text/html"),
+          request.headers.rawGet("x-custom") == Maybe.present("value")
         )
       }
     ),

--- a/http-model/shared/src/test/scala/zio/http/ResponseSpec.scala
+++ b/http-model/shared/src/test/scala/zio/http/ResponseSpec.scala
@@ -18,6 +18,7 @@ package zio.http
 
 import _root_.zio.test._
 import zio.blocks.chunk.Chunk
+import zio.blocks.maybe.Maybe
 
 object ResponseSpec extends HttpModelBaseSpec {
   private object TraceIdHeader extends Header.Codec[String] {
@@ -103,21 +104,17 @@ object ResponseSpec extends HttpModelBaseSpec {
       },
       test("returns custom typed header without Header subtype") {
         val response = Response(Status.Ok, Headers("X-Trace-Id" -> "trace-123"), Body.empty, Version.`HTTP/1.1`)
-        assertTrue(response.header(TraceIdHeader) == Some("trace-123"))
+        assertTrue(response.header(TraceIdHeader) == Maybe.present("trace-123"))
       }
     ),
     suite("contentType")(
       test("returns ContentType from headers") {
         val headers  = Headers("content-type" -> "text/plain")
         val response = Response(Status.Ok, headers, Body.empty, Version.`HTTP/1.1`)
-        val ct       = response.contentType
-        assertTrue(
-          ct.isDefined,
-          ct.get == ContentType.`text/plain`
-        )
+        assertTrue(response.contentType == ContentType.`text/plain`)
       },
       test("falls back to body content type when no content-type header is present") {
-        assertTrue(Response.ok.contentType == Some(ContentType.`application/octet-stream`))
+        assertTrue(Response.ok.contentType == ContentType.`application/octet-stream`)
       }
     ),
     suite("Response.badRequest")(
@@ -151,8 +148,8 @@ object ResponseSpec extends HttpModelBaseSpec {
         assertTrue(
           response.status == Status.Ok,
           response.body == Body.fromString("hello world"),
-          response.headers.rawGet("content-type") == Some("text/plain; charset=UTF-8"),
-          response.contentType == Some(response.body.contentType)
+          response.headers.rawGet("content-type") == Maybe.present("text/plain; charset=UTF-8"),
+          response.contentType == response.body.contentType
         )
       },
       test("accepts explicit status") {
@@ -165,8 +162,8 @@ object ResponseSpec extends HttpModelBaseSpec {
         val response = Response.json("{\"key\": \"value\"}")
         assertTrue(
           response.status == Status.Ok,
-          response.headers.rawGet("content-type") == Some("application/json"),
-          response.contentType == Some(ContentType.`application/json`)
+          response.headers.rawGet("content-type") == Maybe.present("application/json"),
+          response.contentType == ContentType.`application/json`
         )
       },
       test("accepts explicit status") {
@@ -181,7 +178,7 @@ object ResponseSpec extends HttpModelBaseSpec {
         assertTrue(
           response.status == Status.Ok,
           response.body == body,
-          response.headers.rawGet("content-type") == Some(body.contentType.render)
+          response.headers.rawGet("content-type") == Maybe.present(body.contentType.render)
         )
       }
     ),
@@ -190,14 +187,14 @@ object ResponseSpec extends HttpModelBaseSpec {
         val response = Response.redirect("/new-location")
         assertTrue(
           response.status == Status.TemporaryRedirect,
-          response.headers.rawGet("location") == Some("/new-location")
+          response.headers.rawGet("location") == Maybe.present("/new-location")
         )
       },
       test("permanent redirect when isPermanent is true") {
         val response = Response.redirect("/new-location", isPermanent = true)
         assertTrue(
           response.status == Status.PermanentRedirect,
-          response.headers.rawGet("location") == Some("/new-location")
+          response.headers.rawGet("location") == Maybe.present("/new-location")
         )
       }
     ),
@@ -206,18 +203,18 @@ object ResponseSpec extends HttpModelBaseSpec {
         val response = Response.seeOther("/other")
         assertTrue(
           response.status == Status.SeeOther,
-          response.headers.rawGet("location") == Some("/other")
+          response.headers.rawGet("location") == Maybe.present("/other")
         )
       }
     ),
     suite("Response addHeader")(
       test("adds a header") {
         val response = Response.ok.addHeader("X-Custom", "value")
-        assertTrue(response.headers.rawGet("x-custom") == Some("value"))
+        assertTrue(response.headers.rawGet("x-custom") == Maybe.present("value"))
       },
       test("adds a typed header") {
         val response = Response.ok.addHeader(Header.ContentLength(42L))
-        assertTrue(response.header(Header.ContentLength) == Some(Header.ContentLength(42L)))
+        assertTrue(response.header(Header.ContentLength) == Maybe.present(Header.ContentLength(42L)))
       }
     ),
     suite("Response addHeaders")(
@@ -225,8 +222,8 @@ object ResponseSpec extends HttpModelBaseSpec {
         val extra    = Headers("X-A" -> "1", "X-B" -> "2")
         val response = Response.ok.addHeaders(extra)
         assertTrue(
-          response.headers.rawGet("x-a") == Some("1"),
-          response.headers.rawGet("x-b") == Some("2")
+          response.headers.rawGet("x-a") == Maybe.present("1"),
+          response.headers.rawGet("x-b") == Maybe.present("2")
         )
       }
     ),
@@ -241,13 +238,13 @@ object ResponseSpec extends HttpModelBaseSpec {
         val response = Response.ok
           .addHeader("X-Custom", "old")
           .setHeader("X-Custom", "new")
-        assertTrue(response.headers.rawGet("x-custom") == Some("new"))
+        assertTrue(response.headers.rawGet("x-custom") == Maybe.present("new"))
       },
       test("sets a typed header replacing existing") {
         val response = Response.ok
           .addHeader(Header.ContentLength(1L))
           .setHeader(Header.ContentLength(42L))
-        assertTrue(response.header(Header.ContentLength) == Some(Header.ContentLength(42L)))
+        assertTrue(response.header(Header.ContentLength) == Maybe.present(Header.ContentLength(42L)))
       }
     ),
     suite("Response body (setter)")(
@@ -256,7 +253,7 @@ object ResponseSpec extends HttpModelBaseSpec {
         val response = Response.ok.body(newBody)
         assertTrue(
           response.body == newBody,
-          response.headers.rawGet("content-type") == Some(newBody.contentType.render)
+          response.headers.rawGet("content-type") == Maybe.present(newBody.contentType.render)
         )
       }
     ),
@@ -278,8 +275,8 @@ object ResponseSpec extends HttpModelBaseSpec {
           .addHeader("X-A", "1")
           .updateHeaders(_.add("X-B", "2"))
         assertTrue(
-          response.headers.rawGet("x-a") == Some("1"),
-          response.headers.rawGet("x-b") == Some("2")
+          response.headers.rawGet("x-a") == Maybe.present("1"),
+          response.headers.rawGet("x-b") == Maybe.present("2")
         )
       }
     ),


### PR DESCRIPTION
## What changed

Headers gains two strict readers alongside the lenient ones:

- getStrict returns Right(Some(value)) for the first entry that parses, Right(None) when no entry matches, and Left(error) with the first parse error when entries match but none parses.
- getAllStrict collects every matching entry and fails fast with the first parse error instead of skipping bad entries.

The lenient get / getAll behavior is unchanged and now documented as such on the class and on each method, so callers can pick the flavor they need.

## Why

A present-but-wrong-typed header currently reads as absent (None / empty), which makes malformed headers invisible. The strict variants let callers tell "header absent" apart from "header present but unparseable".

## Verification

- Extended HeadersSpec with 8 tests covering absent vs unparseable, scanning past bad entries, first-error reporting, fail-fast collection, and cache reuse with the same codec.
- http-modelJVM/test green on Scala 3.8.3 and 2.13.18 (1117 tests, 0 failures); scalafmt clean.